### PR TITLE
Match incomplete let declaration errors

### DIFF
--- a/.changeset/tidy-incomplete-let-error.md
+++ b/.changeset/tidy-incomplete-let-error.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Match Svelte's reserved-word error for incomplete let declaration tags.

--- a/compatibility/error-known-failures.md
+++ b/compatibility/error-known-failures.md
@@ -98,10 +98,10 @@ of two unrelated errors say nothing, and the code divergence is an
 
 ## Why the per-target files are near-identical
 
-`error-message-known-failures.client.json` holds 7 entries;
-`error-message-known-failures.client-dev.json` holds 7 entries;
-`error-message-known-failures.server.json` holds 7 entries; and
-`error-message-known-failures.server-dev.json` holds 7 entries. All four of
+`error-message-known-failures.client.json` holds 6 entries;
+`error-message-known-failures.client-dev.json` holds 6 entries;
+`error-message-known-failures.server.json` holds 6 entries; and
+`error-message-known-failures.server-dev.json` holds 6 entries. All four of
 `error-position-known-failures.<target>.json` hold 38 entries, all four of
 `error-end-known-failures.<target>.json` hold 51 entries, and all four of
 `error-frame-known-failures.<target>.json` hold 0 entries. The wave-2 enrolment
@@ -125,7 +125,7 @@ from before those passes; they are historical evidence about the backlog's shape
 not a decomposition of the current 38/51 files.
 
 The former client-only asymmetry is gone from the current corpus population, so
-all four files now carry the same seven message entries.
+all four files now carry the same six message entries.
 
 ## Error messages
 
@@ -134,9 +134,9 @@ things on a minor bump": both compilers run on the same source, in the same
 process, at the pinned version, so a difference here is rsvelte's — the argument
 settled for warning text in #2403.
 
-Clustered by code (client target, 7 entries):
+Clustered by code (client target, 6 entries):
 
-- **`js_parse_error` — 6, the whole majority.** The Svelte code is right, but the
+- **`js_parse_error` — 5, the whole majority.** The Svelte code is right, but the
   text is oxc's parser message (`Expected `,` or `}` but found `+`) where upstream
   forwards acorn's (`Unexpected token`). This is the one cluster whose fix is not a
   string edit: the two parsers phrase their own diagnostics, and rsvelte's text is
@@ -159,6 +159,8 @@ Clustered by code (client target, 7 entries):
   fixed-message case: both parsers reject it at the same byte, and the program
   diagnostic adapter now translates OXC's wording to acorn's
   `'return' outside of function`.
+  The incomplete `{let }` declaration tag retired by handling acorn's bare
+  reserved-word error before OXC's generic incomplete-declaration diagnostic.
 - **`expected_token` — 1.** `svelte/…/compiler-errors/samples/malformed-snippet-2`
   names the closing token it wanted: rsvelte says `}` where upstream says `)`. The
   two parsers recover from the malformed snippet header at different points, so

--- a/compatibility/error-message-known-failures.client-dev.json
+++ b/compatibility/error-message-known-failures.client-dev.json
@@ -2,7 +2,6 @@
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
-	"svelte/packages/svelte/tests/parser-modern/samples/loose-declaration-tag/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte"

--- a/compatibility/error-message-known-failures.client.json
+++ b/compatibility/error-message-known-failures.client.json
@@ -2,7 +2,6 @@
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
-	"svelte/packages/svelte/tests/parser-modern/samples/loose-declaration-tag/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte"

--- a/compatibility/error-message-known-failures.server-dev.json
+++ b/compatibility/error-message-known-failures.server-dev.json
@@ -2,7 +2,6 @@
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
-	"svelte/packages/svelte/tests/parser-modern/samples/loose-declaration-tag/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte"

--- a/compatibility/error-message-known-failures.server.json
+++ b/compatibility/error-message-known-failures.server.json
@@ -2,7 +2,6 @@
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
-	"svelte/packages/svelte/tests/parser-modern/samples/loose-declaration-tag/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte"

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -1975,6 +1975,10 @@ pub fn check_params_parse_error(params: &str, ts: bool) -> Option<(String, usize
 /// does not parse as a statement is rethrown in strict mode and surfaces as
 /// `js_parse_error` (e.g. `{let }` → "The keyword 'let' is reserved").
 pub fn check_js_statement_parse_error(content: &str, ts: bool) -> Option<(String, usize)> {
+    let leading_ws = content.len() - content.trim_start_ws().len();
+    if content.trim_ws() == "let" {
+        return Some(("The keyword 'let' is reserved".to_string(), leading_ws));
+    }
     with_oxc_allocator(|allocator| {
         let source_type = if ts {
             SourceType::ts()
@@ -13592,6 +13596,14 @@ mod tests {
             panic!("expected a Svelte parse error");
         };
         assert_eq!(message, "'return' outside of function");
+    }
+
+    #[test]
+    fn incomplete_let_statement_uses_acorns_reserved_word_error() {
+        assert_eq!(
+            check_js_statement_parse_error("  let ", false),
+            Some(("The keyword 'let' is reserved".to_string(), 2))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- report acorn's reserved-word error for a declaration-tag body containing only `let`
- add a focused statement-parser regression test including leading whitespace
- shrink all four error-message compatibility baselines from 7 entries to 6

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- JSON syntax and entry-count checks for all four changed baselines
- local builds and tests intentionally not run per project-owner request; CI is the execution oracle
