### PR TITLE
fix(compiler): map shared rune runtimes in source order

### DIFF
--- a/.changeset/quiet-rune-maps.md
+++ b/.changeset/quiet-rune-maps.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Delete the redundant rune source-map text-matching pass now that runtime identifiers carry rune spans.

--- a/.changeset/quiet-rune-maps.md
+++ b/.changeset/quiet-rune-maps.md
@@ -2,4 +2,4 @@
 '@rsvelte/compiler': patch
 ---
 
-Delete the redundant rune source-map text-matching pass now that runtime identifiers carry rune spans.
+Correct client source maps when `$state` / `$state.raw` or `$derived` / `$derived.by` share a generated runtime name.

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -2028,11 +2028,12 @@ pass at a time: `collapsed_declaration` and `rune` cost **0 segments on `main` a
 same reading is produced by "these samples contain no `$state`/`$derived`/`$props` lowering
 whose position the pass would have supplied" and by "a span now supplies it", and nothing in
 the gate separates them. Deleting a pass on a 0 therefore needs a population that fires it.
-`collapsed_declaration` now has that independent population: a compile-level regression uses
-`let` and its name on separate source lines, verifies that both client and server code
-generation collapse them, and pins the generated name to the original name after the pass
-is deleted. `rune` remains
-unproven. The earlier passes deleted in #3015 (`default_function_wrapper` 84 → 0,
+Both passes now have independent populations before deletion. The `collapsed_declaration`
+regression uses `let` and its name on separate source lines, verifies that both client and server
+code generation collapse them, and pins the generated name to the original name. The `rune`
+regression constructs all eight source/runtime pairs — including the two pairs each sharing
+`$.state` and `$.derived` — and pins both generated endpoints to the corresponding rune endpoints.
+The earlier passes deleted in #3015 (`default_function_wrapper` 84 → 0,
 `effect_callback` 8 → 0) instead carry a *movement*, which is the reading a 0 cannot give.
 
  There is no corpus-wide source-map gate to fall back on: `verify.mjs` compares generated

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -2030,9 +2030,14 @@ whose position the pass would have supplied" and by "a span now supplies it", an
 the gate separates them. Deleting a pass on a 0 therefore needs a population that fires it.
 Both passes now have independent populations before deletion. The `collapsed_declaration`
 regression uses `let` and its name on separate source lines, verifies that both client and server
-code generation collapse them, and pins the generated name to the original name. The `rune`
-regression constructs all eight source/runtime pairs — including the two pairs each sharing
-`$.state` and `$.derived` — and pins both generated endpoints to the corresponding rune endpoints.
+code generation collapse them, and pins the generated name to the original name. The first `rune`
+regression constructed all eight source/runtime pairs, but its declaration runes did not all lower
+to generated calls; making `$state` and `$state.raw` reactive exposed a wrong mapping as soon as the
+pass was removed. Those generated identifiers still come from `RawMapped` script text and have no
+span to replace the pass. The retained pass now combines source spellings that share `$.state` or
+`$.derived`, pairs them in source order, and the regression pins both generated endpoints to the
+corresponding rune endpoints. **[D]** The failed deletion is the discriminating case that a zero in
+the 29-sample gate could not supply.
 The earlier passes deleted in #3015 (`default_function_wrapper` 84 → 0,
 `effect_callback` 8 → 0) instead carry a *movement*, which is the reading a 0 cannot give.
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -301,6 +301,17 @@ pub(crate) fn transform_component_with_scripts<'source>(
                         source_token_positions,
                     )
                 };
+                let rune_mappings = if !map_pass_disabled("rune")
+                    && (source.contains("$effect")
+                        || source.contains("$state")
+                        || source.contains("$derived")
+                        || source.contains("$props")
+                        || source.contains("$bindable"))
+                {
+                    generate_rune_mappings_with_starts(&result.code, source, &mapping_starts)
+                } else {
+                    Vec::new()
+                };
                 // The printer reads one span for both brace mapping and comment
                 // resync, so a comment-bearing component cannot carry its own
                 // function braces yet.
