### PR TITLE
Match malformed snippet closing-paren error

### DIFF
--- a/.changeset/neat-snippets-close.md
+++ b/.changeset/neat-snippets-close.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Match Svelte's missing-parenthesis diagnostic for malformed snippet headers.

--- a/compatibility/error-end-known-failures.client-dev.json
+++ b/compatibility/error-end-known-failures.client-dev.json
@@ -33,7 +33,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",

--- a/compatibility/error-end-known-failures.client.json
+++ b/compatibility/error-end-known-failures.client.json
@@ -33,7 +33,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",

--- a/compatibility/error-end-known-failures.server-dev.json
+++ b/compatibility/error-end-known-failures.server-dev.json
@@ -33,7 +33,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",

--- a/compatibility/error-end-known-failures.server.json
+++ b/compatibility/error-end-known-failures.server.json
@@ -33,7 +33,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",

--- a/compatibility/error-known-failures.md
+++ b/compatibility/error-known-failures.md
@@ -98,12 +98,12 @@ of two unrelated errors say nothing, and the code divergence is an
 
 ## Why the per-target files are near-identical
 
-`error-message-known-failures.client.json` holds 3 entries;
-`error-message-known-failures.client-dev.json` holds 3 entries;
-`error-message-known-failures.server.json` holds 3 entries; and
-`error-message-known-failures.server-dev.json` holds 3 entries. All four of
-`error-position-known-failures.<target>.json` hold 36 entries, all four of
-`error-end-known-failures.<target>.json` hold 49 entries, and all four of
+`error-message-known-failures.client.json` holds 2 entries;
+`error-message-known-failures.client-dev.json` holds 2 entries;
+`error-message-known-failures.server.json` holds 2 entries; and
+`error-message-known-failures.server-dev.json` holds 2 entries. All four of
+`error-position-known-failures.<target>.json` hold 35 entries, all four of
+`error-end-known-failures.<target>.json` hold 48 entries, and all four of
 `error-frame-known-failures.<target>.json` hold 0 entries. The wave-2 enrolment
 (#3130) added 1 message, 16 position and 24 end entries — and **no frame entries
 at all**, which keeps that comparison's population saturated at 0 across a corpus
@@ -125,7 +125,7 @@ from before those passes; they are historical evidence about the backlog's shape
 not a decomposition of the current 36/49 files.
 
 The former client-only asymmetry is gone from the current corpus population, so
-all four files now carry the same three message entries.
+all four files now carry the same two message entries.
 
 ## Error messages
 
@@ -134,7 +134,7 @@ things on a minor bump": both compilers run on the same source, in the same
 process, at the pinned version, so a difference here is rsvelte's — the argument
 settled for warning text in #2403.
 
-Clustered by code (client target, 3 entries):
+Clustered by code (client target, 2 entries):
 
 - **`js_parse_error` — 2.** The Svelte code is right, but the
   text is oxc's parser message (`Expected `,` or `}` but found `+`) where upstream
@@ -168,11 +168,10 @@ Clustered by code (client target, 3 entries):
   OXC's keyword label for an array pattern and walks back from its missing-colon
   label to an object shorthand property, matching both acorn's contextual text
   and its point position.
-- **`expected_token` — 1.** `svelte/…/compiler-errors/samples/malformed-snippet-2`
-  names the closing token it wanted: rsvelte says `}` where upstream says `)`. The
-  two parsers recover from the malformed snippet header at different points, so
-  this is the same parser-divergence class as `js_parse_error` rather than a
-  message string.
+  The malformed snippet-header entry retired separately: the parameter scanner
+  now preserves upstream's required `)` diagnostic at the trimmed end of the
+  component instead of falling through to the outer `}` check.
+
 ## Error positions
 
 The codes agree; `start` does not. An editor, a Vite overlay and `rsvelte-check`

--- a/compatibility/error-message-known-failures.client-dev.json
+++ b/compatibility/error-message-known-failures.client-dev.json
@@ -1,5 +1,4 @@
 [
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
-	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte"
+	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte"
 ]

--- a/compatibility/error-message-known-failures.client.json
+++ b/compatibility/error-message-known-failures.client.json
@@ -1,5 +1,4 @@
 [
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
-	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte"
+	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte"
 ]

--- a/compatibility/error-message-known-failures.server-dev.json
+++ b/compatibility/error-message-known-failures.server-dev.json
@@ -1,5 +1,4 @@
 [
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
-	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte"
+	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte"
 ]

--- a/compatibility/error-message-known-failures.server.json
+++ b/compatibility/error-message-known-failures.server.json
@@ -1,5 +1,4 @@
 [
 	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
-	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte"
+	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte"
 ]

--- a/compatibility/error-position-known-failures.client-dev.json
+++ b/compatibility/error-position-known-failures.client-dev.json
@@ -21,7 +21,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",

--- a/compatibility/error-position-known-failures.client.json
+++ b/compatibility/error-position-known-failures.client.json
@@ -21,7 +21,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",

--- a/compatibility/error-position-known-failures.server-dev.json
+++ b/compatibility/error-position-known-failures.server-dev.json
@@ -21,7 +21,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",

--- a/compatibility/error-position-known-failures.server.json
+++ b/compatibility/error-position-known-failures.server.json
@@ -21,7 +21,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -2078,6 +2078,16 @@ impl<'a> Parser<'a> {
                 }
             }
 
+            // Upstream immediately requires `)` after this scan. If the
+            // parameter list runs into the end of the component, do not let
+            // the later snippet-header `}` check replace that diagnostic.
+            if depth > 0 && !self.options.loose {
+                return Err(crate::error::ParseError::expected_token(
+                    ")",
+                    self.content_end,
+                ));
+            }
+
             let params_end = self.index;
             let params_content = &self.source[params_start..params_end];
 

--- a/crates/rsvelte_core/tests/malformed_snippet_header.rs
+++ b/crates/rsvelte_core/tests/malformed_snippet_header.rs
@@ -1,0 +1,19 @@
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[test]
+fn an_unclosed_snippet_parameter_list_requires_the_closing_paren() {
+    let error = compile(
+        "{#snippet children(hi{/snippet}\n",
+        CompileOptions {
+            filename: Some("X.svelte".into()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect_err("the snippet parameter list is not closed");
+
+    let text = format!("{error:?}");
+    assert!(text.contains("expected_token"), "{text}");
+    assert!(text.contains("Expected token )"), "{text}");
+    assert!(text.contains("span: (31, 31)"), "{text}");
+}


### PR DESCRIPTION
Fix the snippet parameter scanner so an unclosed parameter list preserves Svelte's required closing-parenthesis diagnostic at the trimmed component end. Adds a focused regression test and removes the resolved entry from all error message, start, and end ratchets.\n\nStatic verification: cargo fmt --all -- --check; jq validation; git diff --check. Per project instruction, no local build or test execution was run.