### PR TITLE
Match octal template expression errors

### DIFF
--- a/.changeset/tidy-octal-expression-errors.md
+++ b/.changeset/tidy-octal-expression-errors.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Match Svelte's strict-mode error for legacy octal escapes in template expressions.

--- a/compatibility/error-known-failures.md
+++ b/compatibility/error-known-failures.md
@@ -98,10 +98,10 @@ of two unrelated errors say nothing, and the code divergence is an
 
 ## Why the per-target files are near-identical
 
-`error-message-known-failures.client.json` holds 9 entries;
-`error-message-known-failures.client-dev.json` holds 9 entries;
-`error-message-known-failures.server.json` holds 9 entries; and
-`error-message-known-failures.server-dev.json` holds 9 entries. All four of
+`error-message-known-failures.client.json` holds 8 entries;
+`error-message-known-failures.client-dev.json` holds 8 entries;
+`error-message-known-failures.server.json` holds 8 entries; and
+`error-message-known-failures.server-dev.json` holds 8 entries. All four of
 `error-position-known-failures.<target>.json` hold 38 entries, all four of
 `error-end-known-failures.<target>.json` hold 51 entries, and all four of
 `error-frame-known-failures.<target>.json` hold 0 entries. The wave-2 enrolment
@@ -125,7 +125,7 @@ from before those passes; they are historical evidence about the backlog's shape
 not a decomposition of the current 38/51 files.
 
 The former client-only asymmetry is gone from the current corpus population, so
-all four files now carry the same nine message entries.
+all four files now carry the same eight message entries.
 
 ## Error messages
 
@@ -134,9 +134,9 @@ things on a minor bump": both compilers run on the same source, in the same
 process, at the pinned version, so a difference here is rsvelte's — the argument
 settled for warning text in #2403.
 
-Clustered by code (client target, 9 entries):
+Clustered by code (client target, 8 entries):
 
-- **`js_parse_error` — 8, the whole majority.** The Svelte code is right, but the
+- **`js_parse_error` — 7, the whole majority.** The Svelte code is right, but the
   text is oxc's parser message (`Expected `,` or `}` but found `+`) where upstream
   forwards acorn's (`Unexpected token`). This is the one cluster whose fix is not a
   string edit: the two parsers phrase their own diagnostics, and rsvelte's text is
@@ -150,6 +150,11 @@ Clustered by code (client target, 9 entries):
   (`()`, a trailing comma, an arrow parameter list) that acorn — parsing the body
   unwrapped — never sees, and the body is now re-probed unwrapped when one of
   them fires.
+  The template-expression strict-mode escape then retired separately: OXC had
+  already recovered the string-literal AST, but its generic lexer diagnostic
+  pre-empted the existing acorn-compatible `Octal literal in strict mode`
+  check. Recovered AST restrictions now win only when they occur no later than
+  OXC's first reported position.
 - **`expected_token` — 1.** `svelte/…/compiler-errors/samples/malformed-snippet-2`
   names the closing token it wanted: rsvelte says `}` where upstream says `)`. The
   two parsers recover from the malformed snippet header at different points, so

--- a/compatibility/error-message-known-failures.client-dev.json
+++ b/compatibility/error-message-known-failures.client-dev.json
@@ -1,5 +1,4 @@
 [
-	"pattern/issues/3201-template-fast-path-escape.svelte",
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
 	"svelte.dev/apps/svelte.dev/content/tutorial/01-svelte/08-attachments/01-attach/index.md/4.svelte.js",

--- a/compatibility/error-message-known-failures.client.json
+++ b/compatibility/error-message-known-failures.client.json
@@ -1,5 +1,4 @@
 [
-	"pattern/issues/3201-template-fast-path-escape.svelte",
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
 	"svelte.dev/apps/svelte.dev/content/tutorial/01-svelte/08-attachments/01-attach/index.md/4.svelte.js",

--- a/compatibility/error-message-known-failures.server-dev.json
+++ b/compatibility/error-message-known-failures.server-dev.json
@@ -1,5 +1,4 @@
 [
-	"pattern/issues/3201-template-fast-path-escape.svelte",
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
 	"svelte.dev/apps/svelte.dev/content/tutorial/01-svelte/08-attachments/01-attach/index.md/4.svelte.js",

--- a/compatibility/error-message-known-failures.server.json
+++ b/compatibility/error-message-known-failures.server.json
@@ -1,5 +1,4 @@
 [
-	"pattern/issues/3201-template-fast-path-escape.svelte",
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
 	"svelte.dev/apps/svelte.dev/content/tutorial/01-svelte/08-attachments/01-attach/index.md/4.svelte.js",

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -1847,6 +1847,20 @@ pub fn check_js_parse_error_with_pos(content: &str, ts: bool) -> Option<(String,
                         wrapped_end.saturating_sub(1).min(content.len())
                     })
                     .unwrap_or(0);
+                // OXC recovers an AST for some early errors that acorn reports
+                // more specifically. Keep the OXC diagnostic when it occurs
+                // first, but let an acorn-only restriction at the same or an
+                // earlier byte win. In particular, a legacy octal escape is a
+                // StringLiteral in OXC's recovered tree even though its lexer
+                // also emits a generic diagnostic for the escape.
+                if let Some((at, message)) =
+                    acorn_only_violation(&result.program, &wrapped, source_type.is_typescript())
+                {
+                    let acorn_pos = (at as usize).saturating_sub(1).min(content.len());
+                    if acorn_pos <= pos {
+                        return Some((message, acorn_pos, false));
+                    }
+                }
                 if at_label_start {
                     return Some(("Assigning to rvalue".to_string(), pos, false));
                 }
@@ -13536,6 +13550,14 @@ mod tests {
     }
 
     use super::*;
+
+    #[test]
+    fn recovered_expression_uses_acorns_strict_mode_error() {
+        assert_eq!(
+            check_js_parse_error_with_pos(r"'abc\251def'", false),
+            Some(("Octal literal in strict mode".to_string(), 4))
+        );
+    }
 
     #[test]
     fn test_parse_destructuring_assignment() {


### PR DESCRIPTION
## Summary

- prefer acorn-compatible strict-mode errors found in OXC's recovered expression AST when they occur no later than OXC's first diagnostic
- cover legacy octal escapes in template string expressions
- shrink all four error-message compatibility baselines from 9 entries to 8

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- JSON syntax checks for all four changed baselines
- local builds and tests intentionally not run per project-owner request; CI is the execution oracle
