### PR TITLE
Match lint rule eligibility on Svelte 5

### DIFF
--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -3177,12 +3177,14 @@ Ratchet: `compatibility/lint-conditions-known-failures.json`, justified per key 
 
 **Unit compared:** whether a rule runs at all, per rule id, on two axes — the runes mode pair
 (`runs-in-runes`, `runs-in-legacy`) reduced from upstream's `meta.conditions` against rsvelte's
-`RuleMeta::conditions`, and separately the SvelteKit-gated *set* against the hard-coded
-`SVELTEKIT_ONLY` list in `crates/rsvelte_lint/src/sveltekit.rs`. Key classes: `gate|<id>`,
-`svelte-3-4-only|<id>`, `kit-gate-missing|<id>`, `kit-gate-extra|<id>`.
+`RuleMeta::conditions`, the Svelte-5-unreachable set against `SVELTE_3_4_ONLY` in
+`crates/rsvelte_lint/src/svelte_version.rs`, and separately the SvelteKit-gated *set* against the
+hard-coded `SVELTEKIT_ONLY` list in `crates/rsvelte_lint/src/sveltekit.rs`. Key classes:
+`gate|<id>`, `svelte-3-4-only-{missing,extra,unknown}|<id>`, `kit-gate-missing|<id>`, and
+`kit-gate-extra|<id>`.
 
-Current: 84 shared rules, 14 runes-gated upstream, 5 SvelteKit-gated (agreeing 5 for 5), 3
-recorded divergences.
+Current: the ratchet is empty. The two Svelte-3/4-only rules and all five SvelteKit-only rules are
+modelled explicitly rather than accepted as divergences.
 
 It exists because **a wrong condition flag is unobservable to every finding-level gate unless the
 corpus contains a file in the mode the flag wrongly excludes** — and for a rule whose patterns are
@@ -3206,10 +3208,10 @@ mismatch from its own reduction is worse than none, because its rows read as sur
 ### Blind spot 34a — the gate reads `meta.conditions`, and upstream does not always put it there — **[D]**
 
 `no-at-const-tags` declares no `runes` condition and enforces `if (runes !== true) return {}` in the
-rule **body** instead, so the comparison reports a mismatch against rsvelte's (behaviourally
-correct) `runes_only: true`. Any rule that moves its gate into `create()` is invisible to this gate
-in the same way, and nothing enumerates which rules do that — the one instance was found by reading
-the source after the gate flagged it.
+rule **body** instead. rsvelte mirrors that placement, so its metadata now agrees, but any other rule
+that hides a gate inside `create()` remains invisible to this comparison; nothing enumerates those
+checks. This instance was found only by reading the source after the first gate run flagged the
+previous duplicated `runes_only: true` representation.
 
 The related worry that rsvelte's boolean pair cannot express upstream's tri-state was **checked and
 retracted**: `'undetermined'` is unreachable for any file either linter parses, because
@@ -3232,7 +3234,7 @@ reads from the *wrong* `RuleMeta` in a file declaring two rules.
 ### Blind spot 34c — two of the five condition axes are not compared — **[S]**
 
 `svelteFileTypes` is uncompared outright. `svelteVersions` is used only as the reachability
-filter, so a rule that became Svelte-5-only would move a `svelte-3-4-only` key, but a narrowing
+filter, so a rule entering or leaving the Svelte-5-reachable set moves a version-gate key, but a narrowing
 *within* 5 would not. Neither axis currently carries a value that separates rsvelte from upstream,
 which is a statement about this plugin version and not a guarantee.
 

--- a/compatibility/lint-conditions-known-failures.json
+++ b/compatibility/lint-conditions-known-failures.json
@@ -1,5 +1,1 @@
-[
-	"gate|svelte/no-at-const-tags|upstream runes_only=false legacy_only=false rsvelte runes_only=true legacy_only=false",
-	"svelte-3-4-only|svelte/experimental-require-strict-events",
-	"svelte-3-4-only|svelte/require-event-dispatcher-types"
-]
+[]

