### PR TITLE
Keep compatibility verify observable after esrap failure

### DIFF
--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -257,6 +257,12 @@ jobs:
         run: node scripts/compat-corpus/esrap-verify.mjs
 
       - name: Verify (oxfmt-normalized outputs must be identical)
+        # Keep the independent output/diagnostic/parseability gates observable
+        # when the preceding esrap gate fails. In particular, report.json is
+        # the only retained artifact that records the parser error for each
+        # known-unparseable output; skipping this step leaves that burn-down
+        # with ids but no generated-code location.
+        if: ${{ !cancelled() }}
         run: node scripts/compat-corpus/verify.mjs
 
       # Gate 3 (#2281): the corpus entries as a SEED set, not a test set. Runs


### PR DESCRIPTION
Run the independent output, diagnostic, and parseability verifier even when the preceding esrap gate fails (unless the job was cancelled). This ensures report.json retains parser errors for the remaining known-unparseable outputs and prevents one compatibility gate from masking another.\n\nValidation: git diff --check only; per project instruction, no local build or test was run.