### PR TITLE
Fix nested server derived reads

### DIFF
--- a/.changeset/fix-nested-derived-reads.md
+++ b/.changeset/fix-nested-derived-reads.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Fix server reads of function-local derived variables declared inside statement containers.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/derived_reads_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/derived_reads_ast.rs
@@ -57,8 +57,9 @@ thread_local! {
 
 /// Wrap reads of derived bindings to getter calls. `derived_names` is the set
 /// of derived binding names in this script, `derived_var_names` the subset
-/// declared with `var` (→ `name?.()`), and `extra_derived` cross-context
-/// deriveds read here but declared elsewhere (unresolved references).
+/// declared with `var` (→ `name?.()`), `derived_declarators` the exact source
+/// ranges of those declarations, and `extra_derived` cross-context deriveds
+/// read here but declared elsewhere (unresolved references).
 ///
 /// Returns `Some(rewritten)` when at least one read was wrapped, `None` on a
 /// parse failure or when nothing matched (caller falls back to the byte
@@ -67,6 +68,7 @@ pub(crate) fn wrap_derived_reads_ast(
     script: &str,
     derived_names: &FxHashSet<String>,
     derived_var_names: &FxHashSet<String>,
+    derived_declarators: &[(usize, usize, String)],
     extra_derived: &FxHashSet<String>,
 ) -> Option<String> {
     if derived_names.is_empty() && extra_derived.is_empty() {
@@ -93,6 +95,10 @@ pub(crate) fn wrap_derived_reads_ast(
                 semantic,
                 derived_names,
                 derived_var_names,
+                derived_declarator_spans: derived_declarators
+                    .iter()
+                    .map(|&(start, end, _)| (start as u32, end as u32))
+                    .collect(),
                 extra_derived,
                 edits: Vec::new(),
                 skip_spans: FxHashSet::default(),
@@ -119,6 +125,10 @@ struct DerivedReadCollector<'a, 'sem> {
     semantic: &'sem Semantic<'sem>,
     derived_names: &'a FxHashSet<String>,
     derived_var_names: &'a FxHashSet<String>,
+    /// Exact identifier ranges for declarations found by the rune scanner.
+    /// Symbol identity, rather than scope depth, distinguishes a function-local
+    /// derived declaration from a same-named parameter/local shadow.
+    derived_declarator_spans: FxHashSet<(u32, u32)>,
     extra_derived: &'a FxHashSet<String>,
     /// `(start, end, replacement)` edits applied right-to-left. Most are
     /// zero-width inserts (`end == start`) of the `()` / `?.()` suffix; the
@@ -146,10 +156,11 @@ impl<'a, 'sem> DerivedReadCollector<'a, 'sem> {
         self.derived_names.contains(name) || self.extra_derived.contains(name)
     }
 
-    /// True when this reference binds to a symbol in an inner (non-root) scope
-    /// — i.e. a local declaration / parameter shadowing the derived. An
-    /// unresolved reference (a cross-context derived from `extra_derived`) is
-    /// not shadowed.
+    /// True when this reference resolves to a symbol other than the exact
+    /// derived declarator found in the transformed source. This matters for
+    /// function-local runes: scope depth alone cannot distinguish the rune's
+    /// own symbol from a same-named parameter/local shadow. An unresolved
+    /// reference (a cross-context derived from `extra_derived`) is not shadowed.
     fn is_shadowed(&self, ident: &IdentifierReference) -> bool {
         let Some(reference_id) = ident.reference_id.get() else {
             return false;
@@ -158,8 +169,27 @@ impl<'a, 'sem> DerivedReadCollector<'a, 'sem> {
         let Some(symbol_id) = reference.symbol_id() else {
             return false;
         };
-        let symbol_scope = self.semantic.scoping().symbol_scope_id(symbol_id);
-        symbol_scope != self.semantic.scoping().root_scope_id()
+        let scoping = self.semantic.scoping();
+        let declaration_id = scoping.symbol_declaration(symbol_id);
+        if let oxc_ast::AstKind::VariableDeclarator(declarator) =
+            self.semantic.nodes().get_node(declaration_id).kind()
+        {
+            let span = declarator.id.span();
+            if self
+                .derived_declarator_spans
+                .contains(&(span.start, span.end))
+            {
+                return false;
+            }
+        }
+
+        // Callers that do not have declaration ranges (notably focused unit
+        // tests and cross-slice transforms) retain the former root-binding
+        // behaviour. Production supplies exact ranges for every local rune.
+        if self.derived_declarator_spans.is_empty() {
+            return scoping.symbol_scope_id(symbol_id) != scoping.root_scope_id();
+        }
+        true
     }
 }
 
@@ -328,6 +358,7 @@ mod tests {
             script,
             &names(derived),
             &FxHashSet::default(),
+            &[],
             &FxHashSet::default(),
         )
     }
@@ -432,6 +463,7 @@ mod tests {
             "count += 1;",
             &names(&["count"]),
             &names(&["count"]),
+            &[],
             &FxHashSet::default(),
         )
         .unwrap();
@@ -469,6 +501,7 @@ mod tests {
             "let x = count;",
             &names(&["count"]),
             &names(&["count"]),
+            &[],
             &FxHashSet::default(),
         )
         .unwrap();
@@ -482,11 +515,51 @@ mod tests {
     }
 
     #[test]
+    fn function_local_var_derived_is_not_mistaken_for_a_shadow() {
+        let script =
+            "function probe(flag) { if (flag) var value = $.derived(() => 1); return value; }";
+        let start = script.find("value =").unwrap();
+        let declarators = vec![(start, start + "value".len(), "value".to_string())];
+        let out = wrap_derived_reads_ast(
+            script,
+            &names(&["value"]),
+            &names(&["value"]),
+            &declarators,
+            &FxHashSet::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "function probe(flag) { if (flag) var value = $.derived(() => 1); return value?.(); }"
+        );
+    }
+
+    #[test]
+    fn same_named_parameter_still_shadows_function_local_derived() {
+        let script = "function probe() { var value = $.derived(() => 1); function nested(value) { return value; } return value; }";
+        let start = script.find("value =").unwrap();
+        let declarators = vec![(start, start + "value".len(), "value".to_string())];
+        let out = wrap_derived_reads_ast(
+            script,
+            &names(&["value"]),
+            &names(&["value"]),
+            &declarators,
+            &FxHashSet::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "function probe() { var value = $.derived(() => 1); function nested(value) { return value; } return value?.(); }"
+        );
+    }
+
+    #[test]
     fn extra_derived_unresolved_is_wrapped() {
         let out = wrap_derived_reads_ast(
             "let x = d + 1;",
             &FxHashSet::default(),
             &FxHashSet::default(),
+            &[],
             &names(&["d"]),
         )
         .unwrap();
@@ -536,6 +609,7 @@ mod tests {
             "count++;",
             &names(&["count"]),
             &names(&["count"]),
+            &[],
             &FxHashSet::default(),
         )
         .unwrap();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
@@ -1248,6 +1248,7 @@ fn wrap_derived_reads_in_script(script: &str, extra_derived: &FxHashSet<String>)
         script,
         &derived_names,
         &derived_var_names,
+        &derived_declarators,
         extra_derived,
     ) {
         return out;


### PR DESCRIPTION
## Summary
- identify server derived bindings by their exact declarator symbol instead of assuming every non-root symbol is a shadow
- preserve true parameter/local shadowing
- cover function-local var-derived reads in statement containers

## Compatibility impact
Fixes the module-side rune-statement-container server/server-dev mismatches where nested `var value = $.derived(...)` was left as `$.safe_get(value)` instead of `value?.()`.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- local builds/tests intentionally skipped per project workflow; CI is the execution oracle