### PR TITLE
Fix parser diagnostic API usage

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -231,7 +231,7 @@ pub(super) fn declares_binding_in_statement(statement: &str, name: &str) -> bool
         if finder.found {
             return true;
         }
-        if parsed.errors.is_empty() {
+        if parsed.diagnostics.is_empty() {
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- use the current OXC ParserReturn diagnostics field
- unblock rsvelte_core compilation and every compatibility CI job

## Verification
- cargo fmt --all -- --check
- git diff --check
- local builds/tests intentionally not run per project instruction