### PR TITLE
Match no-target-blank fixability

### DIFF
--- a/compatibility/lint-adversarial-fix-all-known-failures.json
+++ b/compatibility/lint-adversarial-fix-all-known-failures.json
@@ -1,18 +1,4 @@
 [
-	"no-target-blank/01-basic.svelte",
-	"no-target-blank/02-rel-dynamic.svelte",
-	"no-target-blank/03-spread-and-shorthand.svelte",
-	"no-target-blank/04-dynamic-href.svelte",
-	"no-target-blank/05-component.svelte",
-	"no-target-blank/06-svelte-element.svelte",
-	"no-target-blank/07-bind-href.svelte",
-	"no-target-blank/08-external-variants.svelte",
-	"no-target-blank/09-options.svelte",
-	"no-target-blank/10-case-and-decoys.svelte",
-	"no-target-blank/11-svelte-self.svelte",
-	"no-target-blank/12-multibyte-crlf.svelte",
-	"no-target-blank/opt-key-allow-referrer.svelte",
-	"no-target-blank/opt-key-dynamic-never.svelte",
 	"oracle-crash:no-navigation-without-base/06-template-literals.svelte",
 	"shorthand-directive/16-never-mode-modifiers.svelte"
 ]

--- a/compatibility/lint-adversarial-fix-all-known-failures.md
+++ b/compatibility/lint-adversarial-fix-all-known-failures.md
@@ -23,19 +23,18 @@ uncompared, and both turned out to hold defects:
 
 An entry needs a reason that is *not* "rsvelte is wrong here".
 
-`lint-adversarial-fix-all-known-failures.json` holds **16 entries** over 1364
-compared patterns; the oracle and rsvelte each rewrite 793 files.
+`lint-adversarial-fix-all-known-failures.json` holds **2 entries** over 1364
+compared patterns.
 
 Two verdicts share the file, kept apart by the key so neither can suppress the
 other on the same pattern: a bare `<id>` is a text divergence, and
 `oracle-crash:<id>` is a pattern ESLint threw on while fixing, where there is no
 text to compare.
 
-Partition of `lint-adversarial-fix-all-known-failures.json` by cause: `14 + 1 + 1`
+Partition of `lint-adversarial-fix-all-known-failures.json` by cause: `1 + 1`
 
 | cause | entries |
 |---|---|
-| rsvelte-only autofix (upstream rule is report-only) | 14 |
 | upstream autofix defect we decline to reproduce | 1 |
 | upstream rule crashes on text an earlier pass produced | 1 |
 
@@ -66,36 +65,6 @@ The same shape as the `prefer-class-directive` U+FEFF find one gate over: two
 implementations of one decision, and no gate that compares them to each other.
 
 ## Accepted entries
-
-### `svelte/no-target-blank` — 14 patterns
-
-```
-no-target-blank/{01-basic, 02-rel-dynamic, 03-spread-and-shorthand,
-04-dynamic-href, 05-component, 06-svelte-element, 07-bind-href,
-08-external-variants, 09-options, 10-case-and-decoys, 11-svelte-self,
-12-multibyte-crlf, opt-key-allow-referrer, opt-key-dynamic-never}.svelte
-```
-
-Thirteen of them are the per-rule gate's entries reproduced here, and
-[`lint-adversarial-fix-known-failures.md`](lint-adversarial-fix-known-failures.md)
-carries the mechanism: upstream's rule declares no `fixable` and reports only,
-while rsvelte's port repairs the `rel` attribute, deliberately, because Svelte 5
-dropped the compiler's `security-anchor-rel-noreferrer` warning and this rule is
-the only place left where the repair can live.
-
-**`10-case-and-decoys.svelte` is the fourteenth, and it is here and not there.**
-Its links are all decoys for `no-target-blank`, so with only that rule enabled
-neither side reports and the outputs are identical — which is exactly why the
-per-rule doc names it as the directory's one unlisted pattern. With the universe
-enabled, `svelte/no-useless-mustaches` first rewrites
-
-```svelte
-<a href="https://example.com/" target="_blank{''}">mustache in target, ok</a>
-```
-
-to `target="_blank"`, and the *next* pass hands `no-target-blank` a static
-`_blank` it now flags. Both sides report it in that pass; only rsvelte has a
-fixer. Same cause, reached only through another rule's edit.
 
 ### `shorthand-directive/16-never-mode-modifiers.svelte`
 

