### PR TITLE
Match reserved binding pattern diagnostics

### DIFF
--- a/.changeset/neat-binding-keywords.md
+++ b/.changeset/neat-binding-keywords.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Match Svelte's contextual errors for reserved words in destructuring bindings.

--- a/compatibility/error-end-known-failures.client-dev.json
+++ b/compatibility/error-end-known-failures.client-dev.json
@@ -42,8 +42,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
 	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",

--- a/compatibility/error-end-known-failures.client.json
+++ b/compatibility/error-end-known-failures.client.json
@@ -42,8 +42,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
 	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",

--- a/compatibility/error-end-known-failures.server-dev.json
+++ b/compatibility/error-end-known-failures.server-dev.json
@@ -42,8 +42,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
 	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",

--- a/compatibility/error-end-known-failures.server.json
+++ b/compatibility/error-end-known-failures.server.json
@@ -42,8 +42,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
 	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",

--- a/compatibility/error-known-failures.md
+++ b/compatibility/error-known-failures.md
@@ -98,12 +98,12 @@ of two unrelated errors say nothing, and the code divergence is an
 
 ## Why the per-target files are near-identical
 
-`error-message-known-failures.client.json` holds 5 entries;
-`error-message-known-failures.client-dev.json` holds 5 entries;
-`error-message-known-failures.server.json` holds 5 entries; and
-`error-message-known-failures.server-dev.json` holds 5 entries. All four of
-`error-position-known-failures.<target>.json` hold 38 entries, all four of
-`error-end-known-failures.<target>.json` hold 51 entries, and all four of
+`error-message-known-failures.client.json` holds 3 entries;
+`error-message-known-failures.client-dev.json` holds 3 entries;
+`error-message-known-failures.server.json` holds 3 entries; and
+`error-message-known-failures.server-dev.json` holds 3 entries. All four of
+`error-position-known-failures.<target>.json` hold 36 entries, all four of
+`error-end-known-failures.<target>.json` hold 49 entries, and all four of
 `error-frame-known-failures.<target>.json` hold 0 entries. The wave-2 enrolment
 (#3130) added 1 message, 16 position and 24 end entries — and **no frame entries
 at all**, which keeps that comparison's population saturated at 0 across a corpus
@@ -122,10 +122,10 @@ end entries. The scoped-store diagnostic pass retired another 10 position and 10
 end entries by attaching the offending `$name` identifier range. The detailed
 shape partitions below remain the measured snapshot
 from before those passes; they are historical evidence about the backlog's shape,
-not a decomposition of the current 38/51 files.
+not a decomposition of the current 36/49 files.
 
 The former client-only asymmetry is gone from the current corpus population, so
-all four files now carry the same five message entries.
+all four files now carry the same three message entries.
 
 ## Error messages
 
@@ -134,9 +134,9 @@ things on a minor bump": both compilers run on the same source, in the same
 process, at the pinned version, so a difference here is rsvelte's — the argument
 settled for warning text in #2403.
 
-Clustered by code (client target, 5 entries):
+Clustered by code (client target, 3 entries):
 
-- **`js_parse_error` — 4, the whole majority.** The Svelte code is right, but the
+- **`js_parse_error` — 2.** The Svelte code is right, but the
   text is oxc's parser message (`Expected `,` or `}` but found `+`) where upstream
   forwards acorn's (`Unexpected token`). This is the one cluster whose fix is not a
   string edit: the two parsers phrase their own diagnostics, and rsvelte's text is
@@ -164,6 +164,10 @@ Clustered by code (client target, 5 entries):
   The object-pattern rest-comma fixture retired through the exact diagnostic
   adapter: OXC and acorn reject the same grammar error at the same parse site,
   but acorn reports `Comma is not permitted after the rest element`.
+  The two reserved-word binding patterns retired together: the adapter uses
+  OXC's keyword label for an array pattern and walks back from its missing-colon
+  label to an object shorthand property, matching both acorn's contextual text
+  and its point position.
 - **`expected_token` — 1.** `svelte/…/compiler-errors/samples/malformed-snippet-2`
   names the closing token it wanted: rsvelte says `}` where upstream says `)`. The
   two parsers recover from the malformed snippet header at different points, so

--- a/compatibility/error-message-known-failures.client-dev.json
+++ b/compatibility/error-message-known-failures.client-dev.json
@@ -1,7 +1,5 @@
 [
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte"
+	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte"
 ]

--- a/compatibility/error-message-known-failures.client.json
+++ b/compatibility/error-message-known-failures.client.json
@@ -1,7 +1,5 @@
 [
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte"
+	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte"
 ]

--- a/compatibility/error-message-known-failures.server-dev.json
+++ b/compatibility/error-message-known-failures.server-dev.json
@@ -1,7 +1,5 @@
 [
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte"
+	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte"
 ]

--- a/compatibility/error-message-known-failures.server.json
+++ b/compatibility/error-message-known-failures.server.json
@@ -1,7 +1,5 @@
 [
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte"
+	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte"
 ]

--- a/compatibility/error-position-known-failures.client-dev.json
+++ b/compatibility/error-position-known-failures.client-dev.json
@@ -29,8 +29,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
 	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",

--- a/compatibility/error-position-known-failures.client.json
+++ b/compatibility/error-position-known-failures.client.json
@@ -29,8 +29,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
 	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",

--- a/compatibility/error-position-known-failures.server-dev.json
+++ b/compatibility/error-position-known-failures.server-dev.json
@@ -29,8 +29,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
 	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",

--- a/compatibility/error-position-known-failures.server.json
+++ b/compatibility/error-position-known-failures.server.json
@@ -29,8 +29,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured-object/input.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-invalid-context-destructured/input.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
 	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -7564,6 +7564,46 @@ fn acorn_diagnostic_message(message: &str) -> &str {
     }
 }
 
