### PR TITLE
fix(esrap): map hoisted import token boundaries

### DIFF
--- a/.changeset/curly-import-maps.md
+++ b/.changeset/curly-import-maps.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve source-map spans for hoisted client imports.

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -2056,8 +2056,8 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
 
     fn import_declaration(&mut self, node: &ImportDeclaration, ctx: &mut Context<DIRECT>) {
         if node.specifiers.as_ref().is_none_or(|v| v.is_empty()) {
-            ctx.write("import ");
-            ctx.write(Self::string_literal(&node.source));
+            self.write_keyword(ctx, node.span.start, "import", " ");
+            self.write_node(ctx, node.source.span, Self::string_literal(&node.source));
             ctx.write_ascii(b';');
             return;
         }
@@ -2075,19 +2075,23 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             }
         }
 
-        ctx.write("import ");
+        let mut kw = self.keyword_cursor(node.span.start, true);
+        kw.write(ctx, "import ");
         if import_type {
-            ctx.write("type ");
+            kw.write(ctx, "type ");
         }
         if let Some(d) = default_spec {
-            ctx.write(d.local.name.as_str());
+            self.write_node(ctx, d.span, d.local.name.as_str());
             if namespace_spec.is_some() || !named.is_empty() {
                 ctx.write_ascii_bytes(b", ");
             }
         }
         if let Some(ns) = namespace_spec {
-            ctx.write("* as ");
-            ctx.write(ns.local.name.as_str());
+            self.write_node(
+                ctx,
+                ns.span,
+                format_compact!("* as {}", ns.local.name.as_str()),
+            );
         }
         if !named.is_empty() {
             ctx.write_ascii(b'{');
@@ -2102,8 +2106,8 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                         is_elision: false,
                     }
                 },
-                |_p, s, child| {
-                    Printer::<HAS_COMMENTS, DIRECT>::import_specifier(s, child);
+                |p, s, child| {
+                    p.import_specifier(s, child);
                 },
                 None,
                 true,
@@ -2114,7 +2118,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             ctx.write_ascii(b'}');
         }
         ctx.write(" from ");
-        ctx.write(Self::string_literal(&node.source));
+        self.write_node(ctx, node.source.span, Self::string_literal(&node.source));
         Self::import_attributes(node.with_clause.as_deref(), ctx);
         ctx.write_ascii(b';');
     }
@@ -2140,7 +2144,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         ctx.write_ascii_bytes(b" }");
     }
 
-    fn import_specifier(node: &ImportSpecifier, ctx: &mut Context<DIRECT>) {
+    fn import_specifier(&self, node: &ImportSpecifier, ctx: &mut Context<DIRECT>) {
         if matches!(node.import_kind, ImportOrExportKind::Type) {
             ctx.write("type ");
         }
@@ -2154,10 +2158,10 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         if let Some(name) = imported
             && name != node.local.name.as_str()
         {
-            ctx.write(name);
+            self.write_node(ctx, node.imported.span(), name);
             ctx.write_ascii_bytes(b" as ");
         }
-        ctx.write(node.local.name.as_str());
+        self.write_node(ctx, node.local.span, node.local.name.as_str());
     }
 
     fn export_declaration(&mut self, node: &ExportDeclaration, ctx: &mut Context<DIRECT>) {

--- a/crates/rsvelte_esrap/tests/split_coordinates.rs
+++ b/crates/rsvelte_esrap/tests/split_coordinates.rs
@@ -101,6 +101,27 @@ impl<'a> Assembler<'a> {
         self.body.extend(program.body);
     }
 
+    /// A verbatim-copied chunk whose individual byte positions map back to the
+    /// corresponding bytes in the original source.
+    fn push_linear_chunk(&mut self, text: &str, maps_to: u32) {
+        let base = source_offset(self.source.len());
+        let mut padded = " ".repeat(base as usize - 1);
+        padded.push('\n');
+        padded.push_str(text);
+        let owned = self.ab.allocator().alloc_str(&padded);
+        let program = self.parse(owned);
+        self.source.push_str(text);
+        self.source.push('\n');
+        self.comments.extend(program.comments.iter().copied());
+        self.loc_map.push(LocMapEntry {
+            start: base,
+            end: base + source_offset(text.len()),
+            source: Some(maps_to),
+            linear: true,
+        });
+        self.body.extend(program.body);
+    }
+
     fn wrap_body(&mut self, span: Span) {
         let body = ArenaVec::from_iter_in(std::mem::take(&mut self.body), &self.ab);
         self.body
@@ -314,6 +335,32 @@ fn loc_map_resolves_chunk_positions_back_into_the_source() {
         assert_eq!(
             seg.source_line, 1,
             "every chunk offset maps to the anchor line: {seg:?}"
+        );
+    }
+}
+
+#[test]
+fn named_import_tokens_keep_their_linear_source_positions() {
+    let import = "import { dependency } from 'dependency';";
+    let map_source = format!("<script>\n{import}\n</script>\n");
+    let anchor = source_offset(map_source.find(import).expect("import in map source"));
+
+    let allocator = Allocator::default();
+    let mut a = Assembler::new(&allocator, 512);
+    a.push_linear_chunk(import, anchor);
+    let mapped = a.finish().print_mapped(&map_source);
+    assert_eq!(mapped.code, import);
+
+    for (generated, source) in [(0, 0), (7, 7), (9, 9), (19, 19), (27, 27), (39, 39)] {
+        assert!(
+            mapped.mappings.iter().any(|segment| {
+                segment.gen_line == 0
+                    && segment.gen_column == generated
+                    && segment.source_line == 1
+                    && segment.source_column == source
+            }),
+            "missing import token boundary {generated}->{source}: mappings={:?}",
+            mapped.mappings
         );
     }
 }


### PR DESCRIPTION
## Summary

- emit retained import keywords with the same sequential source anchors as upstream esrap
- preserve default, namespace, named-specifier, and module-string node boundaries while printing hoisted imports
- add split-coordinate coverage for every boundary of a representative named import

This is the esrap-only import-token slice stacked after #3853. The retained import construction in #3853 supplies the original spans; this PR makes the printer retain the mappings those spans carry. It addresses part of #3015 and does not close it.

## Why these boundaries

Upstream does not search the source for import punctuation. Its `import ` keyword boundary owns the generated `{` column, the named identifier's end owns the generated `}` column, and the module string's end owns the generated semicolon column. Reproducing those node-boundary writes restores the official segments without adding mappings that official omits.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`

Per repository instructions, I did not run local builds or tests; CI is the execution oracle.
