### PR TITLE
Fix rune binding shadow resolution

### DIFF
--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -313,7 +313,6 @@
 	"syntaxfm-website/src/lib/player/Player.svelte",
 	"syntaxfm-website/src/routes/(blank)/embed/[show_number]/+page.svelte",
 	"syntaxfm-website/src/routes/(site)/guests/+page.svelte",
-	"threlte/packages/extras/src/lib/components/Detailed/Detailed.svelte",
 	"threlte/packages/extras/src/lib/hooks/useGamepad/useGamepad.svelte.ts",
 	"threlte/packages/extras/src/lib/hooks/useViewport.svelte.ts",
 	"threlte/packages/flex/src/routes/+page.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -276,7 +276,6 @@
 	"syntaxfm-website/src/lib/player/Player.svelte",
 	"syntaxfm-website/src/routes/(blank)/embed/[show_number]/+page.svelte",
 	"syntaxfm-website/src/routes/(site)/guests/+page.svelte",
-	"threlte/packages/extras/src/lib/components/Detailed/Detailed.svelte",
 	"threlte/packages/extras/src/lib/hooks/useViewport.svelte.ts",
 	"threlte/packages/flex/src/routes/+page.svelte",
 	"threlte/packages/theatre/src/lib/sequence/Sequence.svelte",

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -27,11 +27,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-## Client (`known-failures.client.json`, 334 entries)
+## Client (`known-failures.client.json`, 333 entries)
 
-Partition of `known-failures.client.json` by verdict: `238 + 36 + 20 + 37 + 3`
+Partition of `known-failures.client.json` by verdict: `237 + 36 + 20 + 37 + 3`
 
-- **238 — the generated JS differs** (`js` / `code-differs`).
+- **237 — the generated JS differs** (`js` / `code-differs`).
 - **36 — both compilers reject the entry with a different error code.**
 - **20 — one compiler rejects and the other compiles** (10 under-rejections,
   10 over-rejections; see § *Wave-2 enrolment* below).
@@ -65,15 +65,15 @@ everywhere". Divergences this target keeps on purpose — because reproducing
 upstream's bytes would emit invalid JavaScript — are recorded in
 [`deliberate-divergences.md`](deliberate-divergences.md), each pinned by a test.
 
-## Server (`known-failures.server.json`, 121 entries)
+## Server (`known-failures.server.json`, 120 entries)
 
-Partition of `known-failures.server.json` by verdict: `63 + 36 + 22`
+Partition of `known-failures.server.json` by verdict: `62 + 36 + 22`
 
-- **63 — the generated JS differs.**
+- **62 — the generated JS differs.**
 - **36 — both compilers reject with a different error code.**
 - **22 — one compiler rejects and the other compiles.**
 
-All 121 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All 120 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it. The last pre-enrolment entry was #2308, from the `runed` / `svelte-toolbelt` enrolment:
 `watch.test.svelte.ts` writes `runs = runs + 1` and rsvelte **contracted** it to
 `runs += 1` (that direction, not the reverse). The `.svelte.(js|ts)` server path
@@ -91,29 +91,29 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Server dev (`known-failures.server-dev.json`, 121 entries)
+## Server dev (`known-failures.server-dev.json`, 120 entries)
 
 The `server-dev` target is the server transform with `dev: true`. It separately
 ratchets server-only development instrumentation: component metadata, element
 locations, dynamic-element validation, snippet validation, and injected CSS.
 
-Partition of `known-failures.server-dev.json` by verdict: `63 + 36 + 22`
+Partition of `known-failures.server-dev.json` by verdict: `62 + 36 + 22`
 
-- **63 — the generated JS differs.**
+- **62 — the generated JS differs.**
 - **36 — both compilers reject with a different error code.**
 - **22 — one compiler rejects and the other compiles.**
 
-All 121 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All 120 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it. Its counts now match `server`. The one extra entry was SoftShadows output
 that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-## Client dev (`known-failures.client-dev.json`, 372 entries)
+## Client dev (`known-failures.client-dev.json`, 371 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `278 + 36 + 20 + 34 + 4`
+Partition of `known-failures.client-dev.json` by verdict: `277 + 36 + 20 + 34 + 4`
 
-- **278 — the generated JS differs.**
+- **277 — the generated JS differs.**
 - **36 — both compilers reject with a different error code.**
 - **20 — one compiler rejects and the other compiles.**
 - **34 — the generated CSS differs** (three fewer than `client`).

