### PR TITLE
fix: keep constant folds inside lexical snippet scopes

### DIFF
--- a/compatibility/pattern-corpus/README.md
+++ b/compatibility/pattern-corpus/README.md
@@ -651,6 +651,7 @@ read as an element's only child, so the resolution decides between a static
 | `key-block.svelte` | `{@const}` inside `{#key}`, keyed on the shadowed binding |
 | `await-then-body.svelte` | `{@const}` in an `{#await … then}` body |
 | `snippet-body.svelte` | `{@const}` inside a `{#snippet}` |
+| `sibling-snippets.svelte` | a `{@const}` in one snippet is unreachable from its sibling |
 | `boundary-children.svelte` | `{@const}` in `<svelte:boundary>` children |
 | `destructured-const.svelte` | destructuring `{@const { value } = …}` |
 | `shadows-prop.svelte` | the shadowed binding is a **prop** (the read must not become `$$props.x`) |

--- a/compatibility/pattern-corpus/matrix/const-shadow/sibling-snippets.svelte
+++ b/compatibility/pattern-corpus/matrix/const-shadow/sibling-snippets.svelte
@@ -1,0 +1,9 @@
+<svelte:boundary>
+	{#snippet children()}
+		{@const value = 'children'}
+	{/snippet}
+
+	{#snippet failed()}
+		{value}
+	{/snippet}
+</svelte:boundary>

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -1,6 +1,42 @@
 use super::*;
 
 #[test]
+fn constant_fold_does_not_resolve_a_binding_from_a_sibling_snippet() {
+    let source = r#"<svelte:boundary>
+    {#snippet children()}
+        {@const foo = 'bar'}
+    {/snippet}
+
+    {#snippet failed()}
+        {foo}
+    {/snippet}
+</svelte:boundary>"#;
+
+    for dev in [false, true] {
+        let output = crate::compiler::compile(
+            source,
+            crate::compiler::CompileOptions {
+                filename: Some("sibling-snippet-constant.svelte".to_string()),
+                dev,
+                ..Default::default()
+            },
+        )
+        .expect("compiles")
+        .js
+        .code;
+
+        assert!(
+            output.contains("text.nodeValue = foo;"),
+            "an unresolved name must not use a sibling snippet's constant in dev={dev}:\n{output}"
+        );
+        assert!(
+            !output.contains("text.nodeValue = \"bar\";"),
+            "a sibling snippet's constant must remain unreachable in dev={dev}:\n{output}"
+        );
+    }
+}
+
+#[test]
 fn leading_semicolon_exposes_the_following_statement_boundary() {
     let source = "const point3 = derived(\n\tpoint4,\n\t($point4) => $point4.slice(0, 3)\n)\n;(point3).set = () => { $point4 = [] }";
     let separated = separate_same_line_top_level_statements(source, false);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -6318,6 +6318,7 @@ impl EvalScope for ClientEvalScope<'_, '_> {
                     .get(name)
                     .filter(|bindings| bindings.len() == 1)
                     .and_then(|_| self.context.state.get_binding(name))
+                    .filter(|binding| self.context.state.scope_chain_contains(binding.scope_index))
             }
         };
         match binding {


### PR DESCRIPTION
Fixes client and client-dev output parity for unresolved identifiers in sibling snippets.

Phase 2 correctly leaves the sibling reference unresolved, but the client constant evaluator fell back to the only same-named binding anywhere in the component. Restrict that fallback to the active lexical scope chain, and add the duplicated upstream shape to the pattern corpus.

Validation: cargo fmt --all -- --check; git diff --check. Local builds/tests intentionally skipped per repository workflow.