--- a/compatibility/lint-conditions-known-failures.md
+++ b/compatibility/lint-conditions-known-failures.md
@@ -1,131 +1,58 @@
-# lint-conditions-known-failures.json — why entries are accepted
+# lint-conditions-known-failures.json
 
-`scripts/compat-corpus/lint-conditions.mjs` compares, per rule id, **whether the
-rule runs at all** in each Svelte mode: upstream's `meta.conditions` reduced to
-the pair (runs-in-runes, runs-in-legacy), against rsvelte's declared
-`RuleConditions { runes_only, legacy_only }`.
+`scripts/compat-corpus/lint-conditions.mjs` compares whether each rule can run
+under Svelte 5. The ratchet is empty: rsvelte and eslint-plugin-svelte agree on
+the runes-mode pair, the Svelte-version eligibility, and the SvelteKit-gated
+set for every shared rule.
 
-A wrong flag here is invisible to every finding-level gate unless the corpus
-happens to contain a file in the mode the flag wrongly excludes — and for a rule
-whose patterns are all one mode, that never happens. Three wrong flags were found
-by hand before this gate existed (`no-inspect`, `prefer-derived-over-derived-by`,
-`experimental-require-slot-types`), each of which made rsvelte run a rule ESLint
-would have skipped. **`lint-conditions-known-failures.json` holds 3 entries and is
-expected to stay at the ones below.**
+The gate derives upstream's answer from `meta.conditions`; it does not maintain
+a copied oracle list. `shouldRun` treats condition objects as alternatives, so
+the reduction first removes objects whose `svelteVersions` does not admit `5`
+and then unions the runes values of the reachable objects. Unioning every
+object would incorrectly make a Svelte-3/4 alternative affect Svelte-5
+behaviour.
 
-Key format: `gate|<id>|<both sides spelled out>`, or `svelte-3-4-only|<id>`.
+## Svelte-version eligibility
 
-## How upstream's side is derived, and the trap in deriving it
+Two upstream rules have no condition object reachable on Svelte 5:
 
-`shouldRun` is an OR over condition objects, and an object with no `runes` key
-constrains nothing on that axis. The reduction must therefore union **only the
-objects reachable at Svelte 5** — rsvelte is a Svelte 5 compiler, and upstream's
-own `getSvelteVersion()` reads the `svelte` package the *plugin* resolves, which
-is 5 here (measured: see `compatibility/gate-coverage.md` 32c).
+- `svelte/experimental-require-strict-events`
+- `svelte/require-event-dispatcher-types`
 
-Unioning across all objects instead reports six correctly-gated rules as wrong,
-because rules like `no-extra-reactive-curlies` carry
-`[{svelteVersions:['3/4']}, {runes:[false,'undetermined'], svelteVersions:['5']}]`
-and the first object — unreachable here — contributes "runs in runes mode". The
-first draft of this comparison did exactly that and produced a 10-row diff of
-which 6 rows were artefacts of the reduction. A comparison that cannot tell a
-real mismatch from its own arithmetic is worse than no comparison, so the
-`svelteVersions` filter is the load-bearing line of `upstreamGate`.
+They are listed in `crates/rsvelte_lint/src/svelte_version.rs`. Both the native
+and script rule engines consult that model, and the source-scan runner uses it
+before invoking either legacy rule. Explicitly configuring either rule
+therefore remains silent, matching upstream; default severity is no longer the
+only protection against an over-report. The condition gate independently
+derives the unreachable upstream set and diffs it against this Rust list with
+`svelte-3-4-only-{missing,extra,unknown}` keys.
 
-## `svelte-3-4-only` — 2 entries
+The finding-level lint universe includes both rules. That makes the ordinary
+parity gates exercise the skip instead of hiding the difference with a manual
+exclusion.
 
-`svelte/experimental-require-strict-events` and
-`svelte/require-event-dispatcher-types` carry exactly `[{svelteVersions:['3/4']}]`,
-so **no** condition object is satisfiable at Svelte 5 and upstream never runs
-them here, in any runes mode. rsvelte's `RuleConditions` has no axis for the
-Svelte version — it is a Svelte 5 compiler, so the axis is a constant — and
-therefore cannot express "never".
+## Body-level runes checks
 
