### PR TITLE
Match block-lang style visitor eligibility

### DIFF
--- a/compatibility/lint-adversarial-known-failures.json
+++ b/compatibility/lint-adversarial-known-failures.json
@@ -1,5 +1,4 @@
 [
-	"html-closing-bracket-new-line/05-script-style-tags.svelte|+svelte/block-lang\t7:1\tThe lang attribute of the <style> block should be omitted.",
 	"no-nested-style-tag/14-component-lookalike.svelte|-svelte/html-self-closing\t5:8\tDisallow self-closing on HTML elements.",
 	"no-top-level-browser-globals/03-guard-browser.svelte|+svelte/no-top-level-browser-globals\t7:14\tUnexpected top-level browser global variable \"navigator\"."
 ]

--- a/compatibility/lint-adversarial-known-failures.md
+++ b/compatibility/lint-adversarial-known-failures.md
@@ -9,31 +9,17 @@ to separate two plausible implementations of one rule, so a divergence is a
 deliberate probe coming back positive rather than an accident of what published
 code happens to contain.
 
-**The expectation is that `lint-adversarial-known-failures.json` stays at 3 entries.**
+**The expectation is that `lint-adversarial-known-failures.json` stays at 2 entries.**
 It is not a burndown backlog: a new entry needs a reason that is *not*
-"rsvelte is wrong here", and the three below are the only such reasons found
+"rsvelte is wrong here", and the two below are the only such reasons found
 across 1365 patterns and 74 rules. Everything else the corpus surfaced (330
 divergences on the first run, 35 more when it grew past 1000 patterns) was fixed.
 
 `+` = rsvelte reports, oracle silent. `-` = oracle reports, rsvelte silent.
 
-## The three accepted entries
+## The two accepted entries
 
-### 1. `html-closing-bracket-new-line/05-script-style-tags.svelte` `+svelte/block-lang 7:1`
-
-An **upstream parser** artifact, not a rule difference. The pattern closes its
-style block as `</style⏎⏎>`. `svelte-eslint-parser` does not produce a
-`SvelteStyleElement` for that spelling, so `block-lang`'s `SvelteStyleElement`
-visitor never fires and the block is never checked; rsvelte's parser does
-recognise it and reports the `lang="css"` that upstream's own default option
-(`style: null`) disallows.
-
-Measured, not assumed: with the end tag written `</style>` and nothing else
-changed, upstream reports both blocks (`1:1` script and `7:1` style); with
-`</style⏎⏎>` it reports only the script. Matching upstream here would mean
-teaching rsvelte's parser to *drop* a style element Svelte itself accepts.
-
-### 2. `no-top-level-browser-globals/03-guard-browser.svelte` `+svelte/no-top-level-browser-globals 7:14`
+### 1. `no-top-level-browser-globals/03-guard-browser.svelte` `+svelte/no-top-level-browser-globals 7:14`
 
 The `globals`-version split already documented as **H4** in
 `compatibility/lint-known-failures.md` and excluded by name in
@@ -45,7 +31,7 @@ because eslint-plugin-svelte's own bundled fixtures — the authority the
 exact-fixture oracle gate enforces — expect exactly that report for this class.
 The two upstream artefacts disagree; rsvelte follows the fixtures.
 
-### 3. `no-nested-style-tag/14-component-lookalike.svelte` `-svelte/html-self-closing 5:8`
+### 2. `no-nested-style-tag/14-component-lookalike.svelte` `-svelte/html-self-closing 5:8`
 
 `<Style />` — a component whose name differs from `style` only in case. Upstream
 reports `html-self-closing` on it; rsvelte does not, and **rsvelte is right**.

--- a/compatibility/lint-adversarial-suggest-known-failures.json
+++ b/compatibility/lint-adversarial-suggest-known-failures.json
@@ -1,3 +1,1 @@
-[
-	"html-closing-bracket-new-line/05-script-style-tags.svelte|svelte/block-lang 7:1"
-]
+[]

--- a/compatibility/lint-adversarial-suggest-known-failures.md
+++ b/compatibility/lint-adversarial-suggest-known-failures.md
@@ -15,25 +15,4 @@ JS string and rsvelte's are UTF-8 byte offsets, so equal edits have unequal
 coordinates.
 
 An entry needs a reason that is *not* "rsvelte is wrong here".
