### PR TITLE
Fix return JSDoc cast parentheses

### DIFF
--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -376,7 +376,6 @@
 	"svelte-tweakpane-ui/src/lib/internal/ClsPad.svelte",
 	"svelte/packages/svelte/tests/runtime-legacy/samples/rest-props-delete/App.svelte",
 	"svelte/packages/svelte/tests/snapshot/samples/delegated-locally-declared-shadowed/index.svelte",
-	"sveltekit/packages/kit/src/runtime/client/remote-functions/shared.svelte.js",
 	"sveltekit/packages/kit/src/runtime/components/root.svelte",
 	"sveltekit/packages/kit/test/apps/basics/src/routes/load/fetch-arraybuffer-b64/+page.svelte",
 	"sveltekit/packages/kit/test/apps/basics/src/routes/load/fetch-body-stream-b64/+page.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -342,7 +342,6 @@
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte",
 	"svelte-tweakpane-ui/src/lib/internal/ClsPad.svelte",
 	"svelte/packages/svelte/tests/runtime-legacy/samples/rest-props-delete/App.svelte",
-	"sveltekit/packages/kit/src/runtime/client/remote-functions/shared.svelte.js",
 	"sveltekit/packages/kit/src/runtime/components/root.svelte",
 	"sveltekit/packages/kit/test/apps/basics/src/routes/load/fetch-arraybuffer-b64/+page.svelte",
 	"sveltekit/packages/kit/test/apps/basics/src/routes/load/fetch-body-stream-b64/+page.svelte",

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -27,11 +27,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-## Client (`known-failures.client.json`, 421 entries)
+## Client (`known-failures.client.json`, 420 entries)
 
-Partition of `known-failures.client.json` by verdict: `325 + 36 + 20 + 37 + 3`
+Partition of `known-failures.client.json` by verdict: `324 + 36 + 20 + 37 + 3`
 
-- **325 — the generated JS differs** (`js` / `code-differs`).
+- **324 — the generated JS differs** (`js` / `code-differs`).
 - **36 — both compilers reject the entry with a different error code.**
 - **20 — one compiler rejects and the other compiles** (10 under-rejections,
   10 over-rejections; see § *Wave-2 enrolment* below).
@@ -40,7 +40,7 @@ Partition of `known-failures.client.json` by verdict: `325 + 36 + 20 + 37 + 3`
   [`parse-known-failures.md`](parse-known-failures.md) and listed here too
   because unparseable output is necessarily byte-different.
 