--- a/compatibility/lint-adversarial-fix-known-failures.json
+++ b/compatibility/lint-adversarial-fix-known-failures.json
@@ -1,16 +1,3 @@
 [
-	"no-target-blank/01-basic.svelte|svelte/no-target-blank",
-	"no-target-blank/02-rel-dynamic.svelte|svelte/no-target-blank",
-	"no-target-blank/03-spread-and-shorthand.svelte|svelte/no-target-blank",
-	"no-target-blank/04-dynamic-href.svelte|svelte/no-target-blank",
-	"no-target-blank/05-component.svelte|svelte/no-target-blank",
-	"no-target-blank/06-svelte-element.svelte|svelte/no-target-blank",
-	"no-target-blank/07-bind-href.svelte|svelte/no-target-blank",
-	"no-target-blank/08-external-variants.svelte|svelte/no-target-blank",
-	"no-target-blank/09-options.svelte|svelte/no-target-blank",
-	"no-target-blank/11-svelte-self.svelte|svelte/no-target-blank",
-	"no-target-blank/12-multibyte-crlf.svelte|svelte/no-target-blank",
-	"no-target-blank/opt-key-allow-referrer.svelte|svelte/no-target-blank",
-	"no-target-blank/opt-key-dynamic-never.svelte|svelte/no-target-blank",
 	"shorthand-directive/16-never-mode-modifiers.svelte|svelte/shorthand-directive"
 ]

--- a/compatibility/lint-adversarial-fix-known-failures.md
+++ b/compatibility/lint-adversarial-fix-known-failures.md
@@ -20,17 +20,16 @@ scheduling policy that belongs to ESLint's driver rather than to any rule's
 port. Within a rule both sides multi-pass to a fixpoint (10 passes, ESLint's
 `Linter.verifyAndFix` bound; `runner.rs::fix_all` mirrors it), so an entry here
 can be a difference in what a *later* pass sees rather than in any single edit —
-and one of the four causes below is exactly that.
+and the remaining cause below is exactly that.
 
 An entry needs a reason that is *not* "rsvelte is wrong here".
 
-`lint-adversarial-fix-known-failures.json` holds **14 entries**.
+`lint-adversarial-fix-known-failures.json` holds **1 entry**.
 
-Partition of `lint-adversarial-fix-known-failures.json` by cause: `13 + 1`
+Partition of `lint-adversarial-fix-known-failures.json` by cause: `1`
 
 | cause | entries |
 |---|---|
-| rsvelte-only autofix (upstream rule is report-only) | 13 |
 | upstream autofix defect we decline to reproduce | 1 |
 
 The gate found one defect no other lint gate could have: a rule's *fix* path and
@@ -43,67 +42,6 @@ every gate keyed on `(ruleId, line, column, message)` by construction. Both path
 now go through `js_trim` / `js_trim_start` / `js_trim_end`.
 
 ## Accepted entries
