### PR TITLE
Preserve comments around removed SSR inspect statements

### DIFF
--- a/.changeset/remap-inspect-empty-comments.md
+++ b/.changeset/remap-inspect-empty-comments.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve leading and trailing comments around removed SSR `$inspect` statements.

--- a/compatibility/matrix-known-failures.json
+++ b/compatibility/matrix-known-failures.json
@@ -82,19 +82,5 @@
   "comment-slot/module-script__L18__line.svelte [comment-mismatch] (server)",
   "comment-slot/module-script__L18__svelte-ignore.svelte [comment-mismatch] (client)",
   "comment-slot/module-script__L18__svelte-ignore.svelte [comment-mismatch] (client-dev)",
-  "comment-slot/module-script__L18__svelte-ignore.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__leading-block-with-paren__instance-fn__succ-stmt.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__leading-block-with-paren__instance-top__succ-none.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__leading-block__instance-fn__succ-stmt.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__leading-block__instance-top__succ-none.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__leading-line-with-brace__instance-top__succ-none.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__leading-line-with-paren__instance-top__succ-none.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__leading-line__instance-top__succ-none.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__leading-svelte-ignore__instance-top__succ-none.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__trailing-block-with-paren__instance-top__succ-none.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__trailing-block__instance-top__succ-none.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__trailing-line-with-brace__instance-top__succ-none.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__trailing-line-with-paren__instance-top__succ-none.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__trailing-line__instance-top__succ-none.svelte [comment-mismatch] (server)",
-  "removed-statement-comment/inspect__trailing-svelte-ignore__instance-top__succ-none.svelte [comment-mismatch] (server)"
+  "comment-slot/module-script__L18__svelte-ignore.svelte [comment-mismatch] (server)"
 ]

