### PR TITLE
Fix client assignment builder import

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
@@ -8,10 +8,9 @@ use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use super::store_transforms::declares_binding_in_statement;
 use super::{
     extract_destructure_targets, extract_member_expression_base, find_assignment_position,
-    get_or_compile_regex, is_simple_identifier, lhs_starts_with_keyword,
-    transform_destructure_assignments_with_props, transform_prop_assignments,
-    transform_prop_reads_in_expr, transform_store_assignments_client, transform_store_reads_client,
-    transform_store_sub_calls, wrap_state_vars_in_expr,
+    get_or_compile_regex, lhs_starts_with_keyword, transform_destructure_assignments_with_props,
+    transform_prop_assignments, transform_prop_reads_in_expr, transform_store_assignments_client,
+    transform_store_reads_client, transform_store_sub_calls, wrap_state_vars_in_expr,
 };
 
 /// Topologically sort reactive statements based on their dependencies.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -5334,6 +5334,8 @@ pub(crate) fn transform_synthesized_assignment(
     original_root_name: Option<&str>,
     context: &mut ComponentContext,
 ) -> JsExpr {
+    use crate::compiler::phases::phase3_transform::js_ast::builders as b;
+
     use super::shared::utils::apply_transforms_to_expression;
 
     let assignment = try_transform_assignment("=", left, right, None, original_root_name, context)


### PR DESCRIPTION
Fixes the main-branch Rust compile failure introduced in #3935 by importing the JS AST builder in transform_synthesized_assignment. Also removes the unused import reported by the same CI build.\n\nValidation: cargo fmt; git diff --check. Per project guidance, no local build/test was run.