-Both are already handled, in the only two places it matters:
+Upstream's `svelte/no-at-const-tags` declares no runes condition and performs
+`runes === true` gating inside the rule body. rsvelte now mirrors that layout:
+its `RuleConditions` has no runes restriction and `check_root` performs the
+mode check. This avoids representing one effective condition twice and makes
+the metadata comparison truthful without changing findings or fixes.
 
-- They default to `off` (`compatibility/lint-preset-known-failures.md` records
-  `require-event-dispatcher-types` and the reasoning), so a user on defaults sees
-  nothing from either.
-- `scripts/compat-corpus/lint-universe.mjs` excludes both from the parity
-  universe, with this exact reason cited, so the finding-level gates never force
-  them to `"warn"` and never compare them.
+The apparent upstream third value, `'undetermined'`, is not reachable for a
+file parsed by svelte-eslint-parser: an unspecified component mode is resolved
+through `hasRunesSymbol` to a boolean. If that parser behaviour changes, a
+body-level gate may need its own explicit comparison; the present gate cannot
+discover arbitrary checks inside `create()`.
 
-They are listed here rather than silently skipped because those two mitigations
-are the *only* thing standing between the current state and a user-visible
-over-report: enabling either rule explicitly makes rsvelte report where ESLint is
-silent. If the exclusion is ever lifted, this entry is what fails.
+## SvelteKit and remaining blind spots
 
-## `gate|svelte/no-at-const-tags` — 1 entry, and it is a genuine behavioural difference
+`svelteKitVersions` and `svelteKitFileTypes` are represented by
+`crates/rsvelte_lint/src/sveltekit.rs`. The gate derives the upstream gated set
+and compares both directions against `SVELTEKIT_ONLY`.
 
-Upstream declares `conditions: [{svelteVersions:['5']}]` — no runes axis at all —
-but enforces the gate in the rule **body** instead
-(`lib/rules/no-at-const-tags.js`):
-
-```js
-const runes = getSvelteContext(context)?.runes;
-// Only report and fix in runes mode, since preserving reactivity requires
-// `$derived(...)`, which is unavailable outside runes mode.
-if (runes !== true) return {};
-```
-
-so the comparison reports a mismatch that is, on the runes/legacy axis, the
-metadata being in a different place rather than saying a different thing.
-rsvelte's `runes_only: true` reproduces the intent, and the entry exists only
-because this gate reads `meta.conditions` and upstream's answer is not there.
-
-**The two spellings look like they disagree about `'undetermined'`, and they do
-not, because that value is unreachable.** `runes !== true` would exclude it while
-`conditions: [{runes: [true, 'undetermined']}]` (no-inspect, no-unused-props,
-prefer-derived-over-derived-by) admits it — but no file either linter parses ever
-carries it:
-
-- `svelte-eslint-parser/lib/parser/index.js:116` publishes a component's context
-  as `runes: svelteParseContext.runes ?? hasRunesSymbol(resultScript.ast)`, and
-  `hasRunesSymbol` returns a **boolean** (`svelte-parse-context.js:65`). So
-  `isRunesAsParseContext` returning `undefined` — no compiler option, no
-  `<svelte:options runes>` — resolves to a definite `true`/`false` here.
-- `resolveSvelteParseContextForSvelteScript` gives a `.svelte.[jt]s` a definite
-  `svelteVersion.gte(5)`.
-- The plugin's `runes: svelteParseContext?.runes ?? 'undetermined'`
-  (`utils/svelte-context.js:253`) fires only when `svelteParseContext` is absent
-  altogether, i.e. the file was parsed by some parser other than
-  svelte-eslint-parser.
-
-So rsvelte's boolean pair is sufficient, and a third state would be
-representation without a referent. The input that looks undetermined — no rune
-identifier anywhere, no options attribute — is `false`, and both sides skip;
-`compatibility/lint-adversarial/runes-mode/03-no-rune-symbol-anywhere.svelte` is
-that input and both sides agree on it.
-
-**This entry therefore has no behavioural consequence**, which is a stronger
-claim than the usual "accepted" and worth re-testing rather than inheriting: it
-holds only while `hasRunesSymbol` returns a boolean. If a future
-svelte-eslint-parser lets `'undetermined'` reach a rule, the two spellings part
-company and this entry becomes a real divergence.
-
-## The SvelteKit axis is compared too, as a separate key class
-
-`meta.conditions` also carries `svelteKitVersions` and `svelteKitFileTypes`, and
-rsvelte enforces that half in `crates/rsvelte_lint/src/sveltekit.rs` against a
-hard-coded `SVELTEKIT_ONLY` list rather than through `RuleConditions`. Comparing
-it on the runes axis would report all five as ungated, so the gate derives
-upstream's kit-gated set separately and diffs the two lists
-(`kit-gate-missing` / `kit-gate-extra`). They currently agree, 5 for 5, which is
-why no key of either class appears in the ratchet.
-
-Deriving rather than transcribing matters here for the same reason as above:
-`svelteKitFileType` is only computed once a version is known, so a rule
-conditioned solely on `svelteKitFileTypes` still requires SvelteKit and belongs
-in the set. Both keys count toward "kit-gated", and a rule is only counted when
-**every** reachable condition object carries one — a rule with an alternative
-ungated object would run without SvelteKit.
-
-## What this gate cannot see
-
-`svelteFileTypes` is the one condition axis still uncompared, and the fifth,
-`svelteVersions`, is compared only as the reachability filter — a rule that
-became Svelte-5-only would move a `svelte-3-4-only` key, but a rule whose
-version set narrowed *within* 5 would not. Neither axis has ever carried a value
-that separates rsvelte's behaviour from upstream's, which is a statement about
-the current plugin and not a guarantee. See `compatibility/gate-coverage.md`
-gate 34.
+`svelteFileTypes` remains uncompared. `svelteVersions` is reduced to whether a
+rule is reachable on Svelte 5, so narrower distinctions within Svelte 5 are not
+represented. The rsvelte metadata side is also a guarded regex over Rust
+source. See gate 34 in `compatibility/gate-coverage.md` for the evidence and
+limits.