@@ -327,6 +338,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                     + import_mappings.len()
                     + template_name_mappings.len()
                     + token_mappings.len()
+                    + rune_mappings.len()
                     + remaining_result_mappings.len();
                 let mut mappings = Vec::with_capacity(mapping_capacity);
                 mappings.extend(wrapper_mappings);
@@ -339,6 +351,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 mappings.extend(import_mappings);
                 mappings.extend(template_name_mappings);
                 mappings.extend(token_mappings);
+                mappings = merge_preferred_mappings(mappings, rune_mappings);
                 mappings.extend(remaining_result_mappings);
                 mappings
                     .sort_by(|a, b| a.gen_line.cmp(&b.gen_line).then(a.gen_col.cmp(&b.gen_col)));
@@ -1072,6 +1085,30 @@ fn is_template_element_name_mapping(
     source.as_bytes().get(source_offset.wrapping_sub(1)) == Some(&b'<')
 }
 
+fn merge_preferred_mappings(
+    mut mappings: Vec<js_ast::codegen::SourceMapping>,
+    mut preferred: Vec<js_ast::codegen::SourceMapping>,
+) -> Vec<js_ast::codegen::SourceMapping> {
+    mappings.sort_by(|a, b| a.gen_line.cmp(&b.gen_line).then(a.gen_col.cmp(&b.gen_col)));
+    preferred.sort_by(|a, b| a.gen_line.cmp(&b.gen_line).then(a.gen_col.cmp(&b.gen_col)));
+    let mut result = Vec::with_capacity(mappings.len() + preferred.len());
+    let mut preferred_index = 0;
+    for mapping in mappings {
+        while preferred_index < preferred.len()
+            && (
+                preferred[preferred_index].gen_line,
+                preferred[preferred_index].gen_col,
+            ) <= (mapping.gen_line, mapping.gen_col)
+        {
+            result.push(preferred[preferred_index].clone());
+            preferred_index += 1;
+        }
+        result.push(mapping);
+    }
+    result.extend(preferred.into_iter().skip(preferred_index));
+    result
+}
+
 /// The generated component function's braces map to the instance script tags.
 #[cfg(test)]
 fn generate_default_function_wrapper_mappings(
@@ -1697,6 +1734,72 @@ fn typescript_declaration_annotation_end(source: &str, start: usize, len: usize)
         cursor += 1;
     }
     None
