### PR TITLE
fix(client): read await values in declaration tags

### DIFF
--- a/compatibility/pattern-corpus/issues/3863-await-import-declaration-tag.svelte
+++ b/compatibility/pattern-corpus/issues/3863-await-import-declaration-tag.svelte
@@ -1,0 +1,32 @@
+<script>
+	import * as traverse from 'neotraverse';
+</script>
+
+{#await import('./data.json') then { default: data }}
+	{const rows = traverse.reduce(
+		data,
+		(_context, accumulator, value) => {
+			if (value && typeof value === 'object') {
+				const { name, age } = value;
+
+				if (name && age) {
+					accumulator.push({ name, age });
+				}
+			}
+
+			return accumulator;
+		},
+		[]
+	)}
+
+	<table>
+		<tbody>
+			{#each rows as { name, age } (name)}
+				<tr>
+					<td>{name}</td>
+					<td>{age}</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+{/await}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -1684,6 +1684,11 @@ pub struct ComponentClientTransformState<'a> {
     /// inside a sibling `{#if}`).
     pub transform_deep_read: ImHashMap<String, ()>,
 
+    /// Await then/catch bindings whose active read transform is `$.get(name)`.
+    /// Await fragments scope these alongside `transform`; text-based template
+    /// declaration lowering uses the set to apply the same scoped reads.
+    pub await_binding_names: ImHashMap<String, ()>,
+
     /// Names a nested template construct (`{@const}`, a snippet parameter) binds
     /// in the block being visited, shadowing an enclosing `{#each}`'s item or
     /// index of the same name. The reactivity probe and the index-usage tracker
@@ -2035,6 +2040,7 @@ impl<'a> ComponentClientTransformState<'a> {
             memoizer: Memoizer::with_scope_declarations(scope, scope_root),
             transform: ImHashMap::new(),
             transform_deep_read: ImHashMap::new(),
+            await_binding_names: ImHashMap::new(),
             each_shadowing_names: ImHashMap::new(),
             events: indexmap::IndexSet::default(),
             metadata: ComponentMetadata::default(),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
@@ -205,6 +205,7 @@ fn build_block_with_argument(
     // const then_context = { ...context, state: { ...context.state, transform: { ...context.state.transform } } };
     let saved_transform = context.state.transform.clone();
     let saved_transform_deep_read = context.state.transform_deep_read.clone();
+    let saved_await_binding_names = context.state.await_binding_names.clone();
 
     // Build the argument and declarations
     let (arg_pattern, declarations) = if let Some(pattern) = argument_pattern {
@@ -230,6 +231,7 @@ fn build_block_with_argument(
     // Restore the transform state
     context.state.transform = saved_transform;
     context.state.transform_deep_read = saved_transform_deep_read;
+    context.state.await_binding_names = saved_await_binding_names;
 
     // Log for debugging if needed
     let _ = block_type;
@@ -278,6 +280,7 @@ fn create_derived_block_argument(
         // Await then/catch bindings are template-kind in the official
         // compiler and need deep_read_state wrapping in legacy reactivity.
         context.state.transform_deep_read.insert(name.clone(), ());
+        context.state.await_binding_names.insert(name.clone(), ());
         return (Some(JsPattern::Identifier(name.into())), vec![]);
     }
 
@@ -355,6 +358,7 @@ fn create_derived_block_argument(
         );
         // Destructured await then/catch values are template-kind.
         context.state.transform_deep_read.insert(id.clone(), ());
+        context.state.await_binding_names.insert(id.clone(), ());
 
         // Build: var id = $.derived(() => $.get($$value).id)
         let get_value_call = b::call(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
@@ -118,26 +118,37 @@ pub fn declaration_tag(node: &DeclarationTag, context: &mut ComponentContext) {
     );
 
     // The instance-script pipeline wraps instance-state reads but is unaware of
-    // the enclosing each block's item bindings. Inside `{#each boxes as box}` a
-    // `{const area = box.width}` must read the reactive item as `$.get(box)`
-    // (mirroring the template-expression transform's each-item handling). Only
-    // REACTIVE each-items qualify — a non-reactive item (e.g. keyed by itself,
-    // `{#each xs as n (n)}`) stays bare. Reactive items are exactly those with a
-    // registered read transform in `context.state.transform` (each_block.rs only
-    // inserts one when `EACH_ITEM_REACTIVE` is set).
-    let reactive_each_names: Vec<String> = context
+    // reactive bindings introduced by the surrounding template scope. Inside
+    // `{#each boxes as box}`, `{const area = box.width}` must read the reactive
+    // item as `$.get(box)`. Likewise, inside
+    // `{#await promise then { default: value }}`, `{const rows = use(value)}`
+    // must read the derived await binding as `$.get(value)`. Without the latter,
+    // the declaration receives the signal object instead of the resolved value.
+    //
+    // Only reactive each-items qualify — a non-reactive item (e.g. keyed by
+    // itself, `{#each xs as n (n)}`) stays bare. Await bindings always have a
+    // registered read transform and are recorded in `await_binding_names` by
+    // await_block.rs. The OXC semantic rewrite below preserves shadowing inside
+    // callbacks declared by the initializer.
+    let mut template_get_names: Vec<String> = context
         .state
         .each_item_names
         .iter()
         .filter(|n| context.state.transform.contains_key(n.as_str()))
         .map(|n| n.to_string())
         .collect();
-    let transformed = if reactive_each_names.is_empty() {
+    for name in context.state.await_binding_names.keys() {
+        if context.state.transform.contains_key(name.as_str()) && !template_get_names.contains(name)
+        {
+            template_get_names.push(name.clone());
+        }
+    }
+    let transformed = if template_get_names.is_empty() {
         transformed
     } else {
         crate::compiler::phases::phase3_transform::client::expression_utils::wrap_state_vars_in_expr(
             &transformed,
-            &reactive_each_names,
+            &template_get_names,
             &[],
             &[],
         )

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -169,6 +169,7 @@ pub fn fragment(
         memoizer: Memoizer::with_parent_conflicts(&context.state.memoizer),
         transform: fragment_transform,
         transform_deep_read: fragment_transform_deep_read,
+        await_binding_names: context.state.await_binding_names.clone(),
         each_shadowing_names: context.state.each_shadowing_names.clone(),
         events: indexmap::IndexSet::default(), // Start empty, merge back later
         metadata: ComponentMetadata {


### PR DESCRIPTION
Closes #3863.

`{const ...}` / `{let ...}` declarations are lowered through the instance-script text transformer, which does not know about active template-scoped await bindings. Track then/catch binding names with the await visitor’s existing save/restore scope and include them in the semantic `$.get(...)` read rewrite used by declaration tags.

Adds the reported dynamic-import + destructured `default` + traversal + keyed-each shape to the pattern corpus.

Static checks only, per repository workflow on this machine:
- `cargo fmt --all -- --check`
- `git diff --check`

Build and compatibility tests are delegated to CI.