### PR TITLE
fix(sourcemap): preserve identical segment occurrences

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -255,21 +255,10 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 mappings.extend(remaining_result_mappings);
                 mappings
                     .sort_by(|a, b| a.gen_line.cmp(&b.gen_line).then(a.gen_col.cmp(&b.gen_col)));
-                // A source map may deliberately carry several segments at the
-                // same generated column. Esrap does this when a container and
-                // its first located child begin together (for example `let`
-                // and the declared identifier), and their order is observable
-                // by source-map consumers. Only remove byte-for-byte duplicate
-                // mappings; collapsing by generated position loses the child's
-                // more precise source location.
-                mappings.dedup_by(|a, b| {
-                    a.gen_line == b.gen_line
-                        && a.gen_col == b.gen_col
-                        && a.source == b.source
-                        && a.orig_line == b.orig_line
-                        && a.orig_col == b.orig_col
-                        && a.name == b.name
-                });
+                // Do not deduplicate source-map segments. Esrap deliberately
+                // emits identical entries when a container and its first child
+                // begin at the same generated and original positions. Their
+                // occurrence count and order are observable by consumers.
                 (result.code, mappings)
             } else {
                 (result.code, Vec::new())
@@ -327,14 +316,8 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 ));
                 mappings
                     .sort_by(|a, b| a.gen_line.cmp(&b.gen_line).then(a.gen_col.cmp(&b.gen_col)));
-                mappings.dedup_by(|a, b| {
-                    a.gen_line == b.gen_line
-                        && a.gen_col == b.gen_col
-                        && a.source == b.source
-                        && a.orig_line == b.orig_line
-                        && a.orig_col == b.orig_col
-                        && a.name == b.name
-                });
+                // Preserve repeated entries for the same reason as the client
+                // path above: a duplicate can represent a distinct AST level.
                 (code, mappings)
             } else {
                 (code, Vec::new())


### PR DESCRIPTION
## Summary
- stop deduplicating client and server source-map segments
- preserve identical parent/child entries at the same generated and original position
- retain the occurrence ordering consumed by the ordered duplicate parity gate

## Why
Official esrap emits repeated identical entries for declarations such as `let foo`: the declaration and identifier nodes can start together. Deduplicating those entries loses observable map resolution.

## Verification
- inspected official and rsvelte fixture maps segment-by-segment
- git diff --check
- local builds/tests intentionally skipped; CI is the execution oracle