+}
+
+/// Generate source mappings for rune-to-runtime transforms whose generated
+/// identifiers are still emitted by the script text rewriter.
+fn generate_rune_mappings_with_starts(
+    generated: &str,
+    source: &str,
+    starts: &MappingLineStarts,
+) -> Vec<js_ast::codegen::SourceMapping> {
+    use js_ast::codegen::offset_to_line_col_utf16;
+
+    // Some distinct source runes lower to the same generated runtime name. Pair
+    // their combined source occurrences in source order so `$state.raw` cannot
+    // claim the first `$.state` independently of an earlier `$state` (and the
+    // same for `$derived.by` / `$derived`).
+    let rune_transforms: &[(&str, &[&str])] = &[
+        ("$.user_pre_effect", &["$effect.pre"]),
+        ("$.user_effect", &["$effect"]),
+        ("$.state", &["$state", "$state.raw"]),
+        ("$.derived", &["$derived", "$derived.by"]),
+        ("$.rest_props", &["$props"]),
+        ("$.prop", &["$bindable"]),
+    ];
+
+    let gen_line_starts = &starts.generated;
+    let src_line_starts = &starts.source;
+    let mut mappings = Vec::new();
+
+    for &(gen_pattern, src_patterns) in rune_transforms {
+        let mut src_positions = Vec::new();
+        for &src_pattern in src_patterns {
+            for abs in memmem::find_iter(source.as_bytes(), src_pattern) {
+                if matches!(src_pattern, "$effect" | "$state" | "$derived")
+                    && source.as_bytes().get(abs + src_pattern.len()) == Some(&b'.')
+                {
+                    continue;
+                }
+                src_positions.push((abs, src_pattern.len()));
+            }
+        }
+        src_positions.sort_unstable_by_key(|&(position, _)| position);
+
+        for (gen_pos, &(src_pos, src_len)) in
+            memmem::find_iter(generated.as_bytes(), gen_pattern).zip(&src_positions)
+        {
+            for (generated_offset, source_offset) in [
+                (gen_pos, src_pos),
+                (gen_pos + gen_pattern.len(), src_pos + src_len),
+            ] {
+                let (gen_line, gen_col) =
+                    offset_to_line_col_utf16(generated, gen_line_starts, generated_offset);
+                let (orig_line, orig_col) =
+                    offset_to_line_col_utf16(source, src_line_starts, source_offset);
+                mappings.push(js_ast::codegen::SourceMapping {
+                    gen_line: gen_line as u32,
+                    gen_col: gen_col as u32,
+                    source: 0,
+                    orig_line: orig_line as u32,
+                    orig_col: orig_col as u32,
+                    name: None,
+                });
+            }
+        }
+    }
+
+    mappings
 }
 
 /// The legacy prop read inserted ahead of a template expression has two distinct
@@ -2616,7 +2719,7 @@ mod tests {
     }
 
     #[test]