-Every one of the 421 arrived with the wave-2 enrolment (#3130) and is described
+Every one of the 420 arrived with the wave-2 enrolment (#3130) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -65,15 +65,15 @@ everywhere". Divergences this target keeps on purpose — because reproducing
 upstream's bytes would emit invalid JavaScript — are recorded in
 [`deliberate-divergences.md`](deliberate-divergences.md), each pinned by a test.
 
-## Server (`known-failures.server.json`, 122 entries)
+## Server (`known-failures.server.json`, 121 entries)
 
-Partition of `known-failures.server.json` by verdict: `64 + 36 + 22`
+Partition of `known-failures.server.json` by verdict: `63 + 36 + 22`
 
-- **64 — the generated JS differs.**
+- **63 — the generated JS differs.**
 - **36 — both compilers reject with a different error code.**
 - **22 — one compiler rejects and the other compiles.**
 
-All 122 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All 121 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it. The last pre-enrolment entry was #2308, from the `runed` / `svelte-toolbelt` enrolment:
 `watch.test.svelte.ts` writes `runs = runs + 1` and rsvelte **contracted** it to
 `runs += 1` (that direction, not the reverse). The `.svelte.(js|ts)` server path
@@ -91,35 +91,35 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Server dev (`known-failures.server-dev.json`, 122 entries)
+## Server dev (`known-failures.server-dev.json`, 121 entries)
 
 The `server-dev` target is the server transform with `dev: true`. It separately
 ratchets server-only development instrumentation: component metadata, element
 locations, dynamic-element validation, snippet validation, and injected CSS.
 
-Partition of `known-failures.server-dev.json` by verdict: `64 + 36 + 22`
+Partition of `known-failures.server-dev.json` by verdict: `63 + 36 + 22`
 
-- **64 — the generated JS differs.**
+- **63 — the generated JS differs.**
 - **36 — both compilers reject with a different error code.**
 - **22 — one compiler rejects and the other compiles.**
 
-All 122 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All 121 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it. Its counts now match `server`. The one extra entry was SoftShadows output
 that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-## Client dev (`known-failures.client-dev.json`, 458 entries)
+## Client dev (`known-failures.client-dev.json`, 457 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `364 + 36 + 20 + 34 + 4`
+Partition of `known-failures.client-dev.json` by verdict: `363 + 36 + 20 + 34 + 4`
 
-- **364 — the generated JS differs.**
+- **363 — the generated JS differs.**
 - **36 — both compilers reject with a different error code.**
 - **20 — one compiler rejects and the other compiles.**
 - **34 — the generated CSS differs** (three fewer than `client`).
 - **4 — rsvelte's output is not JavaScript.**
 
-All 458 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All 457 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 40 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/known-failures.server-dev.json
+++ b/compatibility/known-failures.server-dev.json
@@ -68,7 +68,6 @@
 	"svelte-put/sites/docs/src/packages/inline-svg/docs.md.svelte",
 	"svelte-put/sites/docs/src/packages/preprocess-external-link/docs.md.svelte",
 	"svelte-put/sites/docs/src/packages/qr/docs.md.svelte",
-	"sveltekit/packages/kit/src/runtime/client/remote-functions/shared.svelte.js",
 	"sveltepress/packages/theme-default/src/components/NavItem.svelte",
 	"svelty-picker/src/routes/+layout.svelte",
 	"syntaxfm-website/src/lib/ComponentWindow.svelte",

--- a/compatibility/known-failures.server.json
+++ b/compatibility/known-failures.server.json
@@ -68,7 +68,6 @@
 	"svelte-put/sites/docs/src/packages/inline-svg/docs.md.svelte",
 	"svelte-put/sites/docs/src/packages/preprocess-external-link/docs.md.svelte",
 	"svelte-put/sites/docs/src/packages/qr/docs.md.svelte",
-	"sveltekit/packages/kit/src/runtime/client/remote-functions/shared.svelte.js",
 	"sveltepress/packages/theme-default/src/components/NavItem.svelte",
 	"svelty-picker/src/routes/+layout.svelte",
 	"syntaxfm-website/src/lib/ComponentWindow.svelte",

--- a/compatibility/pattern-corpus/return-jsdoc-cast.svelte.js
+++ b/compatibility/pattern-corpus/return-jsdoc-cast.svelte.js
@@ -1,0 +1,6 @@
+/** @returns {TThen} */
+export function pin(then) {
+	return /** @type {TThen} */ (
+		(...args) => then(...args)
+	);
+}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -1,6 +1,47 @@
 use super::*;
 
 #[test]
+fn module_return_jsdoc_cast_parenthesizes_its_arrow() {
+    let source = r#"
+        /** @returns {TThen} */
+        export function pin(then) {
+            return /** @type {TThen} */ (
+                (...args) => then(...args)
+            );
+        }
+    "#;
+
+    for generate in [
+        crate::compiler::GenerateMode::Client,
+        crate::compiler::GenerateMode::Server,
+    ] {
+        for dev in [false, true] {
+            let output = crate::compiler::compile_module(
+                source,
+                crate::compiler::ModuleCompileOptions {
+                    filename: Some("return-jsdoc-cast.svelte.js".to_string()),
+                    generate,
+                    dev,
+                    ..Default::default()
+                },
+            )
+            .expect("compiles")
+            .js
+            .code;
+
+            assert!(
+                output.contains("return (\n\t\t/** @type {TThen} */"),
+                "a return-leading JSDoc cast must retain the upstream safety parentheses in {generate:?}, dev={dev}:\n{output}"
+            );
+            assert!(
+                !output.contains("return /** @type {TThen} */"),
+                "the cast comment must not remain unparenthesized in {generate:?}, dev={dev}:\n{output}"
+            );
+        }
+    }
+}
+
+#[test]
 fn first_comment_reemitted_from_a_typescript_declaration_repeats_in_client_output() {
     let source = r#"<script lang="ts">
         type OwnProps = {

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -1984,7 +1984,12 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                     let contains_comment = HAS_COMMENTS
                         && self
                             .comment_at(self.comment_index)
-                            .is_some_and(|c| c.start < unparen(arg).span().start);
+                            // A parsed source comment is strictly before its
+                            // argument. Chunk-backed module statements can
+                            // instead give the synthesized comment and rebuilt
+                            // expression the same anchor; upstream still sees
+                            // the comment between `return` and the argument.
+                            .is_some_and(|c| c.start <= unparen(arg).span().start);
                     let start = s.span().start;
                     if contains_comment {
                         self.write_keyword(ctx, start, "return", " (");


### PR DESCRIPTION
## Summary
- treat a synthesized return-leading comment at the expression anchor as preceding the argument
- preserve upstream's safety parentheses around JSDoc-cast arrow returns
- add compileModule coverage for client/server in prod/dev plus a pattern-corpus repro
- remove the fixed SvelteKit entry from all four output ratchets

## Checks
- cargo fmt --all -- --check
- node scripts/compat-corpus/known-failures-md-check.mjs
- JSON parse checks
- git diff --check

No local build or test execution, per the repository-machine constraint; CI is the execution oracle.