-
-### `svelte/no-target-blank` — 13 patterns
-
-```
-no-target-blank/{01-basic, 02-rel-dynamic, 03-spread-and-shorthand,
-04-dynamic-href, 05-component, 06-svelte-element, 07-bind-href,
-08-external-variants, 09-options, 11-svelte-self, 12-multibyte-crlf,
-opt-key-allow-referrer, opt-key-dynamic-never}.svelte
-```
-
-**Mechanism.** Upstream's rule is report-only. `no-target-blank.ts`'s `meta`
-declares no `fixable` key and its single `context.report({ node, message })`
-carries no `fix`, so the oracle's output on every one of these patterns is the
-source byte-for-byte. rsvelte's port declares `fixable: Fixable::Code` and
-repairs the `rel` attribute, so on every pattern where the rule *fires* the two
-outputs differ.
-
-That is the whole entry set: the directory holds 14 patterns and 13 are listed.
-The unlisted one, `10-case-and-decoys.svelte`, is the file whose shapes are all
-decoys — neither side reports anything, so there is nothing to fix and the
-outputs are identical. The entries track "where does this rule fire", not "which
-files did we give up on".
-
-**What rsvelte writes** (`no_target_blank.rs::build_fix`), with the three arms
-the patterns exercise:
-
-| existing `rel` | edit |
-|---|---|
-| none | insert ` rel="noopener noreferrer"` after the `target` attribute |
-| valueless (`rel`) | replace the whole attribute with `rel="noopener noreferrer"` |
-| a single literal | replace the value with the existing tokens plus the missing ones |
-
-`01-basic.svelte` shows two of them:
-
-```svelte
-<a href="https://example.com/" target="_blank">flag</a>
-<!-- → … target="_blank" rel="noopener noreferrer">              -->
-<a href="https://example.com/" target="_blank" rel="noreferrer">flag</a>
-<!-- → … rel="noreferrer noopener">                              -->
-```
-
-The fix returns `None` — no repair, report only, byte-identical to upstream —
-when the existing `rel` is a mustache or a mixed sequence, because rewriting a
-dynamic value would be a guess. `02-rel-dynamic.svelte` is the control for that:
-its `rel={rel}` and `rel="noopener {extra}"` links are reported and left alone by
-both sides, and the file is listed only because of its `rel` and `rel=""` links,
-which take the valueless and empty-value arms. The superset is bounded by value
-*shape*, not by whether the rule fired.
-
-**Why the divergence is deliberate.** Svelte 5 dropped the compiler's
-`security-anchor-rel-noreferrer` warning, so this rule is the only place left
-where the repair can live, and the repair is mechanical: the rule already knows
-which of `noopener` / `noreferrer` is missing, since that is the test it just
-failed. Adding a token to `rel` cannot change what the link points at.
-
-**Why it is in the ratchet rather than skipped.** An intentional superset still
-has to be *bounded*. Listing each pattern means the gate fails the day the fix
-starts firing on a fourteenth shape, or stops firing on one of these thirteen,
-or writes different text — all of which a `svelte/no-target-blank` skip entry
-would swallow. The two-sided ratchet is what makes "rsvelte-only autofix" a
-claim about 13 named files rather than about a rule.
 
 ### `shorthand-directive/16-never-mode-modifiers.svelte` `svelte/shorthand-directive`
 

--- a/crates/rsvelte_lint/src/rules/no_target_blank.rs
+++ b/crates/rsvelte_lint/src/rules/no_target_blank.rs
@@ -15,23 +15,18 @@
 //! Options (`options[0]`): `{ allowReferrer?: boolean = false,
 //! enforceDynamicLinks?: "always" | "never" = "always" }`.
 //!
-//! The autofix is rsvelte-only — upstream reports without repairing — because
-//! Svelte 5 dropped the `security-anchor-rel-noreferrer` compiler warning, so
-//! this rule is now the only place the repair can live.
-
 use rsvelte_core::ast::template::{
     Attribute, AttributeNode, AttributeValue, AttributeValuePart, Component, RegularElement,
     SlotElement, SvelteComponentElement, SvelteDynamicElement, SvelteElement, TitleElement,
 };
 
 use crate::context::LintContext;
-use crate::diagnostic::{Fix, TextEdit};
 use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-target-blank",
     category: RuleCategory::Style,
-    fixable: Fixable::Code,
+    fixable: Fixable::No,
     default_severity: Severity::Warn,
     conditions: RuleConditions {
         runes_only: false,
@@ -66,26 +61,6 @@ fn is_secure_rel(rel: &str, allow_referrer: bool) -> bool {
     let tags: Vec<String> = rel.to_lowercase().split(' ').map(str::to_string).collect();
     tags.iter().any(|t| t == "noopener")
         && (allow_referrer || tags.iter().any(|t| t == "noreferrer"))
-}
-
-/// The tokens a secure `rel` must carry, in the order the fix writes them.
-const fn required_tags(allow_referrer: bool) -> &'static [&'static str] {
-    if allow_referrer {
-        &["noopener"]
-    } else {
-        &["noopener", "noreferrer"]
-    }
-}
-
-/// The required tokens absent from `rel`. Splits exactly like [`is_secure_rel`]
-/// so the fix always clears the condition that produced the report.
-fn missing_tags(rel: &str, allow_referrer: bool) -> Vec<&'static str> {
-    let present: Vec<String> = rel.to_lowercase().split(' ').map(str::to_string).collect();
-    required_tags(allow_referrer)
-        .iter()
-        .copied()
-        .filter(|tag| !present.iter().any(|p| p == tag))
-        .collect()
 }
 
 /// Whether a static `href` text value is an absolute/protocol URL,
