### PR TITLE
Warn for nested classes in template expressions

### DIFF
--- a/compatibility/warning-known-failures.client-dev.json
+++ b/compatibility/warning-known-failures.client-dev.json
@@ -38,8 +38,6 @@
 	"networking-toolbox/src/lib/components/tools/DNSSPFBuilder.svelte",
 	"networking-toolbox/src/lib/components/tools/SSHFPGenerator.svelte",
 	"networking-toolbox/src/lib/components/tools/SVCBHTTPSBuilder.svelte",
-	"pattern/issues/2725-template-class-declaration.svelte",
-	"pattern/issues/3482-template-class-indent.svelte",
 	"primo/src/lib/builder/views/modal/BlockEditor.svelte",
 	"primo/src/lib/builder/views/modal/SectionEditor/SectionEditor.svelte",
 	"sparrow-app/packages/@sparrow-support/src/components/CommentCard.svelte",

--- a/compatibility/warning-known-failures.client.json
+++ b/compatibility/warning-known-failures.client.json
@@ -38,8 +38,6 @@
 	"networking-toolbox/src/lib/components/tools/DNSSPFBuilder.svelte",
 	"networking-toolbox/src/lib/components/tools/SSHFPGenerator.svelte",
 	"networking-toolbox/src/lib/components/tools/SVCBHTTPSBuilder.svelte",
-	"pattern/issues/2725-template-class-declaration.svelte",
-	"pattern/issues/3482-template-class-indent.svelte",
 	"primo/src/lib/builder/views/modal/BlockEditor.svelte",
 	"primo/src/lib/builder/views/modal/SectionEditor/SectionEditor.svelte",
 	"sparrow-app/packages/@sparrow-support/src/components/CommentCard.svelte",

--- a/compatibility/warning-known-failures.md
+++ b/compatibility/warning-known-failures.md
@@ -34,7 +34,7 @@ compilers already run on every entry.
 
 ## Why the four per-target files are currently identical
 
-`warning-known-failures.<target>.json` holds the same 84 entries on all four,
+`warning-known-failures.<target>.json` holds the same 82 entries on all four,
 and `warning-position-known-failures.<target>.json` 0 entries on all four. That is not a
 bug in the partitioning — almost every warning is produced in Phase 1/2 (parse
 and analyze), before the target is consulted, so a divergence shows up on all
@@ -46,36 +46,35 @@ and stays sensitive to an entry that starts diverging on a second target while
 already listed for the first. Expect all eight files to move together in a
 burn-down PR.
 
-## Warning codes (`warning-known-failures.<target>.json`, 84 entries each)
+## Warning codes (`warning-known-failures.<target>.json`, 82 entries each)
 
 The multiset of warning **codes** differs: rsvelte warns where upstream does
 not, or stays silent where upstream warns. This is a semantic bug — a user sees
 noise they cannot suppress, or misses a diagnostic they should have seen.
 
-Not every entry is equally bad. Of the 84 entries that still diverge, **23 are
+Not every entry is equally bad. Of the 82 entries that still diverge, **21 are
 under-warnings** — rsvelte stays silent where upstream warns — and **61 are
 over-warnings**, noise the user cannot suppress. No entry diverges in both
 directions at once. A missing diagnostic and an extra one fail
 differently, and the ratchet count alone does not distinguish them:
 
-Partition of `warning-known-failures.<target>.json` by direction: `23 + 61`
+Partition of `warning-known-failures.<target>.json` by direction: `21 + 61`
 
 **73 of the 83 pre-existing entries arrived with the wave-2 enrolment (#3130)**,
-which took the corpus from 37 corpus sources to 104. Across all 84 entries,
-the codes counted over entries rather than tuples sum to exactly 84:
+which took the corpus from 37 corpus sources to 104. The remaining per-code
+incidences total 83 across 82 entries (one entry differs on two codes):
 `css_unused_selector` 48, `state_referenced_locally` 22,
 `non_reactive_update` 8, `component_name_lowercase` 1,
-`a11y_consider_explicit_label` 4,
-`perf_avoid_nested_class` 1. `css_unused_selector` is half the file and the
+`a11y_consider_explicit_label` 4. `css_unused_selector` is half the file and the
 burn-down target; it is the one that is neither over- nor under-warning in a
 fixed direction — it is a pruning disagreement, so it moves with the CSS entries
 in [`known-failures.md`](known-failures.md).
 
-The 90th entry, `pattern/issues/3482-template-class-indent.svelte`, deliberately
-adds another nested class to exercise client output indentation. Its four target
-tuples are under-warnings for the already-known `perf_avoid_nested_class` gap;
-that diagnostic is independent of the output-formatting repair and remains
-ratcheted here rather than suppressing the fixture from the output gate.
+The two template-expression class fixtures that used to diverge now reach the
+same `perf_avoid_nested_class` check as script classes. The template expression
+walker previously discarded `ClassDeclaration` statements before the regular
+class visitor could see them; its relative function depth is now mapped onto
+the component scope depth used by upstream.
 
 The file was 171 entries before this branch was rebased onto `main`, and this is
 the second re-measurement against a moving `main`: the first removed **81 and

--- a/compatibility/warning-known-failures.server-dev.json
+++ b/compatibility/warning-known-failures.server-dev.json
@@ -38,8 +38,6 @@
 	"networking-toolbox/src/lib/components/tools/DNSSPFBuilder.svelte",
 	"networking-toolbox/src/lib/components/tools/SSHFPGenerator.svelte",
 	"networking-toolbox/src/lib/components/tools/SVCBHTTPSBuilder.svelte",
-	"pattern/issues/2725-template-class-declaration.svelte",
-	"pattern/issues/3482-template-class-indent.svelte",
 	"primo/src/lib/builder/views/modal/BlockEditor.svelte",
 	"primo/src/lib/builder/views/modal/SectionEditor/SectionEditor.svelte",
 	"sparrow-app/packages/@sparrow-support/src/components/CommentCard.svelte",

--- a/compatibility/warning-known-failures.server.json
+++ b/compatibility/warning-known-failures.server.json
@@ -38,8 +38,6 @@
 	"networking-toolbox/src/lib/components/tools/DNSSPFBuilder.svelte",
 	"networking-toolbox/src/lib/components/tools/SSHFPGenerator.svelte",
 	"networking-toolbox/src/lib/components/tools/SVCBHTTPSBuilder.svelte",
-	"pattern/issues/2725-template-class-declaration.svelte",
-	"pattern/issues/3482-template-class-indent.svelte",
 	"primo/src/lib/builder/views/modal/BlockEditor.svelte",
 	"primo/src/lib/builder/views/modal/SectionEditor/SectionEditor.svelte",
 	"sparrow-app/packages/@sparrow-support/src/components/CommentCard.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/class_declaration.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/class_declaration.rs
@@ -35,24 +35,7 @@ pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), An
             validate_identifier_name(binding, None)?;
         }
 
