### PR TITLE
Preserve SCSS line comment parse errors

### DIFF
--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -310,7 +310,6 @@
 	"threlte/packages/flex/src/routes/+page.svelte",
 	"threlte/packages/theatre/src/lib/sequence/Sequence.svelte",
 	"trakt-web/projects/client/src/lib/components/avatar-pill/AvatarPill.svelte",
-	"trakt-web/projects/client/src/lib/components/buttons/Button.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/LineChart.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/Sparkline.svelte",
 	"trakt-web/projects/client/src/lib/components/dropdown/DropdownItem.svelte",
@@ -335,13 +334,8 @@
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/SettingsGroupRow.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceTile.svelte",
-	"trakt-web/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte",
 	"trakt-web/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte",
 	"trakt-web/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionEmoji.svelte",
 	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Hero.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedCard.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024ThanksSection.svelte",
 	"trakt-web/projects/client/test/beds/component/ComponentTestBed.svelte"
 ]

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -272,7 +272,6 @@
 	"threlte/packages/flex/src/routes/+page.svelte",
 	"threlte/packages/theatre/src/lib/sequence/Sequence.svelte",
 	"trakt-web/projects/client/src/lib/components/avatar-pill/AvatarPill.svelte",
-	"trakt-web/projects/client/src/lib/components/buttons/Button.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/LineChart.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/Sparkline.svelte",
 	"trakt-web/projects/client/src/lib/components/dropdown/DropdownItem.svelte",
@@ -297,13 +296,8 @@
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/SettingsGroupRow.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceTile.svelte",
-	"trakt-web/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte",
 	"trakt-web/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte",
 	"trakt-web/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionEmoji.svelte",
 	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Hero.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedCard.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024ThanksSection.svelte",
 	"trakt-web/projects/client/test/beds/component/ComponentTestBed.svelte"
 ]

--- a/compatibility/known-failures.server-dev.json
+++ b/compatibility/known-failures.server-dev.json
@@ -67,7 +67,6 @@
 	"threlte/apps/docs/src/examples/geometry/random-placement/basic-random/assets/bush.svelte",
 	"threlte/apps/docs/src/examples/xr/vr-button/assets/bush.svelte",
 	"trakt-web/projects/client/src/lib/components/avatar-pill/AvatarPill.svelte",
-	"trakt-web/projects/client/src/lib/components/buttons/Button.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/Sparkline.svelte",
 	"trakt-web/projects/client/src/lib/components/dropdown/DropdownItem.svelte",
 	"trakt-web/projects/client/src/lib/components/icons/MediaIcon.svelte",
@@ -85,12 +84,7 @@
 	"trakt-web/projects/client/src/lib/sections/navbar/TopNavbar.svelte",
 	"trakt-web/projects/client/src/lib/sections/profile/components/ProfileItem.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.svelte",
-	"trakt-web/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte",
 	"trakt-web/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte",
 	"trakt-web/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionEmoji.svelte",
-	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Hero.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedCard.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024ThanksSection.svelte"
+	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte"
 ]

--- a/compatibility/known-failures.server.json
+++ b/compatibility/known-failures.server.json
@@ -67,7 +67,6 @@
 	"threlte/apps/docs/src/examples/geometry/random-placement/basic-random/assets/bush.svelte",
 	"threlte/apps/docs/src/examples/xr/vr-button/assets/bush.svelte",
 	"trakt-web/projects/client/src/lib/components/avatar-pill/AvatarPill.svelte",
-	"trakt-web/projects/client/src/lib/components/buttons/Button.svelte",
 	"trakt-web/projects/client/src/lib/components/charts/Sparkline.svelte",
 	"trakt-web/projects/client/src/lib/components/dropdown/DropdownItem.svelte",
 	"trakt-web/projects/client/src/lib/components/icons/MediaIcon.svelte",
@@ -85,12 +84,7 @@
 	"trakt-web/projects/client/src/lib/sections/navbar/TopNavbar.svelte",
 	"trakt-web/projects/client/src/lib/sections/profile/components/ProfileItem.svelte",
 	"trakt-web/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.svelte",
-	"trakt-web/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte",
 	"trakt-web/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte",
 	"trakt-web/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionEmoji.svelte",
-	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Hero.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedCard.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/2024/_internal/Yir2024ThanksSection.svelte"
+	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte"
 ]

--- a/compatibility/pattern-corpus/issues/scss-line-comment-brace-drift.svelte
+++ b/compatibility/pattern-corpus/issues/scss-line-comment-brace-drift.svelte
@@ -1,0 +1,8 @@
+<p>content</p>
+
+<style lang="scss">
+	.a {
+		// can't be scoped here
+	}
+	// isn't a CSS comment
+</style>

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
@@ -582,6 +582,18 @@ impl<'a> Parser<'a> {
                     (lt_pos, lt_pos),
                 ));
             }
+            // A CSS-invalid `//` can make the closing-tag scan treat later
+            // apostrophes as quotes. If two of those apostrophes balance, the
+            // quote check above passes, but braces skipped between them can
+            // still leave the scanner unable to see the real `</style>`.
+            // Upstream stops at the earlier slash instead.
+            if let Some(pos) = first_line_comment {
+                return Err(crate::error::ParseError::svelte(
+                    "css_expected_identifier",
+                    "Expected a valid CSS identifier",
+                    (pos, pos),
+                ));
+            }
             // Style tag was not closed. Upstream's `eat('</style', true)` runs
             // against the right-trimmed template, so the point is its end.
             return Err(crate::error::ParseError::expected_token(

--- a/crates/rsvelte_core/tests/style_close_tag_scan_3281.rs
+++ b/crates/rsvelte_core/tests/style_close_tag_scan_3281.rs
@@ -184,3 +184,21 @@ fn an_apostrophe_in_an_scss_line_comment_does_not_hide_the_css_error() {
         "{err:?}"
     );
 }
+
+#[test]
+fn balanced_apostrophes_in_scss_line_comments_do_not_hide_the_css_error() {
+    let source = "<style lang=\"scss\">\n.a {\n// can't\n}\n// isn't\n</style>\n";
+    let err = compile(
+        source,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect_err("expected a CSS identifier error");
+    assert!(
+        format!("{err:?}").contains("css_expected_identifier"),
+        "{err:?}"
+    );
+}


### PR DESCRIPTION
Fixes the remaining corpus cluster where invalid SCSS-style line comments were reported as a missing style closing tag. Balanced apostrophes could corrupt brace tracking even after quote validation passed, so the parser now preserves the earlier css_expected_identifier error at EOF.

Adds a focused regression and pattern-corpus case, and removes 24 known failures across the four compiler targets.

Static validation: cargo fmt --all -- --check; git diff --check; JSON parse/sort/duplicate checks. Per repository policy, no local build or test run.