### PR TITLE
Match omitted lint diagnostic ends

### DIFF
--- a/apps/npm/language-server/src/diagnostics.ts
+++ b/apps/npm/language-server/src/diagnostics.ts
@@ -7,9 +7,10 @@
  *   { "severity": "error"|"warning", "line": 1, "column": 0,
  *     "endLine": 1, "endColumn": 5, "code": "...", "message": "..." }
  *
- * `line`/`endLine` are 1-indexed; `column`/`endColumn` are 0-indexed UTF-16
- * offsets (the same encoding LSP uses by default), so the mapping to an LSP
- * `Range` is a straight `line - 1` with `character = column`.
+ * The end fields are omitted for a bare upstream location. `line`/`endLine`
+ * are 1-indexed; `column`/`endColumn` are 0-indexed UTF-16 offsets (the same
+ * encoding LSP uses by default), so the mapping to an LSP `Range` is a straight
+ * `line - 1` with `character = column` and a start fallback for an omitted end.
  *
  * This module is deliberately free of any wasm / `vscode-languageserver`
  * runtime dependency so it can be unit-tested in isolation.
@@ -25,8 +26,8 @@ export interface LintEntry {
   severity: string;
   line: number;
   column: number;
-  endLine: number;
-  endColumn: number;
+  endLine?: number;
+  endColumn?: number;
   code: string;
   message: string;
 }

--- a/apps/npm/language-server/test/diagnostics.test.mjs
+++ b/apps/npm/language-server/test/diagnostics.test.mjs
@@ -59,12 +59,9 @@ test("missing end falls back to start", () => {
     severity: "error",
     line: 1,
     column: 0,
-    endLine: 0,
-    endColumn: 0,
     code: "parse-error",
     message: "boom",
   });
-  // endLine 0 → falls back to entry.line (1) → 0-idx 0.
   assert.deepEqual(d.range.start, { line: 0, character: 0 });
   assert.deepEqual(d.range.end, { line: 0, character: 0 });
 });

