### PR TITLE
Fix formatter indentation after escaped regex slashes

### DIFF
--- a/.changeset/fix-formatter-regex-slash-indent.md
+++ b/.changeset/fix-formatter-regex-slash-indent.md
@@ -1,0 +1,5 @@
+---
+"rsvelte_formatter": patch
+---
+
+Preserve the closing-line indentation of multiline attribute expressions containing escaped regex slashes.

--- a/crates/rsvelte_formatter/src/reindent.rs
+++ b/crates/rsvelte_formatter/src/reindent.rs
@@ -139,6 +139,16 @@ fn consume_template_quasi(
     }
 }
 
+fn is_escaped(bytes: &[u8], index: usize) -> bool {
+    bytes[..index]
+        .iter()
+        .rev()
+        .take_while(|byte| **byte == b'\\')
+        .count()
+        % 2
+        == 1
+}
+
 fn consume_code_byte(
     bytes: &[u8],
     byte: u8,
@@ -155,13 +165,13 @@ fn consume_code_byte(
     match byte {
         b'`' => stack.push(Frame::Template),
         b'\'' | b'"' => *string = Some(byte),
-        b'/' if bytes.get(*index + 1) == Some(&b'/') => {
+        b'/' if !is_escaped(bytes, *index) && bytes.get(*index + 1) == Some(&b'/') => {
             *line_comment = true;
             out.extend_from_slice(b"//");
             *index += 2;
             return;
         }
-        b'/' if bytes.get(*index + 1) == Some(&b'*') => {
+        b'/' if !is_escaped(bytes, *index) && bytes.get(*index + 1) == Some(&b'*') => {
             *block_comment = true;
             *is_jsdoc = is_indentable_block_comment(bytes, *index, bytes.len());
             out.extend_from_slice(b"/*");

--- a/crates/rsvelte_formatter/tests/markup_open_tag.rs
+++ b/crates/rsvelte_formatter/tests/markup_open_tag.rs
@@ -297,6 +297,21 @@ fn multiline_attr_forces_multiline_tag_even_when_short() {
 }
 
 #[test]
+fn escaped_regex_slash_does_not_deindent_multiline_attribute_close() {
+    let src = r#"<button
+  onclick={() => {
+    v = v.replace(/(^https?:\/\/[^/]+)\/*$/i, '$1');
+  }}>normalize</button
+>
+"#;
+    let out = fmt(src);
+    assert!(
+        out.contains("\n  }}>normalize</button"),
+        "escaped regex slash was mistaken for a block comment:\n{out}"
+    );
+}
+
+#[test]
 fn multiline_attr_idempotent() {
     let src =
         "<div>\n  <button\n    onclick={() => {\n      foo();\n    }}\n  >x</button>\n</div>\n";


### PR DESCRIPTION
Fixes the new formatter corpus divergence for regex-literal-shapes.svelte.\n\nThe multiline-attribute reindent scanner treated the escaped slash in \/* as the start of a block comment, so it stopped indenting the closing attribute braces. Comment detection now ignores escaped slashes, with a regression fixture for the exact shape.\n\nStatic verification only, per local resource constraints:\n- cargo fmt --all -- --check\n- git diff --check\n\nNo compatibility baseline is increased.