### PR TITLE
fix(sourcemap): retain member root identifier spans

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -64,6 +64,45 @@ fn retained_instance_script_preserves_identifier_and_literal_source_map_spans() 
 }
 
 #[test]
+fn template_member_root_identifier_preserves_source_map_span() {
+    let source = "<p>{Math.random()}</p>";
+    let result = crate::compiler::compile(
+        source,
+        crate::compiler::CompileOptions {
+            filename: Some("member-root-source-map.svelte".to_string()),
+            enable_sourcemap: true,
+            ..Default::default()
+        },
+    )
+    .expect("compiles");
+    let map: serde_json::Value =
+        serde_json::from_str(result.js.map.as_deref().expect("map")).expect("valid source map");
+    let mappings = crate::compiler::phases::phase3_transform::js_ast::codegen::decode_vlq_mappings(
+        map["mappings"].as_str().expect("VLQ mappings"),
+    );
+    let generated_line = result
+        .js
+        .code
+        .lines()
+        .position(|line| line.contains("Math.random()"))
+        .expect("template expression is printed");
+    let generated = result.js.code.lines().nth(generated_line).unwrap();
+    let root_column = generated.find("Math.random()").unwrap() as i64;
+    let line = &mappings[generated_line];
+
+    assert!(
+        line.iter()
+            .any(|segment| segment.as_slice() == [root_column, 0, 0, 4]),
+        "member root must retain its start; generated={generated:?}, segments={line:?}"
+    );
+    assert!(
+        line.iter()
+            .any(|segment| segment.as_slice() == [root_column + 4, 0, 0, 8]),
+        "member root must retain its end; generated={generated:?}, segments={line:?}"
+    );
+}
+
+#[test]
 fn own_line_comments_in_template_arrow_bodies_stay_with_the_following_statement() {
     let source = r#"<Story play={async () => {
 	// first

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -171,6 +171,21 @@ fn without_outer_source_span(expr: JsExpr, context: &ComponentContext) -> JsExpr
     }
 }
 
+/// Allocate an expression while preserving a source span out of band.
+///
+/// Member-expression consumers walk their object chain by IR variant, so a
+/// `Spanned` wrapper in object position is not semantically transparent.
+#[inline]
+fn alloc_without_outer_source_span(expr: JsExpr, context: &ComponentContext) -> ExprId {
+    match expr {
+        JsExpr::Spanned(inner, start, end) => {
+            context.arena.set_bare_expr_span(inner, start, end);
+            inner
+        }
+        other => context.arena.alloc_expr(other),
+    }
+}
+
 /// Convert a JsNode directly to JsExpr via pattern matching, bypassing serde_json::Value
 /// for simple expression types. Complex types fall back to convert_json_value.
 fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
@@ -683,11 +698,8 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
 
                 if let Some((field_type, in_constructor)) = field_info {
                     let base_object = {
-                        let __tmp = without_outer_source_span(
-                            convert_js_node(pa.get_js_node(*object), context),
-                            context,
-                        );
-                        context.arena.alloc_expr(__tmp)
+                        let converted = convert_js_node(pa.get_js_node(*object), context);
+                        alloc_without_outer_source_span(converted, context)
                     };
                     let base_member = JsExpr::Member(JsMemberExpression {
                         object: base_object,
@@ -735,7 +747,7 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
                     JsExpr::Spanned(inner, _, _)
                         if matches!(context.arena.get_expr(*inner), JsExpr::Identifier(_))
                 );
-                let converted = if is_spanned_identifier
+                if is_spanned_identifier
                     && let Some(name) = get_jsnode_identifier_name(object_node)
                     && let Some(binding) = context.state.get_binding(&name)
                     && matches!(binding.kind, BindingKind::Prop | BindingKind::BindableProp)
@@ -745,11 +757,10 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
                     )
                     && let Some(read) = context.state.transform.get(&name).and_then(|t| t.read)
                 {
-                    read(&context.arena, converted)
+                    context.arena.alloc_expr(read(&context.arena, converted))
                 } else {
-                    without_outer_source_span(converted, context)
-                };
-                context.arena.alloc_expr(converted)
+                    alloc_without_outer_source_span(converted, context)
+                }
             };
 
             let prop_node = pa.get_js_node(*property);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/arena.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/arena.rs
