### PR TITLE
fix(compiler): delete comment wrapper map pass

### DIFF
--- a/.changeset/brave-wrappers-map.md
+++ b/.changeset/brave-wrappers-map.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Map comment-bearing client component function braces directly from AST positions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 dependencies = [
  "compact_str",
  "memchr",

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -2029,7 +2029,10 @@ same reading is produced by "these samples contain no `$state`/`$derived`/`$prop
 whose position the pass would have supplied" and by "a span now supplies it", and nothing in
 the gate separates them. Deleting a pass on a 0 therefore needs a population that fires it;
 the passes deleted in #3015 (`default_function_wrapper` 84 → 0, `effect_callback` 8 → 0)
-carry a *movement*, which is the reading a 0 cannot give.
+carry a *movement*, which is the reading a 0 cannot give. The wrapper's original deletion still
+left a comment-only fallback behind; its final regression therefore constructs a component with
+an instance comment and checks all four brace-boundary segments, a population this aggregate
+count does not identify.
 
  There is no corpus-wide source-map gate to fall back on: `verify.mjs` compares generated
  code, and the svelte2tsx map gate (§ 12) covers a different artifact.

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.145", features = ["serialize"] }
 oxc_span = "0.145"
 oxc_diagnostics = "0.145"
 oxc_codegen = "0.145"
-rsvelte_esrap = { version = "=0.10.35", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.36", path = "../rsvelte_esrap" }
 oxc_syntax = "0.145"
 oxc_semantic = "0.145"
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -414,6 +414,7 @@ pub(crate) fn print_module_program(
                         converted.loc_base,
                         None,
                         &converted.loc_map,
+                        &converted.brace_mappings,
                         &print_opts,
                     )
                     .code
@@ -2682,6 +2683,7 @@ pub(crate) fn transform_client(
                             converted.loc_base,
                             map_source,
                             &converted.loc_map,
+                            &converted.brace_mappings,
                             &print_opts,
                         );
                         super::profile::record_esrap_client_split(super::profile::timer_elapsed(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -66,7 +66,7 @@ use oxc_syntax::number::{BigintBase, NumberBase};
 use oxc_syntax::operator::{
     AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
 };
-use rsvelte_esrap::LocRange;
+use rsvelte_esrap::{BraceMapping, LocRange};
 use std::cell::RefCell;
 
 /// A converted program plus the comment coordinate space it needs to be printed
@@ -77,6 +77,7 @@ pub struct Converted<'a> {
     pub comment_source: Option<String>,
     pub loc_base: u32,
     pub loc_map: Vec<LocRange>,
+    pub brace_mappings: Vec<BraceMapping>,
 }
 
 impl<'a> Converted<'a> {
@@ -189,6 +190,7 @@ fn convert_once<'a, 'source>(
         arena,
         islands,
         synth: RefCell::new(Synth::new(loc_base)),
+        brace_mappings: RefCell::new(Vec::new()),
         component_brace_span: program
             .component_brace_span
             .as_ref()
@@ -206,6 +208,7 @@ fn convert_once<'a, 'source>(
     })?;
 
     let synth = cx.synth.into_inner();
+    let brace_mappings = cx.brace_mappings.into_inner();
     let ab = AstBuilder::new(allocator);
     let body = ArenaVec::from_iter_in(body, &ab);
     let comments = ArenaVec::from_iter_in(synth.comments.iter().cloned(), &ab);
@@ -224,6 +227,7 @@ fn convert_once<'a, 'source>(
         comment_source: synth.enabled.then(|| synth.source.clone()),
         loc_base: synth.loc_base,
         loc_map: synth.loc_map.clone(),
+        brace_mappings,
     };
     Some((converted, synth))
 }
@@ -499,6 +503,7 @@ struct Cx<'a, 'arena, 'source> {
     arena: &'arena JsArena,
     islands: &'arena [AstIsland<'source>],
     synth: RefCell<Synth>,
+    brace_mappings: RefCell<Vec<BraceMapping>>,
     /// [`JsProgram::component_brace_span`], matched by function name.
     component_brace_span: Option<(&'arena str, u32, u32)>,
 }
@@ -1195,6 +1200,12 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
         let span = if span.is_empty() {
             Span::new(start, end)
         } else {
+            self.brace_mappings.borrow_mut().push(BraceMapping {
+                body_start: span.start,
+                body_end: span.end,
+                source_start: start,
+                source_end: end,
+            });
             span
         };
         Some((stmts, span))

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -321,24 +321,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 } else {
                     Vec::new()
                 };
-                // The printer reads one span for both brace mapping and comment
-                // resync, so a comment-bearing component cannot carry its own
-                // function braces yet.
-                let wrapper_mappings = if map_pass_disabled("wrapper") {
-                    Vec::new()
-                } else {
-                    ast.instance.as_deref().map_or_else(Vec::new, |script| {
-                        generate_default_function_wrapper_mappings_with_starts(
-                            &result.code,
-                            source,
-                            script.start as usize,
-                            script.end as usize,
-                            &mapping_starts,
-                        )
-                    })
-                };
-                let mapping_capacity = wrapper_mappings.len()
-                    + bind_value_mappings.len()
+                let mapping_capacity = bind_value_mappings.len()
                     + component_bind_mappings.len()
                     + runtime_mappings.len()
                     + legacy_prop_read_mappings.len()
@@ -350,7 +333,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                     + rune_mappings.len()
                     + remaining_result_mappings.len();
                 let mut mappings = Vec::with_capacity(mapping_capacity);
-                mappings.extend(wrapper_mappings);
                 mappings.extend(bind_value_mappings);
                 mappings.extend(component_bind_mappings);
                 mappings.extend(runtime_mappings);
@@ -3108,6 +3090,64 @@ mod tests {
                     ) == expected
                 }),
                 "missing function boundary mapping {expected:?}: {mappings:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn client_maps_comment_bearing_default_function_boundaries_from_ast() {
