### PR TITLE
Fix duplicate-column source map parity

### DIFF
--- a/compatibility/sourcemap-known-failures.json
+++ b/compatibility/sourcemap-known-failures.json
@@ -1,5 +1,1 @@
-[
-  "map-parity\tattached-sourcemap\tclient\t1",
-  "map-parity\tattached-sourcemap\tserver\t1",
-  "map-parity\teffects\tserver\t1"
-]
+[]

--- a/compatibility/sourcemap-known-failures.md
+++ b/compatibility/sourcemap-known-failures.md
@@ -15,7 +15,7 @@ each sample's recorded `metadata.json` still says exactly that).
 | `map-parity` | `map-parity\t<sample>\t<target>\t<count>` | budget: official map segments that rsvelte does not reproduce, where the generated code is byte-identical (missing + wrong) |
 | `out-of-range` | `out-of-range\t<sample>\t<target>\t<count>` | budget: out-of-range segments not also emitted by the official map at the same generated and original position |
 
-**Current baseline: `sourcemap-known-failures.json`, 3 entries.** The
+**Current baseline: `sourcemap-known-failures.json`, 0 entries.** The
 before/after tables further down record what one specific change did at the time
 it landed; they are history, not the current size. Reading the newest number in
 those tables as today's count is the mistake this line exists to prevent — the
@@ -208,20 +208,13 @@ entries to 3, with the `anchor` and `out-of-range` classes eliminated entirely.
 
 No entry is accepted as correct behaviour; all are burndown targets.
 
-- **`map-parity` (3)** — `attached-sourcemap` on `client` and `server`, and
-  `effects` on `server`; one segment each. All three are the same shape: rsvelte
-  emits *two* segments at one generated column, and the one the official map
-  agrees with is the second. The gate compares the first segment at a generated
-  column (upstream's own resolution rule), so the extra leading segment scores as
-  `wrong`. The surplus segment comes from the merge in
-  `3_transform/mod.rs::merge_preferred_mappings`, which interleaves two
-  independently produced mapping lists and can leave both at one position.
+There are currently no known failures.
 
-  Collapsing duplicates at the encoder was tried and rejected: keeping the *last*
-  segment fixes these three and breaks eight server entries that need the first,
-  and keeping the first does the reverse. Neither order is correct, because the
-  merged list combines producers whose emission order does not encode precedence
-  — the fix is to stop emitting the surplus segment at its source, not to pick a
-  winner afterwards. Deliberately *not* worked around by relaxing the comparison
-  to "any segment at this column matches": that would also stop the gate seeing a
-  genuinely mis-anchored token.
+The last three entries were a comparison defect rather than compiler defects.
+The official maps themselves contain two source-backed segments at one generated
+column in `attached-sourcemap` (client and server) and `effects` (server). The gate
+iterated both official segments but compared each one with the first rsvelte
+segment at that column, so even identical ordered pairs necessarily scored one
+`wrong`. Parity now compares the first segment with the first, the second with the
+second, and so on. This is deliberately stricter than accepting any matching
+segment: an extra leading segment shifts every occurrence and remains visible.

--- a/crates/rsvelte_core/tests/sourcemaps_gate.rs
+++ b/crates/rsvelte_core/tests/sourcemaps_gate.rs
@@ -579,14 +579,23 @@ fn snippet(text: &str, line: usize, col: usize, len: usize) -> String {
 
 fn explain_parity(key: &str, theirs: &DecodedMap, ours: &DecodedMap, generated: &str, src: &str) {
     for (line_no, line) in theirs.lines.iter().enumerate() {
+        let mut previous_column = None;
+        let mut occurrence = 0;
         for segment in line {
             if segment.len() < 4 {
                 continue;
             }
-            let mine = ours
-                .lines
-                .get(line_no)
-                .and_then(|l| l.iter().find(|s| s[0] == segment[0] && s.len() >= 4));
+            if previous_column == Some(segment[0]) {
+                occurrence += 1;
+            } else {
+                previous_column = Some(segment[0]);
+                occurrence = 0;
+            }
+            let mine = ours.lines.get(line_no).and_then(|l| {
+                l.iter()
+                    .filter(|s| s.len() >= 4 && s[0] == segment[0])
+                    .nth(occurrence)
+            });
             let gen_text = snippet(generated, line_no, segment[0] as usize, 24);
             let want = snippet(src, segment[2] as usize, segment[3] as usize, 24);
             match mine {
@@ -610,14 +619,23 @@ fn explain_parity(key: &str, theirs: &DecodedMap, ours: &DecodedMap, generated: 
 fn parity(theirs: &DecodedMap, ours: &DecodedMap) -> Parity {
     let mut p = Parity::default();
     for (line_no, line) in theirs.lines.iter().enumerate() {
+        let mut previous_column = None;
+        let mut occurrence = 0;
         for segment in line {
             if segment.len() < 4 {
                 continue;
             }
-            let mine = ours
-                .lines
-                .get(line_no)
-                .and_then(|l| l.iter().find(|s| s[0] == segment[0] && s.len() >= 4));
+            if previous_column == Some(segment[0]) {
+                occurrence += 1;
+            } else {
+                previous_column = Some(segment[0]);
+                occurrence = 0;
+            }
+            let mine = ours.lines.get(line_no).and_then(|l| {
+                l.iter()
+                    .filter(|s| s.len() >= 4 && s[0] == segment[0])
+                    .nth(occurrence)
+            });
             match mine {
                 None => p.missing += 1,
                 Some(m) if m[1..4] == segment[1..4] => p.exact += 1,
@@ -1176,4 +1194,31 @@ fn astral_original_columns_are_in_range_in_utf16_units() {
     };
 
     assert_eq!(out_of_range(&map, source), (0, 1));
+}
+
+#[test]
+fn parity_compares_duplicate_generated_columns_by_occurrence() {
+    let official = DecodedMap {
+        sources: Vec::new(),
+        sources_content: Vec::new(),
+        lines: vec![vec![vec![3, 0, 1, 2], vec![3, 0, 4, 5]]],
+    };
+    let identical = DecodedMap {
+        sources: Vec::new(),
+        sources_content: Vec::new(),
+        lines: official.lines.clone(),
+    };
+    let extra_leading = DecodedMap {
+        sources: Vec::new(),
+        sources_content: Vec::new(),
+        lines: vec![vec![vec![3, 0, 0, 0], vec![3, 0, 1, 2], vec![3, 0, 4, 5]]],
+    };
+
+    let identical_result = parity(&official, &identical);
+    assert_eq!(identical_result.exact, 2);
+    assert_eq!(identical_result.bad(), 0);
+
+    let shifted_result = parity(&official, &extra_leading);
+    assert_eq!(shifted_result.exact, 0);
+    assert_eq!(shifted_result.wrong, 2);
 }


### PR DESCRIPTION
## Summary
- compare duplicate source-map segments at the same generated column by occurrence
- keep extra leading segments observable instead of accepting any match
- remove the final 3 source-map compatibility baseline entries

## Validation
- cargo fmt --all -- --check
- git diff --check
- JSON parse
- known-failures markdown consistency check

Local builds/tests were intentionally not run per project instruction; CI is the execution oracle.