### PR TITLE
Fix member rune source map boundaries

### DIFF
--- a/.changeset/fix-member-rune-map-boundaries.md
+++ b/.changeset/fix-member-rune-map-boundaries.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Preserve the full source callee span when a member rune lowers to a shorter runtime identifier.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -3282,6 +3282,35 @@ fn copied_spans_for_normalized_code(
                 continue;
             }
         }
+        // A lowering can replace a member callee with a shorter generated
+        // identifier (`$state.raw(` -> `$.state(`). The bytes before the
+        // member suffix still form a copied run, but its generated endpoint
+        // belongs to the end of the whole source callee, as in upstream's
+        // `b.id('$.state', init.callee.loc)`. Preserve that non-linear boundary
+        // as a zero-width marker; `RestoreRawMappedSpans` consumes it when it
+        // restores the generated identifier's end span, while the ordinary
+        // copied run beginning at the same byte continues to map the delimiter.
+        if skip_input > 0
+            && skip_output == 0
+            && output > 0
+            && code.as_bytes()[output - 1].is_ascii_alphanumeric()
+            && matches!(code.as_bytes().get(output), Some(b'('))
+            && matches!(stripped.as_bytes().get(input), Some(b'.'))
+            && input_tail.get(..skip_input).is_some_and(|suffix| {
+                suffix[1..]
+                    .iter()
+                    .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$')
+            })
+        {
+            let source = source_at_output
+                .as_deref()
+                .and_then(|table| table.get(input + skip_input).copied().flatten())
+                .unwrap_or(original_offset + (input + skip_input) as u32);
+            spans.push(RawMappedSpan {
+                code: output as u32..output as u32,
+                source: source..source,
+            });
+        }
         input += skip_input;
         output += skip_output;
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -2143,20 +2143,35 @@ mod tests {
             crate::compiler::phases::phase3_transform::js_ast::codegen::decode_vlq_mappings(
                 map["mappings"].as_str().unwrap(),
             );
-        for (line, column, original_line, original_column) in [
-            (16, 14, 4, 0),
-            (16, 19, 4, 6),
-            (16, 27, 4, 19),
-            (16, 30, 4, 22),
-            (16, 55, 4, 19),
-            (16, 58, 4, 22),
-            (16, 59, 4, 19),
-            (16, 62, 4, 22),
-        ] {
+        let line = result
+            .js
+            .code
+            .lines()
+            .position(|line| line.contains("$.bind_value("))
+            .expect("bind_value call is generated");
+        let generated = result.js.code.lines().nth(line).unwrap();
+        let accessor_starts = generated
+            .match_indices("foo().bar.baz")
+            .map(|(start, _)| start)
+            .collect::<Vec<_>>();
+        assert_eq!(accessor_starts.len(), 2, "generated={generated:?}");
+
+        let mut expected = vec![(14, 0), (19, 6)];
+        for start in accessor_starts {
+            expected.extend([
+                (start, 19),
+                (start + 3, 22),
+                (start + 6, 23),
+                (start + 9, 26),
+                (start + 10, 27),
+                (start + 13, 30),
+            ]);
+        }
+        for (column, original_column) in expected {
             assert!(
-                mappings[line]
-                    .iter()
-                    .any(|segment| { segment[..4] == [column, 0, original_line, original_column] }),
+                mappings[line].iter().any(|segment| {
+                    segment[..4] == [column as i64, 0, 4, original_column as i64]
+                }),
                 "missing merged mapping at {line}:{column}: {:?}",
                 mappings[line]
             );


### PR DESCRIPTION
Fixes the two rsvelte_core unit-test failures currently breaking Coverage and crates.io packages on main.\n\n- preserve the full source callee endpoint for shortened member rune runtimes such as `$state.raw` → `$.state`\n- update the bind:value source-map assertion to verify the now-restored child AST spans for both accessors\n- does not grow any compatibility baseline\n\nValidation: rustfmt check on the touched Rust files and git diff --check. Per project direction, compilation/tests are delegated to CI.