### PR TITLE
Fix runtime regressions after compiler integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,6 +478,7 @@ jobs:
         timeout-minutes: 20
         env:
           RUST_MIN_STACK: '33554432'
+          DEBUG_ALL: '1'
 
   test-thread-safety:
     name: Test thread-safety

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,7 +478,6 @@ jobs:
         timeout-minutes: 20
         env:
           RUST_MIN_STACK: '33554432'
-          DEBUG_ALL: '1'
 
   test-thread-safety:
     name: Test thread-safety

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -1762,7 +1762,12 @@ pub fn walk_js_expression_node(
             super::super::literal::visit_typed(expression, context)?;
         }
         JsNode::TaggedTemplateExpression { tag, quasi, .. } => {
-            walk_js_expression_node(arena.get_js_node(*tag), context, metadata)?;
+            let tag_node = arena.get_js_node(*tag);
+            if !is_pure_node(tag_node, context) {
+                metadata.set_has_call(true);
+                metadata.set_has_state(true);
+            }
+            walk_js_expression_node(tag_node, context, metadata)?;
             walk_js_expression_node(arena.get_js_node(*quasi), context, metadata)?;
         }
         JsNode::NewExpression {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
@@ -251,10 +251,11 @@ impl<'a, 'sem> PipelineVisitor<'a, 'sem> {
         )
     }
 
-    /// `var` rune declarations are function-scoped and may be read before
-    /// initialization. Resolve the reference's own symbol instead of reducing
-    /// this decision to a name: a same-named `let`/`const` in another scope
-    /// must continue to use `$.get`.
+    /// Nested `var` rune declarations are function-scoped and may be read
+    /// before initialization. Root-scope module/component declarations keep
+    /// the ordinary getter used by upstream. Resolve the reference's own
+    /// symbol instead of reducing this decision to a name: a same-named
+    /// `let`/`const` in another scope must continue to use `$.get`.
     fn reference_needs_safe_get(&self, ident: &IdentifierReference) -> bool {
         let Some(reference_id) = ident.reference_id.get() else {
             return false;
@@ -263,9 +264,10 @@ impl<'a, 'sem> PipelineVisitor<'a, 'sem> {
         let Some(symbol_id) = scoping.get_reference(reference_id).symbol_id() else {
             return false;
         };
-        scoping
-            .symbol_flags(symbol_id)
-            .contains(SymbolFlags::FunctionScopedVariable)
+        scoping.symbol_scope_id(symbol_id) != scoping.root_scope_id()
+            && scoping
+                .symbol_flags(symbol_id)
+                .contains(SymbolFlags::FunctionScopedVariable)
     }
 
     fn getter_for_reference(&self, ident: &IdentifierReference) -> &'static str {
@@ -634,6 +636,21 @@ mod tests {
         .unwrap();
         assert!(out.contains("return $.safe_get(value);"));
         assert!(out.ends_with("$.get(value);"));
+    }
+
+    #[test]
+    fn root_var_reads_use_get() {
+        let out = transform_state_pipeline_ast(
+            "var value = $.derived(() => 1); value;",
+            &ssv(&["value"]),
+            &[],
+            false,
+            &[],
+            &[],
+        )
+        .unwrap();
+        assert!(out.ends_with("$.get(value);"));
+        assert!(!out.contains("$.safe_get(value)"));
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -1456,6 +1456,14 @@ pub fn apply_transforms_to_expression_with_shadowed(
         }
 
         JsExpr::Sequence(seq) => {
+            // JavaScript source cannot contain a one-element SequenceExpression;
+            // this shape is synthesized by transforms such as the each-item
+            // mutation path. Its child has already been transformed, so walking
+            // it again would wrap the same mutation in another sequence.
+            if seq.expressions.len() == 1 {
+                return JsExpr::Sequence(seq.clone());
+            }
+
             let transformed_exprs: Vec<JsExpr> =
                 seq.expressions.iter().map(|e| recurse!(e)).collect();
 


### PR DESCRIPTION
Diagnostic branch for the client runtime regressions exposed by #3870. The temporary DEBUG_ALL workflow flag will be removed before merge.