--- a/compatibility/lint-conditions-known-failures.md
+++ b/compatibility/lint-conditions-known-failures.md
@@ -1,9 +1,9 @@
 # lint-conditions-known-failures.json
 
 `scripts/compat-corpus/lint-conditions.mjs` compares whether each rule can run
-under Svelte 5. The ratchet is empty: rsvelte and eslint-plugin-svelte agree on
-the runes-mode pair, the Svelte-version eligibility, and the SvelteKit-gated
-set for every shared rule.
+under Svelte 5. `lint-conditions-known-failures.json` has 0 entries. rsvelte and
+eslint-plugin-svelte agree on the runes-mode pair, the Svelte-version
+eligibility, and the SvelteKit-gated set for every shared rule.
 
 The gate derives upstream's answer from `meta.conditions`; it does not maintain
 a copied oracle list. `shouldRun` treats condition objects as alternatives, so

--- a/compatibility/lint-preset-known-failures.md
+++ b/compatibility/lint-preset-known-failures.md
@@ -71,19 +71,12 @@ it will fail rather than rot.
 
 ### `svelte/require-event-dispatcher-types`
 
-`createEventDispatcher` is a Svelte 3/4 API, and rsvelte is a Svelte 5 compiler
-port; the rule is dead weight on the code rsvelte is built for. Separately, its
-type-argument detection is a source scan whose documented divergence is that it
-cannot tell a `<` opening type arguments from a `<` comparison
-(`crates/rsvelte_lint/src/rules/require_event_dispatcher_types.rs`, module
-docs). Neither reason alone would be decisive; together they are enough to keep
-a rule about a removed API off by default rather than shipping its scan
-ambiguity to every user.
-
-Note this is **not** the reason upstream's own condition machinery would give:
-the rule carries no `svelteVersions` condition upstream, so ESLint runs it on
-Svelte 5 code too. The divergence is rsvelte's choice, which is why it is
-recorded here rather than modelled in `RuleConditions`.
+Upstream marks this rule Svelte-3/4-only, and rsvelte's Svelte-5 eligibility
+model now skips it even when explicitly enabled. The preset-severity comparison
+still records the declared-default mismatch independently: this rule remains
+`off` in rsvelte while that gate's upstream configuration declares another
+severity. Runtime reachability is governed and ratcheted separately by
+`lint-conditions-known-failures.json`.
 
 ## `off->warn` — one reason, 22 entries
 

