### PR TITLE
Fix module tail comment borrow

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/module_tail_comment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/module_tail_comment.rs
@@ -31,7 +31,7 @@ pub(crate) fn rehome(
         return code;
     };
     let close = open + 1 + relative_close;
-    let params = code[open + 1..close].trim();
+    let params = code[open + 1..close].trim().to_owned();
     if params.is_empty() || code[open + 1..close].contains(comment) {
         return code;
     }


### PR DESCRIPTION
Fixes the Rust borrow error in module-tail comment rehoming by owning the trimmed parameter text before moving the generated code string.\n\nDetected by main CI after #3881.\n\nChecks: cargo fmt --all -- --check; git diff --check. Heavy local builds/tests intentionally skipped.