### PR TITLE
Retire final error message divergences

### DIFF
--- a/.changeset/calm-parser-messages.md
+++ b/.changeset/calm-parser-messages.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Match Acorn diagnostics for malformed object expressions and untyped snippet parameters.

--- a/compatibility/error-known-failures.md
+++ b/compatibility/error-known-failures.md
@@ -98,10 +98,10 @@ of two unrelated errors say nothing, and the code divergence is an
 
 ## Why the per-target files are near-identical
 
-`error-message-known-failures.client.json` holds 2 entries;
-`error-message-known-failures.client-dev.json` holds 2 entries;
-`error-message-known-failures.server.json` holds 2 entries; and
-`error-message-known-failures.server-dev.json` holds 2 entries. All four of
+`error-message-known-failures.client.json` holds 0 entries;
+`error-message-known-failures.client-dev.json` holds 0 entries;
+`error-message-known-failures.server.json` holds 0 entries; and
+`error-message-known-failures.server-dev.json` holds 0 entries. All four of
 `error-position-known-failures.<target>.json` hold 35 entries, all four of
 `error-end-known-failures.<target>.json` hold 48 entries, and all four of
 `error-frame-known-failures.<target>.json` hold 0 entries. The wave-2 enrolment
@@ -125,7 +125,7 @@ from before those passes; they are historical evidence about the backlog's shape
 not a decomposition of the current 36/49 files.
 
 The former client-only asymmetry is gone from the current corpus population, so
-all four files now carry the same two message entries.
+all four files now carry no message entries.
 
 ## Error messages
 
@@ -134,9 +134,9 @@ things on a minor bump": both compilers run on the same source, in the same
 process, at the pinned version, so a difference here is rsvelte's — the argument
 settled for warning text in #2403.
 
-Clustered by code (client target, 2 entries):
+Clustered by code (client target, 0 entries):
 
-- **`js_parse_error` — 2.** The Svelte code is right, but the
+- **Former `js_parse_error` cluster — 2 entries retired.** The Svelte code is right, but the
   text is oxc's parser message (`Expected `,` or `}` but found `+`) where upstream
   forwards acorn's (`Unexpected token`). This is the one cluster whose fix is not a
   string edit: the two parsers phrase their own diagnostics, and rsvelte's text is
@@ -171,6 +171,10 @@ Clustered by code (client target, 2 entries):
   The malformed snippet-header entry retired separately: the parameter scanner
   now preserves upstream's required `)` diagnostic at the trimmed end of the
   component instead of falling through to the outer `}` check.
+  The final two entries retired together by adapting OXC's expected-delimiter
+  diagnostics to acorn's `Unexpected token`: one malformed object expression
+  in a template and one TypeScript annotation in a plain-JavaScript snippet
+  parameter list.
 
 ## Error positions
 

--- a/compatibility/error-message-known-failures.client-dev.json
+++ b/compatibility/error-message-known-failures.client-dev.json
@@ -1,4 +1,1 @@
-[
-	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
-	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte"
-]
+[]

--- a/compatibility/error-message-known-failures.client.json
+++ b/compatibility/error-message-known-failures.client.json
@@ -1,4 +1,1 @@
-[
-	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
-	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte"
-]
+[]

--- a/compatibility/error-message-known-failures.server-dev.json
+++ b/compatibility/error-message-known-failures.server-dev.json
@@ -1,4 +1,1 @@
-[
-	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
-	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte"
-]
+[]

--- a/compatibility/error-message-known-failures.server.json
+++ b/compatibility/error-message-known-failures.server.json
@@ -1,4 +1,1 @@
-[
-	"svelte.dev/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md/4.svelte",
-	"svelte.dev/apps/svelte.dev/content/docs/kit/30-advanced/25-errors.md/8.svelte"
-]
+[]

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -1866,9 +1866,14 @@ pub fn check_js_parse_error_with_pos(content: &str, ts: bool) -> Option<(String,
                 }
                 // `()` is the wrapper's own diagnostic for an empty tag body;
                 // acorn, given the body unwrapped, calls it an unexpected token.
-                let message = match first_error.message.as_ref() {
-                    "Empty parenthesized expression" => "Unexpected token",
-                    other => other,
+                let message = if first_error.message.as_ref() == "Empty parenthesized expression"
+                    || first_error
+                        .message
+                        .starts_with("Expected `,` or `}` but found ")
+                {
+                    "Unexpected token"
+                } else {
+                    first_error.message.as_ref()
                 };
                 // A label which is itself the offending token already has the
                 // acorn position above. Re-parsing it bare can turn that token
@@ -1960,7 +1965,16 @@ pub fn check_params_parse_error(params: &str, ts: bool) -> Option<(String, usize
                         .min(params.len())
                 })
                 .unwrap_or(0);
-            return Some((first_error.message.to_string(), pos));
+            let message = if !ts
+                && matches!(
+                    first_error.message.as_ref(),
+                    "Expected `,` or `)` but found `:`" | "Expected `,` or `)` but found `?`"
+                ) {
+                "Unexpected token"
+            } else {
+                first_error.message.as_ref()
+            };
+            return Some((message.to_string(), pos));
         }
         acorn_only_violation(&result.program, &wrapped, ts)
             .map(|(at, message)| (message, (at as usize).saturating_sub(1).min(params.len())))
@@ -13694,6 +13708,23 @@ mod tests {
             assert_eq!(message, expected_message, "{source}");
             assert_eq!(span, (10 + expected_at, 10 + expected_at), "{source}");
         }
+    }
+
+    #[test]
+    fn malformed_object_expression_uses_acorns_unexpected_token_message() {
+        assert_eq!(
+            check_js_parse_error_with_pos("{a + b}", false).map(|error| error.0),
+            Some("Unexpected token".to_string())
+        );
+    }
+
+    #[test]
+    fn plain_js_snippet_type_annotation_uses_acorns_message() {
+        assert_eq!(
+            check_params_parse_error("error: App.Error", false),
+            Some(("Unexpected token".to_string(), 5))
+        );
+        assert_eq!(check_params_parse_error("error: App.Error", true), None);
     }
 
     #[test]


### PR DESCRIPTION
Adapt OXC's expected-delimiter diagnostics to Acorn-compatible Unexpected token messages in malformed object expressions and plain-JavaScript snippet parameter lists. Adds focused unit coverage and shrinks all four error-message ratchets from 2 to 0.\n\nStatic verification: cargo fmt --all -- --check; jq validation; git diff --check. Per project instruction, no local build or test execution was run.