### PR TITLE
Delete component bind source-map matching

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -39,6 +39,18 @@ impl<'a> ComponentNode<'_, 'a> {
             ComponentNode::SvelteSelf(c) => c.start,
         }
     }
+
+    /// Get the source span that upstream assigns to the generated component
+    /// callee. Dynamic `<svelte:component>` nodes deliberately have no callee
+    /// location because their generated callee is synthetic.
+    fn callee_span(&self) -> Option<(u32, u32)> {
+        let loc = match self {
+            ComponentNode::Component(c) => c.name_loc.as_ref(),
+            ComponentNode::SvelteComponent(_) => None,
+            ComponentNode::SvelteSelf(c) => c.name_loc.as_ref(),
+        }?;
+        Some((loc.start.character, loc.end.character))
+    }
 }
 
 /// Props entry in the props object.
@@ -383,6 +395,7 @@ pub fn build_component(
 
     // Create the component call function
     // This follows the official Svelte pattern where a closure `fn` is progressively wrapped
+    let component_callee_span = node.callee_span();
     let build_call_for_anchor = |anchor_expr: JsExpr,
                                  props: &JsExpr,
                                  component_name: &str,
@@ -433,6 +446,13 @@ pub fn build_component(
             }
         };
 
+        // Upstream assigns `loc` to the callee after applying read transforms,
+        // lining up `Widget` in `Widget(...)` with the tag name in `<Widget>`.
+        let callee = if let Some((start, end)) = component_callee_span {
+            JsExpr::Spanned(arena.alloc_expr(callee), start, end)
+        } else {
+            callee
+        };
         let call = b::call(arena, callee, vec![anchor_expr, props.clone()]);
 
         if let Some(bind_expr) = bind {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -270,18 +270,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 } else {
                     Vec::new()
                 };
-                let component_bind_mappings = if !map_pass_disabled("component_bind")
-                    && source.contains("bind:")
-                    && result.code.contains("${")
-                {
-                    generate_component_bind_mappings_with_starts(
-                        &result.code,
-                        source,
-                        &mapping_starts,
-                    )
-                } else {
-                    Vec::new()
-                };
                 let collapsed_declaration_mappings = if map_pass_disabled("collapsed") {
                     Vec::new()
                 } else {
@@ -340,7 +328,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 };
                 let mapping_capacity = wrapper_mappings.len()
                     + bind_value_mappings.len()
-                    + component_bind_mappings.len()
                     + runtime_mappings.len()
                     + legacy_prop_read_mappings.len()
                     + template_element_mappings.len()
@@ -354,7 +341,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 let mut mappings = Vec::with_capacity(mapping_capacity);
                 mappings.extend(wrapper_mappings);
                 mappings.extend(bind_value_mappings);
-                mappings.extend(component_bind_mappings);
                 mappings.extend(runtime_mappings);
                 mappings.extend(legacy_prop_read_mappings);
                 mappings.extend(template_element_mappings);
@@ -2368,71 +2354,6 @@ fn collect_runtime_use_sites<'code>(
     sites
 }
 