-        // This warning follows the lexical scope depth, not VisitorContext's
-        // separate derived/template traversal counter. Component instance
-        // scope is depth 1, while a component module script is depth 0.
-        // Standalone `.svelte.(js|ts)` modules deliberately use the component
-        // threshold because upstream's `analyze_module` leaves `ast_type` null.
-        let allowed_depth =
-            if context.ast_type == AstType::Module && !context.analysis.is_module_file {
-                0
-            } else {
-                1
-            };
-        let scope_depth = context.analysis.root.all_scopes[context.scope].function_depth;
-        if scope_depth > allowed_depth {
-            let mut warning = warnings::perf_avoid_nested_class();
-            warning.start = node.start();
-            warning.end = node.end();
-            context.emit_warning(warning);
-        }
+        emit_nested_class_warning(node, context);
 
         // Visit the class body - ClassBody visitor still uses Value,
         // so we walk it via walk_js_node_typed which will convert as needed
@@ -61,6 +44,32 @@ pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), An
     }
 
     Ok(())
+}
+
+/// Emit Svelte's nested-class performance warning.
+///
+/// Script traversal has a lexical `Scope` for every function. Template expressions use
+/// the lightweight expression walker instead, where `function_depth` is relative to the
+/// component scope. Add that implicit component depth so both paths implement upstream's
+/// `scope.function_depth > allowed_depth` test.
+pub(super) fn emit_nested_class_warning(node: &JsNode, context: &mut VisitorContext) {
+    let allowed_depth = if context.ast_type == AstType::Module && !context.analysis.is_module_file {
+        0
+    } else {
+        1
+    };
+    let scope_depth = if context.ast_type == AstType::Template {
+        context.function_depth + 1
+    } else {
+        context.analysis.root.all_scopes[context.scope].function_depth
+    };
+
+    if scope_depth > allowed_depth {
+        let mut warning = warnings::perf_avoid_nested_class();
+        warning.start = node.start();
+        warning.end = node.end();
+        context.emit_warning(warning);
+    }
 }
 
 #[cfg(test)]
@@ -132,6 +141,14 @@ mod tests {
             "<script>\n\tconst value = (() => { class A {} return A; })();\n</script>\n",
         );
         assert_eq!(nested_class(&warnings).len(), 1);
+    }
+
+    #[test]
+    fn component_template_expression_warns_inside_functions() {
+        let warnings = component_warnings(
+            "<script>let enabled = true;</script>\n<p>{(() => { class T {} return new T(); })()}</p>\n{#if enabled}<p>{(() => { class U {} return new U(); })()}</p>{/if}\n",
+        );
+        assert_eq!(nested_class(&warnings).len(), 2);
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -1965,6 +1965,11 @@ pub fn walk_js_statement_node(
             // Walk function declarations like function expressions
             walk_js_expression_node(statement, context, metadata)?;
         }
+        JsNode::ClassDeclaration { .. } => {
+            // Template expressions use this lightweight statement walker rather than
+            // `script::walk_js_node_typed`, so run the class-specific warning here too.
+            super::super::class_declaration::emit_nested_class_warning(statement, context);
+        }
         JsNode::SwitchStatement {
             discriminant,
             cases,


### PR DESCRIPTION
Fixes the template-expression JS walker dropping ClassDeclaration statements before the perf_avoid_nested_class check. Maps its relative function depth to the implicit component scope, adds a two-class regression test, and shrinks all four warning ratchets from 84 to 82.\n\nValidation: cargo fmt --all -- --check; JSON parse/count/duplicate checks; git diff --check. Per repository load policy, Rust tests were left to CI.