@@ -24,6 +24,7 @@
 //!   aliases exist
 
 use super::nodes::{JsExpr, JsStatement};
+use rustc_hash::FxHashMap;
 use std::cell::UnsafeCell;
 use std::mem::MaybeUninit;
 
@@ -96,6 +97,13 @@ impl<T> Drop for NodeStore<T> {
 pub struct JsArena {
     exprs: UnsafeCell<NodeStore<JsExpr>>,
     stmts: UnsafeCell<NodeStore<JsStatement>>,
+    /// Source spans for expressions that must remain bare IR variants.
+    ///
+    /// In particular, member-expression consumers inspect the object by
+    /// variant, so wrapping its root identifier in `JsExpr::Spanned` changes
+    /// transform semantics. Keep those uncommon spans out of band instead of
+    /// growing every expression node.
+    bare_expr_spans: UnsafeCell<Option<FxHashMap<ExprId, (u32, u32)>>>,
 }
 
 // JsArena is explicitly NOT Sync - it's single-threaded only.
@@ -111,6 +119,7 @@ impl JsArena {
         Self {
             exprs: UnsafeCell::new(NodeStore::new()),
             stmts: UnsafeCell::new(NodeStore::new()),
+            bare_expr_spans: UnsafeCell::new(None),
         }
     }
 
@@ -135,6 +144,31 @@ impl JsArena {
         unsafe {
             let store = &*self.exprs.get();
             &*store.ptr(id.0 as usize)
+        }
+    }
+
+    /// Attach a source span without changing the expression's IR variant.
+    #[inline]
+    pub fn set_bare_expr_span(&self, id: ExprId, start: u32, end: u32) {
+        // SAFETY: like node allocation, span metadata is mutated only by the
+        // single thread that owns this arena.
+        unsafe {
+            let spans = &mut *self.bare_expr_spans.get();
+            spans
+                .get_or_insert_with(FxHashMap::default)
+                .insert(id, (start, end));
+        }
+    }
+
+    /// Return an out-of-band source span, when this expression carries one.
+    #[inline]
+    pub fn bare_expr_span(&self, id: ExprId) -> Option<(u32, u32)> {
+        // SAFETY: the arena is single-threaded and callers do not retain a
+        // reference into the map across a mutation.
+        unsafe {
+            (&*self.bare_expr_spans.get())
+                .as_ref()
+                .and_then(|spans| spans.get(&id).copied())
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -1461,7 +1461,13 @@ impl<'a> JsCodegen<'a> {
         if needs_parens {
             self.output.push('(');
         }
-        self.emit_expression(object);
+        if let Some((start, end)) = self.arena.bare_expr_span(member.object) {
+            self.record_span_start(start, end);
+            self.emit_expression(object);
+            self.record_span_start(end, end);
+        } else {
+            self.emit_expression(object);
+        }
         if needs_parens {
             self.output.push(')');
         }
@@ -3219,6 +3225,36 @@ mod tests {
             offset_to_line_col_utf16(source, &starts, source.len()),
             (1, 0)
         );
+    }
+
+    #[test]
+    fn text_fallback_maps_bare_member_object_span() {
+        let arena = JsArena::new();
+        let object = arena.alloc_expr(JsExpr::Identifier("Math".into()));
+        arena.set_bare_expr_span(object, 7, 11);
+        let member = JsExpr::Member(JsMemberExpression {
+            object,
+            property: JsMemberProperty::Identifier("random".into()),
+            computed: false,
+            optional: false,
+        });
+        let program = JsProgram::with_body(vec![stmt(&arena, member)]);
+
+        let generated = generate_with_sourcemap(&program, "xxxxxxxMath.random", &arena).unwrap();
+
+        assert_eq!(generated.code, "Math.random;");
+        assert!(generated.mappings.iter().any(|mapping| {
+            mapping.gen_line == 0
+                && mapping.gen_col == 0
+                && mapping.orig_line == 0
+                && mapping.orig_col == 7
+        }));
+        assert!(generated.mappings.iter().any(|mapping| {
+            mapping.gen_line == 0
+                && mapping.gen_col == 4
+                && mapping.orig_line == 0
+                && mapping.orig_col == 11
+        }));
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -518,6 +518,18 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
         self.expr(self.arena.get_expr(id))
     }
 
+    /// Convert a member object and restore a span that could not be represented
+    /// by an in-band `Spanned` wrapper without hiding its IR variant.
+    #[inline]
+    fn member_object(&self, id: ExprId) -> Option<Expression<'a>> {
+        let mut object = self.expr_id(id)?;
+        if let Some((start, end)) = self.arena.bare_expr_span(id) {
+            *object.span_mut() = Span::new(start, end);
+            self.note_span(end);
+        }
+        Some(object)
+    }
+
     /// Run `f` and report the comment-buffer region it consumed, so a container
     /// node can span the comments its children carry (esrap brackets a body's
     /// leading/trailing comments by the body's own `loc`). [`SPAN`] when the
@@ -2134,7 +2146,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
     /// Build a [`MemberExpression`] node from the IR member expression. Shared
     /// by the `Member` expression arm and the assignment-target helper.
     fn member_expr(&self, m: &JsMemberExpression) -> Option<oxc_ast::ast::MemberExpression<'a>> {
-        let object = self.expr_id(m.object)?;
+        let object = self.member_object(m.object)?;
         let member = match &m.property {
             JsMemberProperty::Identifier(name) => {
                 let property = IdentifierName::new(SPAN, self.str(name), &self.ab);
@@ -2785,9 +2797,11 @@ mod tests {
     use super::{AstIsland, program_to_oxc, program_to_oxc_with_islands};
     use crate::ast::oxc_program::RetainedProgram;
     use crate::compiler::phases::phase3_transform::js_ast::{
-        JsArena, JsProgram, JsStatement, builders as b,
+        JsArena, JsExpr, JsMemberExpression, JsMemberProperty, JsProgram, JsStatement,
+        builders as b,
     };
     use oxc_allocator::Allocator;
+    use oxc_ast::ast::{Expression, Statement};
     use oxc_span::GetSpan;
 
     #[test]
@@ -2849,5 +2863,33 @@ mod tests {
                 .starts_with("export default function Input() {")
         );
         assert!(printed.mappings.iter().all(|mapping| mapping.gen_line != 0));
+    }
+
+    #[test]
+    fn member_object_keeps_out_of_band_identifier_span() {
+        let arena = JsArena::new();
+        let object = arena.alloc_expr(JsExpr::Identifier("Math".into()));
+        arena.set_bare_expr_span(object, 7, 11);
+        let member = JsExpr::Member(JsMemberExpression {
+            object,
+            property: JsMemberProperty::Identifier("random".into()),
+            computed: false,
+            optional: false,
+        });
+        let program = JsProgram::with_body(vec![b::stmt(&arena, member)]);
+        let allocator = Allocator::default();
+        let converted = program_to_oxc(&program, &arena, &allocator).expect("member is supported");
+
+        let Statement::ExpressionStatement(statement) = &converted.program.body[0] else {
+            panic!("expected expression statement");
+        };
+        let Expression::StaticMemberExpression(member) = &statement.expression else {
+            panic!("expected static member");
+        };
+        let Expression::Identifier(object) = &member.object else {
+            panic!("expected bare identifier object");
+        };
+        assert_eq!(object.span.start, 7);
+        assert_eq!(object.span.end, 11);
     }
 }


### PR DESCRIPTION
Part of #3015.

Depends on #3865.

## What changed

- preserve source spans for member-expression root identifiers without wrapping the object in `JsExpr::Spanned`
- store only these uncommon spans in a lazy arena side table, avoiding growth of every `JsExpr` or `JsMemberExpression`
- restore the carrier in both the OXC/esrap path and the handwritten source-map fallback
- cover the IR shape, both printers, and an end-to-end `Math.random()` template expression

This keeps downstream member-chain matchers seeing the original `Member -> Identifier` variants; an in-band wrapper in this position previously changed transform semantics.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `git show --check`

Per project instructions, no local build or test command was run; CI is the test oracle.
