### PR TITLE
Match rest element comma diagnostics

### DIFF
--- a/.changeset/tidy-rest-comma-error.md
+++ b/.changeset/tidy-rest-comma-error.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Match Svelte's parser error for a comma after a destructuring rest element.

--- a/compatibility/error-known-failures.md
+++ b/compatibility/error-known-failures.md
@@ -98,10 +98,10 @@ of two unrelated errors say nothing, and the code divergence is an
 
 ## Why the per-target files are near-identical
 
-`error-message-known-failures.client.json` holds 6 entries;
-`error-message-known-failures.client-dev.json` holds 6 entries;
-`error-message-known-failures.server.json` holds 6 entries; and
-`error-message-known-failures.server-dev.json` holds 6 entries. All four of
+`error-message-known-failures.client.json` holds 5 entries;
+`error-message-known-failures.client-dev.json` holds 5 entries;
+`error-message-known-failures.server.json` holds 5 entries; and
+`error-message-known-failures.server-dev.json` holds 5 entries. All four of
 `error-position-known-failures.<target>.json` hold 38 entries, all four of
 `error-end-known-failures.<target>.json` hold 51 entries, and all four of
 `error-frame-known-failures.<target>.json` hold 0 entries. The wave-2 enrolment
@@ -125,7 +125,7 @@ from before those passes; they are historical evidence about the backlog's shape
 not a decomposition of the current 38/51 files.
 
 The former client-only asymmetry is gone from the current corpus population, so
-all four files now carry the same six message entries.
+all four files now carry the same five message entries.
 
 ## Error messages
 
@@ -134,9 +134,9 @@ things on a minor bump": both compilers run on the same source, in the same
 process, at the pinned version, so a difference here is rsvelte's — the argument
 settled for warning text in #2403.
 
-Clustered by code (client target, 6 entries):
+Clustered by code (client target, 5 entries):
 
-- **`js_parse_error` — 5, the whole majority.** The Svelte code is right, but the
+- **`js_parse_error` — 4, the whole majority.** The Svelte code is right, but the
   text is oxc's parser message (`Expected `,` or `}` but found `+`) where upstream
   forwards acorn's (`Unexpected token`). This is the one cluster whose fix is not a
   string edit: the two parsers phrase their own diagnostics, and rsvelte's text is
@@ -161,6 +161,9 @@ Clustered by code (client target, 6 entries):
   `'return' outside of function`.
   The incomplete `{let }` declaration tag retired by handling acorn's bare
   reserved-word error before OXC's generic incomplete-declaration diagnostic.
+  The object-pattern rest-comma fixture retired through the exact diagnostic
+  adapter: OXC and acorn reject the same grammar error at the same parse site,
+  but acorn reports `Comma is not permitted after the rest element`.
 - **`expected_token` — 1.** `svelte/…/compiler-errors/samples/malformed-snippet-2`
   names the closing token it wanted: rsvelte says `}` where upstream says `)`. The
   two parsers recover from the malformed snippet header at different points, so

--- a/compatibility/error-message-known-failures.client-dev.json
+++ b/compatibility/error-message-known-failures.client-dev.json
@@ -2,7 +2,6 @@
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte"
 ]

--- a/compatibility/error-message-known-failures.client.json
+++ b/compatibility/error-message-known-failures.client.json
@@ -2,7 +2,6 @@
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte"
 ]

--- a/compatibility/error-message-known-failures.server-dev.json
+++ b/compatibility/error-message-known-failures.server-dev.json
@@ -2,7 +2,6 @@
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte"
 ]

--- a/compatibility/error-message-known-failures.server.json
+++ b/compatibility/error-message-known-failures.server.json
@@ -2,7 +2,6 @@
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte"
 ]

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -7557,6 +7557,9 @@ fn acorn_diagnostic_message(message: &str) -> &str {
         "A 'return' statement can only be used within a function body." => {
             "'return' outside of function"
         }
+        "A rest element must be last in a destructuring pattern" => {
+            "Comma is not permitted after the rest element"
+        }
         _ => message,
     }
 }
@@ -12379,10 +12382,11 @@ pub fn parse_binding_pattern<'a>(
                 let err = &result.diagnostics[0];
                 let msg = format!("{}", err);
                 let clean_msg = msg.split('\n').next().unwrap_or(&msg).trim_ws().to_string();
+                let clean_msg = acorn_diagnostic_message(&clean_msg);
                 let err_pos = offset;
                 return Err(crate::error::ParseError::svelte(
                     "js_parse_error",
-                    &clean_msg,
+                    clean_msg,
                     (err_pos, err_pos),
                 ));
             }
@@ -13604,6 +13608,19 @@ mod tests {
             check_js_statement_parse_error("  let ", false),
             Some(("The keyword 'let' is reserved".to_string(), 2))
         );
+    }
+
+    #[test]
+    fn binding_rest_comma_uses_acorns_error() {
+        let source = "{ animal, features: { ...rest, eyes } }";
+        let arena = ParseArena::new();
+        let line_offsets = super::super::super::compute_line_offsets(source, false);
+        let Err(crate::error::ParseError::SvelteError { message, .. }) =
+            parse_binding_pattern(&arena, source, 0, &line_offsets, false)
+        else {
+            panic!("expected a Svelte parse error");
+        };
+        assert_eq!(message, "Comma is not permitted after the rest element");
     }
 
     #[test]

--- a/crates/rsvelte_core/tests/common/mod.rs
+++ b/crates/rsvelte_core/tests/common/mod.rs
@@ -850,9 +850,6 @@ pub const VALIDATOR_MESSAGE_DIVERGENCES: &[&str] = &[
     "each-block-invalid-context-destructured",
     // acorn "Unexpected keyword 'case'" vs OXC "Expected `:` but found `}`"
     "each-block-invalid-context-destructured-object",
-    // acorn "Comma is not permitted after the rest element" vs OXC
-    // "A rest element must be last in a destructuring pattern"
-    "each-block-destructured-object-rest-comma-after",
 ];
 
 /// Compare a resolved `(line, column)` against the fixture's pinned position.


### PR DESCRIPTION
## Summary
- translate OXC's rest-element placement diagnostic to acorn's exact wording
- pin the nested object binding-pattern case
- shrink all four error-message compatibility baselines from 6 to 5

## Verification
- cargo fmt --all -- --check
- git diff --check
- JSON baseline counts checked with jq

Per project guidance, no local build or test suite was run.