### PR TITLE
Keep svelte2tsx compatibility gate observable

### DIFF
--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -288,11 +288,16 @@ jobs:
           retention-days: 14
 
       - name: Convert corpus to TSX (official svelte2tsx + rsvelte)
+        # This is an independent compatibility surface. Keep it observable when
+        # an earlier compiler gate fails; otherwise its report and the concrete
+        # error behind a `map-missing` entry are never produced.
+        if: ${{ !cancelled() }}
         run: node scripts/compat-corpus/svelte2tsx-compile.mjs
 
       # One invocation, two ratchets: TSX text parity against official
       # svelte2tsx, and structural validity of the source map each side returns.
       - name: Verify svelte2tsx (oxfmt-normalized TSX + source maps)
+        if: ${{ !cancelled() }}
         run: node scripts/compat-corpus/svelte2tsx-verify.mjs
 
       # Synthetic combinatorial sweep of unused-CSS pruning — catches


### PR DESCRIPTION
## Summary
- run the independent svelte2tsx conversion and verification after earlier compatibility failures
- preserve the svelte2tsx report needed to diagnose the remaining TSX and source-map ratchets

## Verification
- `git diff --check`
- local builds/tests intentionally skipped to avoid loading the development machine; CI remains the execution oracle