### PR TITLE
Match const tag cycle error span

### DIFF
--- a/compatibility/error-end-known-failures.client-dev.json
+++ b/compatibility/error-end-known-failures.client-dev.json
@@ -5,7 +5,6 @@
 	"svelte.dev/apps/svelte.dev/content/docs/svelte/98-reference/30-compiler-warnings.md/34.svelte",
 	"svelte/documentation/docs/98-reference/.generated/compile-warnings.md/32.svelte",
 	"svelte/packages/svelte/messages/compile-warnings/style.md/1.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-end-known-failures.client.json
+++ b/compatibility/error-end-known-failures.client.json
@@ -5,7 +5,6 @@
 	"svelte.dev/apps/svelte.dev/content/docs/svelte/98-reference/30-compiler-warnings.md/34.svelte",
 	"svelte/documentation/docs/98-reference/.generated/compile-warnings.md/32.svelte",
 	"svelte/packages/svelte/messages/compile-warnings/style.md/1.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-end-known-failures.server-dev.json
+++ b/compatibility/error-end-known-failures.server-dev.json
@@ -5,7 +5,6 @@
 	"svelte.dev/apps/svelte.dev/content/docs/svelte/98-reference/30-compiler-warnings.md/34.svelte",
 	"svelte/documentation/docs/98-reference/.generated/compile-warnings.md/32.svelte",
 	"svelte/packages/svelte/messages/compile-warnings/style.md/1.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-end-known-failures.server.json
+++ b/compatibility/error-end-known-failures.server.json
@@ -5,7 +5,6 @@
 	"svelte.dev/apps/svelte.dev/content/docs/svelte/98-reference/30-compiler-warnings.md/34.svelte",
 	"svelte/documentation/docs/98-reference/.generated/compile-warnings.md/32.svelte",
 	"svelte/packages/svelte/messages/compile-warnings/style.md/1.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-position-known-failures.client-dev.json
+++ b/compatibility/error-position-known-failures.client-dev.json
@@ -1,6 +1,5 @@
 [
 	"svelte-put/sites/docs/src/packages/popover/docs.md.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-position-known-failures.client.json
+++ b/compatibility/error-position-known-failures.client.json
@@ -1,6 +1,5 @@
 [
 	"svelte-put/sites/docs/src/packages/popover/docs.md.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-position-known-failures.server-dev.json
+++ b/compatibility/error-position-known-failures.server-dev.json
@@ -1,6 +1,5 @@
 [
 	"svelte-put/sites/docs/src/packages/popover/docs.md.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-position-known-failures.server.json
+++ b/compatibility/error-position-known-failures.server.json
@@ -1,6 +1,5 @@
 [
 	"svelte-put/sites/docs/src/packages/popover/docs.md.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/const-tag-cyclical/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/fragment.rs
@@ -266,7 +266,16 @@ fn check_const_tag_cycles(nodes: &[TemplateNode]) -> Result<(), AnalysisError> {
     if let Some(cycle) = check_graph_for_cycles::<String>(&edges) {
         // Format the cycle as "a → b → a"
         let cycle_str = cycle.join(" → ");
-        return Err(errors::const_tag_cycle(&cycle_str));
+        let error = errors::const_tag_cycle(&cycle_str);
+        let tag = cycle
+            .first()
+            .and_then(|name| binding_to_tag.get(name))
+            .map(|idx| const_tags[*idx].0);
+        let error = match tag {
+            Some(tag) => error.at(tag.start, tag.end),
+            None => error,
+        };
+        return Err(error);
     }
 
     Ok(())

--- a/crates/rsvelte_core/tests/const_tag_cycle_error_span.rs
+++ b/crates/rsvelte_core/tests/const_tag_cycle_error_span.rs
@@ -1,0 +1,24 @@
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[test]
+fn const_tag_cycle_points_at_the_first_declaration_in_the_cycle() {
+    let source = "{#if true}\n\t{@const a = b}\n\t{@const b = a}\n{/if}";
+    let diagnostic = compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            runes: Some(false),
+            ..Default::default()
+        },
+    )
+    .expect_err("cyclical const tags must be rejected")
+    .diagnostic();
+    let declaration = "{@const a = b}";
+    let start = source.find(declaration).unwrap() as u32;
+
+    assert_eq!(diagnostic.code.as_deref(), Some("const_tag_cycle"));
+    assert_eq!(
+        diagnostic.span,
+        Some((start, start + declaration.len() as u32))
+    );
+}


### PR DESCRIPTION
## Summary

- map the first binding in a const-tag dependency cycle back to its declaring tag
- report `const_tag_cycle` on that full tag, matching official Svelte
- add focused regression coverage
- remove the fixed ID from all client/server dev/prod start/end ratchets (8 target entries)

## Verification

- `cargo fmt --check`
- `git diff --check`
- parsed all eight changed ratchet JSON files with `jq`
- confirmed official Svelte reports `{@const a = b}` for the fixture

Rust builds and tests were not run locally due to the current machine-load constraint; CI is the execution oracle.