+        let source = "<script>\n\t// keep me\n\tlet value = 1;\n</script>\n\n<p>{value}</p>";
+        let script_end = source.find("</script>").unwrap() + "</script>".len();
+        let result = compile(
+            source,
+            CompileOptions {
+                generate: GenerateMode::Client,
+                filename: Some("input.svelte".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(result.js.code.contains("// keep me"), "{}", result.js.code);
+
+        let function_start = result.js.code.find("export default function ").unwrap();
+        let open = function_start + result.js.code[function_start..].find('{').unwrap();
+        let close = result.js.code.rfind('}').unwrap();
+        let map: serde_json::Value =
+            serde_json::from_str(result.js.map.as_deref().unwrap()).unwrap();
+        let decoded =
+            crate::compiler::phases::phase3_transform::js_ast::codegen::decode_vlq_mappings(
+                map["mappings"].as_str().unwrap(),
+            );
+
+        let line_col = |text: &str, offset: usize| {
+            let prefix = &text[..offset];
+            let line = prefix.bytes().filter(|byte| *byte == b'\n').count();
+            let line_start = prefix.rfind('\n').map_or(0, |index| index + 1);
+            let column = text[line_start..offset].encode_utf16().count();
+            (line, column)
+        };
+        for (generated, original) in [
+            (open, 0),
+            (open + 1, 1),
+            (close, script_end - 1),
+            (close + 1, script_end),
+        ] {
+            let (generated_line, generated_column) = line_col(&result.js.code, generated);
+            let (original_line, original_column) = line_col(source, original);
+            assert!(
+                decoded[generated_line].iter().any(|segment| {
+                    segment.len() >= 4
+                        && segment[..4]
+                            == [
+                                generated_column as i64,
+                                0,
+                                original_line as i64,
+                                original_column as i64,
+                            ]
+                }),
+                "missing function boundary mapping {generated_line}:{generated_column} -> {original_line}:{original_column}: {}: {:?}",
+                result.js.code,
+                decoded[generated_line]
             );
         }
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
@@ -418,6 +418,7 @@ pub fn print_with_comments<'a>(
             PAD.len() as u32,
             None,
             &[],
+            &[],
             &rsvelte_esrap::PrintOptions::default(),
         )
         .code

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -40,7 +40,7 @@ mod printer;
 mod internal_tests;
 
 pub use command::Mapping;
-pub use printer::LocRange;
+pub use printer::{BraceMapping, LocRange};
 
 use oxc_ast::ast::Program;
 use oxc_span::Span;
@@ -186,6 +186,7 @@ pub fn print_split(
     loc_base: u32,
     map_source: Option<&str>,
     loc_map: &[LocRange],
+    brace_mappings: &[BraceMapping],
     options: &PrintOptions,
 ) -> PrintWithMap {
     let (comments, line_starts) = comments_and_line_starts(program, comment_source);
@@ -197,6 +198,7 @@ pub fn print_split(
             comment_source,
             map_source,
             loc_map,
+            brace_mappings,
             options,
             comments,
             line_starts,
@@ -209,6 +211,7 @@ pub fn print_split(
             comment_source,
             map_source,
             loc_map,
+            brace_mappings,
             options,
             comments,
             line_starts,
@@ -224,6 +227,7 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
     comment_source: &str,
     map_source: Option<&str>,
     loc_map: &[LocRange],
+    brace_mappings: &[BraceMapping],
     options: &PrintOptions,
     comments: Vec<printer::Cmt>,
     line_starts: Vec<u32>,
@@ -233,7 +237,7 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
         let mut printer =
             printer::Printer::<HAS_COMMENTS, true>::with_comments(options, comments, line_starts)
                 .with_placement_source(comment_source)
-                .with_split_coordinates(map_line_starts, loc_base, loc_map, false);
+                .with_split_coordinates(map_line_starts, loc_base, loc_map, brace_mappings, false);
         let mut ctx = context::Context::new_direct(&options.indent, program.source_text.len());
         printer.print_program(program, &mut ctx);
         let (buffer, returned, indent, dirty) = ctx.into_direct_parts();
@@ -247,7 +251,13 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
     let mut printer =
         printer::Printer::<HAS_COMMENTS, false>::with_comments(options, comments, line_starts)
             .with_placement_source(comment_source)
-            .with_split_coordinates(map_line_starts, loc_base, loc_map, map_source.is_some());
+            .with_split_coordinates(
+                map_line_starts,
+                loc_base,
+                loc_map,
+                brace_mappings,
+                map_source.is_some(),
+            );
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
     let capacity = ctx.measure();

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -123,6 +123,9 @@ pub struct Printer<'opt, const HAS_COMMENTS: bool = true, const DIRECT: bool = f
     /// Sorted, disjoint ranges translating a comment-space offset back to a
     /// source-map-space offset.
     loc_map: Vec<LocRange>,
+    /// Source-backed brace ranges for blocks whose ordinary span must remain in
+    /// comment space. Keyed by that ordinary body span.
+    brace_mappings: Vec<BraceMapping>,
     /// Decorator expressions have no esrap mapping visitor, so their nested
     /// tokens must stay unmapped too.
     map_nodes: bool,
@@ -143,6 +146,17 @@ pub struct LocRange {
     pub source: Option<u32>,
     /// Whether the range advances through the source byte for byte.
     pub linear: bool,
+}
+
+/// A block body whose braces map somewhere other than its comment-placement
+/// span. This lets a synthetic wrapper retain its comment island while its
+/// generated braces map to an enclosing source construct.
+#[derive(Debug, Clone, Copy)]
+pub struct BraceMapping {
+    pub body_start: u32,
+    pub body_end: u32,
+    pub source_start: u32,
+    pub source_end: u32,
 }
 
 /// esrap's `write_comment`: re-emit a comment, splitting a multi-line block
@@ -699,6 +713,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             map_line_starts: None,
             loc_base: None,
             loc_map: Vec::new(),
+            brace_mappings: Vec::new(),
             map_nodes: true,
         }
     }
@@ -723,6 +738,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             placement_source: None,
             loc_base: None,
             loc_map: Vec::new(),
+            brace_mappings: Vec::new(),
             map_nodes: true,
         }
     }
@@ -753,12 +769,14 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         map_line_starts: Vec<u32>,
         loc_base: u32,
         loc_map: &[LocRange],
+        brace_mappings: &[BraceMapping],
         emit_locations: bool,
     ) -> Self {
         self.emit_locations = emit_locations;
         self.map_line_starts = Some(map_line_starts);
         self.loc_base = Some(loc_base);
         self.loc_map = loc_map.to_vec();
+        self.brace_mappings = brace_mappings.to_vec();
         self
     }
 