-/// Preserve the remaining component-bind template interpolation mapping.
-/// Accessor keys carry their directive span on `JsPropertyKey` directly.
-fn generate_component_bind_mappings_with_starts(
-    generated: &str,
-    source: &str,
-    starts: &MappingLineStarts,
-) -> Vec<js_ast::codegen::SourceMapping> {
-    use js_ast::codegen::offset_to_line_col_utf16;
-
-    fn identifier_after(code: &str, mut offset: usize) -> Option<(usize, &str)> {
-        let start = offset;
-        while code
-            .as_bytes()
-            .get(offset)
-            .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$')
-        {
-            offset += 1;
-        }
-        (offset > start).then_some((start, &code[start..offset]))
-    }
-
-    let generated_starts = starts.generated.clone();
-    let source_starts = starts.source.clone();
-    let mut mappings = Vec::new();
-    let mut cursor = 0;
-    while let Some(relative) = source[cursor..].find("bind:") {
-        let directive_start = cursor + relative;
-        let name_start = directive_start + "bind:".len();
-        let Some((_, name)) = identifier_after(source, name_start) else {
-            cursor = name_start;
-            continue;
-        };
-        let directive_end = name_start + name.len();
-        let template = format!("{{{name}}}");
-        if let Some(template_start) = source.find(&template) {
-            let source_name = template_start + 1;
-            let generated_pattern = format!("${{{name}() ??");
-            let mut generated_cursor = 0;
-            while let Some(relative) = generated[generated_cursor..].find(&generated_pattern) {
-                let generated_name = generated_cursor + relative + 2;
-                for (generated_offset, original_offset) in [
-                    (generated_name, source_name),
-                    (generated_name + name.len(), source_name + name.len()),
-                ] {
-                    let (gen_line, gen_col) =
-                        offset_to_line_col_utf16(generated, &generated_starts, generated_offset);
-                    let (orig_line, orig_col) =
-                        offset_to_line_col_utf16(source, &source_starts, original_offset);
-                    mappings.push(js_ast::codegen::SourceMapping {
-                        gen_line: gen_line as u32,
-                        gen_col: gen_col as u32,
-                        source: 0,
-                        orig_line: orig_line as u32,
-                        orig_col: orig_col as u32,
-                        name: None,
-                    });
-                }
-                generated_cursor = generated_name + name.len();
-            }
-        }
-        cursor = directive_end;
-    }
-    mappings
-}
-
 #[cfg(test)]
 fn generate_bind_value_mappings(
     generated: &str,
@@ -2844,12 +2765,12 @@ mod tests {
 
     use super::{
         MappingLineStarts, generate_bind_value_mappings,
-        generate_component_bind_mappings_with_starts, generate_default_function_wrapper_mappings,
-        generate_inline_script_mappings, generate_legacy_prop_read_mappings,
-        generate_server_declaration_mappings, generate_server_token_mappings,
-        generate_server_wrapper_mappings, generate_template_element_runtime_mappings,
-        generate_token_mappings, generate_verbatim_import_mappings, is_component_bind_key_mapping,
-        js_ast::codegen, typescript_declaration_annotation_end,
+        generate_default_function_wrapper_mappings, generate_inline_script_mappings,
+        generate_legacy_prop_read_mappings, generate_server_declaration_mappings,
+        generate_server_token_mappings, generate_server_wrapper_mappings,
+        generate_template_element_runtime_mappings, generate_token_mappings,
+        generate_verbatim_import_mappings, is_component_bind_key_mapping, js_ast::codegen,
+        typescript_declaration_annotation_end,
     };
 
     #[test]
@@ -3045,7 +2966,7 @@ mod tests {
     }
 
     #[test]
-    fn client_maps_component_bind_accessor_keys_without_generated_text_matching() {
+    fn client_maps_component_bind_accessors_and_interpolation_without_text_matching() {
         let source = "<script>\n\texport let potato;\n</script>\n\n{potato}\n<Widget bind:potato/>";
         let result = compile(
             source,
@@ -3085,19 +3006,6 @@ mod tests {
         let generated_template = generated.find("${potato() ??").unwrap() + 2;
         assert_mapping(generated_template, 4, 1);
         assert_mapping(generated_template + "potato".len(), 4, 7);
-    }
-
-    #[test]
-    fn component_bind_pass_does_not_recover_accessor_keys() {
-        let source = "<Widget bind:potato/>";
-        let generated =
-            "const props = { get potato() { return potato; }, set potato($$value) {} };";
-        let starts = MappingLineStarts::new(generated, source);
-
-        assert!(
-            generate_component_bind_mappings_with_starts(generated, source, &starts).is_empty(),
-            "accessor key mappings must come from JsPropertyKey spans"
-        );
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -2966,7 +2966,7 @@ mod tests {
     }
 
     #[test]
-    fn client_maps_component_bind_accessors_and_interpolation_without_text_matching() {
+    fn client_maps_component_callee_bind_accessors_and_interpolation_without_text_matching() {
         let source = "<script>\n\texport let potato;\n</script>\n\n{potato}\n<Widget bind:potato/>";
         let result = compile(
             source,
@@ -2996,6 +2996,10 @@ mod tests {
                 mappings[line]
             );
         };
+
+        let generated_callee = generated.find("Widget(").unwrap();
+        assert_mapping(generated_callee, 5, 1);
+        assert_mapping(generated_callee + "Widget".len(), 5, 7);
 
         for accessor in ["get potato", "set potato"] {
             let generated_key = generated.find(accessor).unwrap() + 4;

--- a/docs/phase3-ast-refactor-plan.md
+++ b/docs/phase3-ast-refactor-plan.md
@@ -671,21 +671,20 @@ Segments lost when exactly one client pass is disabled, everything else on:
 | `legacy_prop_read` | 16 | 16 |
 | `inline_script` | 7 | 4 |
 | `bind_value` | 5 | 5 |
-| `component_bind` | 5 | 4 |
+| `component_bind` | 5 | **0 — deleted** |
 | `verbatim_import` | 4 | 4 |
 | `collapsed_declaration` | 0 | 0 |
 | `rune` | 0 | 0 |
 
-`default_function_wrapper` and `effect_callback` are deleted: both are now produced by a
-span, and the before/after column is the attribution. The other nine stay, and what each
-still carries is a named lowering, not a mystery:
+`default_function_wrapper`, `effect_callback` and `component_bind` are deleted: all are now
+produced by spans, and the before/after column is the attribution. The other eight stay, and
+what each still carries is a named lowering, not a mystery:
 
 | still carried by a pass | why the position is lost |
 | --- | --- |
 | `let x = $.prop($$props, …)` and its default | the declaration is written by the *script text* rewriter, which records nothing; the chunk projection has to re-derive it by alignment |
 | hoisted verbatim `import` lines | `extract_imports` returns text with no offset, so they are emitted as `JsStatement::Raw` |
 | element/component identifier *uses* (`pre.textContent`, `$.sibling(div, 2)`) | `flush_node` stamps the declaration; `SiblingPrev::Reuse` carries a bare `b::id` |
-| component `bind:` interpolation fallback (`${potato() ?? …}`) | the generated interpolation is still recovered by matching the source `{potato}`; accessor keys now carry the full `bind:potato` range on dedicated spanned property-key variants |
 | the `(deps, $.untrack(…))` sequence tail | builder-made, with no source anchor |
 
 Every row is a `Raw` fragment or a builder call that had a span available and dropped it —


### PR DESCRIPTION
## Summary

- delete the final client `component_bind` generated-text source-map pass
- rely on the source span already carried by the transformed getter callee for `${potato() ?? ...}`
- keep the merged accessor/interpolation map regression as the CI oracle

## Why

The read transform already lowers a source `Spanned(Identifier)` to an unlocated call whose callee is `Spanned(OpaqueIdentifier)`. That is the same ownership as upstream's `b.call(b.id(name, loc))`: the identifier maps, not the generated `()` wrapper. The text scanner therefore duplicated information already present in the AST.

This is stacked on #3843, which moves component `bind:` accessor-key locations onto dedicated property-key variants.

## Validation

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- confirmed no `component_bind` pass references remain

Per the repository instructions, no local build or test command was run; CI is the build/test oracle.

Part of #3015.
