### PR TITLE
fix(compiler): map hoisted imports from retained spans

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -691,7 +691,13 @@ pub(crate) fn transform_client(
         } else {
             composed_body_projection.as_ref()
         };
-        instance_script_imports = imports;
+        instance_script_imports = attach_import_origins(
+            imports,
+            retained_scripts.and_then(|scripts| scripts.instance.as_ref()),
+            instance_script.start,
+            analysis.is_typescript,
+            options.enable_sourcemap,
+        );
         let split_top_level_declarations =
             instance_has_top_level_multi_declarator(ast, instance_raw);
         let _script_start = super::profile::timer_start();
@@ -2159,6 +2165,13 @@ pub(crate) fn transform_client(
             // the grouping parens around one have to be gone before the first runs.
             let raw = super::shared::rune_parens::strip_rune_parens(&raw).unwrap_or(raw);
             let (module_imports, rest) = extract_imports(&raw);
+            let module_imports = attach_import_origins(
+                module_imports,
+                retained_scripts.and_then(|scripts| scripts.module.as_ref()),
+                module_content.start,
+                analysis.is_typescript,
+                options.enable_sourcemap,
+            );
             let retained_comment_stripped = if !analysis.is_typescript {
                 retained_scripts
                     .and_then(|scripts| scripts.module.as_ref())
@@ -2175,19 +2188,10 @@ pub(crate) fn transform_client(
                 None
             };
             // Add module script imports first (from module.body in official compiler)
-            for import_line in module_imports {
-                let cleaned = cleanup_import_line(&import_line);
-                if cleaned.is_empty() {
-                    continue;
+            for import in module_imports {
+                if let Some(statement) = mapped_import_statement(import, options.enable_sourcemap) {
+                    body.push(statement);
                 }
-                let trimmed = cleaned.trim();
-                // Ensure import statements end with semicolons, matching esrap behavior.
-                let with_semi = if !trimmed.ends_with(';') {
-                    format!("{};", trimmed)
-                } else {
-                    trimmed.to_string()
-                };
-                body.push(JsStatement::Raw(with_semi.into()));
             }
             let rest_trimmed = rest.trim();
             // A module `<script module>` whose only non-import content is comments
@@ -2216,21 +2220,10 @@ pub(crate) fn transform_client(
     // Extract and add imports from instance script
     // These are in state.hoisted after import * as $ (from analysis.instance_body.hoisted)
     if analysis.instance_script_content.is_some() {
-        for import_line in instance_script_imports {
-            let cleaned = cleanup_import_line(&import_line);
-            if cleaned.is_empty() {
-                continue;
+        for import in instance_script_imports {
+            if let Some(statement) = mapped_import_statement(import, options.enable_sourcemap) {
+                body.push(statement);
             }
-            let trimmed = cleaned.trim();
-            // Ensure import statements end with semicolons, matching esrap behavior.
-            // User code may omit semicolons (ASI), but the Svelte compiler's esrap
-            // printer always adds them.
-            let with_semi = if !trimmed.ends_with(';') {
-                format!("{};", trimmed)
-            } else {
-                trimmed.to_string()
-            };
-            body.push(JsStatement::Raw(with_semi.into()));
         }
     }
 
@@ -3305,6 +3298,114 @@ fn retained_instance_statement_indices(
 // ============================================================================
 // Script Transformation Functions
 // ============================================================================
+
+#[derive(Debug)]
+struct ExtractedImport {
+    text: String,
+    origin: Option<ImportOrigin>,
+}
+
+#[derive(Debug)]
+struct ImportOrigin {
+    source_offset: u32,
+    source: String,
+}
+
+/// Pair extracted import text with the declaration span retained by phase 1.
+///
+/// TypeScript stripping can remove a whole type-only import, and the legacy
+/// extractor can split several imports packed onto one line, so the two lists
+/// cannot be joined by index. Compare each emitted declaration with the next
+/// retained declaration after applying the same TypeScript erasure and import
+/// cleanup. The comparison proves identity; the retained span is the source-map
+/// position and no generated-output/source search is needed later.
+fn attach_import_origins(
+    imports: Vec<String>,
+    retained: Option<&crate::ast::oxc_program::RetainedProgram<'_>>,
+    script_offset: u32,
+    is_typescript: bool,
+    enable_sourcemap: bool,
+) -> Vec<ExtractedImport> {
+    use oxc_span::GetSpan;
+
+    if !enable_sourcemap {
+        return imports
+            .into_iter()
+            .map(|text| ExtractedImport { text, origin: None })
+            .collect();
+    }
+
+    let candidates = retained.map(|retained| {
+        retained
+            .program()
+            .body
+            .iter()
+            .filter_map(|statement| {
+                matches!(statement, oxc_ast::ast::Statement::ImportDeclaration(_)).then(|| {
+                    let span = statement.span();
+                    let source = &retained.source()[span.start as usize..span.end as usize];
+                    let comparable = if is_typescript {
+                        crate::compiler::phases::phase2_analyze::types::strip_typescript(source)
+                    } else {
+                        source.to_string()
+                    };
+                    (span.start, source, cleaned_import_code(&comparable))
+                })
+            })
+            .collect::<Vec<_>>()
+    });
+    let mut next_candidate = 0usize;
+
+    imports
+        .into_iter()
+        .map(|text| {
+            let expected = cleaned_import_code(&text);
+            let origin = candidates.as_ref().and_then(|candidates| {
+                candidates[next_candidate..]
+                    .iter()
+                    .position(|(_, _, comparable)| comparable == &expected)
+                    .map(|relative| {
+                        let index = next_candidate + relative;
+                        next_candidate = index + 1;
+                        let (start, source, _) = &candidates[index];
+                        ImportOrigin {
+                            source_offset: script_offset + *start,
+                            source: (*source).to_string(),
+                        }
+                    })
+            });
+            ExtractedImport { text, origin }
+        })
+        .collect()
+}
+
+fn cleaned_import_code(import: &str) -> String {
+    let cleaned = cleanup_import_line(import);
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() || trimmed.ends_with(';') {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed};")
+    }
+}
+
+fn mapped_import_statement(import: ExtractedImport, enable_sourcemap: bool) -> Option<JsStatement> {
+    let code = cleaned_import_code(&import.text);
+    if code.is_empty() {
+        return None;
+    }
+    let Some(origin) = import.origin.filter(|_| enable_sourcemap) else {
+        return Some(JsStatement::Raw(code.into()));
+    };
+    let copied_spans =
+        copied_spans_for_normalized_code(&code, &origin.source, origin.source_offset, None);
+    Some(JsStatement::RawMapped {
+        code: code.into(),
+        source_offset: origin.source_offset,
+        comment_anchor: None,
+        copied_spans,
+    })
+}
 
 /// Extract import statements from script content.
 /// Returns (imports, rest_of_script).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -40,6 +40,21 @@ fn retained_instance_script_preserves_identifier_and_literal_source_map_spans() 
         "hoisted import must retain its normal output: {}",
         result.js.code
     );
+    let import_line = result
+        .js
+        .code
+        .lines()
+        .position(|line| line.contains("import dependency from 'dependency';"))
+        .expect("hoisted import is printed");
+    let generated_import = result.js.code.lines().nth(import_line).unwrap();
+    let dependency_column = generated_import.find("dependency").unwrap() as i64;
+    assert!(
+        mappings[import_line]
+            .iter()
+            .any(|segment| segment.as_slice() == [dependency_column, 0, 1, 7]),
+        "the hoisted import identifier must carry its retained span; generated={generated_import:?}, segments={:?}",
+        mappings[import_line]
+    );
     let generated_line = result
         .js
         .code
@@ -61,6 +76,31 @@ fn retained_instance_script_preserves_identifier_and_literal_source_map_spans() 
             .any(|segment| segment.as_slice() == [literal_column, 0, 2, 15]),
         "literal must retain its original token span; generated={generated:?}, segments={line:?}"
     );
+}
+
+#[test]
+fn typescript_import_cleanup_keeps_retained_identifier_spans() {
+    let source = "import { type Shape, value } from 'pkg';";
+    let retained = crate::ast::oxc_program::RetainedProgram::parse(source, true);
+    let stripped = crate::compiler::phases::phase2_analyze::types::strip_typescript(source);
+    let (imports, rest) = extract_imports(&stripped);
+    assert!(rest.trim().is_empty());
+
+    let imports = attach_import_origins(imports, Some(&retained), 17, true, true);
+    let statement = mapped_import_statement(imports.into_iter().next().unwrap(), true).unwrap();
+    let JsStatement::RawMapped {
+        code, copied_spans, ..
+    } = statement
+    else {
+        panic!("a retained import must use the mapped raw path");
+    };
+    let code_value = code.find("value").unwrap() as u32;
+    let source_value = 17 + source.find("value").unwrap() as u32;
+    assert!(copied_spans.iter().any(|span| {
+        span.code.start <= code_value
+            && span.code.end >= code_value + "value".len() as u32
+            && span.source.start + code_value - span.code.start == source_value
+    }));
 }
 
 #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -165,13 +165,43 @@ pub(crate) fn transform_component_with_sourcemap_content(
     options: &CompileOptions,
     include_sourcemap_content: bool,
 ) -> Result<TransformResult, TransformError> {
+    // The normal compiler/toolchain path supplies phase 1's retained scripts.
+    // Keep the standalone phase-3 API source-map complete as well: its public
+    // signature predates retained scripts, so reconstruct only the two script
+    // programs here and only when their locations can be observed.
+    let retained_scripts = options.enable_sourcemap.then(|| {
+        let retain = |content: Option<&super::phase2_analyze::types::ScriptContent>,
+                      is_typescript| {
+            content.and_then(|content| {
+                source
+                    .get(content.start as usize..content.end as usize)
+                    .map(|script| {
+                        crate::ast::oxc_program::RetainedProgram::parse(script, is_typescript)
+                    })
+            })
+        };
+        crate::ast::oxc_program::RetainedScripts {
+            instance: retain(
+                analysis.instance_script_content.as_ref(),
+                ast.instance
+                    .as_ref()
+                    .is_some_and(|script| script.is_typescript),
+            ),
+            module: retain(
+                analysis.module_script_content.as_ref(),
+                ast.module
+                    .as_ref()
+                    .is_some_and(|script| script.is_typescript),
+            ),
+        }
+    });
     transform_component_with_scripts(
         analysis,
         ast,
         source,
         options,
         include_sourcemap_content,
-        None,
+        retained_scripts.as_ref(),
         None,
         None,
     )
@@ -279,16 +309,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                         &mapping_starts,
                     )
                 };
-                let import_mappings = if !map_pass_disabled("import") && source.contains("import ")
-                {
-                    generate_verbatim_import_mappings_with_starts(
-                        &result.code,
-                        source,
-                        &mapping_starts,
-                    )
-                } else {
-                    Vec::new()
-                };
                 let token_mappings = if map_pass_disabled("token") {
                     Vec::new()
                 } else {
@@ -332,7 +352,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                     + legacy_prop_read_mappings.len()
                     + template_element_mappings.len()
                     + inline_script_mappings.len()
-                    + import_mappings.len()
                     + template_name_mappings.len()
                     + component_bind_key_mappings.len()
                     + token_mappings.len()
@@ -345,7 +364,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 mappings.extend(legacy_prop_read_mappings);
                 mappings.extend(template_element_mappings);
                 mappings.extend(inline_script_mappings);
-                mappings.extend(import_mappings);
                 mappings.extend(template_name_mappings);
                 mappings.extend(component_bind_key_mappings);
                 mappings.extend(token_mappings);

--- a/docs/phase3-ast-refactor-plan.md
+++ b/docs/phase3-ast-refactor-plan.md
@@ -672,24 +672,28 @@ Segments lost when exactly one client pass is disabled, everything else on:
 | `inline_script` | 7 | 4 |
 | `bind_value` | 5 | 5 |
 | `component_bind` | 5 | **0 — deleted** |
-| `verbatim_import` | 4 | 4 |
+| `verbatim_import` | 4 | **0 — deleted** |
 | `collapsed_declaration` | 0 | 0 |
 | `rune` | 0 | 0 |
 
-`default_function_wrapper`, `effect_callback` and `component_bind` are deleted: all are now
-produced by spans, and the before/after column is the attribution. The other eight stay, and
+`default_function_wrapper`, `effect_callback`, `component_bind` and `verbatim_import` are deleted:
+all are now produced by spans, and the before/after column is the attribution. The other seven stay, and
 what each still carries is a named lowering, not a mystery:
 
 | still carried by a pass | why the position is lost |
 | --- | --- |
 | `let x = $.prop($$props, …)` and its default | the declaration is written by the *script text* rewriter, which records nothing; the chunk projection has to re-derive it by alignment |
-| hoisted verbatim `import` lines | `extract_imports` returns text with no offset, so they are emitted as `JsStatement::Raw` |
 | element/component identifier *uses* (`pre.textContent`, `$.sibling(div, 2)`) | `flush_node` stamps the declaration; `SiblingPrev::Reuse` carries a bare `b::id` |
 | the `(deps, $.untrack(…))` sequence tail | builder-made, with no source anchor |
 
 Every row is a `Raw` fragment or a builder call that had a span available and dropped it —
 i.e. #3015's step 1 really is the prerequisite it claims to be, and this measurement names
 which fragments to eradicate first by how many segments they hold.
+
+Hoisted imports now pair the extractor's output with the phase-1 import declaration that produced
+it. TypeScript erasure and import cleanup are applied only to prove the pair; the retained
+declaration range supplies `RawMapped` token spans, so no generated-output/source line match is
+needed.
 
 **`collapsed_declaration` and `rune` cost 0 on both trees, and that is not evidence they
 are redundant.** They were already contributing nothing before this change, so deleting


### PR DESCRIPTION
## Summary

- carry retained phase-1 import spans through client import hoisting
- delete the client-side generated-text/source matching pass for verbatim imports
- preserve mappings through TypeScript type-only import cleanup and the standalone phase-3 API

Progresses #3015.

## Validation

- cargo fmt --all -- --check
- git diff --check

Rust builds and tests are intentionally delegated to CI because the local machine is under sustained load.