-    fn maps_every_rune_runtime_pair_without_a_text_matching_pass() {
+    fn maps_shared_rune_runtime_names_in_source_order() {
         let source = r#"<script>
 	let state = $state(0);
 	let raw = $state.raw({});
@@ -2658,18 +2761,26 @@ mod tests {
         for (source_pattern, source_nth, generated_pattern, generated_nth) in pairs {
             let source_start = nth_offset(source, source_pattern, source_nth);
             let generated_start = nth_offset(&result.js.code, generated_pattern, generated_nth);
-            let (generated_line, generated_column) =
-                line_col_utf16(&result.js.code, generated_start);
-            let (source_line, source_column) = line_col_utf16(source, source_start);
-            assert!(
-                mappings[generated_line as usize].iter().any(|segment| {
-                    segment[..4] == [generated_column, 0, source_line, source_column]
-                }),
-                "{generated_pattern} at {generated_line}:{generated_column} did not map to \
-                 {source_pattern} at {source_line}:{source_column}: {:?}\n{}",
-                mappings[generated_line as usize],
-                result.js.code
-            );
+            for (generated_offset, source_offset) in [
+                (generated_start, source_start),
+                (
+                    generated_start + generated_pattern.len(),
+                    source_start + source_pattern.len(),
+                ),
+            ] {
+                let (generated_line, generated_column) =
+                    line_col_utf16(&result.js.code, generated_offset);
+                let (source_line, source_column) = line_col_utf16(source, source_offset);
+                assert!(
+                    mappings[generated_line as usize].iter().any(|segment| {
+                        segment[..4] == [generated_column, 0, source_line, source_column]
+                    }),
+                    "{generated_pattern} at {generated_line}:{generated_column} did not map to \
+                     {source_pattern} at {source_line}:{source_column}: {:?}\n{}",
+                    mappings[generated_line as usize],
+                    result.js.code
+                );
+            }
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -2620,6 +2620,8 @@ mod tests {
         let source = r#"<script>
 	let state = $state(0);
 	let raw = $state.raw({});
+	state = 1;
+	raw = {};
 	let derived = $derived(state);
 	let by = $derived.by(() => state);
 	let { value = $bindable(), ...rest } = $props();
@@ -2656,26 +2658,18 @@ mod tests {
         for (source_pattern, source_nth, generated_pattern, generated_nth) in pairs {
             let source_start = nth_offset(source, source_pattern, source_nth);
             let generated_start = nth_offset(&result.js.code, generated_pattern, generated_nth);
-            for (generated_offset, source_offset) in [
-                (generated_start, source_start),
-                (
-                    generated_start + generated_pattern.len(),
-                    source_start + source_pattern.len(),
-                ),
-            ] {
-                let (generated_line, generated_column) =
-                    line_col_utf16(&result.js.code, generated_offset);
-                let (source_line, source_column) = line_col_utf16(source, source_offset);
-                assert!(
-                    mappings[generated_line as usize].iter().any(|segment| {
-                        segment[..4] == [generated_column, 0, source_line, source_column]
-                    }),
-                    "{generated_pattern} at {generated_line}:{generated_column} did not map to \
-                     {source_pattern} at {source_line}:{source_column}: {:?}\n{}",
-                    mappings[generated_line as usize],
-                    result.js.code
-                );
-            }
+            let (generated_line, generated_column) =
+                line_col_utf16(&result.js.code, generated_start);
+            let (source_line, source_column) = line_col_utf16(source, source_start);
+            assert!(
+                mappings[generated_line as usize].iter().any(|segment| {
+                    segment[..4] == [generated_column, 0, source_line, source_column]
+                }),
+                "{generated_pattern} at {generated_line}:{generated_column} did not map to \
+                 {source_pattern} at {source_line}:{source_column}: {:?}\n{}",
+                mappings[generated_line as usize],
+                result.js.code
+            );
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -301,17 +301,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                         source_token_positions,
                     )
                 };
-                let rune_mappings = if !map_pass_disabled("rune")
-                    && (source.contains("$effect")
-                        || source.contains("$state")
-                        || source.contains("$derived")
-                        || source.contains("$props")
-                        || source.contains("$bindable"))
-                {
-                    generate_rune_mappings_with_starts(&result.code, source, &mapping_starts)
-                } else {
-                    Vec::new()
-                };
                 // The printer reads one span for both brace mapping and comment
                 // resync, so a comment-bearing component cannot carry its own
                 // function braces yet.
@@ -338,7 +327,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                     + import_mappings.len()
                     + template_name_mappings.len()
                     + token_mappings.len()
-                    + rune_mappings.len()
                     + remaining_result_mappings.len();
                 let mut mappings = Vec::with_capacity(mapping_capacity);
                 mappings.extend(wrapper_mappings);
@@ -351,7 +339,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 mappings.extend(import_mappings);
                 mappings.extend(template_name_mappings);
                 mappings.extend(token_mappings);
-                mappings.extend(rune_mappings);
                 mappings.extend(remaining_result_mappings);
                 mappings
                     .sort_by(|a, b| a.gen_line.cmp(&b.gen_line).then(a.gen_col.cmp(&b.gen_col)));
@@ -1712,92 +1699,6 @@ fn typescript_declaration_annotation_end(source: &str, start: usize, len: usize)
     None
 }
 
-/// Generate source mappings for rune-to-runtime transforms.
-///
-/// Svelte runes like `$effect`, `$effect.pre`, `$state`, etc. are transformed
-/// into runtime calls like `$.user_effect`, `$.user_pre_effect`, `$.state`, etc.
-/// This function creates mappings from the generated runtime call positions
-/// back to the original rune positions in the source code.
-fn generate_rune_mappings_with_starts(
-    generated: &str,
-    source: &str,
-    starts: &MappingLineStarts,
-) -> Vec<js_ast::codegen::SourceMapping> {
-    use js_ast::codegen::offset_to_line_col_utf16;
-
-    // Rune -> runtime transform pairs: (source_pattern, generated_pattern)
-    let rune_transforms: &[(&str, &str)] = &[
-        ("$effect.pre", "$.user_pre_effect"),
-        ("$effect", "$.user_effect"),
-        ("$state.raw", "$.state"),
-        ("$state", "$.state"),
-        ("$derived.by", "$.derived"),
-        ("$derived", "$.derived"),
-        ("$props", "$.rest_props"),
-        ("$bindable", "$.prop"),
-    ];
-
-    let gen_line_starts = &starts.generated;
-    let src_line_starts = &starts.source;
-    let mut mappings = Vec::new();
-
-    for &(src_pattern, gen_pattern) in rune_transforms {
-        // Find all occurrences of the generated pattern
-        let gen_positions: Vec<usize> =
-            memmem::find_iter(generated.as_bytes(), gen_pattern).collect();
-
-        // Find all occurrences of the source pattern
-        let mut src_positions: Vec<usize> = Vec::new();
-        for abs in memmem::find_iter(source.as_bytes(), src_pattern) {
-            // For patterns like "$effect" that are substrings of "$effect.pre",
-            // ensure we don't match the longer version
-            if matches!(src_pattern, "$effect" | "$state" | "$derived")
-                && abs + src_pattern.len() < source.len()
-                && source.as_bytes()[abs + src_pattern.len()] == b'.'
-            {
-                // "$effect.pre" / "$state.raw" / "$derived.by" own this position.
-                continue;
-            }
-            src_positions.push(abs);
-        }
-
-        // Match 1:1 in order
-        for (gen_pos, src_pos) in gen_positions.iter().zip(src_positions.iter()) {
-            let (gen_line, gen_col) =
-                offset_to_line_col_utf16(generated, gen_line_starts, *gen_pos);
-            let (orig_line, orig_col) = offset_to_line_col_utf16(source, src_line_starts, *src_pos);
-
-            // Start mapping
-            mappings.push(js_ast::codegen::SourceMapping {
-                gen_line: gen_line as u32,
-                gen_col: gen_col as u32,
-                source: 0,
-                orig_line: orig_line as u32,
-                orig_col: orig_col as u32,
-                name: None,
-            });
-
-            // End mapping
-            let gen_end = gen_pos + gen_pattern.len();
-            let src_end = src_pos + src_pattern.len();
-            let (gen_line_end, gen_col_end) =
-                offset_to_line_col_utf16(generated, gen_line_starts, gen_end);
-            let (orig_line_end, orig_col_end) =
-                offset_to_line_col_utf16(source, src_line_starts, src_end);
-            mappings.push(js_ast::codegen::SourceMapping {
-                gen_line: gen_line_end as u32,
-                gen_col: gen_col_end as u32,
-                source: 0,
-                orig_line: orig_line_end as u32,
-                orig_col: orig_col_end as u32,
-                name: None,
-            });
-        }
-    }
-
-    mappings
-}
-
 /// The legacy prop read inserted ahead of a template expression has two distinct
 /// source carriers: the exported binding and the expression itself.
 #[cfg(test)]
@@ -2694,6 +2595,89 @@ mod tests {
         generate_token_mappings, generate_verbatim_import_mappings,
         typescript_declaration_annotation_end,
     };
+
+    fn line_col_utf16(code: &str, offset: usize) -> (i64, i64) {
+        let before = &code[..offset];
+        let line = before.bytes().filter(|byte| *byte == b'\n').count() as i64;
+        let column = before
+            .rsplit_once('\n')
+            .map_or(before, |(_, tail)| tail)
+            .encode_utf16()
+            .count() as i64;
+        (line, column)
+    }
+
+    fn nth_offset(haystack: &str, needle: &str, nth: usize) -> usize {
+        haystack
+            .match_indices(needle)
+            .nth(nth)
+            .map(|(offset, _)| offset)
+            .unwrap_or_else(|| panic!("missing occurrence {nth} of {needle:?} in {haystack}"))
+    }
+
+    #[test]
+    fn maps_every_rune_runtime_pair_without_a_text_matching_pass() {
+        let source = r#"<script>
+	let state = $state(0);
+	let raw = $state.raw({});
+	let derived = $derived(state);
+	let by = $derived.by(() => state);
+	let { value = $bindable(), ...rest } = $props();
+	$effect(() => state);
+	$effect.pre(() => state);
+</script>
+<p>{state}{raw}{derived}{by}{value}{rest}</p>"#;
+        let result = compile(
+            source,
+            CompileOptions {
+                generate: GenerateMode::Client,
+                filename: Some("input.svelte".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let map: serde_json::Value =
+            serde_json::from_str(result.js.map.as_deref().unwrap()).unwrap();
+        let mappings =
+            crate::compiler::phases::phase3_transform::js_ast::codegen::decode_vlq_mappings(
+                map["mappings"].as_str().unwrap(),
+            );
+        let pairs = [
+            ("$state", 0, "$.state", 0),
+            ("$state.raw", 0, "$.state", 1),
+            ("$derived", 0, "$.derived", 0),
+            ("$derived.by", 0, "$.derived", 1),
+            ("$bindable", 0, "$.prop", 0),
+            ("$props", 0, "$.rest_props", 0),
+            ("$effect", 0, "$.user_effect", 0),
+            ("$effect.pre", 0, "$.user_pre_effect", 0),
+        ];
+
+        for (source_pattern, source_nth, generated_pattern, generated_nth) in pairs {
+            let source_start = nth_offset(source, source_pattern, source_nth);
+            let generated_start = nth_offset(&result.js.code, generated_pattern, generated_nth);
+            for (generated_offset, source_offset) in [
+                (generated_start, source_start),
+                (
+                    generated_start + generated_pattern.len(),
+                    source_start + source_pattern.len(),
+                ),
+            ] {
+                let (generated_line, generated_column) =
+                    line_col_utf16(&result.js.code, generated_offset);
+                let (source_line, source_column) = line_col_utf16(source, source_offset);
+                assert!(
+                    mappings[generated_line as usize].iter().any(|segment| {
+                        segment[..4] == [generated_column, 0, source_line, source_column]
+                    }),
+                    "{generated_pattern} at {generated_line}:{generated_column} did not map to \
+                     {source_pattern} at {source_line}:{source_column}: {:?}\n{}",
+                    mappings[generated_line as usize],
+                    result.js.code
+                );
+            }
+        }
+    }
 
     #[test]
     fn maps_collapsed_declarations_without_a_text_matching_pass() {

--- a/docs/phase3-ast-refactor-plan.md
+++ b/docs/phase3-ast-refactor-plan.md
@@ -674,7 +674,7 @@ Segments lost when exactly one client pass is disabled, everything else on:
 | `component_bind` | 5 | 4 |
 | `verbatim_import` | 4 | 4 |
 | `collapsed_declaration` | 0 | **0 — deleted** |
-| `rune` | 0 | 0 |
+| `rune` | 0 | **0 — deleted** |
 
 `default_function_wrapper` and `effect_callback` are deleted: both are now produced by a
 span, and the before/after column is the attribution. The other nine stay, and what each
@@ -692,13 +692,15 @@ Every row is a `Raw` fragment or a builder call that had a span available and dr
 i.e. #3015's step 1 really is the prerequisite it claims to be, and this measurement names
 which fragments to eradicate first by how many segments they hold.
 
-**`rune` costs 0 on both trees, and that is not evidence it is redundant.** It was already
-contributing nothing before this change, so deleting it cannot be attributed to the span
-work, and the gate is 29 samples — a pass that never fires in those samples is
-indistinguishable from a pass whose output is now produced elsewhere. It stays, and the
-distinction is recorded as gate-coverage 14f. `collapsed_declaration` is deleted separately:
-a compile-level regression deliberately fires its multiline-declaration predicate and pins
-the generated client and server names to the source name after the pass is gone.
+**`rune` costs 0 on both trees, and that alone is not evidence it is redundant.** It was already
+contributing nothing before this change, so deleting it cannot be attributed to the span work,
+and the gate is 29 samples — a pass that never fires in those samples is indistinguishable from
+a pass whose output is now produced elsewhere. The pass is deleted only after a separate
+compile-level population fires all eight source/runtime pairs and pins both endpoints of every
+generated runtime name to its rune. `collapsed_declaration` is likewise deleted only after a
+compile-level regression deliberately fires its multiline-declaration predicate and pins the
+generated client and server names to the source name. The distinction is recorded as
+gate-coverage 14g.
 
 ### Two hazards the change created and paid for
 

--- a/docs/phase3-ast-refactor-plan.md
+++ b/docs/phase3-ast-refactor-plan.md
@@ -674,7 +674,7 @@ Segments lost when exactly one client pass is disabled, everything else on:
 | `component_bind` | 5 | 4 |
 | `verbatim_import` | 4 | 4 |
 | `collapsed_declaration` | 0 | **0 — deleted** |
-| `rune` | 0 | **0 — deleted** |
+| `rune` | 0 | 0 |
 
 `default_function_wrapper` and `effect_callback` are deleted: both are now produced by a
 span, and the before/after column is the attribution. The other nine stay, and what each
@@ -692,15 +692,18 @@ Every row is a `Raw` fragment or a builder call that had a span available and dr
 i.e. #3015's step 1 really is the prerequisite it claims to be, and this measurement names
 which fragments to eradicate first by how many segments they hold.
 
-**`rune` costs 0 on both trees, and that alone is not evidence it is redundant.** It was already
-contributing nothing before this change, so deleting it cannot be attributed to the span work,
+**`rune` costs 0 on both measured trees, and that is not evidence it is redundant.** It was already
+contributing nothing before this change, so deleting it could not be attributed to the span work,
 and the gate is 29 samples — a pass that never fires in those samples is indistinguishable from
-a pass whose output is now produced elsewhere. The pass is deleted only after a separate
-compile-level population fires all eight source/runtime pairs and pins both endpoints of every
-generated runtime name to its rune. `collapsed_declaration` is likewise deleted only after a
-compile-level regression deliberately fires its multiline-declaration predicate and pins the
-generated client and server names to the source name. The distinction is recorded as
-gate-coverage 14g.
+a pass whose output is now produced elsewhere. A separate compile-level population initially
+appeared to permit deletion, but making `$state` and `$state.raw` reactive exposed that their
+generated `$.state` identifiers still come from `RawMapped` script text and carry no direct span;
+the same applies to `$derived` and `$derived.by`. The retained pass now combines spellings that
+share a generated runtime name and pairs their occurrences in source order, while the regression
+pins both endpoints of all eight pairs. It can be deleted only after those declarations stop
+dropping their spans. `collapsed_declaration` is deleted after its own compile-level regression
+deliberately fires the multiline-declaration predicate and pins the generated client and server
+names to the source name. The distinction is recorded as gate-coverage 14g.
 
 ### Two hazards the change created and paid for
 


### PR DESCRIPTION
Progresses #3015.

The attempted rune-pass deletion exposed that declaration runes such as `$derived` still lower through `RawMapped` text and therefore do not yet carry a direct span. This keeps the pass until Raw eradication reaches those declarations, and fixes its pairing for source spellings that share one generated runtime name:

- `$state` / `$state.raw` → `$.state`
- `$derived` / `$derived.by` → `$.derived`

The regression makes the state declarations reactive, constructs all eight rune/runtime pairs, and pins both mapped endpoints. Gate-coverage and the Phase 3 plan now record the failed deletion as the discriminating evidence that the pass is still required.

Stacked on #3855 so this PR contains only the rune-map correction.

Validation: `cargo fmt --all -- --check`; `git diff --check`. Rust build/tests are delegated to CI as requested.
