### PR TITLE
Remove stale SoftShadows compatibility baselines

### DIFF
--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -91,23 +91,23 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Server dev (`known-failures.server-dev.json`, 125 entries)
+## Server dev (`known-failures.server-dev.json`, 124 entries)
 
 The `server-dev` target is the server transform with `dev: true`. It separately
 ratchets server-only development instrumentation: component metadata, element
 locations, dynamic-element validation, snippet validation, and injected CSS.
 
-Partition of `known-failures.server-dev.json` by verdict: `66 + 36 + 22 + 1`
+Partition of `known-failures.server-dev.json` by verdict: `66 + 36 + 22`
 
 - **66 — the generated JS differs.**
 - **36 — both compilers reject with a different error code.**
 - **22 — one compiler rejects and the other compiles.**
-- **1 — rsvelte's output is not JavaScript.**
 
-All 125 arrived with the wave-2 enrolment (#3130); this target was at 0 before
-it. Its JS count now matches `server`; the one extra entry is output that becomes
-unparseable only with `dev: true`, which is exactly why the target is ratcheted
-separately.
+All 124 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+it. Its counts now match `server`. The one extra entry was SoftShadows output
+that became unparseable only with `dev: true`; #3877 corrected the component
+callback tail-comment insertion point, so both its parse and output entries have
+been retired.
 
 ## Client dev (`known-failures.client-dev.json`, 477 entries)
 

--- a/compatibility/known-failures.server-dev.json
+++ b/compatibility/known-failures.server-dev.json
@@ -77,7 +77,6 @@
 	"threlte/apps/docs/src/examples/geometry/random-placement/basic-random/assets/bush.svelte",
 	"threlte/apps/docs/src/examples/xr/vr-button/assets/bush.svelte",
 	"threlte/packages/extras/src/lib/components/Detailed/Detailed.svelte",
-	"threlte/packages/extras/src/lib/components/SoftShadows/SoftShadows.svelte",
 	"threlte/packages/extras/src/lib/hooks/useViewport.svelte.ts",
 	"trakt-web/projects/client/src/lib/components/avatar-pill/AvatarPill.svelte",
 	"trakt-web/projects/client/src/lib/components/buttons/Button.svelte",

--- a/compatibility/matrix-known-failures.md
+++ b/compatibility/matrix-known-failures.md
@@ -45,7 +45,7 @@ carrying a key that would absorb the next regression.
 
 ## Matrix known failures (`matrix-known-failures.json`, 0 entries)
 
-Partition of `matrix-known-failures.json` by family: all families are at `0`.
+Partition of `matrix-known-failures.json` by family: `0`
 
 ### `binding-position` — 0 entries
 
@@ -63,6 +63,10 @@ the axis that found #2254 plus `SwitchCase.test`, class-expression field initial
 class-expression computed method keys, all fixed in #2269.
 
 ### `comment-slot` — 0 entries
+
+Partition of `matrix-known-failures.json` entries under `comment-slot/` by what diverges: `0`
+
+Partition of `matrix-known-failures.json` entries under `comment-slot/` by seed: `0`
 
 The final 20 `legacy-reactive` entries had two causes on `client` and `client-dev`.
 Leading `svelte-ignore` comments remained in the ordinary script output even though upstream's

--- a/compatibility/parse-known-failures.md
+++ b/compatibility/parse-known-failures.md
@@ -4,7 +4,7 @@ Gate: the "output parseability" section of `scripts/compat-corpus/verify.mjs`.
 Ratchet: `parse-known-failures.client.json` holds **10 entries**,
 `parse-known-failures.client-dev.json` holds **11 entries**,
 `parse-known-failures.server.json` holds **0 entries** and
-`parse-known-failures.server-dev.json` holds **1 entry**.
+`parse-known-failures.server-dev.json` holds **0 entries**.
 
 ## The question it asks
 
@@ -24,7 +24,7 @@ sources … an empty baseline here is therefore the expected result, not a measu
 was skipped."* The wave-2 enrolment (#3130) made huly, open-webui,
 carbon-components-svelte and SMUI corpus sources, along with 63 more repositories, and the
 ratchet went to **12 entries across two targets on the first run**. The current tree holds
-**12 entries across three targets** after adding one `server-dev` entry and retiring one client-only entry. That is the
+**11 entries across two targets** after retiring the server-dev entry and one client-only entry. That is the
 prediction being paid out, and it is the reason blind spot 19c in
 [`gate-coverage.md`](gate-coverage.md) is now closed for these inputs and for no others.
 
@@ -36,13 +36,12 @@ The 13, by cause — four classes, none of them a formatting difference:
 | `svelte-tweakpane-ui/…/HomeDemo.svelte`, `…/TweakpaneDemo.svelte` | `Assigning to rvalue` | a store write whose **assignment target** was rewritten to a getter call: `$point4() = […]` |
 | `sveltekit/…/query/instance.svelte.js` | `Assigning to rvalue` | the same class, on `$.get(this.#promise) ??= …` |
 | `adventurelog/…/CollectionMap.svelte`, `…/CollectionStats.svelte`, `huly/…/FilePreviewPopup.svelte`, `huly/…/ModernEditbox.svelte`, `huly/…/NavigatorCardsSection.svelte`, `photon/…/Commands.svelte`, `threlte/…/Sequence.svelte` | `Unexpected token` | **not yet diagnosed** — seven separate spots, recorded here as data rather than as a guess |
-| `threlte/…/SoftShadows.svelte` (`server-dev`) | ``Expected `,` or `)` but found `Identifier` `` | comments attached to later `$effect` statements are emitted inside the preceding derived template literal; a backtick in one comment closes the literal before `sampler2D` |
+| `threlte/…/SoftShadows.svelte` (`server-dev`, fixed by #3877) | ``Expected `,` or `)` but found `Identifier` `` | comments attached to later `$effect` statements were emitted inside the preceding derived template literal; #3877 corrected the dev component-callback tail insertion point |
 
 Ten entries appear on `client` and `client-dev` both; `huly/…/FilePreviewPopup.svelte`
-is `client-dev` only, which is the per-target split earning its keep. `server` remains at 0;
-`server-dev` has the one comment-placement
-failure above. The target split prevents that dev-only failure from suppressing the production SSR
-output.
+is `client-dev` only, which is the per-target split earning its keep. Both server targets are
+now at 0. The former target split prevented the dev-only SoftShadows failure from suppressing
+the production SSR output while it remained open.
 
 These entries are listed, not fixed, only because the enrolment PR's job was to enrol; every
 one of them breaks its consumer unconditionally and none should survive a burn-down.

--- a/compatibility/parse-known-failures.server-dev.json
+++ b/compatibility/parse-known-failures.server-dev.json
@@ -1,3 +1,1 @@
-[
-	"threlte/packages/extras/src/lib/components/SoftShadows/SoftShadows.svelte"
-]
+[]


### PR DESCRIPTION
#3877 fixed the server-dev component-tail comment placement that made SoftShadows output unparseable, but the wave-2 corpus ratchets were not remeasured.\n\n- shrink server-dev parse failures from 1 to 0\n- shrink server-dev output failures from 125 to 124\n- restore the required zero-count matrix documentation partitions\n\nValidation: known-failures-md-check (49 ratchets and 30 partitions); JSON length checks; git diff --check. No local build or test run.