@@ -940,6 +958,19 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         body_end: u32,
         open: bool,
     ) {
+        if let Some(mapping) = self
+            .brace_mappings
+            .iter()
+            .find(|mapping| mapping.body_start == body_start && mapping.body_end == body_end)
+        {
+            let span = if open {
+                Span::new(mapping.source_start, mapping.source_start + 1)
+            } else {
+                Span::new(mapping.source_end - 1, mapping.source_end)
+            };
+            self.write_node(ctx, span, if open { "{" } else { "}" });
+            return;
+        }
         if body_start >= body_end {
             ctx.write_ascii(if open { b'{' } else { b'}' });
             return;

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -123,8 +123,8 @@ pub struct Printer<'opt, const HAS_COMMENTS: bool = true, const DIRECT: bool = f
     /// Sorted, disjoint ranges translating a comment-space offset back to a
     /// source-map-space offset.
     loc_map: Vec<LocRange>,
-    /// Source-backed brace ranges for blocks whose ordinary span must remain in
-    /// comment space. Keyed by that ordinary body span.
+    /// Source-backed brace ranges for default-exported wrapper functions whose
+    /// ordinary body span must remain in comment space.
     brace_mappings: Vec<BraceMapping>,
     /// Decorator expressions have no esrap mapping visitor, so their nested
     /// tokens must stay unmapped too.
@@ -956,13 +956,10 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         ctx: &mut Context<DIRECT>,
         body_start: u32,
         body_end: u32,
+        mapping: Option<&BraceMapping>,
         open: bool,
     ) {
-        if let Some(mapping) = self
-            .brace_mappings
-            .iter()
-            .find(|mapping| mapping.body_start == body_start && mapping.body_end == body_end)
-        {
+        if let Some(mapping) = mapping {
             let span = if open {
                 Span::new(mapping.source_start, mapping.source_start + 1)
             } else {
@@ -2276,7 +2273,16 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         match &node.declaration {
             ExportDefaultDeclarationKind::FunctionDeclaration(f) => {
                 // No trailing `;` after a function declaration.
-                self.function(f, ctx);
+                let mapping = f.body.as_ref().and_then(|body| {
+                    let span = body.span();
+                    self.brace_mappings
+                        .iter()
+                        .find(|mapping| {
+                            mapping.body_start == span.start && mapping.body_end == span.end
+                        })
+                        .copied()
+                });
+                self.function_with_brace_mapping(f, mapping.as_ref(), ctx);
             }
             ExportDefaultDeclarationKind::ClassDeclaration(c) => self.class_node(c, ctx),
             ExportDefaultDeclarationKind::TSInterfaceDeclaration(d) => {
@@ -2353,6 +2359,19 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     /// esrap's `FunctionDeclaration|FunctionExpression`:
     /// `[async ]function[* ] id(params) { body }`.
     fn function(&mut self, node: &Function, ctx: &mut Context<DIRECT>) {
+        self.function_with_brace_mapping(node, None, ctx);
+    }
+
+    /// Print a function, optionally overriding the source positions of its body
+    /// braces. The override is supplied only by the default-export declaration
+    /// path, so a nested block with the same comment-space span cannot consume
+    /// the component wrapper's mapping.
+    fn function_with_brace_mapping(
+        &mut self,
+        node: &Function,
+        brace_mapping: Option<&BraceMapping>,
+        ctx: &mut Context<DIRECT>,
+    ) {
         if node.declare {
             ctx.write("declare ");
         }
@@ -2417,11 +2436,12 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             Some(body) => {
                 ctx.write_ascii(b' ');
                 let span = body.span();
-                self.block_with_directives(
+                self.block_with_directives_mapped(
                     &body.directives,
                     &body.statements,
                     span.start,
                     span.end,
+                    brace_mapping,
                     ctx,
                 );
             }
@@ -3227,6 +3247,18 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         body_end: u32,
         ctx: &mut Context<DIRECT>,
     ) {
+        self.block_with_directives_mapped(directives, body, body_start, body_end, None, ctx);
+    }
+
+    fn block_with_directives_mapped(
+        &mut self,
+        directives: &[Directive],
+        body: &[Statement],
+        body_start: u32,
+        body_end: u32,
+        brace_mapping: Option<&BraceMapping>,
+        ctx: &mut Context<DIRECT>,
+    ) {
         if !HAS_COMMENTS {
             let keep_empty = self.options.keep_empty_statements;
             let has_content = !directives.is_empty() || body.iter().any(|statement| {
@@ -3234,12 +3266,12 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                     || !matches!(statement, Statement::EmptyStatement(empty) if empty.span.end != u32::MAX)
             });
             if !has_content {
-                self.write_block_brace(ctx, body_start, body_end, true);
-                self.write_block_brace(ctx, body_start, body_end, false);
+                self.write_block_brace(ctx, body_start, body_end, brace_mapping, true);
+                self.write_block_brace(ctx, body_start, body_end, brace_mapping, false);
                 return;
             }
 
-            self.write_block_brace(ctx, body_start, body_end, true);
+            self.write_block_brace(ctx, body_start, body_end, brace_mapping, true);
             ctx.indent();
             ctx.newline();
             self.body_elems(
@@ -3253,7 +3285,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             );
             ctx.dedent();
             ctx.newline();
-            self.write_block_brace(ctx, body_start, body_end, false);
+            self.write_block_brace(ctx, body_start, body_end, brace_mapping, false);
             return;
         }
 
@@ -3273,18 +3305,18 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 .comment_at(first_comment)
                 .is_some_and(|comment| comment.start < body_end);
             if has_statement || has_comment {
-                self.write_block_brace(ctx, body_start, body_end, true);
+                self.write_block_brace(ctx, body_start, body_end, brace_mapping, true);
                 ctx.indent();
                 ctx.newline();
                 self.block_comment_island(body, body_start, body_end, ctx);
                 ctx.dedent();
                 ctx.newline();
-                self.write_block_brace(ctx, body_start, body_end, false);
+                self.write_block_brace(ctx, body_start, body_end, brace_mapping, false);
                 return;
             }
         }
 
-        self.write_block_brace(ctx, body_start, body_end, true);
+        self.write_block_brace(ctx, body_start, body_end, brace_mapping, true);
         let mark = ctx.event_mark();
         let scope = ctx.begin_scope();
         self.body_elems(
@@ -3305,7 +3337,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             ctx.dedent();
             ctx.newline();
         }
-        self.write_block_brace(ctx, body_start, body_end, false);
+        self.write_block_brace(ctx, body_start, body_end, brace_mapping, false);
     }
 
     /// esrap's `handle_var_declaration` (not the generic `sequence`): break the

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -153,9 +153,13 @@ pub struct LocRange {
 /// generated braces map to an enclosing source construct.
 #[derive(Debug, Clone, Copy)]
 pub struct BraceMapping {
+    /// Start of the wrapper body in comment-placement coordinates.
     pub body_start: u32,
+    /// End of the wrapper body in comment-placement coordinates.
     pub body_end: u32,
+    /// Source offset of the construct that owns the opening brace.
     pub source_start: u32,
+    /// Source offset immediately after the construct's closing brace.
     pub source_end: u32,
 }
 

--- a/crates/rsvelte_esrap/tests/split_coordinates.rs
+++ b/crates/rsvelte_esrap/tests/split_coordinates.rs
@@ -149,6 +149,7 @@ impl Assembled<'_> {
             self.loc_base,
             None,
             &self.loc_map,
+            &[],
             &PrintOptions::default(),
         )
         .code
@@ -161,6 +162,7 @@ impl Assembled<'_> {
             self.loc_base,
             Some(map_source),
             &self.loc_map,
+            &[],
             &PrintOptions::default(),
         )
     }
@@ -372,7 +374,16 @@ fn an_unlocated_program_keeps_its_statements_interior_comments() {
             program.span.start, 0,
             "{name}: program starts below loc_base"
         );
-        let printed = print_split(&program, source, 1, None, &[], &PrintOptions::default()).code;
+        let printed = print_split(
+            &program,
+            source,
+            1,
+            None,
+            &[],
+            &[],
+            &PrintOptions::default(),
+        )
+        .code;
         assert!(
             printed.contains(needle),
             "{name}: lost {needle} from\n{printed}"

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_client"
-version = "1.12.4"
+version = "1.5.0"
 dependencies = [
  "base64",
  "corsa_core",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_core"
-version = "1.12.4"
+version = "1.5.0"
 dependencies = [
  "base64",
  "bumpalo",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_jsonrpc"
-version = "1.12.4"
+version = "1.5.0"
 dependencies = [
  "corsa_core",
  "corsa_runtime",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_runtime"
-version = "1.12.4"
+version = "1.5.0"
 dependencies = [
  "smallvec",
 ]
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 dependencies = [
  "compact_str",
  "memchr",

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_client"
-version = "1.5.0"
+version = "1.12.4"
 dependencies = [
  "base64",
  "corsa_core",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_core"
-version = "1.5.0"
+version = "1.12.4"
 dependencies = [
  "base64",
  "bumpalo",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_jsonrpc"
-version = "1.5.0"
+version = "1.12.4"
 dependencies = [
  "corsa_core",
  "corsa_runtime",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_runtime"
-version = "1.5.0"
+version = "1.12.4"
 dependencies = [
  "smallvec",
 ]

--- a/docs/phase3-ast-refactor-plan.md
+++ b/docs/phase3-ast-refactor-plan.md
@@ -676,9 +676,12 @@ Segments lost when exactly one client pass is disabled, everything else on:
 | `collapsed_declaration` | 0 | 0 |
 | `rune` | 0 | 0 |
 
-`default_function_wrapper` and `effect_callback` are deleted: both are now produced by a
-span, and the before/after column is the attribution. The other nine stay, and what each
-still carries is a named lowering, not a mystery:
+`default_function_wrapper` and `effect_callback` are deleted: both are now produced by AST
+positions, and the before/after column is the attribution. The first wrapper change still
+retained a kill-switch-backed text pass for comment-bearing components because their block span
+also drives comment placement. The follow-up keeps that span in comment space and passes the two
+source-backed brace positions separately to the printer, so the client pass is now actually gone.
+The other nine stay, and what each still carries is a named lowering, not a mystery:
 
 | still carried by a pass | why the position is lost |
 | --- | --- |


### PR DESCRIPTION
## Summary

- carry component function brace mappings separately from comment-placement spans
- delete the retained comment-only client wrapper text-matching pass
- add a comment-bearing compile regression covering all four brace boundary segments
- correct the source-map refactor and gate-coverage documentation

Progresses #3015.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`

Full builds and tests are delegated to CI because the local machine is under heavy load.