--- a/crates/rsvelte_lint/src/engine.rs
+++ b/crates/rsvelte_lint/src/engine.rs
@@ -97,6 +97,9 @@ pub(crate) fn run_native_rules_on_root(
             if severity == Severity::Off {
                 return None;
             }
+            if !crate::svelte_version::supports_svelte5(meta.name) {
+                return None;
+            }
             if !sveltekit && crate::sveltekit::is_sveltekit_only(meta.name) {
                 return None;
             }
@@ -198,6 +201,7 @@ fn enabled_script_rules<'a>(
             let meta = r.meta();
             let severity = config.severity_for(meta);
             if severity == Severity::Off
+                || !crate::svelte_version::supports_svelte5(meta.name)
                 || (!sveltekit && crate::sveltekit::is_sveltekit_only(meta.name))
                 || runes_gate_excludes(meta, runes)
             {

--- a/crates/rsvelte_lint/src/lib.rs
+++ b/crates/rsvelte_lint/src/lib.rs
@@ -37,6 +37,7 @@ pub mod scope;
 pub mod script;
 pub mod suppression;
 pub mod svelte_scan;
+pub mod svelte_version;
 pub mod sveltekit;
 pub mod type_backend;
 pub mod visitor;

--- a/crates/rsvelte_lint/src/rules/no_at_const_tags.rs
+++ b/crates/rsvelte_lint/src/rules/no_at_const_tags.rs
@@ -33,7 +33,9 @@ static META: RuleMeta = RuleMeta {
     fixable: Fixable::Code,
     default_severity: Severity::Warn,
     conditions: RuleConditions {
-        runes_only: true,
+        // Upstream declares no runes condition and performs this check in the
+        // rule body. Keep the metadata faithful and do the same below.
+        runes_only: false,
         legacy_only: false,
     },
     type_aware: false,
@@ -68,8 +70,7 @@ impl Rule for NoAtConstTags {
         if tags.is_empty() {
             return;
         }
-        // Upstream declares no `runes` condition and gates in `create()`
-        // instead, so this cannot move to `RuleConditions`.
+        // Upstream declares no `runes` condition and gates in `create()`.
         if !crate::runes_mode::component_runes_mode(root, ctx.source()) {
             return;
         }

--- a/crates/rsvelte_lint/src/runner.rs
+++ b/crates/rsvelte_lint/src/runner.rs
@@ -160,12 +160,22 @@ pub fn lint_source_messages(
             meta.extend(crate::rules::experimental_require_slot_types::diagnostics(
                 source, file, config,
             ));
-            meta.extend(
-                crate::rules::experimental_require_strict_events::diagnostics(source, file, config),
-            );
-            meta.extend(crate::rules::require_event_dispatcher_types::diagnostics(
-                source, file, config,
-            ));
+            if crate::svelte_version::supports_svelte5(
+                crate::rules::experimental_require_strict_events::META.name,
+            ) {
+                meta.extend(
+                    crate::rules::experimental_require_strict_events::diagnostics(
+                        source, file, config,
+                    ),
+                );
+            }
+            if crate::svelte_version::supports_svelte5(
+                crate::rules::require_event_dispatcher_types::META.name,
+            ) {
+                meta.extend(crate::rules::require_event_dispatcher_types::diagnostics(
+                    source, file, config,
+                ));
+            }
             meta.extend(crate::rules::require_event_prefix::diagnostics(
                 source, file, config,
             ));

--- a/crates/rsvelte_lint/src/svelte_version.rs
+++ b/crates/rsvelte_lint/src/svelte_version.rs
@@ -1,0 +1,31 @@
+//! Svelte-version eligibility for lint rules.
+//!
+//! rsvelte only parses Svelte 5, while upstream still publishes a small number
+//! of rules whose `meta.conditions` admit Svelte 3/4 only. Keep that constant
+//! axis explicit so enabling one of those rules cannot make it run on a file
+//! where eslint-plugin-svelte would skip it.
+
+/// Rules whose upstream conditions cannot be satisfied by Svelte 5.
+const SVELTE_3_4_ONLY: &[&str] = &[
+    "svelte/experimental-require-strict-events",
+    "svelte/require-event-dispatcher-types",
+];
+
+#[must_use]
+pub fn supports_svelte5(rule_name: &str) -> bool {
+    !SVELTE_3_4_ONLY.contains(&rule_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn excludes_only_the_svelte_3_4_rules() {
+        assert!(!supports_svelte5(
+            "svelte/experimental-require-strict-events"
+        ));
+        assert!(!supports_svelte5("svelte/require-event-dispatcher-types"));
+        assert!(supports_svelte5("svelte/no-at-const-tags"));
+    }
+}

--- a/crates/rsvelte_lint/tests/experimental_and_dispatcher.rs
+++ b/crates/rsvelte_lint/tests/experimental_and_dispatcher.rs
@@ -2,10 +2,9 @@
 //! type checker: `experimental-require-slot-types`,
 //! `experimental-require-strict-events`, `require-event-dispatcher-types`.
 //!
-//! `slot-types` is also covered by the oracle, but the other two target Svelte
-//! 3/4 (`strictEvents`, `createEventDispatcher`), so their upstream fixtures are
-//! version-skipped by the oracle. These tests port those fixtures directly so the
-//! rules are still parity-verified.
+//! `slot-types` is also covered by the oracle. The other two target Svelte 3/4,
+//! so their scanners are tested directly below while the public Svelte-5 lint
+//! path is separately pinned to skip them.
 
 use std::path::PathBuf;
 
@@ -14,19 +13,24 @@ use rsvelte_lint::{LintConfig, Severity, lint_source};
 
 fn findings(src: &str, code: &str) -> Vec<(u32, u32, String)> {
     let cfg = LintConfig::empty().with_override(code, Severity::Error);
-    lint_source(
-        src,
-        &PathBuf::from("Test.svelte"),
-        &CompileOptions::default(),
-        &cfg,
-    )
-    .into_iter()
-    .filter(|d| d.code.as_deref() == Some(code))
-    .filter_map(|d| {
-        let r = d.range?;
-        Some((r.start.line, r.start.column + 1, d.message))
-    })
-    .collect()
+    let file = PathBuf::from("Test.svelte");
+    let diagnostics = match code {
+        STRICT => {
+            rsvelte_lint::rules::experimental_require_strict_events::diagnostics(src, &file, &cfg)
+        }
+        DISPATCH => {
+            rsvelte_lint::rules::require_event_dispatcher_types::diagnostics(src, &file, &cfg)
+        }
+        _ => lint_source(src, &file, &CompileOptions::default(), &cfg),
+    };
+    diagnostics
+        .into_iter()
+        .filter(|d| d.code.as_deref() == Some(code))
+        .filter_map(|d| {
+            let r = d.range?;
+            Some((r.start.line, r.start.column + 1, d.message))
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -118,6 +122,29 @@ fn strict_events_valid_cases() {
 // ---------------------------------------------------------------------------
 
 const DISPATCH: &str = "svelte/require-event-dispatcher-types";
+
+#[test]
+fn svelte_3_4_rules_do_not_run_on_svelte_5() {
+    for (src, code) in [
+        ("<script lang=\"ts\">\n</script>", STRICT),
+        (
+            "<script lang=\"ts\">import { createEventDispatcher } from 'svelte'; createEventDispatcher();</script>",
+            DISPATCH,
+        ),
+    ] {
+        let cfg = LintConfig::empty().with_override(code, Severity::Error);
+        let actual = lint_source(
+            src,
+            &PathBuf::from("Test.svelte"),
+            &CompileOptions::default(),
+            &cfg,
+        );
+        assert!(
+            actual.iter().all(|d| d.code.as_deref() != Some(code)),
+            "Svelte 3/4-only rule {code} ran on Svelte 5"
+        );
+    }
+}
 
 #[test]
 fn dispatcher_reports_missing_type_params() {

--- a/crates/rsvelte_lint/tests/non_ascii_word_boundary.rs
+++ b/crates/rsvelte_lint/tests/non_ascii_word_boundary.rs
@@ -8,8 +8,8 @@
 //! pins both directions for each of the four callers — `no-unused-props`,
 //! `require-event-prefix`, `require-event-dispatcher-types`, and
 //! `svelte_scan::declares_type_in` (reached through
-//! `experimental-require-strict-events`). All four are `EXCLUDE`d from the lint
-//! output-parity universe, so its ratchet cannot see this class at all.
+//! `experimental-require-strict-events`). The two Svelte-3/4 scanners are
+//! dormant in the public Svelte-5 path, so they are called directly here.
 
 use std::path::PathBuf;
 
@@ -18,16 +18,21 @@ use rsvelte_lint::{LintConfig, Severity, lint_source};
 
 fn findings(src: &str, code: &str) -> Vec<String> {
     let cfg = LintConfig::empty().with_override(code, Severity::Error);
-    lint_source(
-        src,
-        &PathBuf::from("Test.svelte"),
-        &CompileOptions::default(),
-        &cfg,
-    )
-    .into_iter()
-    .filter(|d| d.code.as_deref() == Some(code))
-    .map(|d| d.message)
-    .collect()
+    let file = PathBuf::from("Test.svelte");
+    let diagnostics = match code {
+        DISPATCH => {
+            rsvelte_lint::rules::require_event_dispatcher_types::diagnostics(src, &file, &cfg)
+        }
+        STRICT => {
+            rsvelte_lint::rules::experimental_require_strict_events::diagnostics(src, &file, &cfg)
+        }
+        _ => lint_source(src, &file, &CompileOptions::default(), &cfg),
+    };
+    diagnostics
+        .into_iter()
+        .filter(|d| d.code.as_deref() == Some(code))
+        .map(|d| d.message)
+        .collect()
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/compat-corpus/lint-conditions.mjs
+++ b/scripts/compat-corpus/lint-conditions.mjs
@@ -5,7 +5,8 @@
  * `eslint-plugin-svelte` decides whether a rule runs at all from `meta.conditions`
  * — an array of objects, satisfied if ANY of them matches the file's Svelte
  * version, runes mode, SvelteKit version and file type. rsvelte mirrors the runes
- * axis in `RuleMeta::conditions` (`RuleConditions { runes_only, legacy_only }`).
+ * axis in `RuleMeta::conditions` (`RuleConditions { runes_only, legacy_only }`)
+ * and the constant Svelte-5 axis in `svelte_version.rs`.
  *
  * Nothing compared the two. A wrong flag is invisible to every finding-level gate
  * unless the corpus happens to contain a file in the mode the flag wrongly
@@ -111,6 +112,20 @@ function rsvelteKitOnly() {
   return [...block[1].matchAll(/"(svelte\/[a-z0-9-]+)"/g)].map((m) => m[1]).sort();
 }
 
+/** Rules `crates/rsvelte_lint/src/svelte_version.rs` excludes on Svelte 5. */
+function rsvelteSvelte34Only() {
+  const src = fs.readFileSync(
+    path.join(ROOT, "crates", "rsvelte_lint", "src", "svelte_version.rs"),
+    "utf8",
+  );
+  const block = /const SVELTE_3_4_ONLY: &\[&str\] = &\[([\s\S]*?)\];/.exec(src);
+  if (!block) {
+    console.error("[lint-conditions] ❌ could not read SVELTE_3_4_ONLY from svelte_version.rs");
+    process.exit(2);
+  }
+  return [...block[1].matchAll(/"(svelte\/[a-z0-9-]+)"/g)].map((m) => m[1]).sort();
+}
+
 /** rsvelte's declared `RuleConditions`, read from each rule module's `META`. */
 function rsvelteConditions(bin) {
   const out = {};
@@ -154,6 +169,7 @@ function main() {
   const bin = findBinary();
   const up = upstreamConditions();
   const mine = rsvelteConditions(bin);
+  const mySvelte34Only = rsvelteSvelte34Only();
 
   const shared = Object.keys(mine).filter((id) => id in up);
   if (shared.length === 0) {
@@ -168,10 +184,11 @@ function main() {
     const m = mine[id];
     if (u.runesOnly || u.legacyOnly || !u.reachable) gated++;
     if (!u.reachable) {
-      // Upstream cannot run this rule on Svelte 5 in ANY mode. rsvelte has no
-      // way to express that, so it is a class of its own rather than a flag
-      // mismatch — see the paired .md.
-      diffs.push(`svelte-3-4-only|${id}`);
+      if (!mySvelte34Only.includes(id)) diffs.push(`svelte-3-4-only-missing|${id}`);
+      continue;
+    }
+    if (mySvelte34Only.includes(id)) {
+      diffs.push(`svelte-3-4-only-extra|${id}`);
       continue;
     }
     if (u.runesOnly !== m.runesOnly || u.legacyOnly !== m.legacyOnly) {
@@ -180,6 +197,9 @@ function main() {
           ` rsvelte runes_only=${m.runesOnly} legacy_only=${m.legacyOnly}`,
       );
     }
+  }
+  for (const id of mySvelte34Only) {
+    if (!(id in mine)) diffs.push(`svelte-3-4-only-unknown|${id}`);
   }
   // The SvelteKit axis lives in a hard-coded list rather than in RuleConditions,
   // so it needs its own comparison or a rule joining/leaving upstream's gated set
@@ -209,8 +229,9 @@ function main() {
   }
 
   console.log(
-    `[lint-conditions] ${shared.length} shared rules, ${gated} runes-gated by upstream on Svelte 5, ` +
-      `${upKit.length} SvelteKit-gated; ${diffs.length} divergence(s)`,
+    `[lint-conditions] ${shared.length} shared rules, ${gated} mode/version-gated by upstream, ` +
+      `${mySvelte34Only.length} Svelte-3/4-only and ${upKit.length} SvelteKit-gated; ` +
+      `${diffs.length} divergence(s)`,
   );
 
   const known = fs.existsSync(KNOWN) ? JSON.parse(fs.readFileSync(KNOWN, "utf8")) : [];

--- a/scripts/compat-corpus/lint-universe.mjs
+++ b/scripts/compat-corpus/lint-universe.mjs
@@ -48,11 +48,6 @@ export const EXCLUDE = new Set([
 	// ── Option-required: schema rejects an empty option list, so the rule is a
 	//    no-op without a per-project allowlist. rsvelte defaults it off too.
 	'svelte/no-restricted-html-elements',
-	// ── Svelte 3/4-only (`meta.conditions: svelteVersions: ['3/4']`). The corpus
-	//    declares Svelte 5 (see lint-collect's synthetic package.json), so the
-	//    oracle skips these; rsvelte doesn't version-gate, so it would over-report.
-	'svelte/experimental-require-strict-events',
-	'svelte/require-event-dispatcher-types',
 	// ── `indent`: a stylistic whitespace rule only partially ported (template
 	//    level; the JS/TS-AST script indentation the fixture oracle skips). Full
 	//    real-world parity is a tracked follow-up — see lint-corpus README. It


### PR DESCRIPTION
## Summary
- model Svelte 3/4-only lint rules and skip them on every Svelte 5 execution path
- mirror upstream's body-level runes check for no-at-const-tags without duplicating it in metadata
- enroll the legacy rules in finding parity and shrink lint condition divergences from 3 to 0

## Verification
- node scripts/compat-corpus/lint-conditions.mjs
- node --check scripts/compat-corpus/lint-conditions.mjs
- node --check scripts/compat-corpus/lint-universe.mjs
- rustfmt --edition 2024 on changed Rust files
- git diff --check

Rust builds/tests intentionally deferred to CI per repository machine-load policy.