### PR TITLE
Carry bind:value accessor source spans

### DIFF
--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -2029,7 +2029,8 @@ same reading is produced by "these samples contain no `$state`/`$derived`/`$prop
 whose position the pass would have supplied" and by "a span now supplies it", and nothing in
 the gate separates them. Deleting a pass on a 0 therefore needs a population that fires it;
 the passes deleted in #3015 (`default_function_wrapper` 84 → 0, `effect_callback` 8 → 0,
-`template_element_runtime` 25 → 0) carry a *movement*, which is the reading a 0 cannot give.
+`template_element_runtime` 25 → 0, `bind_value` 5 → 0) carry a *movement*, which is the
+reading a 0 cannot give.
 
  There is no corpus-wide source-map gate to fall back on: `verify.mjs` compares generated
  code, and the svelte2tsx map gate (§ 12) covers a different artifact.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -2734,7 +2734,7 @@ pub fn emit_validate_binding(
     use crate::compiler::phases::phase2_analyze::scope::BindingKind;
 
     // Extract the root object name from the original AST expression
-    let root_name = extract_root_name_from_json(node.expression.as_json());
+    let root_name = get_ast_root_identifier(&node.expression);
     let root_name = match root_name {
         Some(n) => n,
         None => return,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -391,6 +391,7 @@ fn bind_directive_inner(
         JsExpr::Spanned(inner, _, _) => context.arena.get_expr(inner).clone(),
         expression => expression,
     };
+    let has_custom_accessors = is_sequence_expression(&expression);
 
     // In dev mode with runes, validate binding to non-reactive properties.
     // Reference: BindDirective.js lines 26-41
@@ -437,7 +438,7 @@ fn bind_directive_inner(
     }
 
     // Check if it's a sequence expression (getter/setter pair)
-    let (get, set) = if is_sequence_expression(&expression) {
+    let (get, set) = if has_custom_accessors {
         let (raw_get, raw_set) = extract_getter_setter(&expression);
         // For a user-provided getter/setter pair, BOTH bodies need read transforms
         // (e.g. wrapping $state/each-item/`@const` reads with `$.get()`). The setter
@@ -560,8 +561,20 @@ fn bind_directive_inner(
         call
     };
 
+    let call_id = context.arena.alloc_expr(call);
+    if !has_custom_accessors
+        && binding_name == "value"
+        && parent
+            .as_regular_element()
+            .is_some_and(|element| element.name != "select")
+        && let Some((name, start, end)) = get_ast_root_identifier_span(&node.expression)
+    {
+        context
+            .arena
+            .note_expression_identifier_span(call_id, &name, start, end);
+    }
     let call = JsExpr::Spanned(
-        context.arena.alloc_expr(call),
+        call_id,
         parent
             .as_regular_element()
             .map_or(node.start, |element| element.start),
@@ -2822,19 +2835,27 @@ pub fn emit_validate_binding(
 }
 
 /// Extract the root identifier name from a JSON expression.
-fn extract_root_name_from_json(val: &serde_json::Value) -> Option<String> {
+fn extract_root_identifier_span_from_json(val: &serde_json::Value) -> Option<(String, u32, u32)> {
     let obj = val.as_object()?;
     match obj.get("type")?.as_str()? {
-        "Identifier" => obj.get("name")?.as_str().map(|s| s.to_string()),
-        "MemberExpression" => extract_root_name_from_json(obj.get("object")?),
+        "Identifier" => Some((
+            obj.get("name")?.as_str()?.to_string(),
+            u32::try_from(obj.get("start")?.as_u64()?).ok()?,
+            u32::try_from(obj.get("end")?.as_u64()?).ok()?,
+        )),
+        "MemberExpression" => extract_root_identifier_span_from_json(obj.get("object")?),
         _ => None,
     }
+}
+
+fn get_ast_root_identifier_span(expr: &Expression) -> Option<(String, u32, u32)> {
+    extract_root_identifier_span_from_json(expr.as_json())
 }
 
 /// Get the root identifier name from an AST Expression (JSON-based).
 /// For `form.count` returns `Some("form")`.
 fn get_ast_root_identifier(expr: &Expression) -> Option<String> {
-    extract_root_name_from_json(expr.as_json())
+    get_ast_root_identifier_span(expr).map(|(name, _, _)| name)
 }
 
 /// Build the member property path from an AST Expression (JSON-based).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/arena.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/arena.rs
@@ -253,6 +253,7 @@ impl std::fmt::Debug for JsArena {
             unsafe { ((*self.exprs.get()).len, (*self.stmts.get()).len) };
         // SAFETY: only reading the map length, no mutation.
         let identifier_spans_count = unsafe { (*self.identifier_spans.get()).len() };
+        // SAFETY: only reading the map length, no mutation.
         let expression_identifier_spans_count =
             unsafe { (*self.expression_identifier_spans.get()).len() };
         f.debug_struct("JsArena")

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/arena.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/arena.rs
@@ -103,6 +103,10 @@ pub struct JsArena {
     /// continue to match ordinary `Identifier` nodes while both printers can
     /// recover the location carried by upstream's shared identifier object.
     identifier_spans: UnsafeCell<FxHashMap<CompactString, (u32, u32)>>,
+    /// Source spans inherited by otherwise-unlocated identifiers while one
+    /// generated expression is printed. Keying the scope by `ExprId` keeps
+    /// user identifiers with the same spelling elsewhere independent.
+    expression_identifier_spans: UnsafeCell<FxHashMap<ExprId, (CompactString, (u32, u32))>>,
 }
 
 // JsArena is explicitly NOT Sync - it's single-threaded only.
@@ -119,6 +123,7 @@ impl JsArena {
             exprs: UnsafeCell::new(NodeStore::new()),
             stmts: UnsafeCell::new(NodeStore::new()),
             identifier_spans: UnsafeCell::new(FxHashMap::default()),
+            expression_identifier_spans: UnsafeCell::new(FxHashMap::default()),
         }
     }
 
@@ -136,6 +141,33 @@ impl JsArena {
     pub fn identifier_span(&self, name: &str) -> Option<(u32, u32)> {
         // SAFETY: callers only read during/after single-threaded construction.
         unsafe { (*self.identifier_spans.get()).get(name).copied() }
+    }
+
+    /// Associate unlocated uses of `name` below one generated expression with
+    /// the source identifier that upstream cloned into that expression.
+    pub fn note_expression_identifier_span(
+        &self,
+        expression: ExprId,
+        name: &str,
+        start: u32,
+        end: u32,
+    ) {
+        // SAFETY: like node allocation, span registration is single-threaded.
+        unsafe {
+            (*self.expression_identifier_spans.get())
+                .insert(expression, (CompactString::new(name), (start, end)));
+        }
+    }
+
+    /// Return the identifier span scope attached to an expression handle.
+    #[inline]
+    pub fn expression_identifier_span(&self, expression: ExprId) -> Option<(&str, (u32, u32))> {
+        // SAFETY: callers only read during/after single-threaded construction.
+        unsafe {
+            (*self.expression_identifier_spans.get())
+                .get(&expression)
+                .map(|(name, span)| (name.as_str(), *span))
+        }
     }
 
     // -- expressions --------------------------------------------------------
@@ -221,10 +253,16 @@ impl std::fmt::Debug for JsArena {
             unsafe { ((*self.exprs.get()).len, (*self.stmts.get()).len) };
         // SAFETY: only reading the map length, no mutation.
         let identifier_spans_count = unsafe { (*self.identifier_spans.get()).len() };
+        let expression_identifier_spans_count =
+            unsafe { (*self.expression_identifier_spans.get()).len() };
         f.debug_struct("JsArena")
             .field("exprs_count", &exprs_count)
             .field("stmts_count", &stmts_count)
             .field("identifier_spans_count", &identifier_spans_count)
+            .field(
+                "expression_identifier_spans_count",
+                &expression_identifier_spans_count,
+            )
             .finish()
     }
 }
@@ -323,7 +361,7 @@ mod tests {
         let arena = JsArena::default();
         assert_eq!(
             format!("{:?}", arena),
-            "JsArena { exprs_count: 0, stmts_count: 0, identifier_spans_count: 0 }"
+            "JsArena { exprs_count: 0, stmts_count: 0, identifier_spans_count: 0, expression_identifier_spans_count: 0 }"
         );
     }
 
@@ -334,6 +372,18 @@ mod tests {
 
         assert_eq!(arena.identifier_span("div"), Some((7, 10)));
         assert_eq!(arena.identifier_span("main"), None);
+    }
+
+    #[test]
+    fn test_expression_identifier_span() {
+        let arena = JsArena::new();
+        let expression = arena.alloc_expr(JsExpr::Identifier("foo".into()));
+        arena.note_expression_identifier_span(expression, "foo", 7, 10);
+
+        assert_eq!(
+            arena.expression_identifier_span(expression),
+            Some(("foo", (7, 10)))
+        );
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -91,6 +91,7 @@ pub fn generate_expr(expr: &super::nodes::JsExpr, arena: &JsArena) -> String {
         raw_spans: Vec::new(),
         source_code: None,
         arena,
+        identifier_span_scopes: Vec::new(),
         measuring: false,
         measures: Rc::new(MeasureCache::default()),
     };
@@ -133,6 +134,9 @@ struct JsCodegen<'a> {
     source_code: Option<&'a str>,
     /// Arena containing all expressions and statements
     arena: &'a JsArena,
+    /// Identifier locations inherited from the generated expression currently
+    /// being emitted. Explicit `Spanned(Identifier)` nodes take precedence.
+    identifier_span_scopes: Vec<(&'a str, (u32, u32))>,
     /// Whether this codegen is a throwaway pre-render feeding `measures`
     measuring: bool,
     measures: Rc<MeasureCache>,
@@ -148,6 +152,7 @@ impl<'a> JsCodegen<'a> {
             raw_spans: Vec::new(),
             source_code: None,
             arena,
+            identifier_span_scopes: Vec::new(),
             measuring: false,
             measures: Rc::new(MeasureCache::default()),
         }
@@ -880,8 +885,16 @@ impl<'a> JsCodegen<'a> {
     fn emit_expression_inner(&mut self, expr: &JsExpr) {
         match expr {
             JsExpr::Identifier(name) => {
+                let span = self.arena.identifier_span(name).or_else(|| {
+                    self.identifier_span_scopes
+                        .iter()
+                        .rev()
+                        .find_map(|(scope_name, span)| {
+                            (*scope_name == name.as_str()).then_some(*span)
+                        })
+                });
                 if self.track_mappings
-                    && let Some((start, end)) = self.arena.identifier_span(name)
+                    && let Some((start, end)) = span
                 {
                     self.record_span_start(start, end);
                     self.output.push_str(name);
@@ -890,7 +903,22 @@ impl<'a> JsCodegen<'a> {
                     self.output.push_str(name);
                 }
             }
-            JsExpr::OpaqueIdentifier(name) => self.output.push_str(name),
+            JsExpr::OpaqueIdentifier(name) => {
+                let span = self
+                    .identifier_span_scopes
+                    .iter()
+                    .rev()
+                    .find_map(|(scope_name, span)| (*scope_name == name.as_str()).then_some(*span));
+                if self.track_mappings
+                    && let Some((start, end)) = span
+                {
+                    self.record_span_start(start, end);
+                    self.output.push_str(name);
+                    self.record_span_start(end, end);
+                } else {
+                    self.output.push_str(name);
+                }
+            }
             JsExpr::Literal(lit) => self.emit_literal(lit),
             JsExpr::TemplateLiteral(template) => self.emit_template_literal(template),
             JsExpr::TaggedTemplate(tagged) => self.emit_tagged_template(tagged),
@@ -970,7 +998,18 @@ impl<'a> JsCodegen<'a> {
             }
             JsExpr::Spanned(inner_id, start, end) => {
                 self.record_span_start(*start, *end);
-                self.emit_expression(self.arena.get_expr(*inner_id));
+                let suppress_scope = matches!(
+                    self.arena.get_expr(*inner_id),
+                    JsExpr::Identifier(name) | JsExpr::OpaqueIdentifier(name)
+                        if self.identifier_span_scopes.iter().any(|(scope_name, _)| *scope_name == name.as_str())
+                );
+                if suppress_scope {
+                    let scopes = std::mem::take(&mut self.identifier_span_scopes);
+                    self.emit_expression_id(*inner_id);
+                    self.identifier_span_scopes = scopes;
+                } else {
+                    self.emit_expression_id(*inner_id);
+                }
                 self.record_span_start(*end, *end);
             }
             // The comment coordinates only reach the oxc printer; the text
@@ -978,6 +1017,18 @@ impl<'a> JsCodegen<'a> {
             JsExpr::SourceAnchored(anchor) => {
                 self.emit_expression(self.arena.get_expr(anchor.inner));
             }
+        }
+    }
+
+    /// Emit an arena expression under any identifier-location scope attached
+    /// to that stable handle.
+    fn emit_expression_id(&mut self, id: super::arena::ExprId) {
+        if let Some((name, span)) = self.arena.expression_identifier_span(id) {
+            self.identifier_span_scopes.push((name, span));
+            self.emit_expression(self.arena.get_expr(id));
+            self.identifier_span_scopes.pop();
+        } else {
+            self.emit_expression(self.arena.get_expr(id));
         }
     }
 
@@ -1967,6 +2018,7 @@ impl<'a> JsCodegen<'a> {
             raw_spans: Vec::new(),
             source_code: None,
             arena: self.arena,
+            identifier_span_scopes: Vec::new(),
             measuring: true,
             measures: Rc::clone(&self.measures),
         }
@@ -3217,6 +3269,34 @@ mod tests {
                 "missing generated identifier mapping {expected:?}: {:?}",
                 generated.mappings
             );
+        }
+    }
+
+    #[test]
+    fn expression_identifier_spans_are_scoped_and_keep_explicit_children() {
+        let arena = JsArena::new();
+        let explicit = JsExpr::Spanned(arena.alloc_expr(id("foo")), 1, 4);
+        let call = call(
+            &arena,
+            id("consume"),
+            vec![id("foo"), explicit, JsExpr::OpaqueIdentifier("foo".into())],
+        );
+        let call_id = arena.alloc_expr(call);
+        arena.note_expression_identifier_span(call_id, "foo", 8, 11);
+        let program = program(vec![stmt(&arena, JsExpr::Spanned(call_id, 0, 0))]);
+
+        let generated = generate_with_sourcemap(&program, "xfoo....foo", &arena).unwrap();
+        assert_eq!(generated.code, "consume(foo, foo, foo);");
+        let starts = generated
+            .code
+            .match_indices("foo")
+            .map(|(offset, _)| offset as u32)
+            .collect::<Vec<_>>();
+        for (generated_column, original_column) in [(starts[0], 8), (starts[1], 1), (starts[2], 8)]
+        {
+            assert!(generated.mappings.iter().any(|mapping| {
+                (mapping.gen_col, mapping.orig_col) == (generated_column, original_column)
+            }));
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -189,6 +189,7 @@ fn convert_once<'a, 'source>(
         arena,
         islands,
         synth: RefCell::new(Synth::new(loc_base)),
+        identifier_span_scopes: RefCell::new(Vec::new()),
         component_brace_span: program
             .component_brace_span
             .as_ref()
@@ -499,6 +500,9 @@ struct Cx<'a, 'arena, 'source> {
     arena: &'arena JsArena,
     islands: &'arena [AstIsland<'source>],
     synth: RefCell<Synth>,
+    /// Identifier locations inherited from the generated expression currently
+    /// being converted. A nested `Spanned` node stamps its own final location.
+    identifier_span_scopes: RefCell<Vec<(&'arena str, (u32, u32))>>,
     /// [`JsProgram::component_brace_span`], matched by function name.
     component_brace_span: Option<(&'arena str, u32, u32)>,
 }
@@ -521,13 +525,29 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
     fn identifier_span(&self, name: &str) -> Span {
         self.arena
             .identifier_span(name)
+            .or_else(|| self.scoped_identifier_span(name))
             .map_or(SPAN, |(start, end)| Span::new(start, end))
+    }
+
+    fn scoped_identifier_span(&self, name: &str) -> Option<(u32, u32)> {
+        self.identifier_span_scopes
+            .borrow()
+            .iter()
+            .rev()
+            .find_map(|(scope_name, span)| (*scope_name == name).then_some(*span))
     }
 
     /// Resolve an `ExprId` handle and convert the pointed-to expression.
     #[inline]
     fn expr_id(&self, id: ExprId) -> Option<Expression<'a>> {
-        self.expr(self.arena.get_expr(id))
+        if let Some((name, span)) = self.arena.expression_identifier_span(id) {
+            self.identifier_span_scopes.borrow_mut().push((name, span));
+            let expression = self.expr(self.arena.get_expr(id));
+            self.identifier_span_scopes.borrow_mut().pop();
+            expression
+        } else {
+            self.expr(self.arena.get_expr(id))
+        }
     }
 
     /// Run `f` and report the comment-buffer region it consumed, so a container
@@ -1397,7 +1417,13 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 &self.ab,
             )),
             JsExpr::OpaqueIdentifier(name) => {
-                Some(Expression::new_identifier(SPAN, self.str(name), &self.ab))
+                let span = self
+                    .scoped_identifier_span(name)
+                    .map_or(SPAN, |(start, end)| {
+                        self.note_span(end);
+                        Span::new(start, end)
+                    });
+                Some(Expression::new_identifier(span, self.str(name), &self.ab))
             }
             JsExpr::Literal(lit) => self.literal(lit),
             JsExpr::This => Some(Expression::ThisExpression(ThisExpression::boxed(
@@ -2803,7 +2829,7 @@ mod tests {
         JsArena, JsProgram, JsStatement, builders as b,
     };
     use oxc_allocator::Allocator;
-    use oxc_span::GetSpan;
+    use oxc_span::{GetSpan, Span};
 
     #[test]
     fn generated_identifier_uses_keep_the_registered_span() {
@@ -2844,6 +2870,46 @@ mod tests {
             statement.expression.span(),
             oxc_span::Span::new(1_000, 1_003)
         );
+    }
+
+    #[test]
+    fn expression_identifier_spans_are_scoped_and_keep_explicit_children() {
+        let arena = JsArena::new();
+        let explicit = crate::compiler::phases::phase3_transform::js_ast::JsExpr::Spanned(
+            arena.alloc_expr(b::id("foo")),
+            1,
+            4,
+        );
+        let call = b::call(
+            &arena,
+            b::id("consume"),
+            vec![
+                b::id("foo"),
+                explicit,
+                crate::compiler::phases::phase3_transform::js_ast::JsExpr::OpaqueIdentifier(
+                    "foo".into(),
+                ),
+            ],
+        );
+        let call_id = arena.alloc_expr(call);
+        arena.note_expression_identifier_span(call_id, "foo", 8, 11);
+        let program = JsProgram::with_body(vec![b::stmt(
+            &arena,
+            crate::compiler::phases::phase3_transform::js_ast::JsExpr::Spanned(call_id, 0, 0),
+        )]);
+        let allocator = Allocator::default();
+        let converted = program_to_oxc(&program, &arena, &allocator).expect("call is supported");
+
+        let oxc_ast::ast::Statement::ExpressionStatement(statement) = &converted.program.body[0]
+        else {
+            panic!("expected expression statement");
+        };
+        let oxc_ast::ast::Expression::CallExpression(call) = &statement.expression else {
+            panic!("expected call expression");
+        };
+        assert_eq!(call.arguments[0].span(), Span::new(8, 11));
+        assert_eq!(call.arguments[1].span(), Span::new(1, 4));
+        assert_eq!(call.arguments[2].span(), Span::new(8, 11));
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -2538,7 +2538,7 @@ mod tests {
                 map["mappings"].as_str().unwrap(),
             );
         for (line, column, original_line, original_column) in [
-            (16, 14, 4, 1),
+            (16, 14, 4, 0),
             (16, 19, 4, 6),
             (16, 27, 4, 19),
             (16, 30, 4, 22),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -251,13 +251,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 } else {
                     Vec::new()
                 };
-                let bind_value_mappings = if !map_pass_disabled("bind_value")
-                    && source.contains("bind:value={")
-                {
-                    generate_bind_value_mappings_with_starts(&result.code, source, &mapping_starts)
-                } else {
-                    Vec::new()
-                };
                 let component_bind_mappings = if !map_pass_disabled("component_bind")
                     && source.contains("bind:")
                     && (result.code.contains("get ")
@@ -329,7 +322,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                     })
                 };
                 let mapping_capacity = wrapper_mappings.len()
-                    + bind_value_mappings.len()
                     + component_bind_mappings.len()
                     + runtime_mappings.len()
                     + legacy_prop_read_mappings.len()
@@ -341,7 +333,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                     + remaining_result_mappings.len();
                 let mut mappings = Vec::with_capacity(mapping_capacity);
                 mappings.extend(wrapper_mappings);
-                mappings.extend(bind_value_mappings);
                 mappings.extend(component_bind_mappings);
                 mappings.extend(runtime_mappings);
                 mappings.extend(legacy_prop_read_mappings);
@@ -2118,124 +2109,6 @@ fn generate_component_bind_mappings_with_starts(
 }
 
 #[cfg(test)]
-fn generate_bind_value_mappings(
-    generated: &str,
-    source: &str,
-) -> Vec<js_ast::codegen::SourceMapping> {
-    generate_bind_value_mappings_with_starts(
-        generated,
-        source,
-        &MappingLineStarts::new(generated, source),
-    )
-}
-
-fn generate_bind_value_mappings_with_starts(
-    generated: &str,
-    source: &str,
-    starts: &MappingLineStarts,
-) -> Vec<js_ast::codegen::SourceMapping> {
-    use js_ast::codegen::offset_to_line_col_utf16;
-
-    fn identifier_after(code: &str, mut offset: usize) -> Option<(usize, &str)> {
-        while code
-            .as_bytes()
-            .get(offset)
-            .is_some_and(u8::is_ascii_whitespace)
-        {
-            offset += 1;
-        }
-        let start = offset;
-        while code
-            .as_bytes()
-            .get(offset)
-            .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$')
-        {
-            offset += 1;
-        }
-        (offset > start).then_some((start, &code[start..offset]))
-    }
-
-    let generated_starts = starts.generated.clone();
-    let source_starts = starts.source.clone();
-    let mut mappings = Vec::new();
-    let mut source_cursor = 0;
-    while let Some(relative) = source[source_cursor..].find("bind:value={") {
-        let expression_start = source_cursor + relative + "bind:value={".len();
-        let Some((source_name, name)) = identifier_after(source, expression_start) else {
-            source_cursor = expression_start;
-            continue;
-        };
-        let mut generated_cursor = 0;
-        while let Some(relative) = generated[generated_cursor..].find("$.bind_value(") {
-            let call_start = generated_cursor + relative;
-            let call_end = generated[call_start..]
-                .find('\n')
-                .map_or(generated.len(), |offset| call_start + offset);
-            let argument_start = call_start + "$.bind_value(".len();
-            if let Some((argument_offset, argument)) = identifier_after(generated, argument_start)
-                && let Some(element_start) = source.find(&format!("<{argument}"))
-            {
-                let source_offset = element_start + 1;
-                for (generated_offset, original_offset) in [
-                    (argument_offset, source_offset),
-                    (
-                        argument_offset + argument.len(),
-                        source_offset + argument.len(),
-                    ),
-                ] {
-                    let (gen_line, gen_col) =
-                        offset_to_line_col_utf16(generated, &generated_starts, generated_offset);
-                    let (orig_line, orig_col) =
-                        offset_to_line_col_utf16(source, &source_starts, original_offset);
-                    mappings.push(js_ast::codegen::SourceMapping {
-                        gen_line: gen_line as u32,
-                        gen_col: gen_col as u32,
-                        source: 0,
-                        orig_line: orig_line as u32,
-                        orig_col: orig_col as u32,
-                        name: None,
-                    });
-                }
-            }
-            let mut offset = call_start;
-            while let Some(relative) = generated[offset..call_end].find(name) {
-                let start = offset + relative;
-                let end = start + name.len();
-                let before = generated.as_bytes().get(start.wrapping_sub(1));
-                let after = generated.as_bytes().get(end);
-                if !before.is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
-                    && !after.is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
-                {
-                    for (generated_offset, original_offset) in
-                        [(start, source_name), (end, source_name + name.len())]
-                    {
-                        let (gen_line, gen_col) = offset_to_line_col_utf16(
-                            generated,
-                            &generated_starts,
-                            generated_offset,
-                        );
-                        let (orig_line, orig_col) =
-                            offset_to_line_col_utf16(source, &source_starts, original_offset);
-                        mappings.push(js_ast::codegen::SourceMapping {
-                            gen_line: gen_line as u32,
-                            gen_col: gen_col as u32,
-                            source: 0,
-                            orig_line: orig_line as u32,
-                            orig_col: orig_col as u32,
-                            name: None,
-                        });
-                    }
-                }
-                offset = end;
-            }
-            generated_cursor = call_end;
-        }
-        source_cursor = source_name + name.len();
-    }
-    mappings
-}
-
-#[cfg(test)]
 fn generate_inline_script_mappings(
     generated: &str,
     source: &str,
@@ -2527,10 +2400,9 @@ mod tests {
     use crate::{CompileOptions, GenerateMode, compile};
 
     use super::{
-        generate_bind_value_mappings, generate_default_function_wrapper_mappings,
-        generate_inline_script_mappings, generate_legacy_prop_read_mappings,
-        generate_server_declaration_mappings, generate_server_token_mappings,
-        generate_server_wrapper_mappings, generate_token_mappings,
+        generate_default_function_wrapper_mappings, generate_inline_script_mappings,
+        generate_legacy_prop_read_mappings, generate_server_declaration_mappings,
+        generate_server_token_mappings, generate_server_wrapper_mappings, generate_token_mappings,
         generate_verbatim_import_mappings, is_template_element_name_mapping,
         typescript_declaration_annotation_end,
     };
@@ -2648,28 +2520,7 @@ mod tests {
     }
 
     #[test]
-    fn client_maps_every_bind_value_expression_copy_to_the_template() {
-        let source = "<input bind:value={foo.bar}>";
-        let generated =
-            "$.bind_value(input, () => foo().bar, ($$value) => foo(foo().bar = $$value));";
-        let mappings = generate_bind_value_mappings(generated, source);
-        let starts = generated
-            .match_indices("foo")
-            .map(|(offset, _)| offset)
-            .collect::<Vec<_>>();
-
-        for start in starts {
-            assert!(
-                mappings.iter().any(|mapping| {
-                    (mapping.gen_col, mapping.orig_line, mapping.orig_col) == (start as u32, 0, 19)
-                }),
-                "missing bind expression mapping at {start}: {mappings:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn client_keeps_bind_value_runtime_carriers_after_merging() {
+    fn client_carries_bind_value_runtime_mappings_from_ast_spans() {
         let source = "<script>\n\texport let foo;\n</script>\n\n<input bind:value={foo.bar.baz}>";
         let result = compile(
             source,

--- a/docs/phase3-ast-refactor-plan.md
+++ b/docs/phase3-ast-refactor-plan.md
@@ -670,19 +670,24 @@ Segments lost when exactly one client pass is disabled, everything else on:
 | `template_element_runtime` | 25 | **0 — deleted** |
 | `legacy_prop_read` | 16 | 16 |
 | `inline_script` | 7 | 4 |
-| `bind_value` | 5 | 5 |
+| `bind_value` | 5 | **0 — deleted** |
 | `component_bind` | 5 | 4 |
 | `verbatim_import` | 4 | 4 |
 | `collapsed_declaration` | 0 | 0 |
 | `rune` | 0 | 0 |
 
-`default_function_wrapper`, `effect_callback` and `template_element_runtime` are deleted:
-all three are now produced by source spans, and the before/after column is the attribution.
+`default_function_wrapper`, `effect_callback`, `template_element_runtime` and `bind_value` are
+deleted: all four are now produced by source spans, and the before/after column is the
+attribution.
 For element handles, `flush_node` records the tag-name span against the component-wide unique
 generated name; both printers apply it to ordinary `Identifier` nodes only at emission time.
 That keeps every lowering matcher on `JsExpr::Identifier` unchanged while reproducing
-upstream's reuse of one located identifier for the declaration and all runtime uses. The other
-eight passes stay, and what each still carries is a named lowering, not a mystery:
+upstream's reuse of one located identifier for the declaration and all runtime uses. A
+`bind:value` call similarly records a scope on its stable arena ID: only otherwise-unlocated
+copies of the expression's root identifier inherit that span while the completed accessor call
+is printed. Explicitly located children keep their own spans, and no wrapper enters the member
+chain while lowering can still inspect it. The other seven passes stay, and what each still
+carries is a named lowering, not a mystery:
 
 | still carried by a pass | why the position is lost |
 | --- | --- |


### PR DESCRIPTION
## Summary

- carry the source span for automatic `bind:value` accessor roots on the completed generated call
- apply that scoped span in both the text and OXC printers without wrapping member-chain nodes
- delete the five-segment `bind_value` generated-text source-map recovery pass
- retain explicit child spans and exclude custom accessors and `<select>` bindings

## Stack

This draft is stacked on #3844, whose element-handle spans replace the other half of the deleted recovery pass.

## Verification

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- local builds and tests intentionally not run; CI is the build/test oracle

Part of #3015