+/// Recover acorn's diagnostic for reserved words in a destructuring binding.
+/// OXC reports the keyword itself for array patterns, but parses an object
+/// shorthand keyword as a property name and reports the missing `:` at the
+/// following delimiter. The latter therefore has to walk back to the property.
+fn acorn_binding_pattern_diagnostic(
+    content: &str,
+    message: &str,
+    reported: usize,
+) -> Option<(usize, String)> {
+    let trimmed = content.trim_start_ws();
+    if trimmed.starts_with('[')
+        && let Some(rest) = message.strip_prefix("Identifier expected. '")
+        && let Some((word, _)) = rest.split_once("' is a reserved word")
+        && super::super::utils::is_reserved(word)
+    {
+        let at = reported.min(content.len());
+        return content
+            .get(at..)
+            .is_some_and(|tail| tail.starts_with(word))
+            .then(|| (at, "Unexpected token".to_string()));
+    }
+
+    if !trimmed.starts_with('{') || message != "Expected `:` but found `}`" {
+        return None;
+    }
+    let end = content[..reported.min(content.len())].trim_end_ws().len();
+    let start = content[..end]
+        .rfind(|c: char| !c.is_ascii_alphanumeric() && c != '_' && c != '$')
+        .map_or(0, |at| at + 1);
+    let word = content.get(start..end)?;
+    let before = content[..start].trim_end_ws();
+    if !matches!(before.as_bytes().last(), Some(&b'{') | Some(&b','))
+        || !is_plain_ascii_identifier(word)
+        || !super::super::utils::is_reserved(word)
+    {
+        return None;
+    }
+    Some((start, format!("Unexpected keyword '{word}'")))
+}
+
 /// Repair the one import-attributes spelling acorn-typescript accepts and OXC
 /// rejects: `assert` after a line terminator. Replacing it with `with  ` keeps
 /// the byte length, every span, and the output spelling (upstream normalizes the
@@ -12382,6 +12422,21 @@ pub fn parse_binding_pattern<'a>(
                 let err = &result.diagnostics[0];
                 let msg = format!("{}", err);
                 let clean_msg = msg.split('\n').next().unwrap_or(&msg).trim_ws().to_string();
+                let reported = err
+                    .labels
+                    .first()
+                    .map_or(0, |label| label.offset() as usize)
+                    .saturating_sub(4);
+                if let Some((at, message)) =
+                    acorn_binding_pattern_diagnostic(content, &clean_msg, reported)
+                {
+                    let at = offset + at;
+                    return Err(crate::error::ParseError::svelte(
+                        "js_parse_error",
+                        message,
+                        (at, at),
+                    ));
+                }
                 let clean_msg = acorn_diagnostic_message(&clean_msg);
                 let err_pos = offset;
                 return Err(crate::error::ParseError::svelte(
@@ -13621,6 +13676,24 @@ mod tests {
             panic!("expected a Svelte parse error");
         };
         assert_eq!(message, "Comma is not permitted after the rest element");
+    }
+
+    #[test]
+    fn reserved_binding_words_use_acorns_contextual_errors() {
+        for (source, expected_message, expected_at) in [
+            ("[case]", "Unexpected token", 1),
+            ("{ case }", "Unexpected keyword 'case'", 2),
+        ] {
+            let arena = ParseArena::new();
+            let line_offsets = super::super::super::compute_line_offsets(source, false);
+            let Err(crate::error::ParseError::SvelteError { message, span, .. }) =
+                parse_binding_pattern(&arena, source, 10, &line_offsets, false)
+            else {
+                panic!("expected a Svelte parse error for {source}");
+            };
+            assert_eq!(message, expected_message, "{source}");
+            assert_eq!(span, (10 + expected_at, 10 + expected_at), "{source}");
+        }
     }
 
     #[test]

--- a/crates/rsvelte_core/tests/common/mod.rs
+++ b/crates/rsvelte_core/tests/common/mod.rs
@@ -845,12 +845,7 @@ pub enum ValidatorErrorVerdict {
 /// Validator fixtures whose expected *message* is an acorn diagnostic that
 /// OXC words differently. The code still has to match, and a fixture that
 /// starts matching is reported as a stale entry — the list can only shrink.
-pub const VALIDATOR_MESSAGE_DIVERGENCES: &[&str] = &[
-    // acorn "Unexpected token" vs OXC "Identifier expected. 'case' is a reserved word …"
-    "each-block-invalid-context-destructured",
-    // acorn "Unexpected keyword 'case'" vs OXC "Expected `:` but found `}`"
-    "each-block-invalid-context-destructured-object",
-];
+pub const VALIDATOR_MESSAGE_DIVERGENCES: &[&str] = &[];
 
 /// Compare a resolved `(line, column)` against the fixture's pinned position.
 const fn position_matches(actual: (usize, usize), expected: &ExpectedPosition) -> bool {


### PR DESCRIPTION
## Summary
- recover acorn's contextual reserved-word errors for array and object destructuring bindings
- report the reserved keyword point instead of the pattern opener
- shrink every target's error baselines: message 5 to 3, position 38 to 36, end 51 to 49

## Verification
- cargo fmt --all -- --check
- git diff --check
- all modified JSON baselines validated with jq

Per project guidance, no local build or test suite was run.