### PR TITLE
Match module store subscription error spans

### DIFF
--- a/compatibility/error-end-known-failures.client-dev.json
+++ b/compatibility/error-end-known-failures.client-dev.json
@@ -11,10 +11,8 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"

--- a/compatibility/error-end-known-failures.client.json
+++ b/compatibility/error-end-known-failures.client.json
@@ -11,10 +11,8 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"

--- a/compatibility/error-end-known-failures.server-dev.json
+++ b/compatibility/error-end-known-failures.server-dev.json
@@ -11,10 +11,8 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"

--- a/compatibility/error-end-known-failures.server.json
+++ b/compatibility/error-end-known-failures.server.json
@@ -11,10 +11,8 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"

--- a/compatibility/error-position-known-failures.client-dev.json
+++ b/compatibility/error-position-known-failures.client-dev.json
@@ -6,10 +6,8 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/error-position-known-failures.client.json
+++ b/compatibility/error-position-known-failures.client.json
@@ -6,10 +6,8 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/error-position-known-failures.server-dev.json
+++ b/compatibility/error-position-known-failures.server-dev.json
@@ -6,10 +6,8 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/error-position-known-failures.server.json
+++ b/compatibility/error-position-known-failures.server.json
@@ -6,10 +6,8 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -1213,9 +1213,12 @@ fn check_module_store_subscriptions(
             if phases::phase2_analyze::visitors::shared::function::is_rune(&binding.name) {
                 continue;
             }
-            return Err(CompileError::Analysis(
-                phases::phase2_analyze::errors::store_invalid_subscription_module(),
-            ));
+            let error = phases::phase2_analyze::errors::store_invalid_subscription_module();
+            let error = match binding.references.first() {
+                Some(reference) => error.at(reference.start, reference.end),
+                None => error,
+            };
+            return Err(CompileError::Analysis(error));
         }
     }
     Ok(())

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -445,7 +445,10 @@ pub fn detect_store_subscriptions(
                 // store_invalid_subscription_module error code.
                 // For <script module> in .svelte files, error with store_invalid_subscription.
                 if !is_module_file {
-                    return Err(errors::store_invalid_subscription());
+                    return Err(errors::store_invalid_subscription().at(
+                        store_ref.position as u32,
+                        (store_ref.position + ref_name.len()) as u32,
+                    ));
                 }
             }
         }
@@ -464,11 +467,18 @@ pub fn detect_store_subscriptions(
         }
 
         // Create a synthetic StoreSub binding
-        let new_binding = Binding::with_declaration_kind(
+        let mut new_binding = Binding::with_declaration_kind(
             ref_name.clone(),
             BindingKind::StoreSub,
             DeclarationKind::Synthetic,
             0, // Root scope
+        );
+        new_binding.add_reference(
+            store_ref.position as u32,
+            (store_ref.position + ref_name.len()) as u32,
+            false,
+            false,
+            false,
         );
         let new_binding_idx = analysis.root.push_binding(new_binding);
         analysis

--- a/crates/rsvelte_core/tests/store_subscription_error_spans.rs
+++ b/crates/rsvelte_core/tests/store_subscription_error_spans.rs
@@ -1,0 +1,37 @@
+use rsvelte_core::{CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_module};
+
+#[test]
+fn module_file_store_subscription_points_at_the_first_reference() {
+    let source = "import { store } from 'somewhere';\n\nconsole.log($store);";
+    let diagnostic = compile_module(source, ModuleCompileOptions::default())
+        .expect_err("module store subscriptions must be rejected")
+        .diagnostic();
+    let start = source.find("$store").unwrap() as u32;
+
+    assert_eq!(
+        diagnostic.code.as_deref(),
+        Some("store_invalid_subscription_module")
+    );
+    assert_eq!(diagnostic.span, Some((start, start + 6)));
+}
+
+#[test]
+fn module_script_store_subscription_points_at_the_reference() {
+    let source = "<script module>\n\tconst foo = {};\n\tconst answer = $foo;\n</script>";
+    let diagnostic = compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect_err("module script store subscriptions must be rejected")
+    .diagnostic();
+    let start = source.find("$foo").unwrap() as u32;
+
+    assert_eq!(
+        diagnostic.code.as_deref(),
+        Some("store_invalid_subscription")
+    );
+    assert_eq!(diagnostic.span, Some((start, start + 4)));
+}


### PR DESCRIPTION
## Summary

- attach the first `$store` reference span to module-file store subscription errors
- attach the direct `$store` span to `<script module>` store subscription errors
- add focused regression coverage for both compiler entry points
- remove the two fixed IDs from all client/server dev/prod start/end ratchets (16 target entries)

## Verification

- `cargo fmt --check`
- `git diff --check`
- parsed all eight changed ratchet JSON files with `jq`
- compared both diagnostic ranges with the installed official Svelte compiler

Rust builds and tests were not run locally due to the current machine-load constraint; CI is the execution oracle.
