### PR TITLE
fix(sourcemap): retain copied raw token ends

### DIFF
--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -865,6 +865,29 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         Some((line, offset.saturating_sub(line_start)))
     }
 
+    /// Resolve the exclusive end of a source-backed node. A linear `LocRange`
+    /// carries a copied byte run as `[start, end)`, while an AST span also uses
+    /// `end` as the token's final source-map position. Prefer the copied run
+    /// ending at `offset` over a following range starting at the same boundary;
+    /// this matches `RawMapped`'s fallback span restorer.
+    fn map_end_position(&self, offset: u32) -> Option<(u32, u32)> {
+        if !self.loc_map.is_empty() {
+            let index = self.loc_map.partition_point(|range| range.end < offset);
+            if let Some(range) = self.loc_map.get(index)
+                && range.end == offset
+                && range.linear
+                && let Some(source) = range.source
+            {
+                let mapped = source + (offset - range.start);
+                let line_starts = self.map_line_starts.as_deref().unwrap_or(&self.line_starts);
+                let line = usize_to_u32(line_starts.partition_point(|&s| s <= mapped));
+                let line_start = line_starts[(line - 1) as usize];
+                return Some((line, mapped.saturating_sub(line_start)));
+            }
+        }
+        self.map_position(offset)
+    }
+
     /// esrap's `write_source_keyword`: bracket the literal `keyword` with
     /// source-map anchors for its exact span, so breakpoints land on the keyword.
     fn write_source_keyword(ctx: &mut Context<DIRECT>, line: u32, column: u32, keyword: &str) {
@@ -926,7 +949,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             ctx.location(line, column);
         }
         ctx.write(content);
-        if let Some((line, column)) = self.map_position(span.end) {
+        if let Some((line, column)) = self.map_end_position(span.end) {
             ctx.location(line, column);
         }
     }
@@ -3850,7 +3873,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         }
         self.call_arguments(&node.arguments, node.span().end, ctx);
         if node.span.start != 0
-            && let Some((line, column)) = self.map_position(node.span.end)
+            && let Some((line, column)) = self.map_end_position(node.span.end)
         {
             ctx.location(line, column);
         }

--- a/crates/rsvelte_esrap/tests/split_coordinates.rs
+++ b/crates/rsvelte_esrap/tests/split_coordinates.rs
@@ -334,6 +334,55 @@ fn unmapped_chunks_emit_no_source_positions() {
     );
 }
 
+#[test]
+fn linear_range_maps_a_token_end_before_a_generated_suffix() {
+    let expression = "dependency";
+    let generated = "dependency()";
+    let map_source = format!("<script>\n{expression}\n</script>\n");
+    let anchor = source_offset(
+        map_source
+            .find(expression)
+            .expect("expression in map source"),
+    );
+
+    let allocator = Allocator::default();
+    let mut a = Assembler::new(&allocator, 512);
+    let base = source_offset(a.source.len());
+    let mut padded = " ".repeat(base as usize - 1);
+    padded.push('\n');
+    padded.push_str(generated);
+    let owned = a.ab.allocator().alloc_str(&padded);
+    let program = a.parse(owned);
+    a.source.push_str(generated);
+    a.source.push('\n');
+    a.loc_map.push(LocMapEntry {
+        start: base,
+        end: base + source_offset(expression.len()),
+        source: Some(anchor),
+        linear: true,
+    });
+    a.loc_map.push(LocMapEntry {
+        start: base + source_offset(expression.len()),
+        end: base + source_offset(generated.len()),
+        source: None,
+        linear: false,
+    });
+    a.body.extend(program.body);
+
+    let mapped = a.finish().print_mapped(&map_source);
+    assert_eq!(mapped.code, "dependency();");
+    assert!(
+        mapped.mappings.iter().any(|segment| {
+            segment.gen_line == 0
+                && segment.gen_column == source_offset(expression.len())
+                && segment.source_line == 1
+                && segment.source_column == source_offset(expression.len())
+        }),
+        "missing copied token end before the generated suffix: {:?}",
+        mapped.mappings
+    );
+}
+
 /// A reassembled program's own span starts at 0 — below `loc_base` — because
 /// the `Program` node is synthesized even when its statements are not. The
 /// program-level `reset_comment_index` therefore discards the pending cursor,


### PR DESCRIPTION
Part of #3015.

Depends on #3846.

RawMapped linear ranges represent copied bytes as half-open ranges, but AST spans also use the exclusive end as a source-map boundary. The split-coordinate printer previously looked that end up as the start of the following generated range, dropping exact copied-token end mappings.

This change gives end-position lookup the same boundary ownership as the existing RawMapped fallback restorer: a copied linear range ending at the boundary wins over the following range. Start-position lookup and generated ranges are unchanged. A focused printer test covers a copied identifier followed immediately by a generated call suffix.

Validation: cargo fmt --all -- --check; git diff --check. Per project instruction, no local build or test command was run.