### PR TITLE
Report aligned parse comment owners

### DIFF
--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -239,7 +239,7 @@ jobs:
       # 28k compared pairs, against ~59 minutes for one shard of the job that
       # currently costs the most.
       - name: Verify public parse() AST parity (ratchet)
-        run: node scripts/compat-corpus/parse-ast-verify.mjs
+        run: node scripts/compat-corpus/parse-ast-verify.mjs --comment-owners
 
       # Asserts a PROPERTY of the transform rather than comparing its output, so
       # it sees the #3026 class on inputs whose output is byte-perfect: un-seal

--- a/scripts/compat-corpus/parse-ast-verify.mjs
+++ b/scripts/compat-corpus/parse-ast-verify.mjs
@@ -72,6 +72,7 @@
  *   node scripts/compat-corpus/parse-ast-verify.mjs
  *   node scripts/compat-corpus/parse-ast-verify.mjs --update-baseline
  *   node scripts/compat-corpus/parse-ast-verify.mjs --filter bits-ui --report-only
+ *   node scripts/compat-corpus/parse-ast-verify.mjs --comment-owners
  */
 
 import fs from 'node:fs';
@@ -95,6 +96,7 @@ const argValue = (name, fallback) => {
 const FILTER = argValue('--filter', null);
 const REPORT_ONLY = args.includes('--report-only');
 const UPDATE = args.includes('--update-baseline');
+const COMMENT_OWNERS = args.includes('--comment-owners');
 const BINDING = path.resolve(ROOT, argValue('--binding', BINDING_REL));
 
 /**
@@ -252,6 +254,72 @@ function diffKeys(a, b, out, ctx, rel, depth = 0) {
 }
 
 /**
+ * Index comment ownership independently of the JSON-path diff. A field-level
+ * ratchet key deliberately collapses every instance of (for example)
+ * `ArrowFunctionExpression.leadingComments`, so it cannot say whether 200
+ * comments or one comment still move between otherwise aligned nodes. The
+ * owner index joins comments by their own immutable source range, then names
+ * their owner by `(type, start, end)` — the same alignment #3702 uses.
+ */
+function commentOwnerIndex(root) {
+	const nodeKeys = new Set();
+	const comments = new Map();
+
+	function visit(value) {
+		if (!value || typeof value !== 'object') return;
+		if (Array.isArray(value)) {
+			for (const item of value) visit(item);
+			return;
+		}
+
+		if (typeof value.type === 'string') {
+			const nodeKey = `${value.type}\0${value.start}\0${value.end}`;
+			nodeKeys.add(nodeKey);
+			for (const field of ['leadingComments', 'trailingComments']) {
+				for (const comment of value[field] ?? []) {
+					const commentKey = `${comment.type}\0${comment.start}\0${comment.end}\0${comment.value}`;
+					comments.set(commentKey, {
+						nodeKey,
+						label: `${value.type}.${field}`,
+					});
+				}
+			}
+		}
+
+		for (const [field, child] of Object.entries(value)) {
+			if (field === 'leadingComments' || field === 'trailingComments' || field === 'comments') {
+				continue;
+			}
+			visit(child);
+		}
+	}
+
+	visit(root);
+	return { nodeKeys, comments };
+}
+
+function commentOwnerDiff(expected, actual) {
+	const a = commentOwnerIndex(expected);
+	const b = commentOwnerIndex(actual);
+	const out = [];
+	for (const [commentKey, expectedOwner] of a.comments) {
+		const actualOwner = b.comments.get(commentKey);
+		if (
+			!actualOwner ||
+			(actualOwner.nodeKey === expectedOwner.nodeKey &&
+				actualOwner.label === expectedOwner.label)
+		) {
+			continue;
+		}
+		out.push({
+			transition: `${expectedOwner.label} -> ${actualOwner.label}`,
+			expectedOwnerMissing: !b.nodeKeys.has(expectedOwner.nodeKey),
+		});
+	}
+	return out;
+}
+
+/**
  * One comparison. `both-reject` is a verdict, not a key: rsvelte's binding
  * surfaces a Rust `Debug` string rather than a Svelte error code, so the two
  * rejections are not comparable here (gate-coverage 39c).
@@ -282,9 +350,19 @@ function compareOne(id, source, options) {
 	// harness fault, and scoring it as a rejection is how a probe manufactures a
 	// finding. Nothing is expected to throw now that bigints are handled, so let
 	// it escape rather than be absorbed into a verdict.
+	const expectedJson = jsonSafe(expected);
+	const actualJson = JSON.parse(actual);
 	const keys = new Set();
-	diffKeys(jsonSafe(expected), JSON.parse(actual), keys, '(root)', '');
-	return { compared: true, keys: [...keys] };
+	diffKeys(expectedJson, actualJson, keys, '(root)', '');
+	const hasCommentDiff = [...keys].some((key) =>
+		key.includes('.leadingComments') || key.includes('.trailingComments')
+	);
+	return {
+		compared: true,
+		keys: [...keys],
+		commentOwners:
+			COMMENT_OWNERS && hasCommentDiff ? commentOwnerDiff(expectedJson, actualJson) : [],
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -299,6 +377,11 @@ const AXIS_NAMES = ['modern', 'legacy', 'loose'];
 const compared = { modern: 0, legacy: 0, loose: 0 };
 const bothReject = { modern: 0, legacy: 0, loose: 0 };
 const agreed = { modern: 0, legacy: 0, loose: 0 };
+/** @type {Map<string, number>} aligned comment-owner transitions by axis */
+const commentOwnerTransitions = new Map();
+/** @type {Map<string, string>} */
+const firstCommentOwnerExample = new Map();
+const missingCommentOwnerNodes = { modern: 0, legacy: 0, loose: 0 };
 
 function record(axis, prefix, id, result) {
 	if (!result.compared) {
@@ -306,6 +389,12 @@ function record(axis, prefix, id, result) {
 		return;
 	}
 	compared[axis]++;
+	for (const owner of result.commentOwners ?? []) {
+		const key = `${axis}::${owner.transition}`;
+		commentOwnerTransitions.set(key, (commentOwnerTransitions.get(key) ?? 0) + 1);
+		if (!firstCommentOwnerExample.has(key)) firstCommentOwnerExample.set(key, id);
+		if (owner.expectedOwnerMissing) missingCommentOwnerNodes[axis]++;
+	}
 	if (result.keys.length === 0) {
 		agreed[axis]++;
 		return;
@@ -363,6 +452,24 @@ for (const [c, n] of [...byCluster].sort((a, b) => b[1] - a[1])) {
 }
 for (const [key, count] of sorted) {
 	console.log(`[parse-ast]   ${String(count).padStart(6)}  ${key}   e.g. ${firstExample.get(key)}`);
+}
+
+if (COMMENT_OWNERS) {
+	const transitions = [...commentOwnerTransitions.entries()].sort(
+		(a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1)
+	);
+	const total = transitions.reduce((sum, [, count]) => sum + count, 0);
+	console.log(
+		`[parse-ast] ${total} aligned comment-owner differences (${AXIS_NAMES.map((axis) => `${axis}: ${missingCommentOwnerNodes[axis]} expected-owner nodes absent`).join(', ')}):`
+	);
+	for (const [key, count] of transitions.slice(0, 50)) {
+		console.log(
+			`[parse-ast]   ${String(count).padStart(6)}  ${key}   e.g. ${firstCommentOwnerExample.get(key)}`
+		);
+	}
+	if (transitions.length > 50) {
+		console.log(`[parse-ast]   ... ${transitions.length - 50} more owner transitions`);
+	}
 }
 
 if (REPORT_ONLY) process.exit(0);

--- a/scripts/compat-corpus/parse-ast-verify.mjs
+++ b/scripts/compat-corpus/parse-ast-verify.mjs
@@ -277,7 +277,7 @@ function commentOwnerIndex(root) {
 			nodeKeys.add(nodeKey);
 			for (const field of ['leadingComments', 'trailingComments']) {
 				for (const comment of value[field] ?? []) {
-					const commentKey = `${comment.type}\0${comment.start}\0${comment.end}\0${comment.value}`;
+					const commentKey = `${comment.start}\0${comment.end}`;
 					comments.set(commentKey, {
 						nodeKey,
 						label: `${value.type}.${field}`,
@@ -304,16 +304,32 @@ function commentOwnerDiff(expected, actual) {
 	const out = [];
 	for (const [commentKey, expectedOwner] of a.comments) {
 		const actualOwner = b.comments.get(commentKey);
+		if (!actualOwner) {
+			out.push({
+				transition: `${expectedOwner.label} -> ABSENT`,
+				expectedOwnerMissing: !b.nodeKeys.has(expectedOwner.nodeKey),
+				kind: 'missing',
+			});
+			continue;
+		}
 		if (
-			!actualOwner ||
-			(actualOwner.nodeKey === expectedOwner.nodeKey &&
-				actualOwner.label === expectedOwner.label)
+			actualOwner.nodeKey === expectedOwner.nodeKey &&
+			actualOwner.label === expectedOwner.label
 		) {
 			continue;
 		}
 		out.push({
 			transition: `${expectedOwner.label} -> ${actualOwner.label}`,
 			expectedOwnerMissing: !b.nodeKeys.has(expectedOwner.nodeKey),
+			kind: 'moved',
+		});
+	}
+	for (const [commentKey, actualOwner] of b.comments) {
+		if (a.comments.has(commentKey)) continue;
+		out.push({
+			transition: `ABSENT -> ${actualOwner.label}`,
+			expectedOwnerMissing: false,
+			kind: 'extra',
 		});
 	}
 	return out;
@@ -382,6 +398,11 @@ const commentOwnerTransitions = new Map();
 /** @type {Map<string, string>} */
 const firstCommentOwnerExample = new Map();
 const missingCommentOwnerNodes = { modern: 0, legacy: 0, loose: 0 };
+const commentOwnerKinds = {
+	modern: { moved: 0, missing: 0, extra: 0 },
+	legacy: { moved: 0, missing: 0, extra: 0 },
+	loose: { moved: 0, missing: 0, extra: 0 },
+};
 
 function record(axis, prefix, id, result) {
 	if (!result.compared) {
@@ -394,6 +415,7 @@ function record(axis, prefix, id, result) {
 		commentOwnerTransitions.set(key, (commentOwnerTransitions.get(key) ?? 0) + 1);
 		if (!firstCommentOwnerExample.has(key)) firstCommentOwnerExample.set(key, id);
 		if (owner.expectedOwnerMissing) missingCommentOwnerNodes[axis]++;
+		commentOwnerKinds[axis][owner.kind]++;
 	}
 	if (result.keys.length === 0) {
 		agreed[axis]++;
@@ -459,8 +481,12 @@ if (COMMENT_OWNERS) {
 		(a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1)
 	);
 	const total = transitions.reduce((sum, [, count]) => sum + count, 0);
+	const axisSummary = AXIS_NAMES.map(
+		(axis) =>
+			`${axis}: ${commentOwnerKinds[axis].moved} moved, ${commentOwnerKinds[axis].missing} missing, ${commentOwnerKinds[axis].extra} extra, ${missingCommentOwnerNodes[axis]} expected-owner nodes absent`
+	).join('; ');
 	console.log(
-		`[parse-ast] ${total} aligned comment-owner differences (${AXIS_NAMES.map((axis) => `${axis}: ${missingCommentOwnerNodes[axis]} expected-owner nodes absent`).join(', ')}):`
+		`[parse-ast] ${total} aligned comment differences (${axisSummary}):`
 	);
 	for (const [key, count] of transitions.slice(0, 50)) {
 		console.log(


### PR DESCRIPTION
## Summary

- add an opt-in aligned comment-owner report to the public `parse()` AST parity sweep
- join comments only by their immutable source range and owners by `(type, start, end)`, independently of the field-level ratchet key
- classify moved, missing, and extra comments separately, including whether the official owner node is absent
- enable that report in the corpus CI job so the remaining #3702 serializer-order clusters are measured before they are changed

## Measured result

Corpus Compat run 32962432489 completed green across all jobs. Over 66,511 public AST comparisons, the report found 2,598 aligned comment differences:

- modern: 557 moved, 746 missing, 56 extra, 714 expected-owner nodes absent
- legacy: 437 moved, 746 missing, 56 extra, 1,118 expected-owner nodes absent
- loose: 0 moved, 0 missing, 0 extra

The largest transition is `TSPropertySignature.leadingComments -> ABSENT` at 505 occurrences on each component AST axis. The next clusters move comments from import or type declarations onto export declarations and other statement owners. This supports splitting follow-up fixes by owner transition rather than by aggregate comment count.

## Validation

- `node --check scripts/compat-corpus/parse-ast-verify.mjs`
- `git diff --check`
- full Corpus Compat run 32962432489: green

Stacked on #3822. This is diagnostic infrastructure for #3702; it does not close the issue.