--- a/compatibility/known-failures.server-dev.json
+++ b/compatibility/known-failures.server-dev.json
@@ -73,7 +73,6 @@
 	"syntaxfm-website/src/lib/ComponentWindow.svelte",
 	"threlte/apps/docs/src/examples/geometry/random-placement/basic-random/assets/bush.svelte",
 	"threlte/apps/docs/src/examples/xr/vr-button/assets/bush.svelte",
-	"threlte/packages/extras/src/lib/components/Detailed/Detailed.svelte",
 	"threlte/packages/extras/src/lib/hooks/useViewport.svelte.ts",
 	"trakt-web/projects/client/src/lib/components/avatar-pill/AvatarPill.svelte",
 	"trakt-web/projects/client/src/lib/components/buttons/Button.svelte",

--- a/compatibility/known-failures.server.json
+++ b/compatibility/known-failures.server.json
@@ -73,7 +73,6 @@
 	"syntaxfm-website/src/lib/ComponentWindow.svelte",
 	"threlte/apps/docs/src/examples/geometry/random-placement/basic-random/assets/bush.svelte",
 	"threlte/apps/docs/src/examples/xr/vr-button/assets/bush.svelte",
-	"threlte/packages/extras/src/lib/components/Detailed/Detailed.svelte",
 	"threlte/packages/extras/src/lib/hooks/useViewport.svelte.ts",
 	"trakt-web/projects/client/src/lib/components/avatar-pill/AvatarPill.svelte",
 	"trakt-web/projects/client/src/lib/components/buttons/Button.svelte",

--- a/compatibility/pattern-corpus/nested-derived-shadows-prop.svelte
+++ b/compatibility/pattern-corpus/nested-derived-shadows-prop.svelte
@@ -1,0 +1,21 @@
+<script>
+	let { ref = $bindable() } = $props();
+
+	function observe(read, apply) {
+		apply(read());
+	}
+
+	function setup(value) {
+		const ref = $derived(value);
+		const distance = $derived(1);
+
+		observe(
+			() => [ref, distance],
+			([ref, distance]) => console.log(ref, distance)
+		);
+	}
+
+	setup(1);
+</script>
+
+<div bind:this={ref}></div>

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -457,15 +457,37 @@ impl<'a, 's> StateVarCollector<'a, 's> {
     /// Check if a name is a state variable that should be transformed,
     /// considering non-reactive exclusions and scope shadowing.
     fn is_active_state_var(&self, name: &str) -> bool {
-        self.state_vars.contains(name)
-            && !self.non_reactive_vars.contains(name)
-            && !self.is_state_var_shadowed(name)
+        !self.non_reactive_vars.contains(name)
+            && (self.resolves_to_local_state(name)
+                || (self.state_vars.contains(name) && !self.is_state_var_shadowed(name)))
     }
 
     /// Check if a name is a state variable (including non-reactive),
     /// used for assignment transforms which apply to all state vars.
     fn is_any_state_var(&self, name: &str) -> bool {
-        self.state_vars.contains(name) && !self.is_state_var_shadowed(name)
+        self.resolves_to_local_state(name)
+            || (self.state_vars.contains(name) && !self.is_state_var_shadowed(name))
+    }
+
+    /// Resolve a locally declared rune binding independently of the root
+    /// analysis name set. The root declaration map keeps the outer binding on
+    /// a collision, so an inner `$derived` named like an outer prop is absent
+    /// from `state_vars` even though reads in that scope are reactive.
+    fn resolves_to_local_state(&self, name: &str) -> bool {
+        for (state_scope, scope) in self
+            .active_state_vars
+            .iter()
+            .rev()
+            .zip(self.scoped_vars.iter().rev())
+        {
+            if state_scope.contains(name) {
+                return true;
+            }
+            if scope.contains(name) {
+                return false;
+            }
+        }
+        false
     }
 
     fn is_state_var_shadowed(&self, name: &str) -> bool {
@@ -491,6 +513,21 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             .iter()
             .rev()
             .any(|scope| scope.contains(name))
+    }
+
+    /// Check whether a non-state transform binding (prop/store/rest) is hidden
+    /// by a local declaration. Reactive declarations live in
+    /// `active_state_vars`, rather than `scoped_vars`, so that their own reads
+    /// still receive `$.get(...)`. They nevertheless shadow an outer prop (for
+    /// example an inner `const ref = $derived(...)` shadowing a bindable `ref`
+    /// prop), and must participate in resolving every other binding kind.
+    fn is_non_state_binding_shadowed(&self, name: &str) -> bool {
+        self.is_shadowed(name)
+            || self
+                .active_state_vars
+                .iter()
+                .rev()
+                .any(|scope| scope.contains(name))
     }
 
     /// Declare a variable in the current scope.
@@ -537,22 +574,22 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         self.prop_source_vars.contains(name)
             && !self.read_only_prop_names.contains(name)
             && !self.rest_prop_vars.contains(name)
-            && !self.is_shadowed(name)
+            && !self.is_non_state_binding_shadowed(name)
     }
 
     /// Check if a name is a store subscription variable.
     fn is_active_store_sub(&self, name: &str) -> bool {
-        self.store_sub_vars.contains(name) && !self.is_shadowed(name)
+        self.store_sub_vars.contains(name) && !self.is_non_state_binding_shadowed(name)
     }
 
     /// Check if a name is a read-only prop.
     fn is_active_read_only_prop(&self, name: &str) -> bool {
-        self.read_only_prop_names.contains(name) && !self.is_shadowed(name)
+        self.read_only_prop_names.contains(name) && !self.is_non_state_binding_shadowed(name)
     }
 
     /// Check if a name is a rest prop variable.
     fn is_active_rest_prop(&self, name: &str) -> bool {
-        self.rest_prop_vars.contains(name) && !self.is_shadowed(name)
+        self.rest_prop_vars.contains(name) && !self.is_non_state_binding_shadowed(name)
     }
 
     /// If `expr` is a bare single-level `rest.x` StaticMemberExpression on an active
