### PR TITLE
refactor(client): carry element handle source spans

### DIFF
--- a/.changeset/carry-element-handle-spans.md
+++ b/.changeset/carry-element-handle-spans.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Carry generated element-handle source spans directly through client code generation.

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -2028,8 +2028,8 @@ pass at a time: `collapsed_declaration` and `rune` cost **0 segments on `main` a
 same reading is produced by "these samples contain no `$state`/`$derived`/`$props` lowering
 whose position the pass would have supplied" and by "a span now supplies it", and nothing in
 the gate separates them. Deleting a pass on a 0 therefore needs a population that fires it;
-the passes deleted in #3015 (`default_function_wrapper` 84 → 0, `effect_callback` 8 → 0)
-carry a *movement*, which is the reading a 0 cannot give.
+the passes deleted in #3015 (`default_function_wrapper` 84 → 0, `effect_callback` 8 → 0,
+`template_element_runtime` 25 → 0) carry a *movement*, which is the reading a 0 cannot give.
 
  There is no corpus-wide source-map gate to fall back on: `verify.mjs` compares generated
  code, and the svelte2tsx map gate (§ 12) covers a different artifact.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -253,6 +253,13 @@ pub fn fragment(
             let id = b::id(&id_name);
             let name_start = element.start.saturating_add(1);
             let name_end = name_start.saturating_add(element.name.len() as u32);
+            // Upstream reuses this located Identifier for the declaration and
+            // every runtime use. The shared-fragment path registers the same
+            // identity in `flush_node`; do it here as well for the root path,
+            // which bypasses `process_children` entirely.
+            context
+                .arena
+                .note_identifier_span(&id_name, name_start, name_end);
 
             // Visit the element with the id as the node
             let saved_node = std::mem::replace(&mut context.state.node, id.clone());

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
@@ -328,6 +328,13 @@ pub fn process_children<F>(
             // Generate a unique identifier
             let id_name = ctx.state.memoizer.generate_id(name);
             id = b::id(&id_name);
+            if let Some((start, end)) = loc {
+                // Upstream creates one located Identifier and reuses it for the
+                // declaration and every runtime use. Record that identity by
+                // its component-wide unique generated name without changing
+                // the Identifier variant seen by the rest of lowering.
+                arena_ref.note_identifier_span(&id_name, start, end);
+            }
             ctx.state.init.push(b::var_decl_anchored(
                 arena_ref,
                 &id_name,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/arena.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/arena.rs
@@ -219,6 +219,7 @@ impl std::fmt::Debug for JsArena {
         // SAFETY: only reading len, no mutation
         let (exprs_count, stmts_count) =
             unsafe { ((*self.exprs.get()).len, (*self.stmts.get()).len) };
+        // SAFETY: only reading the map length, no mutation.
         let identifier_spans_count = unsafe { (*self.identifier_spans.get()).len() };
         f.debug_struct("JsArena")
             .field("exprs_count", &exprs_count)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/arena.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/arena.rs
@@ -24,6 +24,8 @@
 //!   aliases exist
 
 use super::nodes::{JsExpr, JsStatement};
+use compact_str::CompactString;
+use rustc_hash::FxHashMap;
 use std::cell::UnsafeCell;
 use std::mem::MaybeUninit;
 
@@ -96,6 +98,11 @@ impl<T> Drop for NodeStore<T> {
 pub struct JsArena {
     exprs: UnsafeCell<NodeStore<JsExpr>>,
     stmts: UnsafeCell<NodeStore<JsStatement>>,
+    /// Source spans for generated identifiers whose names are unique within
+    /// this compilation unit. Keeping this out of [`JsExpr`] lets lowering
+    /// continue to match ordinary `Identifier` nodes while both printers can
+    /// recover the location carried by upstream's shared identifier object.
+    identifier_spans: UnsafeCell<FxHashMap<CompactString, (u32, u32)>>,
 }
 
 // JsArena is explicitly NOT Sync - it's single-threaded only.
@@ -111,7 +118,24 @@ impl JsArena {
         Self {
             exprs: UnsafeCell::new(NodeStore::new()),
             stmts: UnsafeCell::new(NodeStore::new()),
+            identifier_spans: UnsafeCell::new(FxHashMap::default()),
         }
+    }
+
+    /// Associate every use of a generated, compilation-unit-unique identifier
+    /// with the source location from which it was derived.
+    pub fn note_identifier_span(&self, name: &str, start: u32, end: u32) {
+        // SAFETY: like node allocation, span registration is single-threaded.
+        unsafe {
+            (*self.identifier_spans.get()).insert(CompactString::new(name), (start, end));
+        }
+    }
+
+    /// Return the source span attached to a generated identifier name.
+    #[inline]
+    pub fn identifier_span(&self, name: &str) -> Option<(u32, u32)> {
+        // SAFETY: callers only read during/after single-threaded construction.
+        unsafe { (*self.identifier_spans.get()).get(name).copied() }
     }
 
     // -- expressions --------------------------------------------------------
@@ -195,9 +219,11 @@ impl std::fmt::Debug for JsArena {
         // SAFETY: only reading len, no mutation
         let (exprs_count, stmts_count) =
             unsafe { ((*self.exprs.get()).len, (*self.stmts.get()).len) };
+        let identifier_spans_count = unsafe { (*self.identifier_spans.get()).len() };
         f.debug_struct("JsArena")
             .field("exprs_count", &exprs_count)
             .field("stmts_count", &stmts_count)
+            .field("identifier_spans_count", &identifier_spans_count)
             .finish()
     }
 }
@@ -296,8 +322,17 @@ mod tests {
         let arena = JsArena::default();
         assert_eq!(
             format!("{:?}", arena),
-            "JsArena { exprs_count: 0, stmts_count: 0 }"
+            "JsArena { exprs_count: 0, stmts_count: 0, identifier_spans_count: 0 }"
         );
+    }
+
+    #[test]
+    fn test_generated_identifier_span() {
+        let arena = JsArena::new();
+        arena.note_identifier_span("div", 7, 10);
+
+        assert_eq!(arena.identifier_span("div"), Some((7, 10)));
+        assert_eq!(arena.identifier_span("main"), None);
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -879,7 +879,17 @@ impl<'a> JsCodegen<'a> {
 
     fn emit_expression_inner(&mut self, expr: &JsExpr) {
         match expr {
-            JsExpr::Identifier(name) => self.output.push_str(name),
+            JsExpr::Identifier(name) => {
+                if self.track_mappings
+                    && let Some((start, end)) = self.arena.identifier_span(name)
+                {
+                    self.record_span_start(start, end);
+                    self.output.push_str(name);
+                    self.record_span_start(end, end);
+                } else {
+                    self.output.push_str(name);
+                }
+            }
             JsExpr::OpaqueIdentifier(name) => self.output.push_str(name),
             JsExpr::Literal(lit) => self.emit_literal(lit),
             JsExpr::TemplateLiteral(template) => self.emit_template_literal(template),
@@ -3185,6 +3195,30 @@ pub fn generate_sourcemap_json_multi(
 mod tests {
     use super::*;
     use crate::compiler::phases::phase3_transform::js_ast::builders::*;
+
+    #[test]
+    fn generated_identifier_uses_carry_the_registered_source_span() {
+        let arena = JsArena::new();
+        arena.note_identifier_span("div", 1, 4);
+        let program = program(vec![stmt(&arena, id("div")), stmt(&arena, id("div"))]);
+
+        let generated = generate_with_sourcemap(&program, "<div>", &arena).unwrap();
+        assert_eq!(generated.code, "div;\ndiv;");
+        for expected in [(0, 0, 0, 1), (0, 3, 0, 4), (1, 0, 0, 1), (1, 3, 0, 4)] {
+            assert!(
+                generated.mappings.iter().any(|mapping| {
+                    (
+                        mapping.gen_line,
+                        mapping.gen_col,
+                        mapping.orig_line,
+                        mapping.orig_col,
+                    ) == expected
+                }),
+                "missing generated identifier mapping {expected:?}: {:?}",
+                generated.mappings
+            );
+        }
+    }
 
     #[test]
     fn sourcemap_can_externalize_single_source_content() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -512,15 +512,16 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
         self.ab.allocator().alloc_str(s)
     }
 
-    /// Resolve an out-of-band generated-identifier span and include it when
-    /// sizing the source-coordinate side of the split comment space.
+    /// Resolve an out-of-band generated-identifier span.
+    ///
+    /// This is an original-source coordinate, so it must not raise
+    /// [`Synth::max_span`]: `loc_base` separates synthesized/comment-space
+    /// coordinates from source coordinates, and moving that boundary to one
+    /// source offset would make later source offsets look comment-bearing.
     fn identifier_span(&self, name: &str) -> Span {
         self.arena
             .identifier_span(name)
-            .map_or(SPAN, |(start, end)| {
-                self.note_span(end);
-                Span::new(start, end)
-            })
+            .map_or(SPAN, |(start, end)| Span::new(start, end))
     }
 
     /// Resolve an `ExprId` handle and convert the pointed-to expression.
@@ -2819,6 +2820,30 @@ mod tests {
         };
         assert_eq!(statement.expression.span().start, 7);
         assert_eq!(statement.expression.span().end, 10);
+    }
+
+    #[test]
+    fn generated_identifier_source_span_does_not_raise_comment_boundary() {
+        let arena = JsArena::new();
+        arena.note_identifier_span("div", 1_000, 1_003);
+        let program = JsProgram::with_body(vec![
+            JsStatement::Raw("/* comment */ value;".into()),
+            b::stmt(&arena, b::id("div")),
+        ]);
+        let allocator = Allocator::default();
+        let converted =
+            program_to_oxc(&program, &arena, &allocator).expect("commented chunk is supported");
+
+        assert!(converted.comment_source.is_some());
+        assert!(converted.loc_base < 1_000);
+        let oxc_ast::ast::Statement::ExpressionStatement(statement) = &converted.program.body[1]
+        else {
+            panic!("expected expression statement");
+        };
+        assert_eq!(
+            statement.expression.span(),
+            oxc_span::Span::new(1_000, 1_003)
+        );
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -512,6 +512,17 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
         self.ab.allocator().alloc_str(s)
     }
 
+    /// Resolve an out-of-band generated-identifier span and include it when
+    /// sizing the source-coordinate side of the split comment space.
+    fn identifier_span(&self, name: &str) -> Span {
+        self.arena
+            .identifier_span(name)
+            .map_or(SPAN, |(start, end)| {
+                self.note_span(end);
+                Span::new(start, end)
+            })
+    }
+
     /// Resolve an `ExprId` handle and convert the pointed-to expression.
     #[inline]
     fn expr_id(&self, id: ExprId) -> Option<Expression<'a>> {
@@ -1379,9 +1390,11 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
 
     fn expr(&self, expr: &JsExpr) -> Option<Expression<'a>> {
         match expr {
-            JsExpr::Identifier(name) => {
-                Some(Expression::new_identifier(SPAN, self.str(name), &self.ab))
-            }
+            JsExpr::Identifier(name) => Some(Expression::new_identifier(
+                self.identifier_span(name),
+                self.str(name),
+                &self.ab,
+            )),
             JsExpr::OpaqueIdentifier(name) => {
                 Some(Expression::new_identifier(SPAN, self.str(name), &self.ab))
             }
@@ -2199,7 +2212,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
         match expr {
             JsExpr::Identifier(name) => {
                 Some(SimpleAssignmentTarget::new_assignment_target_identifier(
-                    SPAN,
+                    self.identifier_span(name),
                     self.str(name),
                     &self.ab,
                 ))
@@ -2337,7 +2350,8 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 }
                 _ => return None,
             };
-            let binding = IdentifierReference::new(SPAN, self.str(name), &self.ab);
+            let binding =
+                IdentifierReference::new(self.identifier_span(name), self.str(name), &self.ab);
             return Some(
                 oxc_ast::ast::AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(
                     AssignmentTargetPropertyIdentifier::boxed(SPAN, binding, init, &self.ab),
@@ -2789,6 +2803,23 @@ mod tests {
     };
     use oxc_allocator::Allocator;
     use oxc_span::GetSpan;
+
+    #[test]
+    fn generated_identifier_uses_keep_the_registered_span() {
+        let arena = JsArena::new();
+        arena.note_identifier_span("div", 7, 10);
+        let program = JsProgram::with_body(vec![b::stmt(&arena, b::id("div"))]);
+        let allocator = Allocator::default();
+        let converted =
+            program_to_oxc(&program, &arena, &allocator).expect("identifier is supported");
+
+        let oxc_ast::ast::Statement::ExpressionStatement(statement) = &converted.program.body[0]
+        else {
+            panic!("expected expression statement");
+        };
+        assert_eq!(statement.expression.span().start, 7);
+        assert_eq!(statement.expression.span().end, 10);
+    }
 
     #[test]
     fn retained_island_keeps_absolute_source_spans() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -239,15 +239,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                     } else {
                         Vec::new()
                     };
-                let template_element_mappings = if map_pass_disabled("template_element") {
-                    Vec::new()
-                } else {
-                    generate_template_element_runtime_mappings_with_starts(
-                        &result.code,
-                        source,
-                        &mapping_starts,
-                    )
-                };
                 let inline_script_mappings = if !map_pass_disabled("inline_script")
                     && source.contains("<script>")
                     && source.contains("export ")
@@ -342,7 +333,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                     + component_bind_mappings.len()
                     + runtime_mappings.len()
                     + legacy_prop_read_mappings.len()
-                    + template_element_mappings.len()
                     + inline_script_mappings.len()
                     + import_mappings.len()
                     + template_name_mappings.len()
@@ -355,7 +345,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 mappings.extend(component_bind_mappings);
                 mappings.extend(runtime_mappings);
                 mappings.extend(legacy_prop_read_mappings);
-                mappings.extend(template_element_mappings);
                 mappings.extend(inline_script_mappings);
                 mappings.extend(import_mappings);
                 mappings.extend(template_name_mappings);
@@ -2027,276 +2016,6 @@ fn generate_legacy_prop_read_mappings_with_starts(
     mappings
 }
 
-/// Runtime element handles retain the source span of the corresponding template tag.
-#[cfg(test)]
-fn generate_template_element_runtime_mappings(
-    generated: &str,
-    source: &str,
-) -> Vec<js_ast::codegen::SourceMapping> {
-    generate_template_element_runtime_mappings_with_starts(
-        generated,
-        source,
-        &MappingLineStarts::new(generated, source),
-    )
-}
-
-fn generate_template_element_runtime_mappings_with_starts(
-    generated: &str,
-    source: &str,
-    starts: &MappingLineStarts,
-) -> Vec<js_ast::codegen::SourceMapping> {
-    use js_ast::codegen::offset_to_line_col_utf16;
-
-    fn identifier_after(code: &str, mut offset: usize) -> Option<(usize, &str)> {
-        loop {
-            while code
-                .as_bytes()
-                .get(offset)
-                .is_some_and(u8::is_ascii_whitespace)
-            {
-                offset += 1;
-            }
-            if code[offset..].starts_with("//") {
-                offset += 2;
-                while code
-                    .as_bytes()
-                    .get(offset)
-                    .is_some_and(|byte| *byte != b'\n')
-                {
-                    offset += 1;
-                }
-                continue;
-            }
-            break;
-        }
-        let start = offset;
-        while code
-            .as_bytes()
-            .get(offset)
-            .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$')
-        {
-            offset += 1;
-        }
-        (offset > start).then_some((start, &code[start..offset]))
-    }
-
-    fn template_elements(source: &str) -> Vec<(usize, &str)> {
-        let mut elements = Vec::new();
-        let mut cursor = 0;
-        let mut opaque_until = None;
-        while let Some(relative) = source[cursor..].find('<') {
-            let start = cursor + relative;
-            if let Some(end) = opaque_until {
-                if start < end {
-                    cursor = end;
-                    opaque_until = None;
-                    continue;
-                }
-                opaque_until = None;
-            }
-            let Some((name_start, name)) = identifier_after(source, start + 1) else {
-                cursor = start + 1;
-                continue;
-            };
-            if name == "script" || name == "style" {
-                if let Some(relative_end) =
-                    source[name_start + name.len()..].find(if name == "script" {
-                        "</script"
-                    } else {
-                        "</style"
-                    })
-                {
-                    opaque_until = Some(name_start + name.len() + relative_end + name.len() + 2);
-                }
-            } else if name.as_bytes().first().is_some_and(u8::is_ascii_lowercase) {
-                elements.push((name_start, name));
-            }
-            cursor = name_start + name.len();
-        }
-        elements
-    }
-
-    fn push_pair(
-        mappings: &mut Vec<js_ast::codegen::SourceMapping>,
-        generated: &str,
-        source: &str,
-        generated_starts: &[usize],
-        source_starts: &[usize],
-        generated_offset: usize,
-        source_offset: usize,
-        len: usize,
-    ) {
-        for (gen_offset, orig_offset) in [
-            (generated_offset, source_offset),
-            (generated_offset + len, source_offset + len),
-        ] {
-            let (gen_line, gen_col) =
-                offset_to_line_col_utf16(generated, generated_starts, gen_offset);
-            let (orig_line, orig_col) =
-                offset_to_line_col_utf16(source, source_starts, orig_offset);
-            mappings.push(js_ast::codegen::SourceMapping {
-                gen_line: gen_line as u32,
-                gen_col: gen_col as u32,
-                source: 0,
-                orig_line: orig_line as u32,
-                orig_col: orig_col as u32,
-                name: None,
-            });
-        }
-    }
-
-    let elements = template_elements(source);
-    let generated_starts = starts.generated.clone();
-    let source_starts = starts.source.clone();
-    let mut known = rustc_hash::FxHashMap::default();
-    let mut next_element = 0;
-    let mut mappings = Vec::new();
-
-    let mut cursor = 0;
-    while let Some(relative) = generated[cursor..].find("var ") {
-        let declaration = cursor + relative + "var ".len();
-        let Some((variable_offset, variable)) = identifier_after(generated, declaration) else {
-            cursor = declaration;
-            continue;
-        };
-        let Some((element_offset, element)) = elements.get(next_element).copied() else {
-            break;
-        };
-        let tail = &generated[variable_offset + variable.len()..];
-        let is_handle = tail.trim_start().starts_with("= root()")
-            || tail.trim_start().starts_with("= $.child(")
-            || tail.trim_start().starts_with("= $.sibling(");
-        if is_handle && variable == element {
-            push_pair(
-                &mut mappings,
-                generated,
-                source,
-                &generated_starts,
-                &source_starts,
-                variable_offset,
-                element_offset,
-                variable.len(),
-            );
-            known.insert(variable, (element_offset, element.len()));
-            next_element += 1;
-        } else if tail.trim_start().starts_with("= root()") {
-            // A fragment handle owns the leading static root element without
-            // itself having a source tag name.
-            next_element += 1;
-        }
-        cursor = variable_offset + variable.len();
-    }
-
-    let hits = collect_runtime_use_sites(generated, &known);
-    for (variable, &(element_offset, len)) in &known {
-        let Some(sites) = hits.get(variable) else {
-            continue;
-        };
-        for offsets in sites {
-            for &start in offsets {
-                push_pair(
-                    &mut mappings,
-                    generated,
-                    source,
-                    &generated_starts,
-                    &source_starts,
-                    start,
-                    element_offset,
-                    len,
-                );
-            }
-        }
-    }
-    mappings
-}
-
-/// The seven runtime call shapes that name an element handle, in the order the
-/// mapping list expects them.
-const RUNTIME_USE_PATTERNS: [(&str, bool); 7] = [
-    ("$.reset(", true),
-    ("$.remove_input_defaults(", true),
-    ("$.bind_value(", false),
-    (".textContent", false),
-    ("$.child(", false),
-    ("$.sibling(", false),
-    ("$.append($$anchor, ", true),
-];
-
-/// Locate every runtime use of a known element handle in one scan per call
-/// shape. Scanning per `(variable, shape)` instead re-walks the whole output
-/// 7×K times.
-fn collect_runtime_use_sites<'code>(
-    generated: &'code str,
-    known: &rustc_hash::FxHashMap<&'code str, (usize, usize)>,
-) -> rustc_hash::FxHashMap<&'code str, [Vec<usize>; 7]> {
-    fn identifier_run(code: &str, start: usize) -> &str {
-        let bytes = code.as_bytes();
-        let mut end = start;
-        while bytes
-            .get(end)
-            .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$')
-        {
-            end += 1;
-        }
-        &code[start..end]
-    }
-
-    let mut sites: rustc_hash::FxHashMap<&str, [Vec<usize>; 7]> = rustc_hash::FxHashMap::default();
-    let mut record = |name: &'code str, kind: usize, offset: usize| {
-        sites
-            .entry(name)
-            .or_default()
-            .get_mut(kind)
-            .expect("kind is within the pattern table")
-            .push(offset);
-    };
-    for (kind, (needle, closed)) in RUNTIME_USE_PATTERNS.iter().enumerate() {
-        for hit in memmem::find_iter(generated.as_bytes(), needle) {
-            if kind == 3 {
-                // `{variable}.textContent`: the name ends where the needle starts,
-                // and the source pattern was unanchored on its left.
-                let bytes = generated.as_bytes();
-                let mut start = hit;
-                while start > 0
-                    && bytes[start - 1].is_ascii_alphanumeric()
-                        | (bytes[start - 1] == b'_')
-                        | (bytes[start - 1] == b'$')
-                {
-                    start -= 1;
-                }
-                for offset in start..hit {
-                    if known.contains_key(&generated[offset..hit]) {
-                        record(&generated[offset..hit], kind, offset);
-                    }
-                }
-                continue;
-            }
-            let start = hit + needle.len();
-            let run = identifier_run(generated, start);
-            if *closed {
-                if generated.as_bytes().get(start + run.len()) == Some(&b')')
-                    && known.contains_key(&run)
-                {
-                    record(&generated[start..start + run.len()], kind, start);
-                }
-                continue;
-            }
-            // An unterminated pattern matched any prefix of the identifier.
-            for end in 1..=run.len() {
-                if known.contains_key(&&run[..end]) {
-                    record(&generated[start..start + end], kind, start);
-                }
-            }
-        }
-    }
-    for offsets in sites.values_mut() {
-        for kind in offsets.iter_mut() {
-            kind.sort_unstable();
-        }
-    }
-    sites
-}
-
 /// Inline instance declarations survive lowering verbatim after `export` is removed.
 fn generate_component_bind_mappings_with_starts(
     generated: &str,
@@ -2800,9 +2519,8 @@ mod tests {
         generate_bind_value_mappings, generate_default_function_wrapper_mappings,
         generate_inline_script_mappings, generate_legacy_prop_read_mappings,
         generate_server_declaration_mappings, generate_server_token_mappings,
-        generate_server_wrapper_mappings, generate_template_element_runtime_mappings,
-        generate_token_mappings, generate_verbatim_import_mappings,
-        typescript_declaration_annotation_end,
+        generate_server_wrapper_mappings, generate_token_mappings,
+        generate_verbatim_import_mappings, typescript_declaration_annotation_end,
     };
 
     #[test]
@@ -2863,56 +2581,6 @@ mod tests {
                     (mapping.gen_col, mapping.orig_line, mapping.orig_col) == expected
                 }),
                 "missing prop-read mapping {expected:?}: {mappings:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn client_maps_template_handles_to_element_tags() {
-        let source = "<main><div>{name}</div></main>";
-        let generated = "var main = root();\nvar div = $.child(main);\nvar text = $.child(div, true);\n$.reset(div);\n$.reset(main);\n$.remove_input_defaults(div);\n$.bind_value(div, () => value, set);";
-        let mappings = generate_template_element_runtime_mappings(generated, source);
-
-        for expected in [
-            (0, 4, 0, 1),
-            (1, 4, 0, 7),
-            (3, 8, 0, 7),
-            (4, 8, 0, 1),
-            (5, 24, 0, 7),
-            (6, 13, 0, 7),
-        ] {
-            assert!(
-                mappings.iter().any(|mapping| {
-                    (
-                        mapping.gen_line,
-                        mapping.gen_col,
-                        mapping.orig_line,
-                        mapping.orig_col,
-                    ) == expected
-                }),
-                "missing element-handle mapping {expected:?}: {mappings:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn client_maps_handle_after_preserved_script_comment() {
-        let source =
-            "<script>\n// retained\n</script>\n<style>div { color: red; }</style>\n<div />";
-        let generated = "var // retained\ndiv = root();";
-        let mappings = generate_template_element_runtime_mappings(generated, source);
-
-        for expected in [(1, 0, 4, 1), (1, 3, 4, 4)] {
-            assert!(
-                mappings.iter().any(|mapping| {
-                    (
-                        mapping.gen_line,
-                        mapping.gen_col,
-                        mapping.orig_line,
-                        mapping.orig_col,
-                    ) == expected
-                }),
-                "missing comment-separated handle mapping {expected:?}: {mappings:?}"
             );
         }
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -1088,7 +1088,18 @@ fn is_template_element_name_mapping(
         return false;
     };
     let source_offset = line_start.saturating_add(mapping.orig_col as usize);
-    source.as_bytes().get(source_offset.wrapping_sub(1)) == Some(&b'<')
+    let bytes = source.as_bytes();
+    let mut name_start = source_offset;
+    while name_start > 0
+        && bytes
+            .get(name_start - 1)
+            .is_some_and(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':'))
+    {
+        name_start -= 1;
+    }
+
+    bytes.get(name_start.wrapping_sub(1)) == Some(&b'<')
+        && bytes.get(name_start).is_some_and(u8::is_ascii_lowercase)
 }
 
 fn merge_preferred_mappings(
@@ -2520,8 +2531,38 @@ mod tests {
         generate_inline_script_mappings, generate_legacy_prop_read_mappings,
         generate_server_declaration_mappings, generate_server_token_mappings,
         generate_server_wrapper_mappings, generate_token_mappings,
-        generate_verbatim_import_mappings, typescript_declaration_annotation_end,
+        generate_verbatim_import_mappings, is_template_element_name_mapping,
+        typescript_declaration_annotation_end,
     };
+
+    #[test]
+    fn prioritizes_both_ends_of_template_element_name_mappings() {
+        let source = "<my-element class={value}>";
+        let mapping_at = |orig_col| super::js_ast::codegen::SourceMapping {
+            gen_line: 0,
+            gen_col: 0,
+            source: 0,
+            orig_line: 0,
+            orig_col,
+            name: None,
+        };
+
+        assert!(is_template_element_name_mapping(
+            &[0],
+            source,
+            &mapping_at(1)
+        ));
+        assert!(is_template_element_name_mapping(
+            &[0],
+            source,
+            &mapping_at(11)
+        ));
+        assert!(!is_template_element_name_mapping(
+            &[0],
+            source,
+            &mapping_at(17)
+        ));
+    }
 
     #[test]
     fn maps_binding_end_past_erased_typescript_annotation() {

--- a/crates/rsvelte_core/tests/sourcemaps_gate.rs
+++ b/crates/rsvelte_core/tests/sourcemaps_gate.rs
@@ -839,7 +839,9 @@ fn measure() -> Report {
                 report.identical_code.push(key.clone());
                 match theirs.map.as_deref().and_then(decode_map) {
                     Some(their_map) => {
-                        if std::env::var_os("SOURCEMAP_PARITY_DETAIL").is_some() {
+                        if std::env::var_os("SOURCEMAP_PARITY_DETAIL").is_some()
+                            || std::env::var_os("CI").is_some()
+                        {
                             explain_parity(&key, &their_map, &map, &ours.code, &input);
                         }
                         report.parity.insert(key.clone(), parity(&their_map, &map));

--- a/docs/phase3-ast-refactor-plan.md
+++ b/docs/phase3-ast-refactor-plan.md
@@ -667,7 +667,7 @@ Segments lost when exactly one client pass is disabled, everything else on:
 | `default_function_wrapper` | 84 | **0 — deleted** |
 | `effect_callback` | 8 | **0 — deleted** |
 | `token` | 80 | 23 |
-| `template_element_runtime` | 25 | 21 |
+| `template_element_runtime` | 25 | **0 — deleted** |
 | `legacy_prop_read` | 16 | 16 |
 | `inline_script` | 7 | 4 |
 | `bind_value` | 5 | 5 |
@@ -676,15 +676,18 @@ Segments lost when exactly one client pass is disabled, everything else on:
 | `collapsed_declaration` | 0 | 0 |
 | `rune` | 0 | 0 |
 
-`default_function_wrapper` and `effect_callback` are deleted: both are now produced by a
-span, and the before/after column is the attribution. The other nine stay, and what each
-still carries is a named lowering, not a mystery:
+`default_function_wrapper`, `effect_callback` and `template_element_runtime` are deleted:
+all three are now produced by source spans, and the before/after column is the attribution.
+For element handles, `flush_node` records the tag-name span against the component-wide unique
+generated name; both printers apply it to ordinary `Identifier` nodes only at emission time.
+That keeps every lowering matcher on `JsExpr::Identifier` unchanged while reproducing
+upstream's reuse of one located identifier for the declaration and all runtime uses. The other
+eight passes stay, and what each still carries is a named lowering, not a mystery:
 
 | still carried by a pass | why the position is lost |
 | --- | --- |
 | `let x = $.prop($$props, …)` and its default | the declaration is written by the *script text* rewriter, which records nothing; the chunk projection has to re-derive it by alignment |
 | hoisted verbatim `import` lines | `extract_imports` returns text with no offset, so they are emitted as `JsStatement::Raw` |
-| element/component identifier *uses* (`pre.textContent`, `$.sibling(div, 2)`) | `flush_node` stamps the declaration; `SiblingPrev::Reuse` carries a bare `b::id` |
 | component `bind:` accessor pairs (`get potato()`) | built from `JsExpr::Raw` text |
 | the `(deps, $.untrack(…))` sequence tail | builder-made, with no source anchor |
 


### PR DESCRIPTION
## Summary

- retain source spans for generated element-handle identifiers in the JS arena
- teach both the handwritten and OXC printers to map those identifier uses directly
- delete the client source-map pass that recovered element runtime uses by scanning generated JavaScript

## Safety

The span registry is out-of-band, so generated handles remain ordinary `JsExpr::Identifier` values and existing lowering matchers keep seeing the variants they expect. Handle names are generated from the component-wide memoizer, making the registry key unique within a compilation.

## Validation

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`
- confirmed the removed template-element runtime scan symbols no longer occur in phase 3

Per the repository instructions, no local build or test suite was run; CI is the execution oracle.

Part of #3015