--- a/apps/npm/oxlint-plugin/index.js
+++ b/apps/npm/oxlint-plugin/index.js
@@ -48,7 +48,11 @@ function analyze(fullSource, filename) {
 	const byKey = new Map();
 	for (const d of lintSource(fullSource, filename)) {
 		const startOffset = offsetOf(starts, d.line, d.column);
-		const endOffset = offsetOf(starts, d.endLine, d.endColumn);
+		const endOffset = offsetOf(
+			starts,
+			d.endLine ?? d.line,
+			d.endColumn ?? d.column,
+		);
 		const key = ruleKey(d.code);
 		let list = byKey.get(key);
 		if (!list) byKey.set(key, (list = []));

--- a/apps/npm/oxlint-plugin/src/engine.js
+++ b/apps/npm/oxlint-plugin/src/engine.js
@@ -55,7 +55,7 @@ export const engineKind = kind;
  *
  * @param {string} source Full component source (markup + script + style).
  * @param {string} filename Absolute path, used for filename-aware rules.
- * @returns {Array<{severity:string,line:number,column:number,endLine:number,endColumn:number,code:string,message:string}>}
+ * @returns {Array<{severity:string,line:number,column:number,endLine?:number,endColumn?:number,code:string,message:string}>}
  */
 export function lintSource(source, filename) {
 	return JSON.parse(binding.lint(source, filename));

--- a/apps/playground/src/lib/compiler.ts
+++ b/apps/playground/src/lib/compiler.ts
@@ -72,8 +72,8 @@ export interface LintDiagnostic {
 	line: number;
 	/** 0-indexed (UTF-16) column. */
 	column: number;
-	endLine: number;
-	endColumn: number;
+	endLine?: number;
+	endColumn?: number;
 	/** Rule id or compiler code, e.g. `svelte/no-at-html-tags` or `a11y_missing_attribute`. */
 	code: string;
 	message: string;

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -3036,14 +3036,15 @@ here**, as previously-unmatched findings become comparable. A count that grows a
 is expected, not a regression — and a count that shrinks because a finding *stopped* being
 reported is a gate-28 regression wearing this gate's clothes.
 
-### Blind spot 31b — `null` is compared as a value, and rsvelte cannot produce it — **[D]**
+### Closed 31b — `null` is compared as a value, and lint output can represent it — **[D]**
 
 ESLint omits `endLine`/`endColumn` entirely when a rule reports a bare position (`loc: {line,
-column}`). `rsvelte_diagnostics::Range` has no way to express an absent end, and adding one would
-change a type svelte-check and the language server share, so 7 findings (5
-`experimental-require-slot-types`, 2 `block-lang`) are structurally unfixable and ratcheted. The
-gate compares them rather than skipping them, so an accidental change of the invented end is
-still caught.
+column}`). `rsvelte_diagnostics::Range` still requires an end because svelte-check and the
+language server need a concrete range; lint findings carry separate `omit_end` metadata, and the
+SARIF / engine-JSON compatibility encoders omit the two fields when it is set. That closed the
+12 residual `experimental-require-slot-types` / `block-lang` rows without weakening the shared
+type. The gate continues comparing `null` rather than skipping it, so the representation stays
+pinned.
 
 ### Blind spot 31c — no message-independent identity, so a message change hides an end change — **[S]**
 

--- a/compatibility/lint-adversarial-end-known-failures.json
+++ b/compatibility/lint-adversarial-end-known-failures.json
@@ -1,14 +1,1 @@
-[
-	"block-lang/08-enforce-style-present.svelte|svelte/block-lang 1:2\tnull\t1:3",
-	"block-lang/opt-key-enforce-style-present-only.svelte|svelte/block-lang 1:2\tnull\t1:3",
-	"experimental-require-slot-types/01-basic-report.svelte|svelte/experimental-require-slot-types 1:2\tnull\t1:2",
-	"experimental-require-slot-types/07-module-js-instance-ts.svelte|svelte/experimental-require-slot-types 1:2\tnull\t1:2",
-	"experimental-require-slot-types/08-comment-decoy.svelte|svelte/experimental-require-slot-types 1:2\tnull\t1:2",
-	"experimental-require-slot-types/09-class-decoy.svelte|svelte/experimental-require-slot-types 1:2\tnull\t1:2",
-	"experimental-require-slot-types/11-lang-typescript.svelte|svelte/experimental-require-slot-types 1:2\tnull\t1:2",
-	"experimental-require-slot-types/13-options-runes-false.svelte|svelte/experimental-require-slot-types 1:2\tnull\t1:2",
-	"experimental-require-slot-types/17-slot-inside-blocks.svelte|svelte/experimental-require-slot-types 1:2\tnull\t1:2",
-	"experimental-require-slot-types/19-lang-case-variants.svelte|svelte/experimental-require-slot-types 1:2\tnull\t1:2",
-	"experimental-require-slot-types/21-generics-attribute.svelte|svelte/experimental-require-slot-types 1:2\tnull\t1:2",
-	"experimental-require-slot-types/22-similar-names.svelte|svelte/experimental-require-slot-types 1:2\tnull\t1:2"
-]
+[]

--- a/compatibility/lint-adversarial-end-known-failures.md
+++ b/compatibility/lint-adversarial-end-known-failures.md
@@ -1,4 +1,4 @@
-# lint-adversarial-end-known-failures.json — why entries are accepted
+# lint-adversarial-end-known-failures.json — history and invariant
 
 `scripts/compat-corpus/lint-adversarial-end.mjs` compares, for every finding
 whose full `(ruleId, line, column, message)` key **already matches** on both
@@ -11,21 +11,17 @@ because an entry listed for one suppresses everything about that entry.
 Entry format: `<pattern>|<ruleId> <start>\t<oracle end>\t<rsvelte end>`.
 
 The first run reported **670 divergences over 4611 compared findings across 20
-rules**. All but the accepted shape below were fixed, and in every case the cause
+rules**. Every divergence is now fixed, and in every ranged case the cause
 was one wrong `ctx.report` argument rather than many separate bugs — four rules
 were passing `end == start`, i.e. a zero-width range, which alone accounted for
 73 rows.
 
-**The expectation is that every entry in this file is of one shape**, described
-next. `lint-adversarial-end-known-failures.json` currently holds 12 entries over
-5519 compared findings; it was at 7
-before ~290 patterns were added, and the growth is the coupling this file's last
-section describes rather than a regression — 5 of the new patterns reach
-`experimental-require-slot-types`, whose report has no upstream end at all.
-Judge this ratchet by whether every entry is the accepted shape, not by its
-count.
+`lint-adversarial-end-known-failures.json` currently holds **0 entries** over
+5519 compared findings. It briefly grew from 7 to 12 when ~290 patterns made
+five more `experimental-require-slot-types` findings comparable; the last
+section explains why fixing the report gate can expose new end comparisons.
 
-## The one accepted shape: upstream has no end at all
+## The last shape closed: upstream has no end at all
 
 ESLint omits `endLine` / `endColumn` entirely when a rule reports a bare
 position (`loc: { line, column }`) instead of a node. Two rules do that:
@@ -44,11 +40,12 @@ condition that arm tests. Neither an HTML comment nor a CSS comment is picked up
 (measured). The arm was checked by hand instead, driving both sides with an
 explicit config: both report at 1:2 with the same message.
 
-`rsvelte_diagnostics::Range` has no way to express an absent end, and giving it
-one would change a type `svelte-check` and the language server share, where a
-diagnostic without an end is meaningless. The gate compares these as the literal
-string `null` rather than skipping them, so an accidental change to the end
-rsvelte invents is still caught.
+The shared `rsvelte_diagnostics::Range` remains unchanged: internal consumers,
+fixes and the language server still receive a concrete range. Lint findings now
+carry separate `omit_end` metadata. The SARIF and engine JSON compatibility
+encoders use it to omit `endLine` / `endColumn`, while consumers that need a
+range fall back to the start. This represents upstream's bare location without
+weakening the shared diagnostic model.
 
 ## Reading this gate next to gate 28
 

--- a/crates/rsvelte_lint/src/context.rs
+++ b/crates/rsvelte_lint/src/context.rs
@@ -244,7 +244,7 @@ impl<'a> LintContext<'a> {
 
     /// Report a finding spanning `[start, end)` (UTF-8 byte offsets).
     pub fn report(&mut self, start: u32, end: u32, message: impl Into<String>) {
-        self.push(start, end, message.into(), None, None, Vec::new());
+        self.push(start, end, message.into(), false, None, None, Vec::new());
     }
 
     /// Report with an attached `help:` note.
@@ -259,6 +259,7 @@ impl<'a> LintContext<'a> {
             start,
             end,
             message.into(),
+            false,
             Some(help.into()),
             None,
             Vec::new(),
@@ -267,7 +268,15 @@ impl<'a> LintContext<'a> {
 
     /// Report with an autofix.
     pub fn report_with_fix(&mut self, start: u32, end: u32, message: impl Into<String>, fix: Fix) {
-        self.push(start, end, message.into(), None, Some(fix), Vec::new());
+        self.push(
+            start,
+            end,
+            message.into(),
+            false,
+            None,
+            Some(fix),
+            Vec::new(),
+        );
     }
 
     /// Report with editor suggestions (code actions never applied by `--fix`).
@@ -280,7 +289,19 @@ impl<'a> LintContext<'a> {
         message: impl Into<String>,
         suggestions: Vec<Suggestion>,
     ) {
-        self.push(start, end, message.into(), None, None, suggestions);
+        self.push(start, end, message.into(), false, None, None, suggestions);
+    }
+
+    /// Report with suggestions when upstream exposes only the start location.
+    /// `end` remains available to fixes and internal range consumers.
+    pub fn report_without_end_with_suggestions(
+        &mut self,
+        start: u32,
+        end: u32,
+        message: impl Into<String>,
+        suggestions: Vec<Suggestion>,
+    ) {
+        self.push(start, end, message.into(), true, None, None, suggestions);
     }
 
     fn push(
@@ -288,6 +309,7 @@ impl<'a> LintContext<'a> {
         start: u32,
         end: u32,
         message: String,
+        omit_end: bool,
         help: Option<String>,
         fix: Option<Fix>,
         suggestions: Vec<Suggestion>,
@@ -298,6 +320,7 @@ impl<'a> LintContext<'a> {
             message,
             start,
             end,
+            omit_end,
             help,
             fix,
             suggestions,

--- a/crates/rsvelte_lint/src/diagnostic.rs
+++ b/crates/rsvelte_lint/src/diagnostic.rs
@@ -75,6 +75,10 @@ pub struct LintDiagnostic {
     pub start: u32,
     /// Exclusive-end byte offset.
     pub end: u32,
+    /// Upstream reported a bare location rather than a range. Keep `end` for
+    /// internal consumers that require a concrete span, but omit it from
+    /// compatibility output formats.
+    pub omit_end: bool,
     pub help: Option<String>,
     pub fix: Option<Fix>,
     /// Editor-offered suggestions (never auto-applied). Empty for most findings.
@@ -97,6 +101,8 @@ pub struct LintMessage {
     pub diagnostic: Diagnostic,
     /// `(start, end)` UTF-8 byte offsets; `None` for validator-wrap findings.
     pub span: Option<(u32, u32)>,
+    /// Whether compatibility output formats must omit the range end.
+    pub omit_end: bool,
     pub help: Option<String>,
     /// The `--fix` autofix, when the rule offers one.
     pub fix: Option<Fix>,
@@ -119,6 +125,7 @@ impl LintMessage {
         Self {
             diagnostic: d.to_output(file, line_index),
             span: Some((d.start, d.end)),
+            omit_end: d.omit_end,
             help: d.help,
             fix: d.fix,
             suggestions: d.suggestions,
@@ -132,6 +139,20 @@ impl LintMessage {
         Self {
             diagnostic,
             span: None,
+            omit_end: false,
+            help: None,
+            fix: None,
+            suggestions: Vec::new(),
+        }
+    }
+
+    /// Wrap a diagnostic whose upstream rule reports only a start location.
+    #[must_use]
+    pub const fn from_diagnostic_without_end(diagnostic: Diagnostic) -> Self {
+        Self {
+            diagnostic,
+            span: None,
+            omit_end: true,
             help: None,
             fix: None,
             suggestions: Vec::new(),

--- a/crates/rsvelte_lint/src/json_api.rs
+++ b/crates/rsvelte_lint/src/json_api.rs
@@ -27,8 +27,8 @@ struct Entry {
     severity: &'static str,
     line: u32,
     column: u32,
-    end_line: u32,
-    end_column: u32,
+    end_line: Option<u32>,
+    end_column: Option<u32>,
     code: String,
     message: String,
 }
@@ -59,7 +59,7 @@ fn compile_error_code(e: &CompileError) -> String {
 /// Lint source into JSON diagnostics.
 ///
 /// Lint `source`, returning a JSON array of diagnostics:
-/// `[{ "severity", "line", "column", "endLine", "endColumn", "code", "message" }]`.
+/// `[{ "severity", "line", "column", "endLine"?, "endColumn"?, "code", "message" }]`.
 /// Lines are 1-indexed, columns 0-indexed (UTF-16), matching `rsvelte check`.
 #[must_use]
 pub fn lint(source: &str, filename: &str) -> String {
@@ -115,8 +115,8 @@ fn lint_with(source: &str, filename: &str, config: &LintConfig) -> String {
                     severity: sev_str(sev),
                     line: l,
                     column: c,
-                    end_line: el,
-                    end_column: ec,
+                    end_line: Some(el),
+                    end_column: Some(ec),
                     code: w.code,
                     message: w.message,
                 });
@@ -126,8 +126,8 @@ fn lint_with(source: &str, filename: &str, config: &LintConfig) -> String {
             severity: "error",
             line: 1,
             column: 0,
-            end_line: 1,
-            end_column: 0,
+            end_line: Some(1),
+            end_column: Some(0),
             code: compile_error_code(&e),
             message: format!("{e}"),
         }),
@@ -147,8 +147,8 @@ fn lint_with(source: &str, filename: &str, config: &LintConfig) -> String {
             severity: sev_str(d.severity),
             line: l,
             column: c,
-            end_line: el,
-            end_column: ec,
+            end_line: (!d.omit_end).then_some(el),
+            end_column: (!d.omit_end).then_some(ec),
             code: d.rule,
             message: d.message,
         });
@@ -158,15 +158,20 @@ fn lint_with(source: &str, filename: &str, config: &LintConfig) -> String {
     let arr: Vec<_> = entries
         .into_iter()
         .map(|e| {
-            json!({
+            let mut value = json!({
                 "severity": e.severity,
                 "line": e.line,
                 "column": e.column,
-                "endLine": e.end_line,
-                "endColumn": e.end_column,
                 "code": e.code,
                 "message": e.message,
-            })
+            });
+            if let Some(end_line) = e.end_line {
+                value["endLine"] = json!(end_line);
+            }
+            if let Some(end_column) = e.end_column {
+                value["endColumn"] = json!(end_column);
+            }
+            value
         })
         .collect();
     serde_json::to_string(&arr).unwrap_or_else(|_| "[]".to_string())
@@ -279,6 +284,29 @@ mod tests {
             r#"{ "rules": { "svelte/no-at-html-tags": "off" } }"#,
         );
         assert!(!codes(&json).iter().any(|c| c == "svelte/no-at-html-tags"));
+    }
+
+    #[test]
+    fn a_bare_upstream_location_omits_its_end() {
+        let json = lint_with_config(
+            "<div />",
+            "App.svelte",
+            r#"{
+                "extends": ["none"],
+                "rules": {
+                    "svelte/block-lang": ["warn", { "enforceStylePresent": true }]
+                }
+            }"#,
+        );
+        let entries: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+        let entry = entries
+            .iter()
+            .find(|entry| entry["code"] == "svelte/block-lang")
+            .expect("block-lang finding");
+        assert_eq!(entry["line"], 1);
+        assert_eq!(entry["column"], 1);
+        assert!(entry.get("endLine").is_none());
+        assert!(entry.get("endColumn").is_none());
     }
 
     #[test]

--- a/crates/rsvelte_lint/src/output.rs
+++ b/crates/rsvelte_lint/src/output.rs
@@ -111,6 +111,7 @@ pub fn render_messages(
                 .map(|m| Payload {
                     fix: m.fix.as_ref(),
                     suggestions: &m.suggestions,
+                    omit_end: m.omit_end,
                 })
                 .collect();
             let refs: Vec<Option<&Payload>> = payloads.iter().map(Some).collect();
@@ -145,6 +146,7 @@ pub fn write_sarif(
 pub struct Payload<'a> {
     pub fix: Option<&'a crate::diagnostic::Fix>,
     pub suggestions: &'a [crate::diagnostic::Suggestion],
+    pub omit_end: bool,
 }
 
 fn edits_json(fix: &crate::diagnostic::Fix) -> Value {
@@ -220,12 +222,15 @@ fn sarif_result(d: &Diagnostic, payload: Option<&Payload>, workspace_root: &Path
     if let Some(r) = d.range {
         // SARIF lines and columns are both 1-indexed. Our lines are already
         // 1-indexed; columns are 0-indexed → +1.
-        location["physicalLocation"]["region"] = json!({
+        let mut region = json!({
             "startLine": r.start.line.max(1),
             "startColumn": r.start.column + 1,
-            "endLine": r.end.line.max(1),
-            "endColumn": r.end.column + 1,
         });
+        if !payload.is_some_and(|p| p.omit_end) {
+            region["endLine"] = json!(r.end.line.max(1));
+            region["endColumn"] = json!(r.end.column + 1);
+        }
+        location["physicalLocation"]["region"] = region;
     }
 
     let mut result = json!({
@@ -303,6 +308,32 @@ mod tests {
         let v: Value = serde_json::from_str(&out).unwrap();
         let rules = v["runs"][0]["tool"]["driver"]["rules"].as_array().unwrap();
         assert!(rules.iter().any(|r| r["id"] == "svelte/no-at-html-tags"));
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn sarif_omits_end_for_a_bare_upstream_location() {
+        let message = crate::diagnostic::LintMessage {
+            diagnostic: diag(),
+            span: None,
+            omit_end: true,
+            help: None,
+            fix: None,
+            suggestions: Vec::new(),
+        };
+        let out = render_messages(
+            &[message],
+            Path::new("/work"),
+            1,
+            LintFormat::Sarif,
+            "0.1.0",
+        );
+        let v: Value = serde_json::from_str(&out).unwrap();
+        let region = &v["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"];
+        assert_eq!(region["startLine"], 5);
+        assert_eq!(region["startColumn"], 4);
+        assert!(region.get("endLine").is_none());
+        assert!(region.get("endColumn").is_none());
     }
 
     #[test]

--- a/crates/rsvelte_lint/src/rules/block_lang.rs
+++ b/crates/rsvelte_lint/src/rules/block_lang.rs
@@ -394,7 +394,7 @@ impl Rule for BlockLang {
             );
             // Suggestions: only when allowed langs include non-null values.
             let suggestions = build_enforce_script_suggestions(&allowed_script);
-            ctx.report_with_suggestions(1, 2, msg, suggestions);
+            ctx.report_without_end_with_suggestions(1, 2, msg, suggestions);
         }
 
         // Check each script block's lang.
@@ -426,7 +426,7 @@ impl Rule for BlockLang {
                 pretty_print_langs(&allowed_style)
             );
             let suggestions = build_enforce_style_suggestions(&allowed_style, &source);
-            ctx.report_with_suggestions(1, 2, msg, suggestions);
+            ctx.report_without_end_with_suggestions(1, 2, msg, suggestions);
         }
 
         if let Some(css) = css {

--- a/crates/rsvelte_lint/src/rules/comment_directive.rs
+++ b/crates/rsvelte_lint/src/rules/comment_directive.rs
@@ -249,6 +249,7 @@ pub fn unused_directive_diagnostics(
                 message: c.message.clone(),
                 start: c.start,
                 end: c.end,
+                omit_end: false,
                 help: None,
                 fix: None,
                 suggestions: Vec::new(),

--- a/crates/rsvelte_lint/src/runner.rs
+++ b/crates/rsvelte_lint/src/runner.rs
@@ -195,7 +195,17 @@ pub fn lint_source_messages(
                 ),
             );
 
-            diags.extend(meta.into_iter().map(LintMessage::from_diagnostic));
+            diags.extend(meta.into_iter().map(|diagnostic| {
+                if diagnostic.code.as_deref()
+                    == Some(crate::rules::experimental_require_slot_types::META.name)
+                {
+                    // Upstream reports this rule with a bare `loc`, so its
+                    // public result has a start but no end.
+                    LintMessage::from_diagnostic_without_end(diagnostic)
+                } else {
+                    LintMessage::from_diagnostic(diagnostic)
+                }
+            }));
             diags
         }
     };

--- a/crates/rsvelte_lint_bindings/src/wasm.rs
+++ b/crates/rsvelte_lint_bindings/src/wasm.rs
@@ -13,7 +13,7 @@
 use wasm_bindgen::prelude::*;
 
 /// Lint `source`, returning a JSON array of diagnostics:
-/// `[{ "severity", "line", "column", "endLine", "endColumn", "code", "message" }]`.
+/// `[{ "severity", "line", "column", "endLine"?, "endColumn"?, "code", "message" }]`.
 /// Lines are 1-indexed, columns 0-indexed (UTF-16), matching `rsvelte check`.
 #[wasm_bindgen]
 #[must_use]


### PR DESCRIPTION
## Summary

- preserve concrete internal diagnostic ranges while marking upstream bare-location reports
- omit `endLine` / `endColumn` from SARIF and engine JSON for those reports, with consumer fallbacks
- match `block-lang` missing-block and `experimental-require-slot-types` positions
- shrink `lint-adversarial-end-known-failures.json` from 12 entries to 0

## Verification

- `rustfmt --edition 2024 --check` on changed Rust files
- `node --check` on changed JavaScript and diagnostic tests
- `jq -e 'length == 0' compatibility/lint-adversarial-end-known-failures.json`
- `git diff --check`

Rust builds/tests were intentionally left to CI to avoid adding local machine load.
