### PR TITLE
fix(compiler): delete collapsed declaration map pass

### DIFF
--- a/.changeset/tidy-collapsed-declaration-maps.md
+++ b/.changeset/tidy-collapsed-declaration-maps.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Remove the redundant text-matching source-map pass for declarations collapsed onto one line.

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -2027,9 +2027,13 @@ pass at a time: `collapsed_declaration` and `rune` cost **0 segments on `main` a
 #3015's span work**. **[D]** That is a discriminating case in the negative direction — the
 same reading is produced by "these samples contain no `$state`/`$derived`/`$props` lowering
 whose position the pass would have supplied" and by "a span now supplies it", and nothing in
-the gate separates them. Deleting a pass on a 0 therefore needs a population that fires it;
-the passes deleted in #3015 (`default_function_wrapper` 84 → 0, `effect_callback` 8 → 0)
-carry a *movement*, which is the reading a 0 cannot give.
+the gate separates them. Deleting a pass on a 0 therefore needs a population that fires it.
+`collapsed_declaration` now has that independent population: a compile-level regression uses
+`let` and its name on separate source lines, verifies that both client and server code
+generation collapse them, and pins the generated name to the original name after the pass
+is deleted. `rune` remains
+unproven. The earlier passes deleted in #3015 (`default_function_wrapper` 84 → 0,
+`effect_callback` 8 → 0) instead carry a *movement*, which is the reading a 0 cannot give.
 
  There is no corpus-wide source-map gate to fall back on: `verify.mjs` compares generated
  code, and the svelte2tsx map gate (§ 12) covers a different artifact.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -281,15 +281,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 } else {
                     Vec::new()
                 };
-                let collapsed_declaration_mappings = if map_pass_disabled("collapsed") {
-                    Vec::new()
-                } else {
-                    generate_collapsed_declaration_mappings_with_starts(
-                        &result.code,
-                        source,
-                        &mapping_starts,
-                    )
-                };
                 let import_mappings = if !map_pass_disabled("import") && source.contains("import ")
                 {
                     generate_verbatim_import_mappings_with_starts(
@@ -365,9 +356,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 mappings
                     .sort_by(|a, b| a.gen_line.cmp(&b.gen_line).then(a.gen_col.cmp(&b.gen_col)));
                 mappings.dedup_by(|a, b| a.gen_line == b.gen_line && a.gen_col == b.gen_col);
-                if !collapsed_declaration_mappings.is_empty() {
-                    mappings = merge_preferred_mappings(mappings, collapsed_declaration_mappings);
-                }
                 (result.code, mappings)
             } else {
                 (result.code, Vec::new())
@@ -416,11 +404,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                         &mapping_starts,
                     ));
                 }