--- a/compatibility/matrix-known-failures.md
+++ b/compatibility/matrix-known-failures.md
@@ -43,9 +43,9 @@ comment carrier in `opaque-keyword` diverged on comment placement (#2990), so re
 Those entries are gone now, which is what the split was for: the family clears rather than
 carrying a key that would absorb the next regression.
 
-## Matrix known failures (`matrix-known-failures.json`, 98 entries)
+## Matrix known failures (`matrix-known-failures.json`, 84 entries)
 
-Partition of `matrix-known-failures.json` by family: `0 + 84 + 0 + 0 + 0 + 0 + 0 + 14 + 0 + 0 + 0 + 0 + 0 + 0`
+Partition of `matrix-known-failures.json` by family: `0 + 84 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0`
 
 ### `binding-position` — 0 entries
 
@@ -139,7 +139,7 @@ Partition of `matrix-known-failures.json` entries under `directive-element/` by 
 
 All 189 generated comparisons now match. #2484's three special-element dev setter cases are
 covered by the direct regression tests as well as this zero-residue matrix family.
-### `removed-statement-comment` — 14 entries
+### `removed-statement-comment` — 0 entries
 
 The family crosses statements the SERVER transform removes (`$effect`, `$effect.pre`,
 `$effect.root`, `$inspect`) with the comment slot (leading / interior / trailing), 6 comment
@@ -147,13 +147,8 @@ kinds, 3 hosts (`compileModule`, the instance script's top level, one function d
 whether a statement survives after the removed one. 396 cases, 1188 comparisons; the fix that
 landed with it cleared 79 of them (403 → 324, all on `server`).
 
-Every remaining entry is in one of the clusters below.
-
-| entries | target | cluster | issue |
-|---|---|---|---|
-| 14 | `server` | removed `$inspect` comment placement across `instance-top` and `instance-fn` | — |
 Partition of `matrix-known-failures.json` entries under `removed-statement-comment/` by
-cluster: `14`
+cluster: `0`
 
 The 24 `js-mismatch` entries were one lexical-context bug: non-dev `$inspect` removal read
 the last byte of a leading line comment as JavaScript syntax and emitted `undefined` instead
@@ -167,12 +162,14 @@ comments belonging beside an argument became statement-leading or statement-trai
 comments. The lowering now clones the original argument AST into location-less generated
 wrappers, matching upstream's builder shape and retaining the argument locations.
 
+The final 14 `server` mismatches were one location-carrier bug. The two kept empty statements
+that model upstream's removed `$inspect` residue preserved `;;`, but their sentinel spans were
+excluded from comment-region placement. Their keep marker now remains in the span end while
+the source-backed start is remapped and participates as a statement anchor, so leading and
+trailing comments stay on the removed statement's side of the following markup or statement.
+
 **[D].** It was reduced to a hand-written repro outside the family and measured against the
 pinned official compiler.
-
-Note the enrolment cost, because it is real: a ratchet entry suppresses everything about the
-entry it lists, so these 14 ids are now blind to any *further* regression on the same shapes
-until their issues are fixed.
 
 ---
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
@@ -30,7 +30,8 @@ const PAD: &str = "\n";
 const COMPONENT_BODY_MARKER: Span = Span::new(u32::MAX - 1, u32::MAX - 1);
 
 /// A deliberately-kept `EmptyStatement` (`B::empty_kept`) encodes itself in its
-/// span end, so neither pass may rewrite it.
+/// span end. Its start still carries the removed source statement's comment
+/// position, so the placement passes remap that half while preserving the tag.
 fn is_sentinel(span: Span) -> bool {
     span.end == u32::MAX
 }
@@ -186,6 +187,18 @@ pub enum Place {
 impl VisitMut<'_> for Place {
     fn visit_span(&mut self, span: &mut Span) {
         if is_sentinel(*span) {
+            span.start = match *self {
+                Place::At(at) => at,
+                Place::Shift(by) => span.start + by,
+                Place::Remap {
+                    source_start,
+                    source_end,
+                    base,
+                } if span.start >= source_start && span.start <= source_end => {
+                    base + span.start - source_start
+                }
+                Place::Remap { .. } => span.start,
+            };
             return;
         }
         match *self {
@@ -238,7 +251,12 @@ impl<'a> VisitMut<'a> for Encounter<'_> {
         // reaching it first inside an expression means the owning statement was
         // dropped and only a fragment of it was rehomed elsewhere. Empty
         // statements are filtered out by the printer, so they cannot host one.
-        self.mark(it.span(), !matches!(it, Statement::EmptyStatement(_)));
+        let span = it.span();
+        if is_sentinel(span) {
+            self.mark(Span::new(span.start, span.start), true);
+        } else {
+            self.mark(span, !matches!(it, Statement::EmptyStatement(_)));
+        }
         walk_mut::walk_statement(self, it);
     }
 
@@ -256,7 +274,14 @@ struct Remap<'m> {
 
 impl VisitMut<'_> for Remap<'_> {
     fn visit_span(&mut self, span: &mut Span) {
-        if is_sentinel(*span) || *span == COMPONENT_BODY_MARKER {
+        if is_sentinel(*span) {
+            let position = Span::new(span.start, span.start);
+            if let Some(delta) = chunk_of(self.bases, position).and_then(|i| self.shift[i]) {
+                span.start = (i64::from(span.start) + delta) as u32;
+            }
+            return;
+        }
+        if *span == COMPONENT_BODY_MARKER {
             return;
         }
         match chunk_of(self.bases, *span).and_then(|i| self.shift[i]) {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -700,12 +700,11 @@ fn register_comment_region(
     registry.register(text, &kept)
 }
 
-/// Whether an emitted statement can carry a comment region. An `EmptyStatement`
-/// cannot: a bare one is filtered out by the printer, and a kept one (`;;`) is a
-/// span sentinel that [`comments::Place`] refuses to rewrite — either way the
-/// region would go unreferenced and its comments die.
+/// Whether an emitted statement can carry a comment region. A bare
+/// `EmptyStatement` is filtered out by the printer, but a kept one (`;;`) keeps
+/// its start as the removed source statement's comment anchor.
 fn anchors_a_region(stmt: &Statement<'_>) -> bool {
-    !matches!(stmt, Statement::EmptyStatement(_))
+    !matches!(stmt, Statement::EmptyStatement(empty) if empty.span.end != u32::MAX)
 }
 
 /// Source offset the spans of a statement re-parsed from `src[start..end]` are
@@ -1182,6 +1181,10 @@ fn transform_script<'a>(
                             inspect_residue(&es.expression, es.span.start, src, true, state)
                         {
                             out.extend(residue);
+                            // Kept empty statements retain the removed statement's
+                            // source starts. Carry the whole region so their starts
+                            // are remapped alongside ordinary source-backed nodes.
+                            carried = true;
                         }
                         break 'emit;
                     }

--- a/crates/rsvelte_core/tests/server_removed_statement_comments_2567.rs
+++ b/crates/rsvelte_core/tests/server_removed_statement_comments_2567.rs
@@ -123,18 +123,54 @@ fn effect_nested_in_a_function_keeps_both_comments() {
     );
 }
 
-/// A removed `$inspect` leaves two kept `EmptyStatement` sentinels behind, and a
-/// sentinel span is exactly what the comment carry-over refuses to rewrite — so
-/// "it emitted something" is not the same question as "it emitted something that
-/// can host a region". Exact bytes are not asserted: the `;;` the sentinels print
-/// as differs from official's in whitespace alone, which every normalizer erases
-/// and which this test is not about.
+/// A removed `$inspect` leaves two kept `EmptyStatement` sentinels behind. Their
+/// end is a keep-marker, while their start is still the removed statement's
+/// comment anchor and must be remapped with the surrounding source region.
 #[test]
 fn instance_inspect_rehomes_its_leading_comment_past_the_sentinels() {
     let out = ssr(
         "<script>\n\tlet a = $state(1);\n\n\t// leading\n\t$inspect(a);\n\n\tconsole.log(2);\n</script>\n\n<p>{a}</p>\n",
     );
     assert!(out.contains("// leading"), "leading comment lost:\n{out}");
+}
+
+#[test]
+fn nested_inspect_keeps_a_leading_block_comment_on_its_own_line() {
+    let out = ssr(
+        "<script>\n\tlet a = 1;\n\n\tfunction f() {\n\t\t/* ) c */\n\t\t$inspect(a);\n\t\tconsole.log(2);\n\t}\n\n\tf();\n</script>\n<p>{a}</p>\n",
+    );
+    assert!(
+        out.find("/* ) c */").is_some_and(|comment| {
+            out.find("console.log(2)")
+                .is_some_and(|successor| comment < successor)
+        }) && !out.contains("/* ) c */ console.log(2)"),
+        "leading comment collapsed onto its successor:\n{out}"
+    );
+}
+
+#[test]
+fn final_inspect_keeps_its_leading_and_trailing_comments_before_markup() {
+    let leading =
+        ssr("<script>\n\tlet a = 1;\n\n\t// leading\n\t$inspect(a);\n</script>\n<p>{a}</p>\n");
+    assert!(
+        leading.find("// leading").is_some_and(|comment| {
+            leading
+                .find("$$renderer.push")
+                .is_some_and(|markup| comment < markup)
+        }),
+        "leading comment moved behind the rendered markup:\n{leading}"
+    );
+
+    let trailing =
+        ssr("<script>\n\tlet a = 1;\n\t$inspect(a); /* trailing */\n</script>\n<p>{a}</p>\n");
+    assert!(
+        trailing.find("/* trailing */").is_some_and(|comment| {
+            trailing
+                .find("$$renderer.push")
+                .is_some_and(|markup| comment < markup)
+        }),
+        "trailing comment moved behind the rendered markup:\n{trailing}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes the remaining removed-statement-comment compatibility residue for non-dev SSR `$inspect` lowering.

The kept empty-statement sentinels now preserve their marker while remapping their source-backed starts, allowing them to anchor comment regions. This keeps leading and trailing comments before successor statements and rendered markup.

- shrinks matrix known failures from 98 to 84
- clears all 14 remaining removed-statement-comment entries
- adds direct regressions for nested leading and top-level terminal comments
- static checks: cargo fmt --check, git diff --check, JSON uniqueness/count
- local builds/tests intentionally skipped; CI will verify