### PR TITLE
Match deferred interface body errors

### DIFF
--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -280,7 +280,6 @@
 	"svelte-lexical/packages/svelte-lexical/src/lib/components/toolbar/BlockFormatDropDown/HeadingDropDownItem.svelte",
 	"svelte-lexical/packages/svelte-lexical/src/lib/core/NestedComposer.svelte",
 	"svelte-maplibre-gl/src/content/examples/geolocate/Geolocate.svelte",
-	"svelte-put/sites/docs/src/packages/inline-svg/docs.md.svelte",
 	"svelte-spa-router/test/app/src/App.svelte",
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte",
 	"svelte-tweakpane-ui/src/lib/internal/ClsPad.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -246,7 +246,6 @@
 	"svelte-gantt/packages/svelte-gantt/src/Gantt.svelte",
 	"svelte-lexical/packages/svelte-lexical/src/lib/components/toolbar/BlockFormatDropDown/HeadingDropDownItem.svelte",
 	"svelte-maplibre-gl/src/content/examples/geolocate/Geolocate.svelte",
-	"svelte-put/sites/docs/src/packages/inline-svg/docs.md.svelte",
 	"svelte-spa-router/test/app/src/App.svelte",
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte",
 	"svelte-tweakpane-ui/src/lib/internal/ClsPad.svelte",

--- a/compatibility/known-failures.server-dev.json
+++ b/compatibility/known-failures.server-dev.json
@@ -57,7 +57,6 @@
 	"svelte-bits/src/lib/components/library/Components/CircularGallery/CircularGallery.svelte",
 	"svelte-commerce/src/lib/theme/sections/tile-grid.svelte",
 	"svelte-french-toast/src/routes/+page.svelte",
-	"svelte-put/sites/docs/src/packages/inline-svg/docs.md.svelte",
 	"sveltepress/packages/theme-default/src/components/NavItem.svelte",
 	"svelty-picker/src/routes/+layout.svelte",
 	"syntaxfm-website/src/lib/ComponentWindow.svelte",

--- a/compatibility/known-failures.server.json
+++ b/compatibility/known-failures.server.json
@@ -57,7 +57,6 @@
 	"svelte-bits/src/lib/components/library/Components/CircularGallery/CircularGallery.svelte",
 	"svelte-commerce/src/lib/theme/sections/tile-grid.svelte",
 	"svelte-french-toast/src/routes/+page.svelte",
-	"svelte-put/sites/docs/src/packages/inline-svg/docs.md.svelte",
 	"sveltepress/packages/theme-default/src/components/NavItem.svelte",
 	"svelty-picker/src/routes/+layout.svelte",
 	"syntaxfm-website/src/lib/ComponentWindow.svelte",

--- a/compatibility/pattern-corpus/deferred-interface-body-error.svelte
+++ b/compatibility/pattern-corpus/deferred-interface-body-error.svelte
@@ -1,0 +1,3 @@
+export interface Config {
+  src: string;
+}

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -2120,9 +2120,10 @@ pub fn trailing_token_offset(content: &str, ts: bool) -> Option<usize> {
         .then_some(content_pos)
 }
 
