### PR TITLE
Fix remaining warning message mismatches

### DIFF
--- a/.changeset/witty-warnings-match.md
+++ b/.changeset/witty-warnings-match.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Match Svelte warning messages for namespaced self-closing elements and ARIA roles with multiple required properties.

--- a/compatibility/warning-message-known-failures.client-dev.json
+++ b/compatibility/warning-message-known-failures.client-dev.json
@@ -1,4 +1,1 @@
-[
-	"open-webui/src/lib/components/common/Tags.svelte",
-	"svelte/packages/svelte/tests/migrate/samples/self-closing-elements/input.svelte"
-]
+[]

--- a/compatibility/warning-message-known-failures.client.json
+++ b/compatibility/warning-message-known-failures.client.json
@@ -1,4 +1,1 @@
-[
-	"open-webui/src/lib/components/common/Tags.svelte",
-	"svelte/packages/svelte/tests/migrate/samples/self-closing-elements/input.svelte"
-]
+[]

--- a/compatibility/warning-message-known-failures.md
+++ b/compatibility/warning-message-known-failures.md
@@ -85,7 +85,7 @@ distinct warning codes seen         74   (of 89 in VALID_WARNING_CODES)
   — codes already agree by then. It is stripped so a code-level defect cannot leak into
   this ratchet, and so the two gates share one definition of "message".
 
-## Current baseline: `warning-message-known-failures.<target>.json`, 2 entries per target
+## Current baseline: `warning-message-known-failures.<target>.json`, 0 entries
 
 Empty because the corpus says so, not because the gate was scoped until it was. The
 first full run found **exactly one** message divergence in 14,131 entries, on all three
@@ -100,7 +100,7 @@ That is #2413, fixed by #2451, which lands before this. Re-measured against a bu
 carrying that fix, the count is **0** with the denominator unchanged at 592 — so the
 entry became a match rather than dropping out of comparison.
 
-The first entry is
+The final two entries were fixed together. The first was
 `svelte/packages/svelte/tests/migrate/samples/self-closing-elements/input.svelte`.
 All four targets agree on the warning code and position, but rsvelte renders the
 element name as `table` where upstream preserves the namespace form `f:table` in
@@ -114,6 +114,12 @@ The second arrived with the wave-2 enrolment (#3130):
 the position agree, so this ratchet is the only one that can see it — and the
 defect is in how the list is built, not in which attribute is detected, which makes
 it one fix for every role with more than one required prop.
+
+Both implementations now follow the upstream distinction directly: the local
+name is used only for void/SVG/MathML classification while the original element
+name is rendered in the warning, and a role warning renders the role's complete
+required-prop contract once any required prop is absent. The four target
+baselines therefore shrink from two entries each to zero.
 
 Every entry added later must carry a justification here naming the divergence and,
 where known, the issue tracking it.

--- a/compatibility/warning-message-known-failures.server-dev.json
+++ b/compatibility/warning-message-known-failures.server-dev.json
@@ -1,4 +1,1 @@
-[
-	"open-webui/src/lib/components/common/Tags.svelte",
-	"svelte/packages/svelte/tests/migrate/samples/self-closing-elements/input.svelte"
-]
+[]

--- a/compatibility/warning-message-known-failures.server.json
+++ b/compatibility/warning-message-known-failures.server.json
@@ -1,4 +1,1 @@
-[
-	"open-webui/src/lib/components/common/Tags.svelte",
-	"svelte/packages/svelte/tests/migrate/samples/self-closing-elements/input.svelte"
-]
+[]

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -702,7 +702,9 @@ pub fn visit<'a, 'b: 'a>(
                 && !is_mathml(node_name)
             {
                 context.emit_warning(
-                    warnings::element_invalid_self_closing_tag(node_name)
+                    // Void/SVG/MathML classification uses the local name, but
+                    // upstream preserves the source spelling in the message.
+                    warnings::element_invalid_self_closing_tag(&element.name)
                         .at(element.start, element.end),
                 );
             }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
@@ -258,18 +258,18 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
                             && !is_semantic_role_element(current_role, node.name, &attribute_map)
                             && let Some(required_props) = ROLE_REQUIRED_PROPS.get(current_role)
                         {
-                            let missing_props: Vec<&str> = if !has_spread {
-                                required_props
+                            let has_missing_props = !has_spread
+                                && required_props
                                     .iter()
-                                    .filter(|prop| !attribute_map.contains_key(**prop))
-                                    .copied()
-                                    .collect()
-                            } else {
-                                Vec::new()
-                            };
-                            if !missing_props.is_empty() {
-                                let quoted_props: Vec<String> =
-                                    missing_props.iter().map(|p| format!("\"{}\"", p)).collect();
+                                    .any(|prop| !attribute_map.contains_key(*prop));
+                            if has_missing_props {
+                                // Upstream reports the role's complete required-prop
+                                // contract once any prop is missing, rather than only
+                                // the missing subset.
+                                let quoted_props: Vec<String> = required_props
+                                    .iter()
+                                    .map(|p| format!("\"{}\"", p))
+                                    .collect();
                                 let quoted_refs: Vec<&str> =
                                     quoted_props.iter().map(|s| s.as_str()).collect();
                                 let props_list = list(&quoted_refs, "and");

--- a/crates/rsvelte_core/tests/validator_message_wording.rs
+++ b/crates/rsvelte_core/tests/validator_message_wording.rs
@@ -72,6 +72,22 @@ fn aria_token_values_are_quoted_and_joined_with_or() {
 }
 
 #[test]
+fn required_role_props_lists_the_complete_contract() {
+    assert_message(
+        "<div role=\"combobox\" aria-expanded=\"false\"></div>",
+        "Elements with the ARIA role \"combobox\" must have the following attributes defined: \"aria-controls\" and \"aria-expanded\"",
+    );
+}
+
+#[test]
+fn self_closing_warning_preserves_the_namespaced_element_name() {
+    assert_message(
+        "<f:table />",
+        "Self-closing HTML tags for non-void elements are ambiguous — use `<f:table ...></f:table>` rather than `<f:table ... />`",
+    );
+}
+
+#[test]
 fn invalid_placement_under_the_direct_parent_says_child() {
     let msgs = messages("<div><form>{#if foo}<form><input /></form>{/if}</form></div>");
     assert!(


### PR DESCRIPTION
Fixes the final two warning-message incompatibilities across all four corpus targets.\n\n- preserve namespaced element names in self-closing-tag warning prose\n- list the complete required ARIA property contract when any property is missing\n- shrink all four warning-message baselines from 2 entries to 0\n\nValidation: cargo fmt; JSON baseline checks; git diff --check. Per request, no local builds or tests were run.