@@ -695,6 +732,32 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             }
         }
         false
+    }
+
+    /// Whether a known transform declaration introduces a reactive binding,
+    /// rather than a prop/store helper binding. This distinction matters when
+    /// root analysis retained an outer same-named prop declaration.
+    fn is_reactive_transform_declaration(&self, declarator: &VariableDeclarator<'_>) -> bool {
+        let Some(init) = &declarator.init else {
+            return false;
+        };
+        let init_start = init.span().start as usize;
+        let init_end = init.span().end as usize;
+        if init_end <= self.source.len() {
+            let init_text = &self.source[init_start..init_end];
+            if init_text.starts_with("$.state(")
+                || init_text.starts_with("$.state.raw(")
+                || init_text.starts_with("$.derived(")
+                || init_text.starts_with("$.derived_by(")
+                || init_text.starts_with("await $.async_derived(")
+            {
+                return true;
+            }
+        }
+        self.is_state_call_init(init)
+            || self.is_state_raw_or_frozen_init(init)
+            || self.is_derived_call_init(init)
+            || self.is_derived_by_init(init)
     }
 
     /// Returns true if `init` is a plain `$derived(...)` CallExpression whose
@@ -2786,6 +2849,36 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         self.collect_binding_names_inner(pattern, true);
     }
 
