### PR TITLE
Match CSS empty declaration error spans

### DIFF
--- a/compatibility/error-end-known-failures.client-dev.json
+++ b/compatibility/error-end-known-failures.client-dev.json
@@ -1,10 +1,4 @@
 [
-	"appwrite-console/src/lib/components/consent.svelte",
-	"appwrite-console/src/lib/layout/unauthenticated.svelte",
-	"appwrite-console/src/routes/(authenticated)/mfa/+page.svelte",
-	"appwrite-console/src/routes/(console)/onboarding/create-organization/+page.svelte",
-	"appwrite-console/src/routes/(console)/onboarding/create-project/+page.svelte",
-	"appwrite-console/src/routes/+layout.svelte",
 	"date-picker-svelte/src/lib/DateInput.svelte",
 	"date-picker-svelte/src/lib/DatePicker.svelte",
 	"date-picker-svelte/src/lib/TimePicker.svelte",

--- a/compatibility/error-end-known-failures.client.json
+++ b/compatibility/error-end-known-failures.client.json
@@ -1,10 +1,4 @@
 [
-	"appwrite-console/src/lib/components/consent.svelte",
-	"appwrite-console/src/lib/layout/unauthenticated.svelte",
-	"appwrite-console/src/routes/(authenticated)/mfa/+page.svelte",
-	"appwrite-console/src/routes/(console)/onboarding/create-organization/+page.svelte",
-	"appwrite-console/src/routes/(console)/onboarding/create-project/+page.svelte",
-	"appwrite-console/src/routes/+layout.svelte",
 	"date-picker-svelte/src/lib/DateInput.svelte",
 	"date-picker-svelte/src/lib/DatePicker.svelte",
 	"date-picker-svelte/src/lib/TimePicker.svelte",

--- a/compatibility/error-end-known-failures.server-dev.json
+++ b/compatibility/error-end-known-failures.server-dev.json
@@ -1,10 +1,4 @@
 [
-	"appwrite-console/src/lib/components/consent.svelte",
-	"appwrite-console/src/lib/layout/unauthenticated.svelte",
-	"appwrite-console/src/routes/(authenticated)/mfa/+page.svelte",
-	"appwrite-console/src/routes/(console)/onboarding/create-organization/+page.svelte",
-	"appwrite-console/src/routes/(console)/onboarding/create-project/+page.svelte",
-	"appwrite-console/src/routes/+layout.svelte",
 	"date-picker-svelte/src/lib/DateInput.svelte",
 	"date-picker-svelte/src/lib/DatePicker.svelte",
 	"date-picker-svelte/src/lib/TimePicker.svelte",

--- a/compatibility/error-end-known-failures.server.json
+++ b/compatibility/error-end-known-failures.server.json
@@ -1,10 +1,4 @@
 [
-	"appwrite-console/src/lib/components/consent.svelte",
-	"appwrite-console/src/lib/layout/unauthenticated.svelte",
-	"appwrite-console/src/routes/(authenticated)/mfa/+page.svelte",
-	"appwrite-console/src/routes/(console)/onboarding/create-organization/+page.svelte",
-	"appwrite-console/src/routes/(console)/onboarding/create-project/+page.svelte",
-	"appwrite-console/src/routes/+layout.svelte",
 	"date-picker-svelte/src/lib/DateInput.svelte",
 	"date-picker-svelte/src/lib/DatePicker.svelte",
 	"date-picker-svelte/src/lib/TimePicker.svelte",

--- a/compatibility/pattern-corpus/issues/css-interpolation-empty-declaration-end.svelte
+++ b/compatibility/pattern-corpus/issues/css-interpolation-empty-declaration-end.svelte
@@ -1,0 +1,7 @@
+<style>
+	@media #{devices.$break1} {
+		.card {
+			bottom: 0.5rem;
+		}
+	}
+</style>

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
@@ -1924,9 +1924,9 @@ impl<'a> CssParser<'a> {
     fn parse_declaration(&mut self) -> Option<Value> {
         self.skip_whitespace();
         let start = self.offset + self.index;
+        let property_start = self.index;
 
         // Read property name
-        let property_start = self.index;
         while !self.is_eof() {
             let c = self.current_char();
             if c == ':' || c == '}' || c == ';' {
@@ -1958,12 +1958,36 @@ impl<'a> CssParser<'a> {
                 .map(|(_, rest)| rest.trim_ws())
                 .unwrap_or("");
             if upstream_value.is_empty() && !upstream_property.starts_with("--") {
+                // Upstream saves the diagnostic end after reading the property
+                // to the first whitespace-or-colon, consuming whitespace, and
+                // optionally eating `:`. That position can be later than this
+                // parser's declaration scan. In SCSS-shaped `@media #{x} {`,
+                // for example, our scan stops before the interpolation's `}`
+                // while upstream includes it and the following space.
+                let mut upstream_index = property_start;
+                while upstream_index < self.source.len() {
+                    let c = self.source[upstream_index..].chars().next().unwrap_or('\0');
+                    if is_js_whitespace(c) || c == ':' {
+                        break;
+                    }
+                    upstream_index += c.len_utf8();
+                }
+                while upstream_index < self.source.len() {
+                    let c = self.source[upstream_index..].chars().next().unwrap_or('\0');
+                    if !is_js_whitespace(c) {
+                        break;
+                    }
+                    upstream_index += c.len_utf8();
+                }
+                if self.source[upstream_index..].starts_with(':') {
+                    upstream_index += 1;
+                }
                 record_first_error(
                     &self.error,
                     crate::error::ParseError::svelte(
                         "css_empty_declaration",
                         "Declaration cannot be empty",
-                        (start, self.offset + self.index),
+                        (start, self.offset + upstream_index),
                     ),
                 );
             }

--- a/crates/rsvelte_core/tests/css_block_item_progress.rs
+++ b/crates/rsvelte_core/tests/css_block_item_progress.rs
@@ -27,6 +27,15 @@ fn empty_block_item_selector_terminates_with_the_upstream_error() {
             )
             .expect_err("upstream rejects this CSS");
             assert_eq!(error.diagnostic().code.as_deref(), Some(code));
+            if code == "css_empty_declaration" {
+                assert_eq!(
+                    error.diagnostic().span,
+                    Some((
+                        source.find("devices.$break1").unwrap(),
+                        source.find(" {\n\t\t.card").unwrap() + 1,
+                    ))
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes the error-end mismatch for SCSS-style media interpolation such as `@media #{devices.$break1} {`.

The CSS parser used its own declaration scan endpoint, which stops before the interpolation closing brace. Upstream reports the position saved after reading the property through its first whitespace and consuming that whitespace. This change computes that upstream endpoint for `css_empty_declaration` without mutating parser progress.

- adds an exact span assertion and pattern-corpus repro
- removes 6 affected Appwrite entries from all 4 error-end ratchets (24 target entries)
- error-end baselines shrink from 48 to 42 per target

Validation (no local Rust build per project constraint): cargo fmt check, JSON parse, git diff check, and official Svelte diagnostic position comparison.