### PR TITLE
Fix slash classification in template expressions

### DIFF
--- a/compatibility/pattern-corpus/adversarial/expressions/regex-literal-shapes.svelte
+++ b/compatibility/pattern-corpus/adversarial/expressions/regex-literal-shapes.svelte
@@ -18,3 +18,11 @@
 <b>{lookahead.source}{lookbehind.source}</b>
 <b>{unicodeProp.source}{braceInside.source}</b>
 <b>{divisionNotRegex}{afterParen}</b>
+
+<!-- Template expressions use the Svelte bracket scanner before the JS parser.
+     A slash inside a regex character class is data, not the literal's end. -->
+<button
+  onclick={() => {
+    v = v.replace(/(^https?:\/\/[^/]+)\/*$/i, '$1');
+  }}>normalize</button
+>

--- a/compatibility/pattern-corpus/adversarial/typescript/non-null-division-in-attribute.svelte
+++ b/compatibility/pattern-corpus/adversarial/typescript/non-null-division-in-attribute.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  let duration: number | undefined = $state(1000);
+</script>
+
+<!-- A postfix non-null assertion ends an operand. The following slash is
+     division, while the slash after prefix logical-not below opens a regex. -->
+<output data-seconds={duration! / 1000}>
+  {!/negative/.test(String(duration))}
+</output>

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/utils/bracket.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/utils/bracket.rs
@@ -47,7 +47,32 @@ fn find_string_end(string: &str, search_start_index: usize, string_start_char: u
 /// # Returns
 /// The index of the end of this regex expression, or `usize::MAX` if not found
 fn find_regex_end(string: &str, search_start_index: usize) -> usize {
-    find_unescaped_char(string, search_start_index, b'/')
+    let bytes = string.as_bytes();
+    let mut i = search_start_index;
+    let mut in_character_class = false;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            // An escape consumes the following byte both inside and outside a
+            // character class. In particular, `\]` must not close the class.
+            b'\\' => i += 2,
+            b'[' if !in_character_class => {
+                in_character_class = true;
+                i += 1;
+            }
+            b']' if in_character_class => {
+                in_character_class = false;
+                i += 1;
+            }
+            // A slash inside `[...]` is data, not the regex delimiter.
+            b'/' if !in_character_class => return i,
+            // JavaScript regex literals cannot contain a bare line terminator.
+            b'\n' | b'\r' => return usize::MAX,
+            _ => i += 1,
+        }
+    }
+
+    usize::MAX
 }
 
 /// Find the closing backtick of a template literal, properly handling `${...}`
@@ -378,5 +403,28 @@ mod tests {
         assert_eq!(find_matching_bracket("{width/4}", 1, '{'), Some(8));
         assert_eq!(find_matching_bracket("{width/4*3}", 1, '{'), Some(10));
         assert_eq!(find_matching_bracket("{a + b/c}", 1, '{'), Some(8));
+
+        let non_null = "{asset.duration! / 1000}";
+        assert_eq!(
+            find_matching_bracket(non_null, 1, '{'),
+            Some(non_null.len() - 1)
+        );
+    }
+
+    #[test]
+    fn test_find_matching_bracket_with_slash_in_regex_character_class() {
+        let expression = r#"{v.replace(/(^wss:\/\/[^/]+)\/*$/i, '$1')}"#;
+        assert_eq!(
+            find_matching_bracket(expression, 1, '{'),
+            Some(expression.len() - 1)
+        );
+
+        // Escaped class closers do not expose a following slash as the regex
+        // delimiter either.
+        let escaped_close = r#"{/[[\]/}]+/.test(value)}"#;
+        assert_eq!(
+            find_matching_bracket(escaped_close, 1, '{'),
+            Some(escaped_close.len() - 1)
+        );
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
@@ -151,6 +151,26 @@ pub(crate) fn slash_starts_regex_at(bytes: &[u8], i: usize, prev: Option<u8>) ->
     if token_visible && end >= 2 && matches!(&bytes[end - 2..end], b"++" | b"--") {
         return false;
     }
+    // In TypeScript, a postfix non-null assertion also ends an operand:
+    // `value! / 2`. A bare byte test reads every slash after `!` as a regex
+    // opener and can make a template-expression scanner swallow the rest of
+    // the component. Distinguish it from prefix logical not (`! /re/.test(x)`)
+    // by asking whether the token before `!` can itself end an operand.
+    if token_visible && bytes[end - 1] == b'!' {
+        let mut before = end - 1;
+        while before > 0 && bytes[before - 1].is_ascii_whitespace() {
+            before -= 1;
+        }
+        if before > 0
+            && matches!(
+                bytes[before - 1],
+                c if c.is_ascii_alphanumeric()
+                    || matches!(c, b'_' | b'$' | b')' | b']' | b'}' | b'\'' | b'"' | b'`')
+            )
+        {
+            return false;
+        }
+    }
     if slash_starts_regex(prev) {
         return true;
     }
@@ -844,6 +864,16 @@ mod tests {
         assert!(!decide("f(x) /"));
         assert!(!decide("arr[0] /"));
         assert!(!decide("1 /"));
+        assert!(!decide("value! /"));
+        assert!(!decide("call()! /"));
+        assert!(!decide("value!\n/"));
+    }
+
+    #[test]
+    fn a_regex_after_prefix_logical_not_is_still_a_regex() {
+        assert!(decide("! /"));
+        assert!(decide("return ! /"));
+        assert!(decide("x && ! /"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes two independent template lexical scanner incompatibilities found in collected corpus entries:

- regex delimiters now ignore `/` inside character classes, so callbacks containing patterns such as `[^/]` keep their closing brace
- `/` after a TypeScript postfix non-null assertion is division, while `/` after prefix logical-not remains a regex literal

Adds focused unit coverage and pattern-corpus regressions for both shapes.

Local builds/tests were intentionally not run per request. Static validation passed: `cargo fmt --all -- --check` and `git diff --check`.