### PR TITLE
refactor(client): carry component bind key spans

### DIFF
--- a/.changeset/tidy-potatoes-map.md
+++ b/.changeset/tidy-potatoes-map.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Map generated component binding accessor keys to their source directives.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 dependencies = [
  "compact_str",
  "memchr",

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -2034,6 +2034,13 @@ carry a *movement*, which is the reading a 0 cannot give.
  There is no corpus-wide source-map gate to fall back on: `verify.mjs` compares generated
  code, and the svelte2tsx map gate (§ 12) covers a different artifact.
 
+The component-bind pass illustrates why the discriminating test must survive a partial
+deletion too: its generated-text search formerly supplied both `get`/`set` property-key
+segments and a template-interpolation segment. The accessor keys now carry the complete raw
+directive-name range as dedicated spanned property-key variants, and the pass no longer searches
+for `get` or `set`; its remaining `${name() ?? …}` scan is a separate carrier and must not be
+declared redundant from the accessor movement alone.
+
 ### Blind spot 14h — the unit is a segment, so a change that improves the map and breaks the *code* scores green
 
 Every comparison here reads `map.mappings`; nothing in the file looks at the generated JS the

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.145", features = ["serialize"] }
 oxc_span = "0.145"
 oxc_diagnostics = "0.145"
 oxc_codegen = "0.145"
-rsvelte_esrap = { version = "=0.10.35", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.36", path = "../rsvelte_esrap" }
 oxc_syntax = "0.145"
 oxc_semantic = "0.145"
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -3669,7 +3669,13 @@ pub fn pattern_to_string(pattern: &JsPattern) -> String {
                                 s.push('[');
                             }
                             match key {
-                                JsPropertyKey::Identifier(n) => s.push_str(n),
+                                JsPropertyKey::Identifier(n)
+                                | JsPropertyKey::SpannedIdentifier { name: n, .. } => s.push_str(n),
+                                JsPropertyKey::SpannedStringLiteral { value, .. } => {
+                                    s.push('"');
+                                    s.push_str(value);
+                                    s.push('"');
+                                }
                                 JsPropertyKey::Literal(lit) => match lit {
                                     JsLiteral::String(n) => {
                                         s.push('"');

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -1083,8 +1083,12 @@ pub(crate) fn collect_ids_from_expr_props(
                         // Check if this property is named "children" or "$$slots" -
                         // skip their arrow/function values as children handle their own async
                         let prop_name = match &prop.key {
-                            JsPropertyKey::Identifier(name) => Some(name.as_str()),
+                            JsPropertyKey::Identifier(name)
+                            | JsPropertyKey::SpannedIdentifier { name, .. } => Some(name.as_str()),
                             JsPropertyKey::Literal(JsLiteral::String(name)) => Some(name.as_str()),
+                            JsPropertyKey::SpannedStringLiteral { value, .. } => {
+                                Some(value.as_str())
+                            }
                             _ => None,
                         };
                         let is_children_prop = matches!(prop_name, Some("children" | "$$slots"));

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -1559,6 +1559,27 @@ fn process_bind_directive<'a>(
         return;
     }
 
+    // Upstream stamps both generated accessor keys with `attribute.name_loc`,
+    // whose range is the complete raw directive name (`bind:name|modifiers`).
+    // Parsed directives retain that exact range; the fallback only serves
+    // synthetic directives whose source location was deliberately omitted.
+    let (bind_key_start, bind_key_end) = bind.name_loc.map_or_else(
+        || {
+            (
+                bind.start,
+                bind.start
+                    + "bind:".len() as u32
+                    + bind.name.len() as u32
+                    + bind
+                        .modifiers
+                        .iter()
+                        .map(|modifier| 1 + modifier.len() as u32)
+                        .sum::<u32>(),
+            )
+        },
+        |loc| (loc.start.character, loc.end.character),
+    );
+
     // In runes mode, when a bind directive's expression is rooted at an each block
     // item (e.g., bind:checked={partner.inTimeline}), flag the each block so it
     // emits the $$index parameter. This mirrors the official compiler's `mutate`
@@ -1617,9 +1638,13 @@ fn process_bind_directive<'a>(
                 use crate::compiler::phases::phase3_transform::js_ast::codegen::generate_expr;
                 generate_expr(&get_expr, &context.arena)
             };
-            let getter = b::getter(&context.arena,
-                bind.name.as_str(),
-                vec![b::return_value(&context.arena, JsExpr::Raw(get_body_str.into()))],
+            let getter = b::with_property_key_span(
+                b::getter(&context.arena,
+                    bind.name.as_str(),
+                    vec![b::return_value(&context.arena, JsExpr::Raw(get_body_str.into()))],
+                ),
+                bind_key_start,
+                bind_key_end,
             );
 
             if let Some(set_fn) = set_expr {
@@ -1643,10 +1668,14 @@ fn process_bind_directive<'a>(
                     use crate::compiler::phases::phase3_transform::js_ast::codegen::generate_expr;
                     format!("({})($$value)", generate_expr(&set_fn, &context.arena))
                 };
-                let setter = b::setter(&context.arena,
-                    bind.name.as_str(),
-                    "$$value",
-                    vec![b::stmt(&context.arena, JsExpr::Raw(set_body_str.into()))],
+                let setter = b::with_property_key_span(
+                    b::setter(&context.arena,
+                        bind.name.as_str(),
+                        "$$value",
+                        vec![b::stmt(&context.arena, JsExpr::Raw(set_body_str.into()))],
+                    ),
+                    bind_key_start,
+                    bind_key_end,
                 );
                 delayed_props.push(DelayedProp { prop: getter });
                 delayed_props.push(DelayedProp { prop: setter });
@@ -1793,7 +1822,11 @@ fn process_bind_directive<'a>(
         )]
     };
 
-    let getter = b::getter(&context.arena, bind.name.as_str(), getter_body);
+    let getter = b::with_property_key_span(
+        b::getter(&context.arena, bind.name.as_str(), getter_body),
+        bind_key_start,
+        bind_key_end,
+    );
 
     // Create setter
     // For store member expressions, we need to use $.store_mutate
@@ -2062,7 +2095,11 @@ fn process_bind_directive<'a>(
         }
     };
 
-    let setter = b::setter(&context.arena, bind.name.as_str(), "$$value", setter_body);
+    let setter = b::with_property_key_span(
+        b::setter(&context.arena, bind.name.as_str(), "$$value", setter_body),
+        bind_key_start,
+        bind_key_end,
+    );
 
     // Add as delayed props (bindings come at the end)
     delayed_props.push(DelayedProp { prop: getter });

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -1563,7 +1563,7 @@ fn process_bind_directive<'a>(
     // whose range is the complete raw directive name (`bind:name|modifiers`).
     // Parsed directives retain that exact range; the fallback only serves
     // synthetic directives whose source location was deliberately omitted.
-    let (bind_key_start, bind_key_end) = bind.name_loc.map_or_else(
+    let (bind_key_start, bind_key_end) = bind.name_loc.as_ref().map_or_else(
         || {
             (
                 bind.start,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
@@ -257,6 +257,31 @@ pub fn getter(
     })
 }
 
+/// Attach a source span to a static property key.
+///
+/// The key remains a property-key variant rather than becoming a spanned
+/// expression, so object/member lowering can continue to match its structure.
+pub fn with_property_key_span(mut member: JsObjectMember, start: u32, end: u32) -> JsObjectMember {
+    if let JsObjectMember::Property(property) = &mut member {
+        property.key = match &property.key {
+            JsPropertyKey::Identifier(name) => JsPropertyKey::SpannedIdentifier {
+                name: name.clone(),
+                start,
+                end,
+            },
+            JsPropertyKey::Literal(JsLiteral::String(value)) => {
+                JsPropertyKey::SpannedStringLiteral {
+                    value: value.clone(),
+                    start,
+                    end,
+                }
+            }
+            key => key.clone(),
+        };
+    }
+    member
+}
+
 /// Create a setter property.
 /// If the name is not a valid identifier (e.g., contains hyphens), uses a string literal key.
 pub fn setter(
@@ -1558,7 +1583,7 @@ pub fn literal_number(value: f64) -> JsExpr {
 }
 
 #[cfg(test)]
-mod await_walker_tests {
+mod tests {
     use super::*;
 
     fn awaited(arena: &JsArena, name: &str) -> JsExpr {
@@ -1603,5 +1628,41 @@ mod await_walker_tests {
             expression: arena.alloc_expr(inner_call),
         });
         assert!(!js_expr_has_await(&arena, &chain));
+    }
+
+    #[test]
+    fn property_key_span_preserves_identifier_shape() {
+        let arena = JsArena::new();
+        let member = with_property_key_span(getter(&arena, "value", vec![]), 4, 14);
+
+        assert!(matches!(
+            member,
+            JsObjectMember::Property(JsProperty {
+                key: JsPropertyKey::SpannedIdentifier {
+                    ref name,
+                    start: 4,
+                    end: 14,
+                },
+                ..
+            }) if name == "value"
+        ));
+    }
+
+    #[test]
+    fn property_key_span_preserves_quoted_key_shape() {
+        let arena = JsArena::new();
+        let member = with_property_key_span(getter(&arena, "foo-bar", vec![]), 4, 16);
+
+        assert!(matches!(
+            member,
+            JsObjectMember::Property(JsProperty {
+                key: JsPropertyKey::SpannedStringLiteral {
+                    ref value,
+                    start: 4,
+                    end: 16,
+                },
+                ..
+            }) if value == "foo-bar"
+        ));
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -1284,6 +1284,16 @@ impl<'a> JsCodegen<'a> {
     fn emit_property_key(&mut self, key: &JsPropertyKey) {
         match key {
             JsPropertyKey::Identifier(name) => self.output.push_str(name),
+            JsPropertyKey::SpannedIdentifier { name, start, end } => {
+                self.record_span_start(*start, *end);
+                self.output.push_str(name);
+                self.record_span_start(*end, *end);
+            }
+            JsPropertyKey::SpannedStringLiteral { value, start, end } => {
+                self.record_span_start(*start, *end);
+                self.emit_literal(&JsLiteral::String(value.clone()));
+                self.record_span_start(*end, *end);
+            }
             JsPropertyKey::Literal(lit) => self.emit_literal(lit),
             JsPropertyKey::Computed(expr_id) => self.emit_expression(self.arena.get_expr(*expr_id)),
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
@@ -560,6 +560,22 @@ pub struct JsProperty {
 #[derive(Debug, Clone)]
 pub enum JsPropertyKey {
     Identifier(CompactString),
+    /// An identifier key whose source range belongs to the key itself.
+    ///
+    /// Keep this distinct from `JsExpr::Spanned`: property keys are not
+    /// expressions, and wrapping an expression changes the variants seen by
+    /// downstream structural lowering.
+    SpannedIdentifier {
+        name: CompactString,
+        start: u32,
+        end: u32,
+    },
+    /// A string-literal key whose source range belongs to the key itself.
+    SpannedStringLiteral {
+        value: CompactString,
+        start: u32,
+        end: u32,
+    },
     Literal(JsLiteral),
     Computed(ExprId),
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -2425,6 +2425,22 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                     let expr = Expression::new_identifier(SPAN, self.str(name), &self.ab);
                     PropertyKey::from(expr)
                 }
+                JsPropertyKey::SpannedIdentifier { name, start, end } => {
+                    let expr = Expression::new_identifier(
+                        Span::new(*start, *end),
+                        self.str(name),
+                        &self.ab,
+                    );
+                    PropertyKey::from(expr)
+                }
+                JsPropertyKey::SpannedStringLiteral { value, start, end } => {
+                    PropertyKey::from(Expression::StringLiteral(StringLiteral::new(
+                        Span::new(*start, *end),
+                        self.str(value),
+                        None,
+                        &self.ab,
+                    )))
+                }
                 JsPropertyKey::Literal(lit) => {
                     let expr = self.literal(lit)?;
                     PropertyKey::from(expr)
@@ -2455,6 +2471,18 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 self.str(name),
                 &self.ab,
             )),
+            JsPropertyKey::SpannedIdentifier { name, start, end } => {
+                Some(PropertyKey::new_static_identifier(
+                    Span::new(*start, *end),
+                    self.str(name),
+                    &self.ab,
+                ))
+            }
+            JsPropertyKey::SpannedStringLiteral { value, start, end } => {
+                Some(PropertyKey::from(Expression::StringLiteral(
+                    StringLiteral::new(Span::new(*start, *end), self.str(value), None, &self.ab),
+                )))
+            }
             JsPropertyKey::Literal(lit) => {
                 // A literal key is the literal expression in key position.
                 let expr = self.literal(lit)?;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -2426,6 +2426,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                     PropertyKey::from(expr)
                 }
                 JsPropertyKey::SpannedIdentifier { name, start, end } => {
+                    self.note_span(*end);
                     let expr = Expression::new_identifier(
                         Span::new(*start, *end),
                         self.str(name),
@@ -2434,6 +2435,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                     PropertyKey::from(expr)
                 }
                 JsPropertyKey::SpannedStringLiteral { value, start, end } => {
+                    self.note_span(*end);
                     PropertyKey::from(Expression::StringLiteral(StringLiteral::new(
                         Span::new(*start, *end),
                         self.str(value),
@@ -2472,6 +2474,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 &self.ab,
             )),
             JsPropertyKey::SpannedIdentifier { name, start, end } => {
+                self.note_span(*end);
                 Some(PropertyKey::new_static_identifier(
                     Span::new(*start, *end),
                     self.str(name),
@@ -2479,6 +2482,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 ))
             }
             JsPropertyKey::SpannedStringLiteral { value, start, end } => {
+                self.note_span(*end);
                 Some(PropertyKey::from(Expression::StringLiteral(
                     StringLiteral::new(Span::new(*start, *end), self.str(value), None, &self.ab),
                 )))

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -2436,12 +2436,12 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 }
                 JsPropertyKey::SpannedStringLiteral { value, start, end } => {
                     self.note_span(*end);
-                    PropertyKey::from(Expression::StringLiteral(StringLiteral::new(
+                    PropertyKey::from(Expression::new_string_literal(
                         Span::new(*start, *end),
                         self.str(value),
                         None,
                         &self.ab,
-                    )))
+                    ))
                 }
                 JsPropertyKey::Literal(lit) => {
                     let expr = self.literal(lit)?;
@@ -2483,8 +2483,11 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
             }
             JsPropertyKey::SpannedStringLiteral { value, start, end } => {
                 self.note_span(*end);
-                Some(PropertyKey::from(Expression::StringLiteral(
-                    StringLiteral::new(Span::new(*start, *end), self.str(value), None, &self.ab),
+                Some(PropertyKey::from(Expression::new_string_literal(
+                    Span::new(*start, *end),
+                    self.str(value),
+                    None,
+                    &self.ab,
                 )))
             }
             JsPropertyKey::Literal(lit) => {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -2426,7 +2426,6 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                     PropertyKey::from(expr)
                 }
                 JsPropertyKey::SpannedIdentifier { name, start, end } => {
-                    self.note_span(*end);
                     let expr = Expression::new_identifier(
                         Span::new(*start, *end),
                         self.str(name),
@@ -2435,7 +2434,6 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                     PropertyKey::from(expr)
                 }
                 JsPropertyKey::SpannedStringLiteral { value, start, end } => {
-                    self.note_span(*end);
                     PropertyKey::from(Expression::new_string_literal(
                         Span::new(*start, *end),
                         self.str(value),
@@ -2474,7 +2472,6 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 &self.ab,
             )),
             JsPropertyKey::SpannedIdentifier { name, start, end } => {
-                self.note_span(*end);
                 Some(PropertyKey::new_static_identifier(
                     Span::new(*start, *end),
                     self.str(name),
@@ -2482,7 +2479,6 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 ))
             }
             JsPropertyKey::SpannedStringLiteral { value, start, end } => {
-                self.note_span(*end);
                 Some(PropertyKey::from(Expression::new_string_literal(
                     Span::new(*start, *end),
                     self.str(value),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -269,9 +269,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 };
                 let component_bind_mappings = if !map_pass_disabled("component_bind")
                     && source.contains("bind:")
-                    && (result.code.contains("get ")
-                        || result.code.contains("set ")
-                        || result.code.contains("${"))
+                    && result.code.contains("${")
                 {
                     generate_component_bind_mappings_with_starts(
                         &result.code,
@@ -2297,7 +2295,8 @@ fn collect_runtime_use_sites<'code>(
     sites
 }
 
-/// Inline instance declarations survive lowering verbatim after `export` is removed.
+/// Preserve the remaining component-bind template interpolation mapping.
+/// Accessor keys carry their directive span on `JsPropertyKey` directly.
 fn generate_component_bind_mappings_with_starts(
     generated: &str,
     source: &str,
@@ -2329,32 +2328,6 @@ fn generate_component_bind_mappings_with_starts(
             continue;
         };
         let directive_end = name_start + name.len();
-        for prefix in ["get ", "set "] {
-            let pattern = format!("{prefix}{name}");
-            let mut generated_cursor = 0;
-            while let Some(relative) = generated[generated_cursor..].find(&pattern) {
-                let key_start = generated_cursor + relative + prefix.len();
-                for (generated_offset, original_offset) in [
-                    (key_start, directive_start),
-                    (key_start + name.len(), directive_end),
-                ] {
-                    let (gen_line, gen_col) =
-                        offset_to_line_col_utf16(generated, &generated_starts, generated_offset);
-                    let (orig_line, orig_col) =
-                        offset_to_line_col_utf16(source, &source_starts, original_offset);
-                    mappings.push(js_ast::codegen::SourceMapping {
-                        gen_line: gen_line as u32,
-                        gen_col: gen_col as u32,
-                        source: 0,
-                        orig_line: orig_line as u32,
-                        orig_col: orig_col as u32,
-                        name: None,
-                    });
-                }
-                generated_cursor = key_start + name.len();
-            }
-        }
-
         let template = format!("{{{name}}}");
         if let Some(template_start) = source.find(&template) {
             let source_name = template_start + 1;
@@ -2998,7 +2971,7 @@ mod tests {
     }
 
     #[test]
-    fn client_keeps_component_bind_shorthand_carriers_after_merging() {
+    fn client_maps_component_bind_accessor_keys_without_generated_text_matching() {
         let source = "<script>\n\texport let potato;\n</script>\n\n{potato}\n<Widget bind:potato/>";
         let result = compile(
             source,
@@ -3030,6 +3003,19 @@ mod tests {
                 mappings[line]
             );
         }
+    }
+
+    #[test]
+    fn component_bind_pass_does_not_recover_accessor_keys() {
+        let source = "<Widget bind:potato/>";
+        let generated =
+            "const props = { get potato() { return potato; }, set potato($$value) {} };";
+        let starts = MappingLineStarts::new(generated, source);
+
+        assert!(
+            generate_component_bind_mappings_with_starts(generated, source, &starts).is_empty(),
+            "accessor key mappings must come from JsPropertyKey spans"
+        );
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -2770,7 +2770,8 @@ mod tests {
     use crate::{CompileOptions, GenerateMode, compile};
 
     use super::{
-        generate_bind_value_mappings, generate_default_function_wrapper_mappings,
+        MappingLineStarts, generate_bind_value_mappings,
+        generate_component_bind_mappings_with_starts, generate_default_function_wrapper_mappings,
         generate_inline_script_mappings, generate_legacy_prop_read_mappings,
         generate_server_declaration_mappings, generate_server_token_mappings,
         generate_server_wrapper_mappings, generate_template_element_runtime_mappings,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -2775,7 +2775,7 @@ mod tests {
         generate_inline_script_mappings, generate_legacy_prop_read_mappings,
         generate_server_declaration_mappings, generate_server_token_mappings,
         generate_server_wrapper_mappings, generate_template_element_runtime_mappings,
-        generate_token_mappings, generate_verbatim_import_mappings,
+        generate_token_mappings, generate_verbatim_import_mappings, js_ast::codegen,
         typescript_declaration_annotation_end,
     };
 
@@ -2989,21 +2989,29 @@ mod tests {
             crate::compiler::phases::phase3_transform::js_ast::codegen::decode_vlq_mappings(
                 map["mappings"].as_str().unwrap(),
             );
-        for (line, column, original_line, original_column) in [
-            (16, 6, 5, 8),
-            (16, 12, 5, 19),
-            (20, 6, 5, 8),
-            (20, 12, 5, 19),
-            (26, 51, 4, 7),
-        ] {
+        let generated = result.js.code.as_str();
+        let starts = MappingLineStarts::new(generated, source);
+        let assert_mapping = |generated_offset, original_line, original_column| {
+            let (line, column) =
+                codegen::offset_to_line_col_utf16(generated, &starts.generated, generated_offset);
             assert!(
-                mappings[line]
-                    .iter()
-                    .any(|segment| { segment[..4] == [column, 0, original_line, original_column] }),
+                mappings[line].iter().any(|segment| {
+                    segment[..4] == [column as i64, 0, original_line, original_column]
+                }),
                 "missing merged component-bind mapping at {line}:{column}: {:?}",
                 mappings[line]
             );
+        };
+
+        for accessor in ["get potato", "set potato"] {
+            let generated_key = generated.find(accessor).unwrap() + 4;
+            assert_mapping(generated_key, 5, 8);
+            assert_mapping(generated_key + "potato".len(), 5, 19);
         }
+
+        let generated_template = generated.find("${potato() ??").unwrap() + 2;
+        assert_mapping(generated_template, 4, 1);
+        assert_mapping(generated_template + "potato".len(), 4, 7);
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -214,6 +214,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 // emitter anchors are considered.
                 let mut runtime_mappings = Vec::new();
                 let mut template_name_mappings = Vec::new();
+                let mut component_bind_key_mappings = Vec::new();
                 let mut remaining_result_mappings = Vec::new();
                 for mapping in result.mappings {
                     if is_template_append_mapping(
@@ -225,6 +226,8 @@ pub(crate) fn transform_component_with_scripts<'source>(
                     } else if is_template_element_name_mapping(source_line_starts, source, &mapping)
                     {
                         template_name_mappings.push(mapping);
+                    } else if is_component_bind_key_mapping(source_line_starts, source, &mapping) {
+                        component_bind_key_mappings.push(mapping);
                     } else {
                         remaining_result_mappings.push(mapping);
                     }
@@ -344,6 +347,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                     + inline_script_mappings.len()
                     + import_mappings.len()
                     + template_name_mappings.len()
+                    + component_bind_key_mappings.len()
                     + token_mappings.len()
                     + rune_mappings.len()
                     + remaining_result_mappings.len();
@@ -357,6 +361,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 mappings.extend(inline_script_mappings);
                 mappings.extend(import_mappings);
                 mappings.extend(template_name_mappings);
+                mappings.extend(component_bind_key_mappings);
                 mappings.extend(token_mappings);
                 mappings.extend(rune_mappings);
                 mappings.extend(remaining_result_mappings);
@@ -1098,6 +1103,74 @@ fn is_template_element_name_mapping(
     };
     let source_offset = line_start.saturating_add(mapping.orig_col as usize);
     source.as_bytes().get(source_offset.wrapping_sub(1)) == Some(&b'<')
+}
+
+/// Accessor keys created for component `bind:` directives carry the directive's
+/// source span. Keep those printer mappings ahead of the token-recovery pass:
+/// both can target the generated key, but only the AST span identifies the
+/// directive rather than an earlier interpolation with the same name.
+fn is_component_bind_key_mapping(
+    line_starts: &[usize],
+    source: &str,
+    mapping: &js_ast::codegen::SourceMapping,
+) -> bool {
+    let Some(source_offset) = source_offset_from_utf16_position(
+        line_starts,
+        source,
+        mapping.orig_line as usize,
+        mapping.orig_col as usize,
+    ) else {
+        return false;
+    };
+    let bytes = source.as_bytes();
+    let is_boundary_before = |offset: usize| {
+        offset == 0
+            || bytes
+                .get(offset - 1)
+                .is_some_and(|byte| byte.is_ascii_whitespace() || *byte == b'<')
+    };
+
+    if source[source_offset..].starts_with("bind:") && is_boundary_before(source_offset) {
+        return true;
+    }
+
+    let line_start = line_starts
+        .get(mapping.orig_line as usize)
+        .copied()
+        .unwrap_or(0);
+    let Some(relative_start) = source[line_start..source_offset].rfind("bind:") else {
+        return false;
+    };
+    let directive_start = line_start + relative_start;
+    is_boundary_before(directive_start)
+        && source[directive_start + "bind:".len()..source_offset]
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$' | b'-' | b'|'))
+        && bytes
+            .get(source_offset)
+            .is_none_or(|byte| byte.is_ascii_whitespace() || matches!(byte, b'=' | b'/' | b'>'))
+}
+
+fn source_offset_from_utf16_position(
+    line_starts: &[usize],
+    source: &str,
+    line: usize,
+    column: usize,
+) -> Option<usize> {
+    let line_start = *line_starts.get(line)?;
+    let line_end = line_starts.get(line + 1).copied().unwrap_or(source.len());
+    let line_source = &source[line_start..line_end];
+    let mut utf16_column = 0;
+    for (byte_offset, character) in line_source.char_indices() {
+        if utf16_column == column {
+            return Some(line_start + byte_offset);
+        }
+        utf16_column += character.len_utf16();
+        if utf16_column > column {
+            return None;
+        }
+    }
+    (utf16_column == column).then_some(line_end)
 }
 
 fn merge_preferred_mappings(
@@ -2775,8 +2848,8 @@ mod tests {
         generate_inline_script_mappings, generate_legacy_prop_read_mappings,
         generate_server_declaration_mappings, generate_server_token_mappings,
         generate_server_wrapper_mappings, generate_template_element_runtime_mappings,
-        generate_token_mappings, generate_verbatim_import_mappings, js_ast::codegen,
-        typescript_declaration_annotation_end,
+        generate_token_mappings, generate_verbatim_import_mappings, is_component_bind_key_mapping,
+        js_ast::codegen, typescript_declaration_annotation_end,
     };
 
     #[test]
@@ -3025,6 +3098,40 @@ mod tests {
             generate_component_bind_mappings_with_starts(generated, source, &starts).is_empty(),
             "accessor key mappings must come from JsPropertyKey spans"
         );
+    }
+
+    #[test]
+    fn component_bind_ast_mappings_are_preferred_at_both_span_boundaries() {
+        let source = "<Widget title=\"🎉\" bind:potato/>\n{potato}";
+        let starts = codegen::build_line_starts(source);
+        let bind_start = source.find("bind:potato").unwrap();
+        let bind_end = bind_start + "bind:potato".len();
+
+        for offset in [bind_start, bind_end] {
+            let (orig_line, orig_col) = codegen::offset_to_line_col_utf16(source, &starts, offset);
+            let mapping = codegen::SourceMapping {
+                gen_line: 0,
+                gen_col: 0,
+                source: 0,
+                orig_line: orig_line as u32,
+                orig_col: orig_col as u32,
+                name: None,
+            };
+            assert!(is_component_bind_key_mapping(&starts, source, &mapping));
+        }
+
+        let interpolation = source.rfind("potato").unwrap();
+        let (orig_line, orig_col) =
+            codegen::offset_to_line_col_utf16(source, &starts, interpolation);
+        let mapping = codegen::SourceMapping {
+            gen_line: 0,
+            gen_col: 0,
+            source: 0,
+            orig_line: orig_line as u32,
+            orig_col: orig_col as u32,
+            name: None,
+        };
+        assert!(!is_component_bind_key_mapping(&starts, source, &mapping));
     }
 
     #[test]

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -4240,12 +4240,16 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
 
     fn property_key(&mut self, key: &PropertyKey, ctx: &mut Context<DIRECT>) {
         match key {
-            PropertyKey::StaticIdentifier(id) => ctx.write(id.name.as_str()),
+            PropertyKey::StaticIdentifier(id) => {
+                self.write_node(ctx, id.span, id.name.as_str());
+            }
             PropertyKey::PrivateIdentifier(id) => {
                 ctx.write_ascii(b'#');
                 ctx.write(id.name.as_str());
             }
-            PropertyKey::StringLiteral(s) => ctx.write(Self::string_literal(s)),
+            PropertyKey::StringLiteral(s) => {
+                self.write_node(ctx, s.span, Self::string_literal(s));
+            }
             PropertyKey::NumericLiteral(n) => ctx.write(literal_raw(
                 n.raw.as_ref().map(oxc_ast::ast::Str::as_str),
                 || format_compact!("{}", n.value),

--- a/crates/rsvelte_esrap/tests/sourcemap_keywords.rs
+++ b/crates/rsvelte_esrap/tests/sourcemap_keywords.rs
@@ -93,6 +93,26 @@ fn identifiers_and_literals_map_both_span_boundaries() {
 }
 
 #[test]
+fn object_accessor_keys_map_both_span_boundaries() {
+    let m = mapped("const x = { get potato() {}, set potato(value) {} };");
+    let generated_starts: Vec<_> = m.code.match_indices("potato").map(|(i, _)| i).collect();
+    let source_starts: Vec<_> = m.source.match_indices("potato").map(|(i, _)| i).collect();
+
+    assert_eq!(generated_starts.len(), 2, "unexpected output: {}", m.code);
+    assert_eq!(source_starts.len(), 2, "unexpected source: {}", m.source);
+    for (generated, source) in generated_starts.into_iter().zip(source_starts) {
+        assert_eq!(
+            mapping_at_index(&m.code, generated, &m.mappings)[2..],
+            [0, source as i64]
+        );
+        assert_eq!(
+            mapping_at_index(&m.code, generated + "potato".len(), &m.mappings)[2..],
+            [0, (source + "potato".len()) as i64]
+        );
+    }
+}
+
+#[test]
 fn block_braces_map_to_their_source_positions() {
     let m = mapped("function f() {}");
     let open = m.code.find('{').expect("opening brace");

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 dependencies = [
  "compact_str",
  "memchr",

--- a/docs/phase3-ast-refactor-plan.md
+++ b/docs/phase3-ast-refactor-plan.md
@@ -685,7 +685,7 @@ still carries is a named lowering, not a mystery:
 | `let x = $.prop($$props, …)` and its default | the declaration is written by the *script text* rewriter, which records nothing; the chunk projection has to re-derive it by alignment |
 | hoisted verbatim `import` lines | `extract_imports` returns text with no offset, so they are emitted as `JsStatement::Raw` |
 | element/component identifier *uses* (`pre.textContent`, `$.sibling(div, 2)`) | `flush_node` stamps the declaration; `SiblingPrev::Reuse` carries a bare `b::id` |
-| component `bind:` accessor pairs (`get potato()`) | built from `JsExpr::Raw` text |
+| component `bind:` interpolation fallback (`${potato() ?? …}`) | the generated interpolation is still recovered by matching the source `{potato}`; accessor keys now carry the full `bind:potato` range on dedicated spanned property-key variants |
 | the `(deps, $.untrack(…))` sequence tail | builder-made, with no source anchor |
 
 Every row is a `Raw` fragment or a builder call that had a span available and dropped it —


### PR DESCRIPTION
## Summary

- carry component `bind:` accessor-key locations on dedicated `JsPropertyKey` variants
- preserve both identifier and quoted property-key shapes through the text and OXC printers
- remove the generated-text search that reconstructed `get`/`set` key mappings
- retain and document the separate component-bind interpolation fallback

## Upstream parity

This mirrors upstream `component.js`, which assigns `attribute.name_loc` to the generated getter and setter keys. Parsed directives use the retained `name_loc` directly; only synthetic directives fall back to reconstructing the directive-name range.

The explicit getter/setter SequenceExpression form remains unstamped because upstream does not assign `name_loc` in that branch.

This is an independent follow-up slice for #3015 and does not close the umbrella issue.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- added builder shape tests for identifier and quoted keys
- strengthened the client source-map test so the deleted generated-text pass cannot supply accessor mappings

Per project instructions, no local build or test command was run; CI is the execution oracle.