-`lint-adversarial-suggest-known-failures.json` currently holds 1 entry.
-
-## Accepted entries
-
-### `html-closing-bracket-new-line/05-script-style-tags.svelte` `svelte/block-lang 7:1`
-
-Not an independent divergence: it restates the report-level entry of the same
-name in
-[`lint-adversarial-known-failures.md`](lint-adversarial-known-failures.md).
-`svelte-eslint-parser` builds no `SvelteStyleElement` for a `</style⏎⏎>` end
-tag, so upstream's rule never runs and offers no suggestion, while rsvelte's
-parser recognises the block and reports it — with the suggestion its
-`enforceStylePresent` arm carries. The comparison key starts with the finding
-position, so a finding only one side reports lands here as an empty list against
-a one-element list.
-
-It is listed rather than skipped because the alternative — comparing suggestions
-only where the *report* already matches — would silently drop this whole class,
-and the class contains real cases: a rule that reports correctly but attaches a
-suggestion upstream does not attach would look identical to a rule that does not
-report at all. Expect this entry to disappear if the report-level entry is ever
-resolved; the ratchet is two-sided, so it will fail rather than rot.
+`lint-adversarial-suggest-known-failures.json` currently holds 0 entries.

--- a/crates/rsvelte_lint/src/rules/block_lang.rs
+++ b/crates/rsvelte_lint/src/rules/block_lang.rs
@@ -156,6 +156,26 @@ fn style_lang_attr_range(css: &StyleSheet) -> Option<(u32, u32)> {
     None
 }
 
+/// Whether `svelte-eslint-parser` exposes this style block to rule visitors.
+///
+/// Its AST can contain a `SvelteStyleElement` for a closing tag with trivia
+/// before `>`, but its traversal keys expose the node only for the exact
+/// `</style>` spelling. Keep this quirk local to lint compatibility rather than
+/// making the compiler parser discard a valid Svelte style block.
+fn eslint_parser_exposes_style(source: &str, content_end: u32) -> bool {
+    let Ok(close_start) = usize::try_from(content_end) else {
+        return true;
+    };
+    let Some(rest) = source.as_bytes().get(close_start..) else {
+        return true;
+    };
+    if !rest.starts_with(b"</style") {
+        // Self-closing styles have no end tag and are exposed by the parser.
+        return true;
+    }
+    rest.get(b"</style".len()) == Some(&b'>')
+}
+
 // ---------------------------------------------------------------------------
 // Pretty-print the allowed languages list
 // ---------------------------------------------------------------------------
@@ -396,7 +416,10 @@ impl Rule for BlockLang {
         }
 
         // Style block.
-        let css = root.css.as_deref();
+        let css = root
+            .css
+            .as_deref()
+            .filter(|css| eslint_parser_exposes_style(&source, css.content.end));
         if css.is_none() && enforce_style {
             let msg = format!(
                 "The <style> block should be present and its lang attribute should be {}.",
@@ -678,5 +701,30 @@ mod tests {
             pretty_print_langs(&[Some("ts".to_string()), Some("js".to_string())]),
             "one of \"ts\", \"js\""
         );
+    }
+
+    #[test]
+    fn style_visibility_matches_eslint_parser_closing_tag_quirk() {
+        let prefix = "<style>div { color: red; }";
+        let end = source_offset(prefix.len());
+
+        assert!(eslint_parser_exposes_style(
+            &format!("{prefix}</style>"),
+            end
+        ));
+        for close in [
+            "</style >",
+            "</style\t>",
+            "</style\n>",
+            "</style\n\n>",
+            "</style/**/>",
+        ] {
+            assert!(!eslint_parser_exposes_style(
+                &format!("{prefix}{close}"),
+                end
+            ));
+        }
+
+        assert!(eslint_parser_exposes_style("<style />", 9));
     }
 }


### PR DESCRIPTION
## Summary
- mirror the svelte-eslint-parser style visitor boundary inside block-lang
- keep the compiler parser accepting valid closing-tag trivia
- shrink adversarial lint findings from 3 to 2 and suggestion divergences from 1 to 0

## Validation
- measured upstream behavior for exact, whitespace, tab, newline, CRLF, and comment-bearing style end tags
- rustfmt check
- JSON baseline count check
- git diff --check
- doc parity recognizes the updated ratchets; remaining failures are pre-existing stale counts on main

Rust builds/tests were intentionally left to CI to avoid local machine load.