### PR TITLE
Show generated source for parse failures

### DIFF
--- a/scripts/compat-corpus/parseable.mjs
+++ b/scripts/compat-corpus/parseable.mjs
@@ -31,9 +31,9 @@ import { Parser } from 'acorn';
 export const OPTIONS = { ecmaVersion: 'latest', sourceType: 'module', allowHashBang: true };
 
 /**
- * `null` when `code` parses, otherwise a one-line reason including the position
- * acorn reported. Never throws: a parser crash is reported as a failure rather
- * than taking the run down.
+ * `null` when `code` parses, otherwise a reason including the position and the
+ * generated source line acorn rejected. Never throws: a parser crash is
+ * reported as a failure rather than taking the run down.
  */
 export function parseFailure(code) {
 	try {
@@ -43,6 +43,17 @@ export function parseFailure(code) {
 		const at = e?.loc ? ` (${e.loc.line}:${e.loc.column})` : '';
 		// acorn already appends `(line:col)`; only add one when it did not.
 		const message = String(e?.message ?? e);
-		return message.includes('(') ? message : message + at;
+		const reason = message.includes('(') ? message : message + at;
+		if (!e?.loc) return reason;
+
+		const line = code.split(/\r?\n/)[e.loc.line - 1];
+		if (line === undefined) return reason;
+
+		const gutter = String(e.loc.line);
+		// Acorn's column is zero-based. Expand tabs in the prefix so the caret
+		// still points at the rejected token in a terminal or CI log.
+		const prefix = line.slice(0, e.loc.column).replaceAll('\t', '  ');
+		const displayedLine = line.replaceAll('\t', '  ');
+		return `${reason}\n${gutter} | ${displayedLine}\n${' '.repeat(gutter.length)} | ${' '.repeat(prefix.length)}^`;
 	}
 }

--- a/scripts/dev/test-corpus-parse-gate.mjs
+++ b/scripts/dev/test-corpus-parse-gate.mjs
@@ -175,6 +175,11 @@ console.log('\nthe OUTPUT ratchet does not suppress it (the whole reason for a s
 	check('exit 1 despite e7 being a known output failure', r.status === 1, `status ${r.status}\n${r.stdout.slice(-800)}`);
 	check('names the entry', /e7/.test(r.stdout), r.stdout.slice(-600));
 	check('reported as an output-parseability failure', /NEW output-parseability failures/.test(r.stdout), r.stdout.slice(-600));
+	check(
+		'includes the rejected generated source line and caret',
+		/1 \| export default foo\(bar\n  \| +\^/.test(r.stdout),
+		r.stdout.slice(-600),
+	);
 	restore();
 }
 


### PR DESCRIPTION
## Summary
- include the rejected generated source line and caret in Acorn parse diagnostics
- preserve the diagnostic in report.json for known failures
- guard the diagnostic in the synthetic parse-gate test

## Verification
- git diff --check
- local builds/tests intentionally skipped to avoid machine load; CI is the execution oracle