### PR TITLE
Match attribute sequence error spans

### DIFF
--- a/compatibility/error-end-known-failures.client-dev.json
+++ b/compatibility/error-end-known-failures.client-dev.json
@@ -5,8 +5,6 @@
 	"svelte.dev/apps/svelte.dev/content/docs/svelte/98-reference/30-compiler-warnings.md/34.svelte",
 	"svelte/documentation/docs/98-reference/.generated/compile-warnings.md/32.svelte",
 	"svelte/packages/svelte/messages/compile-warnings/style.md/1.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression-2/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",

--- a/compatibility/error-end-known-failures.client.json
+++ b/compatibility/error-end-known-failures.client.json
@@ -5,8 +5,6 @@
 	"svelte.dev/apps/svelte.dev/content/docs/svelte/98-reference/30-compiler-warnings.md/34.svelte",
 	"svelte/documentation/docs/98-reference/.generated/compile-warnings.md/32.svelte",
 	"svelte/packages/svelte/messages/compile-warnings/style.md/1.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression-2/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",

--- a/compatibility/error-end-known-failures.server-dev.json
+++ b/compatibility/error-end-known-failures.server-dev.json
@@ -5,8 +5,6 @@
 	"svelte.dev/apps/svelte.dev/content/docs/svelte/98-reference/30-compiler-warnings.md/34.svelte",
 	"svelte/documentation/docs/98-reference/.generated/compile-warnings.md/32.svelte",
 	"svelte/packages/svelte/messages/compile-warnings/style.md/1.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression-2/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",

--- a/compatibility/error-end-known-failures.server.json
+++ b/compatibility/error-end-known-failures.server.json
@@ -5,8 +5,6 @@
 	"svelte.dev/apps/svelte.dev/content/docs/svelte/98-reference/30-compiler-warnings.md/34.svelte",
 	"svelte/documentation/docs/98-reference/.generated/compile-warnings.md/32.svelte",
 	"svelte/packages/svelte/messages/compile-warnings/style.md/1.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression-2/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",

--- a/compatibility/error-position-known-failures.client-dev.json
+++ b/compatibility/error-position-known-failures.client-dev.json
@@ -1,7 +1,5 @@
 [
 	"svelte-put/sites/docs/src/packages/popover/docs.md.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression-2/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",

--- a/compatibility/error-position-known-failures.client.json
+++ b/compatibility/error-position-known-failures.client.json
@@ -1,7 +1,5 @@
 [
 	"svelte-put/sites/docs/src/packages/popover/docs.md.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression-2/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",

--- a/compatibility/error-position-known-failures.server-dev.json
+++ b/compatibility/error-position-known-failures.server-dev.json
@@ -1,7 +1,5 @@
 [
 	"svelte-put/sites/docs/src/packages/popover/docs.md.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression-2/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",

--- a/compatibility/error-position-known-failures.server.json
+++ b/compatibility/error-position-known-failures.server.json
@@ -1,7 +1,5 @@
 [
 	"svelte-put/sites/docs/src/packages/popover/docs.md.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression-2/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -136,8 +136,16 @@ pub fn visit_component<'a, 'b: 'a>(
                             &context.analysis.source,
                         )
                     {
-                        return Err(errors::attribute_invalid_sequence_expression()
-                            .at(expression_tag.start, expression_tag.end));
+                        let error = errors::attribute_invalid_sequence_expression();
+                        let error = match expression_tag
+                            .expression
+                            .start()
+                            .zip(expression_tag.expression.end())
+                        {
+                            Some((start, end)) => error.at(start, end),
+                            None => error,
+                        };
+                        return Err(error);
                     }
                 }
                 super::attribute::warn_attribute_quoted(context, attr);

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/element.rs
@@ -93,7 +93,16 @@ pub fn validate_element(
                                 }
 
                                 if !is_parenthesized {
-                                    return Err(errors::attribute_invalid_sequence_expression());
+                                    let error = errors::attribute_invalid_sequence_expression();
+                                    let error = match expression_tag
+                                        .expression
+                                        .start()
+                                        .zip(expression_tag.expression.end())
+                                    {
+                                        Some((start, end)) => error.at(start, end),
+                                        None => error,
+                                    };
+                                    return Err(error);
                                 }
                             }
                         }

--- a/crates/rsvelte_core/tests/attribute_sequence_error_spans.rs
+++ b/crates/rsvelte_core/tests/attribute_sequence_error_spans.rs
@@ -1,0 +1,34 @@
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn assert_sequence_error_span(source: &str) {
+    let diagnostic = compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect_err("unparenthesized sequence attributes must be rejected in runes mode")
+    .diagnostic();
+    let start = source.rfind("x, y, z").unwrap() as u32;
+
+    assert_eq!(
+        diagnostic.code.as_deref(),
+        Some("attribute_invalid_sequence_expression")
+    );
+    assert_eq!(diagnostic.span, Some((start, start + 7)));
+}
+
+#[test]
+fn component_sequence_error_points_at_the_expression() {
+    assert_sequence_error_span(
+        "<script>let { x, y, z } = $props();</script>\n<Child foo={x, y, z} />",
+    );
+}
+
+#[test]
+fn element_sequence_error_points_at_the_expression() {
+    assert_sequence_error_span(
+        "<script>let { x, y, z } = $props();</script>\n<span foo={x, y, z} />",
+    );
+}


### PR DESCRIPTION
## Summary

- report `attribute_invalid_sequence_expression` on the inner sequence expression for both components and regular elements
- add focused regression coverage for both element paths
- remove the two fixed IDs from all client/server dev/prod start/end ratchets (16 target entries)

## Verification

- `cargo fmt --check`
- `git diff --check`
- parsed all eight changed ratchet JSON files with `jq`
- confirmed the exact official Svelte diagnostic range

Rust builds and tests were not run locally due to the current machine-load constraint; CI is the execution oracle.
