### PR TITLE
Reject arguments references in template expressions

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -370,6 +370,10 @@ pub struct VisitorContext<'a> {
     pub parent_element: Option<String>,
     /// Current function depth.
     pub function_depth: usize,
+    /// Depth inside ordinary functions while walking a template expression.
+    /// Arrow functions do not introduce their own `arguments`, but inherit one
+    /// from an enclosing ordinary function.
+    pub template_regular_function_depth: usize,
     /// Depth inside $derived(...) expressions (but not $derived.by(...)) or @const
     pub derived_function_depth: usize,
     /// Whether we have a $props() rune.
@@ -604,6 +608,7 @@ impl<'a> VisitorContext<'a> {
             bind_has_await: false,
             parent_element: None,
             function_depth: 0,
+            template_regular_function_depth: 0,
             derived_function_depth: 0,
             has_props_rune: false,
             component_slots: rustc_hash::FxHashSet::default(),

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -1229,6 +1229,13 @@ pub fn walk_js_expression_node(
         JsNode::Identifier {
             name, start, end, ..
         } => {
+            // Template expressions do not pass through the script-side
+            // Identifier visitor. `arguments` is only available inside an
+            // ordinary function; an arrow inherits it from an enclosing one.
+            if name == "arguments" && context.template_regular_function_depth == 0 {
+                return Err(super::super::super::errors::invalid_arguments_usage().at(*start, *end));
+            }
+
             // Handle legacy mode special variables
             if !context.analysis.runes {
                 if name == "$$props" {
@@ -1508,7 +1515,14 @@ pub fn walk_js_expression_node(
             body: Some(body),
             ..
         } => {
+            let introduces_arguments = matches!(
+                expression,
+                JsNode::FunctionExpression { .. } | JsNode::FunctionDeclaration { .. }
+            );
             context.function_depth += 1;
+            if introduces_arguments {
+                context.template_regular_function_depth += 1;
+            }
 
             let decl_undo_mark = context.decl_undo_log.len();
 
@@ -1598,6 +1612,9 @@ pub fn walk_js_expression_node(
                 }
             }
             context.function_depth -= 1;
+            if introduces_arguments {
+                context.template_regular_function_depth -= 1;
+            }
         }
         JsNode::FunctionExpression { body: None, .. }
         | JsNode::FunctionDeclaration { body: None, .. } => {

--- a/crates/rsvelte_core/tests/template_arguments_3707.rs
+++ b/crates/rsvelte_core/tests/template_arguments_3707.rs
@@ -1,0 +1,77 @@
+//! Regression tests for #3707: template expressions use a typed expression
+//! walker and therefore never reached the script-side `Identifier` visitor's
+//! `invalid_arguments_usage` check.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_error(
+    source: &str,
+    generate: GenerateMode,
+) -> Option<(Option<String>, Option<(u32, u32)>)> {
+    match compile(
+        source,
+        CompileOptions {
+            filename: Some("main.svelte".to_string()),
+            generate,
+            ..Default::default()
+        },
+    ) {
+        Ok(_) => None,
+        Err(error) => {
+            let diagnostic = error.diagnostic();
+            Some((diagnostic.code, diagnostic.span))
+        }
+    }
+}
+
+#[track_caller]
+fn assert_invalid_arguments(source: &str) {
+    let start = source
+        .find("arguments")
+        .expect("test case contains arguments") as u32;
+    let expected = Some((
+        Some("invalid_arguments_usage".to_string()),
+        Some((start, start + "arguments".len() as u32)),
+    ));
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        assert_eq!(
+            compile_error(source, generate),
+            expected,
+            "for {source:?} ({generate:?})"
+        );
+    }
+}
+
+#[track_caller]
+fn assert_compiles(source: &str) {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        assert_eq!(
+            compile_error(source, generate),
+            None,
+            "for {source:?} ({generate:?})"
+        );
+    }
+}
+
+#[test]
+fn template_references_to_arguments_are_rejected() {
+    assert_invalid_arguments("{arguments}");
+    assert_invalid_arguments("<p title={arguments.length}></p>");
+    assert_invalid_arguments("{#if String(arguments)}ok{/if}");
+    assert_invalid_arguments("{#each [arguments[0]] as item}{item}{/each}");
+    assert_invalid_arguments("{#if true}{@const value = arguments}<p>{value}</p>{/if}");
+    assert_invalid_arguments("{@html arguments}");
+}
+
+#[test]
+fn a_top_level_arrow_does_not_introduce_arguments() {
+    assert_invalid_arguments("{(() => arguments)()}");
+}
+
+#[test]
+fn an_ordinary_function_introduces_arguments_for_nested_arrows() {
+    assert_compiles("{(function () { return arguments; })()}");
+    assert_compiles("{(function () { return () => arguments; })()}");
+    assert_compiles("{(function (value = arguments) { return value; })()}");
+    assert_compiles("{ok}");
+}


### PR DESCRIPTION
Closes #3707.

Template expressions use the typed expression walker and bypassed the script Identifier visitor, so invalid_arguments_usage never fired there. Track ordinary-function depth in that walker: function declarations/expressions introduce arguments, arrows only inherit it.

Regression coverage checks client and server across text, attribute, if, each, const, and html hosts; it also covers top-level arrows, nested arrows, default parameters, and exact diagnostic spans.

Local verification (no local build per project workflow):
- cargo fmt --all -- --check
- git diff --check

Full validation is delegated to CI.