### PR TITLE
Track each item mutation in bind this setters

### DIFF
--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -313,7 +313,6 @@
 	"syntaxfm-website/src/lib/player/Player.svelte",
 	"syntaxfm-website/src/routes/(blank)/embed/[show_number]/+page.svelte",
 	"syntaxfm-website/src/routes/(site)/guests/+page.svelte",
-	"threlte/apps/docs/src/examples/rapier/rigid-body/Particle.svelte",
 	"threlte/packages/extras/src/lib/components/Detailed/Detailed.svelte",
 	"threlte/packages/extras/src/lib/hooks/useGamepad/useGamepad.svelte.ts",
 	"threlte/packages/extras/src/lib/hooks/useViewport.svelte.ts",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -276,7 +276,6 @@
 	"syntaxfm-website/src/lib/player/Player.svelte",
 	"syntaxfm-website/src/routes/(blank)/embed/[show_number]/+page.svelte",
 	"syntaxfm-website/src/routes/(site)/guests/+page.svelte",
-	"threlte/apps/docs/src/examples/rapier/rigid-body/Particle.svelte",
 	"threlte/packages/extras/src/lib/components/Detailed/Detailed.svelte",
 	"threlte/packages/extras/src/lib/hooks/useViewport.svelte.ts",
 	"threlte/packages/flex/src/routes/+page.svelte",

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -27,11 +27,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-## Client (`known-failures.client.json`, 335 entries)
+## Client (`known-failures.client.json`, 334 entries)
 
-Partition of `known-failures.client.json` by verdict: `239 + 36 + 20 + 37 + 3`
+Partition of `known-failures.client.json` by verdict: `238 + 36 + 20 + 37 + 3`
 
-- **239 — the generated JS differs** (`js` / `code-differs`).
+- **238 — the generated JS differs** (`js` / `code-differs`).
 - **36 — both compilers reject the entry with a different error code.**
 - **20 — one compiler rejects and the other compiles** (10 under-rejections,
   10 over-rejections; see § *Wave-2 enrolment* below).
@@ -109,11 +109,11 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-## Client dev (`known-failures.client-dev.json`, 373 entries)
+## Client dev (`known-failures.client-dev.json`, 372 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `279 + 36 + 20 + 34 + 4`
+Partition of `known-failures.client-dev.json` by verdict: `278 + 36 + 20 + 34 + 4`
 
-- **279 — the generated JS differs.**
+- **278 — the generated JS differs.**
 - **36 — both compilers reject with a different error code.**
 - **20 — one compiler rejects and the other compiles.**
 - **34 — the generated CSS differs** (three fewer than `client`).
@@ -389,6 +389,10 @@ store scan ignored the await scope and synthesized a root `$gltf` subscription;
 template-block collection now removes each/await/snippet bindings only inside
 the fragment where they shadow, retiring four target-pairs without hiding a
 same-named top-level store reference elsewhere.
+Threlte's `Particle.svelte` binds a component instance into a member of a runes
+mode each item. The synthesized `bind:this={audio.ref}` setter now records the
+same each-item mutation as upstream's transform, retaining the required index
+parameter and retiring its client and client-dev entries.
 The three AdventureLog entries whose same-line legacy-prop comments disappeared
 from the final `$.prop` argument were fixed by #3937's comment-preserving prop
 lowering and are now retired from both client baselines.