@@ -195,95 +170,6 @@ impl NoTargetBlank {
             _ => false,
         }
     }
-
-    /// The repair: add the missing `rel` tokens. `None` when the existing `rel`
-    /// is dynamic (or otherwise not a single literal), since rewriting a
-    /// mustache would be a guess.
-    fn build_fix(
-        source: &str,
-        attrs: &[Attribute],
-        target: &AttributeNode,
-        allow_referrer: bool,
-    ) -> Option<Fix> {
-        let Some(rel) = Self::rel_attr(attrs) else {
-            let tags = required_tags(allow_referrer).join(" ");
-            return Some(Fix {
-                message: format!("Add rel=\"{tags}\""),
-                edits: vec![TextEdit {
-                    start: target.end,
-                    end: target.end,
-                    new_text: format!(" rel=\"{tags}\""),
-                }],
-            });
-        };
-
-        // A valueless `rel` carries no tokens, so the whole attribute is rewritten.
-        let parts = match &rel.value {
-            AttributeValue::True(_) => {
-                let tags = required_tags(allow_referrer).join(" ");
-                return Some(Fix {
-                    message: format!("Add rel=\"{tags}\""),
-                    edits: vec![TextEdit {
-                        start: rel.start,
-                        end: rel.end,
-                        new_text: format!("rel=\"{tags}\""),
-                    }],
-                });
-            }
-            AttributeValue::Expression(_) => return None,
-            AttributeValue::Sequence(parts) => parts,
-        };
-
-        let (value_start, value_end, existing) = match parts.as_slice() {
-            // An empty `Sequence` is `rel=""`: with no text node to replace, the
-            // tokens go in the empty slot just inside the closing quote.
-            [] => {
-                let slot = rel.end.checked_sub(1)?;
-                if !matches!(source.as_bytes().get(slot as usize), Some(b'"' | b'\'')) {
-                    return None;
-                }
-                (slot, slot, "")
-            }
-            [AttributeValuePart::Text(text)] => (
-                text.start,
-                text.end,
-                source.get(text.start as usize..text.end as usize)?,
-            ),
-            _ => return None,
-        };
-
-        let missing = missing_tags(existing, allow_referrer);
-        if missing.is_empty() {
-            return None;
-        }
-        let added = missing.join(" ");
-        let extended = if existing.is_empty() {
-            added.clone()
-        } else {
-            format!("{existing} {added}")
-        };
-        // An unquoted value cannot hold a space, so extending it needs quotes.
-        let quoted = matches!(
-            value_start
-                .checked_sub(1)
-                .and_then(|i| source.as_bytes().get(i as usize)),
-            Some(b'"' | b'\'')
-        );
-        let new_text = if quoted {
-            extended
-        } else {
-            format!("\"{extended}\"")
-        };
-
-        Some(Fix {
-            message: format!("Add {added} to rel"),
-            edits: vec![TextEdit {
-                start: value_start,
-                end: value_end,
-                new_text,
-            }],
-        })
-    }
 }
 
 impl Rule for NoTargetBlank {
@@ -344,10 +230,7 @@ fn check_attributes(ctx: &mut LintContext, attrs: &[Attribute]) {
         return;
     }
 
-    match NoTargetBlank::build_fix(ctx.source(), attrs, target, allow_referrer) {
-        Some(fix) => ctx.report_with_fix(target.start, target.end, MESSAGE, fix),
-        None => ctx.report(target.start, target.end, MESSAGE),
-    }
+    ctx.report(target.start, target.end, MESSAGE);
 }
 
 #[cfg(test)]