+    fn collect_active_state_binding_names(&mut self, pattern: &BindingPattern<'_>) {
+        match pattern {
+            BindingPattern::BindingIdentifier(id) => {
+                self.active_state_vars
+                    .last_mut()
+                    .expect("scope stacks stay aligned")
+                    .insert(id.name.to_string());
+            }
+            BindingPattern::ObjectPattern(object) => {
+                for property in &object.properties {
+                    self.collect_active_state_binding_names(&property.value);
+                }
+                if let Some(rest) = &object.rest {
+                    self.collect_active_state_binding_names(&rest.argument);
+                }
+            }
+            BindingPattern::ArrayPattern(array) => {
+                for element in array.elements.iter().flatten() {
+                    self.collect_active_state_binding_names(element);
+                }
+                if let Some(rest) = &array.rest {
+                    self.collect_active_state_binding_names(&rest.argument);
+                }
+            }
+            BindingPattern::AssignmentPattern(assignment) => {
+                self.collect_active_state_binding_names(&assignment.left);
+            }
+        }
+    }
+
     /// Check if a name is any known transform variable (state, prop, store, read-only, rest-prop)
     /// that should not be registered as shadowed at program scope.
     fn is_any_known_transform_var(&self, name: &str) -> bool {
@@ -2903,7 +2996,11 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
         // `is_shadowed()` true and suppress every transform for them.
         for declarator in &decl.declarations {
             if self.is_known_transform_declaration(declarator) {
-                self.collect_binding_names_skip_state(&declarator.id);
+                if self.is_reactive_transform_declaration(declarator) {
+                    self.collect_active_state_binding_names(&declarator.id);
+                } else {
+                    self.collect_binding_names_skip_state(&declarator.id);
+                }
             } else {
                 self.collect_binding_names(&declarator.id);
             }
@@ -6096,6 +6193,36 @@ mod tests {
         let expected =
             "function wrap(initial) {\nlet _value = $.state(initial);\nreturn $.get(_value);\n}";
         assert_eq!(transform(input, &["_value"]), expected);
+    }
+
+    #[test]
+    fn local_derived_shadows_same_named_outer_prop() {
+        let prop_vars = vec!["ref".to_string()];
+        let config = AstTransformConfig {
+            state_vars: &[],
+            non_reactive_vars: &[],
+            raw_state_vars: &[],
+            derived_vars: &[],
+            non_proxy_vars: &[],
+            reassign_non_proxy_vars: &[],
+            is_runes: true,
+            dev: false,
+            analysis_source: None,
+            filename: None,
+            async_derived_locations: None,
+            prop_source_vars: &prop_vars,
+            prop_assignment_transform_vars: &prop_vars,
+            non_bindable_prop_vars: &[],
+            store_sub_vars: &[],
+            read_only_props: &[],
+            rest_prop_vars: &[],
+            analysis: None,
+            exported_names: &[],
+        };
+        let input = "function setup(value) { const ref = $derived(value); return ref; } ref;";
+        let expected = "function setup(value) { const ref = $.derived(() => value); return $.get(ref); } ref();";
+
+        assert_eq!(transform_state_vars_ast(input, &config).unwrap(), expected);
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -1602,10 +1602,11 @@ fn lower_module_export_runes<'a>(stmt: &mut Statement<'a>, state: &ServerTransfo
 /// `let` removes it from the derived set for that frame).
 struct NestedRuneLower<'a> {
     b: B<'a>,
-    /// Stack of lexical frames. Each map records a derived binding name and
-    /// whether it was declared with `var`, which needs an optional call before
-    /// its initializer has run.
-    derived: Vec<rustc_hash::FxHashMap<String, bool>>,
+    /// Stack of lexical frames. `Some(is_var)` records a derived binding;
+    /// `None` is an explicit lexical shadow for an outer derived binding.
+    /// Keeping the shadow marker is essential: removing a name only from the
+    /// current frame makes lookup fall through to the outer declaration.
+    derived: Vec<rustc_hash::FxHashMap<String, Option<bool>>>,
     /// Whether we are inside a nested function / block body (i.e. below the
     /// script top level). Lowering only fires when this is `true`, so the
     /// script-level statements already handled by `transform_script` are not
@@ -1626,7 +1627,44 @@ struct NestedRuneLower<'a> {
 impl<'a> NestedRuneLower<'a> {
     /// Whether `name` resolves to a derived binding in any enclosing frame.
     fn derived_is_var(&self, name: &str) -> Option<bool> {
-        self.derived.iter().rev().find_map(|f| f.get(name).copied())
+        for frame in self.derived.iter().rev() {
+            if let Some(binding) = frame.get(name) {
+                return *binding;
+            }
+        }
+        None
+    }
+
+    fn mask_name(&mut self, name: &str) {
+        if let Some(frame) = self.derived.last_mut() {
+            frame.insert(name.to_string(), None);
+        }
+    }
+
+    fn mask_binding_pattern(&mut self, pattern: &oxc_ast::ast::BindingPattern<'a>) {
+        use oxc_ast::ast::BindingPattern;
+        match pattern {
+            BindingPattern::BindingIdentifier(id) => self.mask_name(id.name.as_str()),
+            BindingPattern::ObjectPattern(object) => {
+                for property in &object.properties {
+                    self.mask_binding_pattern(&property.value);
+                }
+                if let Some(rest) = &object.rest {
+                    self.mask_binding_pattern(&rest.argument);
+                }
+            }
+            BindingPattern::ArrayPattern(array) => {
+                for element in array.elements.iter().flatten() {
+                    self.mask_binding_pattern(element);
+                }
+                if let Some(rest) = &array.rest {
+                    self.mask_binding_pattern(&rest.argument);
+                }
+            }
+            BindingPattern::AssignmentPattern(assignment) => {
+                self.mask_binding_pattern(&assignment.left);
+            }
+        }
     }
 
     /// Lower the declarators of a `let/const/var` in place when nested. Records
@@ -1649,11 +1687,7 @@ impl<'a> NestedRuneLower<'a> {
             let Some(rune) = d.init.as_ref().and_then(detect_decl_rune) else {
                 // A plain re-declaration of a name shadows any outer derived
                 // binding for this frame.
-                if let oxc_ast::ast::BindingPattern::BindingIdentifier(id) = &d.id
-                    && let Some(frame) = self.derived.last_mut()
-                {
-                    frame.remove(id.name.as_str());
-                }
+                self.mask_binding_pattern(&d.id);
                 continue;
             };
             // Only handle the identifier-pattern forms here (the destructured
@@ -1676,6 +1710,7 @@ impl<'a> NestedRuneLower<'a> {
             match rune {
                 DeclRune::State => {
                     d.init = Some(arg.unwrap_or_else(|| b.void0()));
+                    self.mask_binding_pattern(&d.id);
                 }
                 DeclRune::Derived => {
                     d.init = arg.map(|e| {
@@ -1702,7 +1737,7 @@ impl<'a> NestedRuneLower<'a> {
                         && let Some(n) = bind_name
                         && let Some(frame) = self.derived.last_mut()
                     {
-                        frame.insert(n, declaration_is_var);
+                        frame.insert(n, Some(declaration_is_var));
                     }
                 }
                 DeclRune::DerivedBy => {
@@ -1711,13 +1746,13 @@ impl<'a> NestedRuneLower<'a> {
                         && let Some(n) = bind_name
                         && let Some(frame) = self.derived.last_mut()
                     {
-                        frame.insert(n, declaration_is_var);
+                        frame.insert(n, Some(declaration_is_var));
                     }
                 }
                 // `$props` / `$props.id` are not valid in a nested factory body in
                 // any in-scope fixture; leave them untouched (init already taken,
                 // restore is unnecessary because this never matches here).
-                DeclRune::Props | DeclRune::PropsId => {}
+                DeclRune::Props | DeclRune::PropsId => self.mask_binding_pattern(&d.id),
             }
         }
     }
@@ -1804,6 +1839,15 @@ impl<'a> VisitMut<'a> for NestedRuneLower<'a> {
         let prev = self.in_nested_body;
         self.in_nested_body = true;
         self.derived.push(rustc_hash::FxHashMap::default());
+        if let Some(id) = &it.id {
+            self.mask_name(id.name.as_str());
+        }
+        for parameter in &it.params.items {
+            self.mask_binding_pattern(&parameter.pattern);
+        }
+        if let Some(rest) = &it.params.rest {
+            self.mask_binding_pattern(&rest.rest.argument);
+        }
         oxc_ast_visit::walk_mut::walk_function(self, it, flags);
         self.derived.pop();
         self.in_nested_body = prev;
@@ -1816,6 +1860,12 @@ impl<'a> VisitMut<'a> for NestedRuneLower<'a> {
         let prev = self.in_nested_body;
         self.in_nested_body = true;
         self.derived.push(rustc_hash::FxHashMap::default());
+        for parameter in &it.params.items {
+            self.mask_binding_pattern(&parameter.pattern);
+        }
+        if let Some(rest) = &it.params.rest {
+            self.mask_binding_pattern(&rest.rest.argument);
+        }
         oxc_ast_visit::walk_mut::walk_arrow_function_expression(self, it);
         self.derived.pop();
         self.in_nested_body = prev;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/tests.rs
@@ -4907,6 +4907,37 @@ fn ast_matches_oracle_derived_readwrap_cluster() {
     );
 }
 
+#[test]
+fn nested_derived_is_shadowed_by_callback_parameters() {
+    let source = r#"<script>
+let { ref = $bindable() } = $props();
+
+function observe(read, apply) {
+    apply(read());
+}
+
+function setup(value) {
+    const ref = $derived(value);
+    const distance = $derived(1);
+    observe(
+        () => [ref, distance],
+        ([ref, distance]) => console.log(ref, distance)
+    );
+}
+
+setup(1);
+</script>
+<div bind:this={ref}></div>"#;
+
+    let ours = run(source);
+    let oracle = oracle_dump(source);
+    assert_eq!(
+        canon(&ours),
+        canon(&oracle),
+        "\nOURS:\n{ours}\nORACLE:\n{oracle}"
+    );
+}
+
 /// SSR async template-shape parity with the (correct) `transform_server`
 /// oracle for the `{#await}` / `{@html await …}` / async-attribute /
 /// async-prop cluster. Compared with [`canon_js`] (the runtime harness


### PR DESCRIPTION
Fixes the remaining Detailed.svelte mismatches across client, client-dev, server, and server-dev.

- resolve nested reactive rune declarations before same-named outer prop bindings on the client
- preserve explicit lexical shadows for nested SSR derived lowering, including destructured callback parameters
- add a pattern-corpus regression and client/server regression tests
- shrink all four output baselines by one

Static verification only, per repository workflow constraints: rustfmt check, baseline documentation check, JSON parse check, and git diff check.