--- a/compatibility/pattern-corpus/issues/each-bind-this-item-member.svelte
+++ b/compatibility/pattern-corpus/issues/each-bind-this-item-member.svelte
@@ -1,0 +1,16 @@
+<script>
+  import Widget from './Widget.svelte';
+
+  let rows = $state([
+    { component: undefined, element: undefined },
+    { component: undefined, element: undefined }
+  ]);
+</script>
+
+{#each rows as row}
+  <div bind:this={row.element}></div>
+{/each}
+
+{#each rows as row}
+  <Widget bind:this={row.component} />
+{/each}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -129,9 +129,25 @@ pub fn unified_build_bind_this(
 
     let mut set = apply_transforms_to_expression_with_shadowed(&setter_raw, context, &local_scope);
 
-    // In legacy mode, when bind:this is inside an each block AND the expression's root
-    // object is an each item variable (e.g., bind:this={item.ref}), the setter needs to
-    // include $.invalidate_inner_signals() to properly propagate changes.
+    // A synthesized `bind:this={item.ref}` setter mutates the each item. Upstream's
+    // each-item `mutate` transform therefore marks the render callback as using its
+    // index in both legacy and runes mode. Our local scope deliberately shadows that
+    // transform while building the setter, so record the mutation explicitly.
+    let expr_root = get_expression_root_identifier(&raw_expr, &context.arena);
+    let mutated_each_item = expr_root.as_ref().and_then(|root_name| {
+        context
+            .state
+            .each_binding_context
+            .iter()
+            .rev()
+            .find(|each_ctx| each_ctx.item_name == *root_name)
+    });
+    if mutated_each_item.is_some() {
+        context.state.each_item_assign_or_mutate.set(true);
+    }
+
+    // In legacy mode the setter also needs $.invalidate_inner_signals() to
+    // propagate the member assignment.
     //
     // This does NOT apply when the root object is a different variable (e.g.,
     // bind:this={items1[item.id]} where items1 is a state variable - item is only used
@@ -142,39 +158,23 @@ pub fn unified_build_bind_this(
     // invalidation wrapping directly here.
     //
     // Expected output: ($$value, item) => (item.ref = $$value, $.invalidate_inner_signals(() => (items())))
-    if !context.state.analysis.runes && !each_ids.is_empty() {
-        // Check if the bind:this expression's root object is an each item variable
-        let expr_root = get_expression_root_identifier(&raw_expr, &context.arena);
-        if let Some(ref root_name) = expr_root
-            && let Some(each_ctx) = context
-                .state
-                .each_binding_context
-                .iter()
-                .rev()
-                .find(|ctx| ctx.item_name == *root_name)
-            && !each_ctx.invalidation_exprs.is_empty()
-        {
-            // Mark that an each item was mutated. In the official compiler, this
-            // happens via the `mutate` transform callback which sets `uses_index = true`.
-            // Since our local_scope shadows the each item transforms, the mutation
-            // isn't detected by apply_transforms_to_expression_with_shadowed.
-            // We must set this flag here so that the each block callback includes
-            // the $$index and $$array parameters.
-            context.state.each_item_assign_or_mutate.set(true);
-
-            let invalidation_exprs = each_ctx.invalidation_exprs.clone();
-            let invalidation_inner_exprs: Vec<JsExpr> = invalidation_exprs
-                .iter()
-                .map(|s| JsExpr::Raw(s.clone().into()))
-                .collect();
-            let inner = b::sequence(invalidation_inner_exprs);
-            let invalidate_call = b::call(
-                &context.arena,
-                b::member_path(&context.arena, "$.invalidate_inner_signals"),
-                vec![b::thunk(&context.arena, inner)],
-            );
-            set = b::sequence(vec![set, invalidate_call]);
-        }
+    if !context.state.analysis.runes
+        && !each_ids.is_empty()
+        && let Some(each_ctx) = mutated_each_item
+        && !each_ctx.invalidation_exprs.is_empty()
+    {
+        let invalidation_exprs = each_ctx.invalidation_exprs.clone();
+        let invalidation_inner_exprs: Vec<JsExpr> = invalidation_exprs
+            .iter()
+            .map(|s| JsExpr::Raw(s.clone().into()))
+            .collect();
+        let inner = b::sequence(invalidation_inner_exprs);
+        let invalidate_call = b::call(
+            &context.arena,
+            b::member_path(&context.arena, "$.invalidate_inner_signals"),
+            vec![b::thunk(&context.arena, inner)],
+        );
+        set = b::sequence(vec![set, invalidate_call]);
     }
 
     // Restore the original skip_proxy value


### PR DESCRIPTION
Fixes runes-mode bind:this setters rooted at an each item. The unified setter path now records the same each-item mutation as upstream, retaining the required render callback index parameter.

This retires the threlte Particle client and client-dev compatibility entries and adds a pattern-corpus regression covering element and component bindings.

Static verification: cargo fmt check, known-failures documentation check, JSON validation, and git diff check. Per request, no local build or test suite was run.