@@ -387,170 +270,5 @@ mod tests {
         assert!(is_secure_rel("noopener", true));
         assert!(is_secure_rel("noopener noreferrer", true));
         assert!(!is_secure_rel("noreferrer", true));
-    }
-
-    #[test]
-    fn missing_tags_reports_only_absent_tokens() {
-        use super::missing_tags;
-        assert_eq!(missing_tags("", false), ["noopener", "noreferrer"]);
-        assert_eq!(missing_tags("noopener", false), ["noreferrer"]);
-        assert_eq!(missing_tags("NOREFERRER", false), ["noopener"]);
-        assert!(missing_tags("noopener noreferrer", false).is_empty());
-        assert!(missing_tags("noopener", true).is_empty());
-        assert_eq!(missing_tags("noreferrer", true), ["noopener"]);
-        // Same splitting as `is_secure_rel`, so the fix always clears the report.
-        assert_eq!(
-            missing_tags("noopenernoreferrer", false),
-            ["noopener", "noreferrer"]
-        );
-    }
-
-    #[cfg(feature = "native")]
-    mod fix {
-        use serde_json::json;
-
-        use crate::config::LintConfig;
-        use crate::rule::Severity;
-        use crate::runner::fix_source;
-
-        fn config(allow_referrer: bool) -> LintConfig {
-            let cfg = LintConfig::empty().with_override("svelte/no-target-blank", Severity::Error);
-            if allow_referrer {
-                cfg.with_options("svelte/no-target-blank", json!([{"allowReferrer": true}]))
-            } else {
-                cfg
-            }
-        }
-
-        #[track_caller]
-        fn fixed(src: &str) -> String {
-            fix_source(src, &config(false)).output
-        }
-
-        #[track_caller]
-        fn fixed_allow_referrer(src: &str) -> String {
-            fix_source(src, &config(true)).output
-        }
-
-        #[test]
-        fn adds_rel_when_absent() {
-            assert_eq!(
-                fixed(r#"<a href="https://svelte.dev/" target="_blank">x</a>"#),
-                r#"<a href="https://svelte.dev/" target="_blank" rel="noopener noreferrer">x</a>"#
-            );
-        }
-
-        #[test]
-        fn inserts_after_target_not_at_tag_end() {
-            assert_eq!(
-                fixed(r#"<a target="_blank" href="https://svelte.dev/">x</a>"#),
-                r#"<a target="_blank" rel="noopener noreferrer" href="https://svelte.dev/">x</a>"#
-            );
-        }
-
-        #[test]
-        fn extends_partial_rel_keeping_existing_tokens() {
-            assert_eq!(
-                fixed(r#"<a href="https://svelte.dev/" target="_blank" rel="noopener">x</a>"#),
-                r#"<a href="https://svelte.dev/" target="_blank" rel="noopener noreferrer">x</a>"#
-            );
-            assert_eq!(
-                fixed(r#"<a href="https://svelte.dev/" target="_blank" rel="noreferrer">x</a>"#),
-                r#"<a href="https://svelte.dev/" target="_blank" rel="noreferrer noopener">x</a>"#
-            );
-            assert_eq!(
-                fixed(r#"<a href="https://svelte.dev/" target="_blank" rel="nofollow">x</a>"#),
-                r#"<a href="https://svelte.dev/" target="_blank" rel="nofollow noopener noreferrer">x</a>"#
-            );
-        }
-
-        #[test]
-        fn preserves_quoting_style() {
-            assert_eq!(
-                fixed("<a href=\"https://svelte.dev/\" target=\"_blank\" rel='noopener'>x</a>"),
-                "<a href=\"https://svelte.dev/\" target=\"_blank\" rel='noopener noreferrer'>x</a>"
-            );
-            // An unquoted value cannot hold a space, so the fix adds quotes.
-            assert_eq!(
-                fixed(r#"<a href="https://svelte.dev/" target="_blank" rel=noopener>x</a>"#),
-                r#"<a href="https://svelte.dev/" target="_blank" rel="noopener noreferrer">x</a>"#
-            );
-            assert_eq!(
-                fixed(r#"<a href="https://svelte.dev/" target="_blank" rel="">x</a>"#),
-                r#"<a href="https://svelte.dev/" target="_blank" rel="noopener noreferrer">x</a>"#
-            );
-        }
-
-        #[test]
-        fn rewrites_valueless_rel() {
-            assert_eq!(
-                fixed(r#"<a href="https://svelte.dev/" target="_blank" rel>x</a>"#),
-                r#"<a href="https://svelte.dev/" target="_blank" rel="noopener noreferrer">x</a>"#
-            );
-        }
-
-        #[test]
-        fn leaves_dynamic_rel_alone() {
-            for src in [
-                r#"<a href="https://svelte.dev/" target="_blank" rel={rel}>x</a>"#,
-                r#"<a href="https://svelte.dev/" target="_blank" rel="a {b}">x</a>"#,
-                r#"<a href="https://svelte.dev/" target="_blank" {rel}>x</a>"#,
-            ] {
-                let res = fix_source(src, &config(false));
-                assert_eq!(res.applied, 0, "unexpected fix for {src}");
-                assert_eq!(res.output, src);
-            }
-        }
-
-        #[test]
-        fn allow_referrer_only_adds_noopener() {
-            assert_eq!(
-                fixed_allow_referrer(r#"<a href="https://svelte.dev/" target="_blank">x</a>"#),
-                r#"<a href="https://svelte.dev/" target="_blank" rel="noopener">x</a>"#
-            );
-            assert_eq!(
-                fixed_allow_referrer(
-                    r#"<a href="https://svelte.dev/" target="_blank" rel="noreferrer">x</a>"#
-                ),
-                r#"<a href="https://svelte.dev/" target="_blank" rel="noreferrer noopener">x</a>"#
-            );
-        }
-
-        #[test]
-        fn secure_and_safe_links_are_untouched() {
-            for src in [
-                r#"<a href="https://svelte.dev/" target="_blank" rel="noopener noreferrer">x</a>"#,
-                r#"<a href="/local" target="_blank">x</a>"#,
-                r#"<a href="https://svelte.dev/">x</a>"#,
-            ] {
-                let res = fix_source(src, &config(false));
-                assert_eq!(res.applied, 0, "unexpected fix for {src}");
-                assert_eq!(res.output, src);
-            }
-        }
-
-        #[test]
-        fn fixes_the_whole_upstream_invalid_fixture() {
-            let src = concat!(
-                "<a href=\"https://svelte.dev/\" target=\"_blank\">link</a>\n",
-                "<a href=\"https://svelte.dev/\" target=\"_blank\" rel=\"noopenernoreferrer\">link</a>\n",
-                "<a href={link} target=\"_blank\" rel=\"3\">link</a>\n",
-                "<a href={link} target=\"_blank\">link</a>\n",
-                "<a href=\"https://svelte.dev/\" target=\"_blank\" rel=\"noopener\">link</a>\n",
-            );
-            let out = fix_source(src, &config(false)).output;
-            assert_eq!(
-                out,
-                concat!(
-                    "<a href=\"https://svelte.dev/\" target=\"_blank\" rel=\"noopener noreferrer\">link</a>\n",
-                    "<a href=\"https://svelte.dev/\" target=\"_blank\" rel=\"noopenernoreferrer noopener noreferrer\">link</a>\n",
-                    "<a href={link} target=\"_blank\" rel=\"3 noopener noreferrer\">link</a>\n",
-                    "<a href={link} target=\"_blank\" rel=\"noopener noreferrer\">link</a>\n",
-                    "<a href=\"https://svelte.dev/\" target=\"_blank\" rel=\"noopener noreferrer\">link</a>\n",
-                )
-            );
-            // The fixed source no longer reports.
-            assert_eq!(fix_source(&out, &config(false)).applied, 0);
-        }
     }
 }


### PR DESCRIPTION
## Summary
- make `svelte/no-target-blank` report-only, matching eslint-plugin-svelte
- remove the rsvelte-only fixer and its fixer-only tests
- shrink the per-rule fix ratchet 14 -> 1 and fix-all ratchet 16 -> 2 (27 entries from one cause)

## Validation
- `rustfmt --edition 2024 --check crates/rsvelte_lint/src/rules/no_target_blank.rs`
- JSON counts and `git diff --check`
- known-failures doc checker accepts the two changed lint documents; it still reports only pre-existing stale counts in unrelated main documents

Per repository resource policy, no local Rust build/test was run; CI is the execution oracle.