### PR TITLE
Match CSS declaration scanning in SCSS comments

### DIFF
--- a/compatibility/error-end-known-failures.client-dev.json
+++ b/compatibility/error-end-known-failures.client-dev.json
@@ -26,11 +26,5 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
-	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
-	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",
-	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirRatedSection.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirStatsSection.svelte"
+	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/error-end-known-failures.client.json
+++ b/compatibility/error-end-known-failures.client.json
@@ -26,11 +26,5 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
-	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
-	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",
-	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirRatedSection.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirStatsSection.svelte"
+	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/error-end-known-failures.server-dev.json
+++ b/compatibility/error-end-known-failures.server-dev.json
@@ -26,11 +26,5 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
-	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
-	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",
-	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirRatedSection.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirStatsSection.svelte"
+	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/error-end-known-failures.server.json
+++ b/compatibility/error-end-known-failures.server.json
@@ -26,11 +26,5 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
-	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
-	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",
-	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirRatedSection.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirStatsSection.svelte"
+	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/error-position-known-failures.client-dev.json
+++ b/compatibility/error-position-known-failures.client-dev.json
@@ -19,11 +19,5 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-invalid-export/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
-	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
-	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",
-	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirRatedSection.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirStatsSection.svelte"
+	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/error-position-known-failures.client.json
+++ b/compatibility/error-position-known-failures.client.json
@@ -19,11 +19,5 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-invalid-export/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
-	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
-	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",
-	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirRatedSection.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirStatsSection.svelte"
+	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/error-position-known-failures.server-dev.json
+++ b/compatibility/error-position-known-failures.server-dev.json
@@ -19,11 +19,5 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-invalid-export/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
-	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
-	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",
-	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirRatedSection.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirStatsSection.svelte"
+	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/error-position-known-failures.server.json
+++ b/compatibility/error-position-known-failures.server.json
@@ -19,11 +19,5 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-invalid-export/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte",
-	"trakt-web/projects/client/src/lib/components/charts/SegmentedBar.svelte",
-	"trakt-web/projects/client/src/lib/sections/profile/leaderboard/_internal/LeaderboardItem.svelte",
-	"trakt-web/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceBadge.svelte",
-	"trakt-web/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirRatedSection.svelte",
-	"trakt-web/projects/client/src/lib/sections/yir/_internal/YirStatsSection.svelte"
+	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/pattern-corpus/issues/scss-line-comment-declaration-boundary.svelte
+++ b/compatibility/pattern-corpus/issues/scss-line-comment-declaration-boundary.svelte
@@ -1,0 +1,19 @@
+<style lang="scss">
+  .chart {
+    // An apostrophe opens CSS's string state.
+    padding: 1px;
+
+    // This nested rule is swallowed with the comment value.
+    .child {
+      display: block;
+    }
+
+    // A second apostrophe closes CSS's string state.
+    grid-template-columns: minmax(0, 1fr);
+
+    // This is the first block item both parsers reject.
+    @include mobile {
+      padding: 0;
+    }
+  }
+</style>

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
@@ -1789,75 +1789,23 @@ impl<'a> CssParser<'a> {
         let start = self.offset + self.index;
         let property_start = self.index;
 
-        // Read property name
+        // Upstream's `read_declaration` reads the property only up to the first
+        // whitespace or `:`. This matters for invalid SCSS `//` comments: the
+        // first word becomes the property and the rest of the comment becomes
+        // the value, so semicolons and quotes in prose determine where the next
+        // block item starts.
         while !self.is_eof() {
             let c = self.current_char();
-            if c == ':' || c == '}' || c == ';' {
+            if is_js_whitespace(c) || c == ':' {
                 break;
             }
             self.advance();
         }
-        let property = self.source[property_start..self.index]
-            .trim_ws()
-            .to_string();
+        let property = self.source[property_start..self.index].to_string();
 
-        // An empty property is not on its own an error: upstream's rule is
-        // `!value && !property.startsWith('--')`, so `{ : red }` is a
-        // declaration with property `''`, and the empty-value half is checked
-        // in phase 2 against the built node.
-        if self.is_eof() || self.current_char() != ':' {
-            // No `property: value` shape. Upstream's `read_declaration` reads
-            // the property up to the first whitespace-or-colon, optionally eats
-            // a `:`, then reads the value up to `;` / `}`. When that value is
-            // empty (and the property is not a `--custom-property`), it raises
-            // `css_empty_declaration` (read/style.js L474-476). Examples:
-            // `div { ... }`, `div { ; }`, `:global { p {...} }`.
-            // A non-empty remainder after the first token (`div { foo bar }`)
-            // parses upstream as a declaration with property `foo` and value
-            // `bar`, so it is NOT an error — keep skipping it silently.
-            let upstream_property = property.split_whitespace().next().unwrap_or("");
-            let upstream_value = property
-                .split_once(is_js_whitespace)
-                .map(|(_, rest)| rest.trim_ws())
-                .unwrap_or("");
-            if upstream_value.is_empty() && !upstream_property.starts_with("--") {
-                // Upstream saves the diagnostic end after reading the property
-                // to the first whitespace-or-colon, consuming whitespace, and
-                // optionally eating `:`. That position can be later than this
-                // parser's declaration scan. In SCSS-shaped `@media #{x} {`,
-                // for example, our scan stops before the interpolation's `}`
-                // while upstream includes it and the following space.
-                let mut upstream_index = property_start;
-                while upstream_index < self.source.len() {
-                    let c = self.source[upstream_index..].chars().next().unwrap_or('\0');
-                    if is_js_whitespace(c) || c == ':' {
-                        break;
-                    }
-                    upstream_index += c.len_utf8();
-                }
-                while upstream_index < self.source.len() {
-                    let c = self.source[upstream_index..].chars().next().unwrap_or('\0');
-                    if !is_js_whitespace(c) {
-                        break;
-                    }
-                    upstream_index += c.len_utf8();
-                }
-                if self.source[upstream_index..].starts_with(':') {
-                    upstream_index += 1;
-                }
-                record_first_error(
-                    &self.error,
-                    crate::error::ParseError::svelte(
-                        "css_empty_declaration",
-                        "Declaration cannot be empty",
-                        (start, self.offset + upstream_index),
-                    ),
-                );
-            }
-            return None;
-        }
-
-        self.advance(); // consume ':'
+        self.skip_whitespace();
+        self.eat_optional(":");
+        let empty_declaration_end = self.offset + self.index;
         self.skip_whitespace();
 
         // Read value, respecting parentheses, strings, and CSS escape sequences so
@@ -1922,6 +1870,17 @@ impl<'a> CssParser<'a> {
             self.advance();
         }
         let value = self.source[value_start..self.index].trim_ws().to_string();
+
+        if value.is_empty() && !property.starts_with("--") {
+            record_first_error(
+                &self.error,
+                crate::error::ParseError::svelte(
+                    "css_empty_declaration",
+                    "Declaration cannot be empty",
+                    (start, empty_declaration_end),
+                ),
+            );
+        }
 
         // End position is before the semicolon
         let end = self.offset + self.index;

--- a/crates/rsvelte_core/tests/css_scss_line_comment_position.rs
+++ b/crates/rsvelte_core/tests/css_scss_line_comment_position.rs
@@ -32,3 +32,26 @@ fn block_item_lookahead_distinguishes_line_comment_declarations_and_rules() {
     let second = source[first + 2..].find("//").unwrap() + first + 2;
     assert_error_at(source, second);
 }
+
+#[test]
+fn line_comment_declaration_uses_the_first_word_as_its_property() {
+    let source = "<style lang=\"scss\">\n.a {\n  // declaration text;\n  %bad {}\n}\n</style>";
+    assert_error_at(source, source.find("%bad").unwrap());
+}
+
+#[test]
+fn quotes_in_line_comment_values_can_span_multiple_block_items() {
+    let source = r#"<style lang="scss">
+.a {
+  // Vertical offset keeps the row's baseline.
+  padding: 1px;
+  // hidden but takes space
+  .child {}
+  // min-size. Carbon's width
+  grid: 1fr;
+  // target on smaller
+  @include mobile {}
+}
+</style>"#;
+    assert_error_at(source, source.find("// target").unwrap());
+}


### PR DESCRIPTION
## Summary
- mirror upstream's whitespace-or-colon CSS property boundary
- preserve upstream block-item progression through invalid SCSS line comments
- add focused regressions and a pattern-corpus case
- remove six Trakt IDs from error position/end ratchets across all four targets (48 target entries)

## Validation
- cargo fmt --package rsvelte_core -- --check
- jq validation for all eight changed ratchets
- git diff --check
- official Svelte diagnostic checks for the fixed source shapes

Rust builds/tests were intentionally left to CI due local machine load.