### PR TITLE
Match snippet conflict error span

### DIFF
--- a/compatibility/error-end-known-failures.client-dev.json
+++ b/compatibility/error-end-known-failures.client-dev.json
@@ -8,7 +8,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"

--- a/compatibility/error-end-known-failures.client.json
+++ b/compatibility/error-end-known-failures.client.json
@@ -8,7 +8,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"

--- a/compatibility/error-end-known-failures.server-dev.json
+++ b/compatibility/error-end-known-failures.server-dev.json
@@ -8,7 +8,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"

--- a/compatibility/error-end-known-failures.server.json
+++ b/compatibility/error-end-known-failures.server.json
@@ -8,7 +8,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/void-closing/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"

--- a/compatibility/error-position-known-failures.client-dev.json
+++ b/compatibility/error-position-known-failures.client-dev.json
@@ -3,7 +3,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/error-position-known-failures.client.json
+++ b/compatibility/error-position-known-failures.client.json
@@ -3,7 +3,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/error-position-known-failures.server-dev.json
+++ b/compatibility/error-position-known-failures.server-dev.json
@@ -3,7 +3,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/compatibility/error-position-known-failures.server.json
+++ b/compatibility/error-position-known-failures.server.json
@@ -3,7 +3,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-derived-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/snippet-children-conflict/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte",
 	"svelte/packages/svelte/tests/validator/samples/each-block-destructured-object-rest-comma-after/input.svelte"
 ]

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -326,7 +326,7 @@ fn validate_slot_attributes(component: &Component) -> Result<(), AnalysisError> 
     let mut has_explicit_default = false;
     let mut has_implicit_default = false;
     let mut implicit_default_span = None;
-    let mut has_children_snippet = false;
+    let mut children_snippet_span = None;
     let mut has_other_content = false;
 
     for node in &component.fragment.nodes {
@@ -346,7 +346,7 @@ fn validate_slot_attributes(component: &Component) -> Result<(), AnalysisError> 
             if let TemplateNode::SnippetBlock(snippet) = node
                 && snippet.expression.is_identifier("children")
             {
-                has_children_snippet = true;
+                children_snippet_span.get_or_insert((snippet.start, snippet.end));
             }
 
             // Check if this is implicit default slot content
@@ -376,8 +376,10 @@ fn validate_slot_attributes(component: &Component) -> Result<(), AnalysisError> 
 
     // Check for snippet_conflict: cannot have both {#snippet children()} and other content
     // Corresponds to SnippetBlock.js lines 59-73
-    if has_children_snippet && has_other_content {
-        return Err(errors::snippet_conflict());
+    if let Some((start, end)) = children_snippet_span
+        && has_other_content
+    {
+        return Err(errors::snippet_conflict().at(start, end));
     }
 
     // Check for slot_default_duplicate error

--- a/crates/rsvelte_core/tests/snippet_conflict_error_span.rs
+++ b/crates/rsvelte_core/tests/snippet_conflict_error_span.rs
@@ -1,0 +1,20 @@
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[test]
+fn snippet_conflict_points_at_the_explicit_children_snippet() {
+    let source = "<Button>\n\thello\n\t{#snippet children()}hi{/snippet}\n</Button>";
+    let diagnostic = compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect_err("explicit and implicit children must conflict")
+    .diagnostic();
+    let snippet = "{#snippet children()}hi{/snippet}";
+    let start = source.find(snippet).unwrap() as u32;
+
+    assert_eq!(diagnostic.code.as_deref(), Some("snippet_conflict"));
+    assert_eq!(diagnostic.span, Some((start, start + snippet.len() as u32)));
+}


### PR DESCRIPTION
## Summary

- retain the explicit `children` snippet span while validating component content
- report `snippet_conflict` on that full snippet, matching official Svelte
- add focused regression coverage
- remove the fixed ID from all client/server dev/prod start/end ratchets (8 target entries)

## Verification

- `cargo fmt --check`
- `git diff --check`
- parsed all eight changed ratchet JSON files with `jq`
- confirmed official Svelte reports the explicit `{#snippet children()}` block

Rust builds and tests were not run locally due to the current machine-load constraint; CI is the execution oracle.