-                mappings.extend(generate_collapsed_declaration_mappings_with_starts(
-                    &code,
-                    source,
-                    &mapping_starts,
-                ));
                 mappings.extend(generate_token_mappings_inner(
                     &code,
                     source,
@@ -1413,75 +1396,6 @@ fn generate_server_declaration_mappings_with_starts(
                 orig_col: orig_col as u32,
                 name: None,
             });
-        }
-    }
-    mappings
-}
-
-fn generate_collapsed_declaration_mappings_with_starts(
-    generated: &str,
-    source: &str,
-    starts: &MappingLineStarts,
-) -> Vec<js_ast::codegen::SourceMapping> {
-    use js_ast::codegen::offset_to_line_col_utf16;
-
-    let generated_starts = starts.generated.clone();
-    let source_starts = starts.source.clone();
-    let mut mappings = Vec::new();
-    for keyword in ["let", "const", "var"] {
-        let mut cursor = 0;
-        while let Some(relative) = source[cursor..].find(keyword) {
-            let start = cursor + relative;
-            let end = start + keyword.len();
-            let valid = !source
-                .as_bytes()
-                .get(start.wrapping_sub(1))
-                .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
-                && source
-                    .as_bytes()
-                    .get(end)
-                    .is_some_and(u8::is_ascii_whitespace);
-            if !valid {
-                cursor = end;
-                continue;
-            }
-            let Some(name_start) = source[end..]
-                .find(|character: char| !character.is_whitespace())
-                .map(|offset| end + offset)
-            else {
-                break;
-            };
-            if !source[end..name_start].contains('\n') {
-                cursor = end;
-                continue;
-            }
-            let name_len = source[name_start..]
-                .bytes()
-                .take_while(|byte| byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$')
-                .count();
-            if name_len == 0 {
-                cursor = name_start;
-                continue;
-            }
-            let name = &source[name_start..name_start + name_len];
-            let pattern = format!("{keyword} {name}");
-            let (orig_line, orig_col) = offset_to_line_col_utf16(source, &source_starts, start);
-            let mut generated_cursor = 0;
-            while let Some(relative) = generated[generated_cursor..].find(&pattern) {
-                let generated_name = generated_cursor + relative + keyword.len() + 1;
-                let (gen_line, gen_col) =
-                    offset_to_line_col_utf16(generated, &generated_starts, generated_name);
-                mappings.push(js_ast::codegen::SourceMapping {
-                    gen_line: gen_line as u32,
-                    gen_col: gen_col as u32,
-                    source: 0,
-                    orig_line: orig_line as u32,
-                    orig_col: (orig_col + keyword.len() + 1) as u32,
-                    name: None,
-                });
-                generated_cursor = generated_name + name_len;
-            }
-            cursor = name_start + name_len;
         }
     }
     mappings
@@ -2804,6 +2718,51 @@ mod tests {
         generate_token_mappings, generate_verbatim_import_mappings,
         typescript_declaration_annotation_end,
     };
+
+    #[test]
+    fn maps_collapsed_declarations_without_a_text_matching_pass() {
+        let source = "<script>\n\tlet\n\t\tvalue = 1;\n</script>\n<p>{value}</p>";
+        for generate in [GenerateMode::Client, GenerateMode::Server] {
+            let result = compile(
+                source,
+                CompileOptions {
+                    generate,
+                    filename: Some("input.svelte".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            let generated_line = result
+                .js
+                .code
+                .lines()
+                .position(|line| line.contains("let value = 1"))
+                .unwrap();
+            let generated_column = result
+                .js
+                .code
+                .lines()
+                .nth(generated_line)
+                .unwrap()
+                .find("value")
+                .unwrap();
+            let map: serde_json::Value =
+                serde_json::from_str(result.js.map.as_deref().unwrap()).unwrap();
+            let mappings =
+                crate::compiler::phases::phase3_transform::js_ast::codegen::decode_vlq_mappings(
+                    map["mappings"].as_str().unwrap(),
+                );
+
+            assert!(
+                mappings[generated_line]
+                    .iter()
+                    .any(|segment| { segment[..4] == [generated_column as i64, 0, 2, 2] }),
+                "{}: {:?}",
+                result.js.code,
+                mappings[generated_line]
+            );
+        }
+    }
 
     #[test]
     fn maps_binding_end_past_erased_typescript_annotation() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -1085,30 +1085,6 @@ fn is_template_element_name_mapping(
     source.as_bytes().get(source_offset.wrapping_sub(1)) == Some(&b'<')
 }
 
-fn merge_preferred_mappings(
-    mut mappings: Vec<js_ast::codegen::SourceMapping>,
-    mut preferred: Vec<js_ast::codegen::SourceMapping>,
-) -> Vec<js_ast::codegen::SourceMapping> {
-    mappings.sort_by(|a, b| a.gen_line.cmp(&b.gen_line).then(a.gen_col.cmp(&b.gen_col)));
-    preferred.sort_by(|a, b| a.gen_line.cmp(&b.gen_line).then(a.gen_col.cmp(&b.gen_col)));
-    let mut result = Vec::with_capacity(mappings.len() + preferred.len());
-    let mut preferred_index = 0;
-    for mapping in mappings {
-        while preferred_index < preferred.len()
-            && (
-                preferred[preferred_index].gen_line,
-                preferred[preferred_index].gen_col,
-            ) <= (mapping.gen_line, mapping.gen_col)
-        {
-            result.push(preferred[preferred_index].clone());
-            preferred_index += 1;
-        }
-        result.push(mapping);
-    }
-    result.extend(preferred.into_iter().skip(preferred_index));
-    result
-}
-
 /// The generated component function's braces map to the instance script tags.
 #[cfg(test)]
 fn generate_default_function_wrapper_mappings(

--- a/docs/phase3-ast-refactor-plan.md
+++ b/docs/phase3-ast-refactor-plan.md
@@ -673,7 +673,7 @@ Segments lost when exactly one client pass is disabled, everything else on:
 | `bind_value` | 5 | 5 |
 | `component_bind` | 5 | 4 |
 | `verbatim_import` | 4 | 4 |
-| `collapsed_declaration` | 0 | 0 |
+| `collapsed_declaration` | 0 | **0 — deleted** |
 | `rune` | 0 | 0 |
 
 `default_function_wrapper` and `effect_callback` are deleted: both are now produced by a
@@ -692,11 +692,13 @@ Every row is a `Raw` fragment or a builder call that had a span available and dr
 i.e. #3015's step 1 really is the prerequisite it claims to be, and this measurement names
 which fragments to eradicate first by how many segments they hold.
 
-**`collapsed_declaration` and `rune` cost 0 on both trees, and that is not evidence they
-are redundant.** They were already contributing nothing before this change, so deleting
-them cannot be attributed to it, and the gate is 29 samples — a pass that never fires in
-those samples is indistinguishable from a pass whose output is now produced elsewhere. Both
-stay, and the distinction is recorded as gate-coverage 14f.
+**`rune` costs 0 on both trees, and that is not evidence it is redundant.** It was already
+contributing nothing before this change, so deleting it cannot be attributed to the span
+work, and the gate is 29 samples — a pass that never fires in those samples is
+indistinguishable from a pass whose output is now produced elsewhere. It stays, and the
+distinction is recorded as gate-coverage 14f. `collapsed_declaration` is deleted separately:
+a compile-level regression deliberately fires its multiline-declaration predicate and pins
+the generated client and server names to the source name after the pass is gone.
 
 ### Two hazards the change created and paid for
 


### PR DESCRIPTION
## Summary

- delete the client/server `collapsed_declaration` text-matching source-map pass
- add a compile-level regression that deliberately puts `let` and its name on separate source lines, verifies both generated targets collapse the declaration, and pins the generated name to the source name
- document the constructed population that makes deletion safe despite the upstream sourcemap fixture gate measuring zero contribution
- add a compiler patch changeset

Progresses #3015.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`

Full builds and tests are delegated to CI because the local machine is under high load.