### PR TITLE
Match top-level return parse errors

### DIFF
--- a/.changeset/tidy-top-level-return-error.md
+++ b/.changeset/tidy-top-level-return-error.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Match Svelte's parse error message for top-level return statements.

--- a/compatibility/error-known-failures.md
+++ b/compatibility/error-known-failures.md
@@ -98,10 +98,10 @@ of two unrelated errors say nothing, and the code divergence is an
 
 ## Why the per-target files are near-identical
 
-`error-message-known-failures.client.json` holds 8 entries;
-`error-message-known-failures.client-dev.json` holds 8 entries;
-`error-message-known-failures.server.json` holds 8 entries; and
-`error-message-known-failures.server-dev.json` holds 8 entries. All four of
+`error-message-known-failures.client.json` holds 7 entries;
+`error-message-known-failures.client-dev.json` holds 7 entries;
+`error-message-known-failures.server.json` holds 7 entries; and
+`error-message-known-failures.server-dev.json` holds 7 entries. All four of
 `error-position-known-failures.<target>.json` hold 38 entries, all four of
 `error-end-known-failures.<target>.json` hold 51 entries, and all four of
 `error-frame-known-failures.<target>.json` hold 0 entries. The wave-2 enrolment
@@ -125,7 +125,7 @@ from before those passes; they are historical evidence about the backlog's shape
 not a decomposition of the current 38/51 files.
 
 The former client-only asymmetry is gone from the current corpus population, so
-all four files now carry the same eight message entries.
+all four files now carry the same seven message entries.
 
 ## Error messages
 
@@ -134,9 +134,9 @@ things on a minor bump": both compilers run on the same source, in the same
 process, at the pinned version, so a difference here is rsvelte's — the argument
 settled for warning text in #2403.
 
-Clustered by code (client target, 8 entries):
+Clustered by code (client target, 7 entries):
 
-- **`js_parse_error` — 7, the whole majority.** The Svelte code is right, but the
+- **`js_parse_error` — 6, the whole majority.** The Svelte code is right, but the
   text is oxc's parser message (`Expected `,` or `}` but found `+`) where upstream
   forwards acorn's (`Unexpected token`). This is the one cluster whose fix is not a
   string edit: the two parsers phrase their own diagnostics, and rsvelte's text is
@@ -155,6 +155,10 @@ Clustered by code (client target, 8 entries):
   pre-empted the existing acorn-compatible `Octal literal in strict mode`
   check. Recovered AST restrictions now win only when they occur no later than
   OXC's first reported position.
+  The top-level `return` fragment from the attachments tutorial retired as the
+  fixed-message case: both parsers reject it at the same byte, and the program
+  diagnostic adapter now translates OXC's wording to acorn's
+  `'return' outside of function`.
 - **`expected_token` — 1.** `svelte/…/compiler-errors/samples/malformed-snippet-2`
   names the closing token it wanted: rsvelte says `}` where upstream says `)`. The
   two parsers recover from the malformed snippet header at different points, so

--- a/compatibility/error-message-known-failures.client-dev.json
+++ b/compatibility/error-message-known-failures.client-dev.json
@@ -1,7 +1,6 @@
 [
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
-	"svelte.dev/apps/svelte.dev/content/tutorial/01-svelte/08-attachments/01-attach/index.md/4.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/parser-modern/samples/loose-declaration-tag/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",

--- a/compatibility/error-message-known-failures.client.json
+++ b/compatibility/error-message-known-failures.client.json
@@ -1,7 +1,6 @@
 [
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
-	"svelte.dev/apps/svelte.dev/content/tutorial/01-svelte/08-attachments/01-attach/index.md/4.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/parser-modern/samples/loose-declaration-tag/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",

--- a/compatibility/error-message-known-failures.server-dev.json
+++ b/compatibility/error-message-known-failures.server-dev.json
@@ -1,7 +1,6 @@
 [
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
-	"svelte.dev/apps/svelte.dev/content/tutorial/01-svelte/08-attachments/01-attach/index.md/4.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/parser-modern/samples/loose-declaration-tag/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",

--- a/compatibility/error-message-known-failures.server.json
+++ b/compatibility/error-message-known-failures.server.json
@@ -1,7 +1,6 @@
 [
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
-	"svelte.dev/apps/svelte.dev/content/tutorial/01-svelte/08-attachments/01-attach/index.md/4.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/parser-modern/samples/loose-declaration-tag/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -7520,7 +7520,7 @@ fn ts_class_modifier_stop(content: &str, from: u32) -> Option<u32> {
 /// and take acorn's wording with it.
 fn realign_missing_semicolon(content: &str, at: usize, message: &str) -> (usize, String) {
     if !message.starts_with("Expected a semicolon or an implicit semicolon") {
-        return (at, message.to_string());
+        return (at, acorn_diagnostic_message(message).to_string());
     }
     let bytes = content.as_bytes();
     let mut i = at;
@@ -7544,6 +7544,17 @@ fn realign_missing_semicolon(content: &str, at: usize, message: &str) -> (usize,
         return (at, message.to_string());
     }
     (i, "Unexpected token".to_string())
+}
+
+/// Translate diagnostics for grammar errors both parsers identify at the same
+/// byte but describe differently. Upstream forwards acorn's text verbatim.
+fn acorn_diagnostic_message(message: &str) -> &str {
+    match message {
+        "A 'return' statement can only be used within a function body." => {
+            "'return' outside of function"
+        }
+        _ => message,
+    }
 }
 
 /// Repair the one import-attributes spelling acorn-typescript accepts and OXC
@@ -13557,6 +13568,30 @@ mod tests {
             check_js_parse_error_with_pos(r"'abc\251def'", false),
             Some(("Octal literal in strict mode".to_string(), 4))
         );
+    }
+
+    #[test]
+    fn program_uses_acorns_top_level_return_error() {
+        let source = "return () => {};";
+        let arena = ParseArena::new();
+        let line_offsets = super::super::super::compute_line_offsets(source, false);
+        let (_, error) = parse_program_with_error(
+            &arena,
+            ProgramParseParams {
+                content: source,
+                offset: 0,
+                line_offsets: &line_offsets,
+                is_typescript: false,
+                is_script: false,
+                leading_comments: &[],
+                script_tag_start: 0,
+                script_tag_end: source.len(),
+            },
+        );
+        let Some(crate::error::ParseError::SvelteError { message, .. }) = error else {
+            panic!("expected a Svelte parse error");
+        };
+        assert_eq!(message, "'return' outside of function");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- normalize OXC's top-level return diagnostic to the acorn wording forwarded by Svelte
- add a program-parser regression test for the exact error
- shrink all four error-message compatibility baselines from 8 entries to 7

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- JSON syntax and entry-count checks for all four changed baselines
- local builds and tests intentionally not run per project-owner request; CI is the execution oracle
