### PR TITLE
Match top-level global modifier error span

### DIFF
--- a/compatibility/error-end-known-failures.client-dev.json
+++ b/compatibility/error-end-known-failures.client-dev.json
@@ -6,7 +6,6 @@
 	"svelte/documentation/docs/98-reference/.generated/compile-warnings.md/32.svelte",
 	"svelte/packages/svelte/messages/compile-warnings/style.md/1.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-end-known-failures.client.json
+++ b/compatibility/error-end-known-failures.client.json
@@ -6,7 +6,6 @@
 	"svelte/documentation/docs/98-reference/.generated/compile-warnings.md/32.svelte",
 	"svelte/packages/svelte/messages/compile-warnings/style.md/1.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-end-known-failures.server-dev.json
+++ b/compatibility/error-end-known-failures.server-dev.json
@@ -6,7 +6,6 @@
 	"svelte/documentation/docs/98-reference/.generated/compile-warnings.md/32.svelte",
 	"svelte/packages/svelte/messages/compile-warnings/style.md/1.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-end-known-failures.server.json
+++ b/compatibility/error-end-known-failures.server.json
@@ -6,7 +6,6 @@
 	"svelte/documentation/docs/98-reference/.generated/compile-warnings.md/32.svelte",
 	"svelte/packages/svelte/messages/compile-warnings/style.md/1.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-position-known-failures.client-dev.json
+++ b/compatibility/error-position-known-failures.client-dev.json
@@ -1,7 +1,6 @@
 [
 	"svelte-put/sites/docs/src/packages/popover/docs.md.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-position-known-failures.client.json
+++ b/compatibility/error-position-known-failures.client.json
@@ -1,7 +1,6 @@
 [
 	"svelte-put/sites/docs/src/packages/popover/docs.md.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-position-known-failures.server-dev.json
+++ b/compatibility/error-position-known-failures.server-dev.json
@@ -1,7 +1,6 @@
 [
 	"svelte-put/sites/docs/src/packages/popover/docs.md.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-position-known-failures.server.json
+++ b/compatibility/error-position-known-failures.server.json
@@ -1,7 +1,6 @@
 [
 	"svelte-put/sites/docs/src/packages/popover/docs.md.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/css-global-modifier-start-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css/analyze.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css/analyze.rs
@@ -551,7 +551,10 @@ fn validate_single_nesting_selector(
     // and the parent has a lone :global selector
     if let Some(parent_rule) = state.parent_rule {
         if is_parent_lone_global_block(parent_rule) && !state.parent_rule_has_parent {
-            return Err(errors::css_global_block_invalid_modifier_start());
+            return Err(at_node(
+                errors::css_global_block_invalid_modifier_start(),
+                nesting_node,
+            ));
         }
     }
 

--- a/crates/rsvelte_core/tests/css_global_modifier_error_span.rs
+++ b/crates/rsvelte_core/tests/css_global_modifier_error_span.rs
@@ -1,0 +1,22 @@
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[test]
+fn top_level_global_modifier_error_points_at_the_nesting_selector() {
+    let source = "<style>\n:global {\n\t&.x { color: red; }\n}\n</style>";
+    let diagnostic = compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect_err("a top-level :global block cannot be modified")
+    .diagnostic();
+    let start = source.find('&').unwrap() as u32;
+
+    assert_eq!(
+        diagnostic.code.as_deref(),
+        Some("css_global_block_invalid_modifier_start")
+    );
+    assert_eq!(diagnostic.span, Some((start, start + 1)));
+}


### PR DESCRIPTION
## Summary

- attach the nesting selector node to the top-level `:global` modifier diagnostic
- add a focused regression test for the exact `&` span
- remove the fixed ID from all client/server dev/prod start/end ratchets (8 target entries)

## Verification

- `cargo fmt --check`
- `git diff --check`
- parsed all eight changed ratchet JSON files with `jq`
- confirmed official Svelte reports the `&` one-character range

Rust builds and tests were not run locally due to the current machine-load constraint; CI is the execution oracle.