-/// The start of the leftmost TypeScript-only postfix operator (`as`,
-/// `satisfies`, `!`) OXC recovered while parsing a JavaScript file — i.e. the
-/// byte where acorn would have stopped. `None` when the program carries none.
+/// The start of the leftmost TypeScript-only construct (`as`, `satisfies`, `!`,
+/// or a type annotation) OXC recovered while parsing a JavaScript file — i.e.
+/// the byte where acorn would have stopped. `None` when the program carries
+/// none.
 fn typescript_operator_start(program: &OxcProgram<'_>) -> Option<u32> {
     use oxc_ast_visit::Visit;
 
@@ -2150,6 +2151,12 @@ fn typescript_operator_start(program: &OxcProgram<'_>) -> Option<u32> {
         fn visit_ts_non_null_expression(&mut self, node: &oxc_ast::ast::TSNonNullExpression<'a>) {
             self.record(node.expression.span().end);
             oxc_ast_visit::walk::walk_ts_non_null_expression(self, node);
+        }
+        fn visit_ts_type_annotation(&mut self, node: &oxc_ast::ast::TSTypeAnnotation<'a>) {
+            // `node.span.start` points at the colon in the parenthesised probe;
+            // strip the synthetic opening `(` to get the content offset.
+            self.record(node.span.start.saturating_sub(1));
+            oxc_ast_visit::walk::walk_ts_type_annotation(self, node);
         }
     }
 
@@ -2191,6 +2198,30 @@ pub fn close_token_or_parse_error(
         .map_or(trimmed_offset + trimmed.len(), |(_, pos)| {
             trimmed_offset + pos
         });
+    crate::error::ParseError::svelte("js_parse_error", msg, (at, at))
+}
+
+/// Rebuild the diagnostic raised by a failed mustache expression parse.
+///
+/// Template expressions have eager and deferred entry points. Keep their
+/// classification here so deferring work cannot turn a missing `}` after a
+/// complete expression into a `js_parse_error` (or the reverse).
+pub fn mustache_parse_error(
+    msg: String,
+    content: &str,
+    start: usize,
+    ts: bool,
+) -> crate::error::ParseError {
+    // A dangling optional-chain token is part of the broken expression, not
+    // trailing input that the caller would encounter while eating `}`.
+    if !content.ends_with("?.")
+        && let Some(pos) = trailing_token_offset(content, ts)
+    {
+        return crate::error::ParseError::expected_token("}", start + pos);
+    }
+
+    let at = check_js_parse_error_with_pos(content, ts)
+        .map_or(start, |(_, content_pos)| start + content_pos);
     crate::error::ParseError::svelte("js_parse_error", msg, (at, at))
 }
 
@@ -13717,6 +13748,11 @@ mod tests {
             assert_eq!(trailing_token_offset(source, false), *js, "js: `{source}`");
             assert_eq!(trailing_token_offset(source, true), *ts, "ts: `{source}`");
         }
+
+        // OXC recovers a type annotation in a JavaScript parse. Acorn returns
+        // the complete `src` expression and leaves the colon for Svelte's
+        // close-token check.
+        assert_eq!(trailing_token_offset("src: string;", false), Some(3));
     }
 
     use super::*;

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/resolve_lazy.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/resolve_lazy.rs
@@ -473,23 +473,8 @@ fn lazy_parse_error(
     Some(match kind {
         LazyKind::Lenient => return None,
         LazyKind::AwaitHead => super::state::tag::await_head_parse_error(source, start, msg, ts),
-        // Upstream's `read_expression` parses ONE maximal expression with acorn
-        // and then `eat('}', true)`: a complete leading expression followed by
-        // leftover tokens (e.g. `{foo();}` — the `;` is left over) surfaces as
-        // `expected_token` (Expected token }), while a malformed expression
-        // (e.g. `{42 = nope}`, where the error is *inside* the expression) is a
-        // `js_parse_error`.
         LazyKind::Mustache => {
-            match super::read::expression::trailing_token_offset(content, ts) {
-                Some(offset) => crate::error::ParseError::expected_token("}", start + offset),
-                // Upstream rethrows acorn's `err.pos` as a point error, so the
-                // span is where it stopped consuming, not the whole expression.
-                None => {
-                    let at = super::read::expression::check_js_parse_error_with_pos(content, ts)
-                        .map_or(start + content.len(), |(_, pos)| start + pos);
-                    crate::error::ParseError::svelte("js_parse_error", msg, (at, at))
-                }
-            }
+            super::read::expression::mustache_parse_error(msg, content, start, ts)
         }
         // `parse_js_expression_attribute`: leftover input after a complete
         // expression is a missing `}`, anything else a point error at the byte

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -2716,25 +2716,12 @@ impl<'a> Parser<'a> {
             self.ts,
         )
         .map_err(|(msg, _)| {
-            // The deferred twin of this arm (`LazyKind::Mustache`) classifies
-            // leftover input as a missing `}`; without the same test here the
-            // two disagree whenever the parse is not deferred.
-            if !trimmed.ends_with("?.")
-                && let Some(pos) = leftover_token_offset(trimmed, self.ts)
-            {
-                return crate::error::ParseError::expected_token("}", trimmed_offset + pos);
-            }
-            // Recover the precise failure position from OXC's labeled span,
-            // mirroring upstream Svelte's `js_parse_error(err.pos, ...)` —
-            // a *point* error at the byte where acorn stopped consuming
-            // input. svelte2tsx's `expected.error.json` fixtures rely on
-            // this character-accurate location.
-            let abs_pos =
-                super::super::read::expression::check_js_parse_error_with_pos(trimmed, self.ts)
-                    .map_or(trimmed_offset, |(_, content_pos)| {
-                        trimmed_offset + content_pos
-                    });
-            crate::error::ParseError::svelte("js_parse_error", msg, (abs_pos, abs_pos))
+            super::super::read::expression::mustache_parse_error(
+                msg,
+                trimmed,
+                trimmed_offset,
+                self.ts,
+            )
         })
     }
 

--- a/crates/rsvelte_core/tests/deferred_error_order.rs
+++ b/crates/rsvelte_core/tests/deferred_error_order.rs
@@ -1,7 +1,7 @@
 //! Deferred expression parsing must not change which parse error wins.
 
 use rsvelte_core::error::ParseError;
-use rsvelte_core::{ParseOptions, parse};
+use rsvelte_core::{ParseOptions, parse, resolve_lazy_expressions};
 
 fn error_code(source: &str) -> String {
     let options = ParseOptions {
@@ -12,6 +12,23 @@ fn error_code(source: &str) -> String {
         Ok(_) => panic!("expected a parse error for:\n{source}"),
         Err(ParseError::SvelteError { code, .. }) => code,
         Err(other) => panic!("expected a SvelteError, got {other:?} for:\n{source}"),
+    }
+}
+
+fn expression_error_code(source: &str, defer: bool) -> String {
+    let options = ParseOptions {
+        defer_script_parse: defer,
+        ..Default::default()
+    };
+    let mut ast = match parse(source, &oxc_allocator::Allocator::default(), options) {
+        Ok(ast) => ast,
+        Err(ParseError::SvelteError { code, .. }) => return code,
+        Err(other) => panic!("expected a SvelteError, got {other:?} for:\n{source}"),
+    };
+    match resolve_lazy_expressions(&mut ast, source) {
+        Some(ParseError::SvelteError { code, .. }) => code,
+        Some(other) => panic!("expected a SvelteError, got {other:?} for:\n{source}"),
+        None => panic!("expected a parse error for:\n{source}"),
     }
 }
 
@@ -45,4 +62,16 @@ fn a_deferred_script_error_precedes_a_later_unclosed_block() {
     let source = "<script>let = ;</script>\n{#if true}";
 
     assert_eq!(error_code(source), "js_parse_error");
+}
+
+#[test]
+fn deferred_and_eager_mustaches_classify_interface_bodies_identically() {
+    // Markdown documentation is compiled as Svelte by the corpus. A raw
+    // TypeScript interface body therefore becomes a mustache whose complete
+    // leading `src` expression is followed by `:`, so upstream reports the
+    // missing `}` rather than a JavaScript parse error.
+    let source = "export interface Config {\n  src: string;\n}";
+
+    assert_eq!(expression_error_code(source, false), "expected_token");
+    assert_eq!(expression_error_code(source, true), "expected_token");
 }


### PR DESCRIPTION
Fix the remaining inline-svg documentation error-code mismatch across all four corpus targets.

OXC recovers JavaScript-mode type annotations in its AST, so the trailing-token probe now treats the type annotation colon as the point where Acorn would stop. The eager and deferred mustache paths also share one diagnostic classifier to prevent future drift.

Adds a focused parser regression and pattern-corpus case, and removes the fixed ID from the four output baselines (4 entries).

Local builds/tests intentionally not run per repository policy; cargo fmt, JSON parsing, and diff checks passed.