### PR TITLE
Align state warning proxy eligibility

### DIFF
--- a/compatibility/warning-known-failures.client-dev.json
+++ b/compatibility/warning-known-failures.client-dev.json
@@ -27,7 +27,6 @@
 	"huly/plugins/text-editor-resources/src/components/extension/table/TableNodeView.svelte",
 	"huly/plugins/view-resources/src/components/RelationshipTable.svelte",
 	"joy-of-code/src/lib/ui/header/preferences/dyslexic.svelte",
-	"layerchart/docs/src/examples/components/Treemap/nested-filter.svelte",
 	"mathesar/mathesar_ui/src/components/breadcrumb/BreadcrumbSelector.svelte",
 	"musicat/src/lib/settings/InfoPopup.svelte",
 	"musicat/src/lib/your-music/Scrapbook.svelte",

--- a/compatibility/warning-known-failures.client.json
+++ b/compatibility/warning-known-failures.client.json
@@ -27,7 +27,6 @@
 	"huly/plugins/text-editor-resources/src/components/extension/table/TableNodeView.svelte",
 	"huly/plugins/view-resources/src/components/RelationshipTable.svelte",
 	"joy-of-code/src/lib/ui/header/preferences/dyslexic.svelte",
-	"layerchart/docs/src/examples/components/Treemap/nested-filter.svelte",
 	"mathesar/mathesar_ui/src/components/breadcrumb/BreadcrumbSelector.svelte",
 	"musicat/src/lib/settings/InfoPopup.svelte",
 	"musicat/src/lib/your-music/Scrapbook.svelte",

--- a/compatibility/warning-known-failures.md
+++ b/compatibility/warning-known-failures.md
@@ -46,24 +46,24 @@ and stays sensitive to an entry that starts diverging on a second target while
 already listed for the first. Expect all eight files to move together in a
 burn-down PR.
 
-## Warning codes (`warning-known-failures.<target>.json`, 81 entries each)
+## Warning codes (`warning-known-failures.<target>.json`, 80 entries each)
 
 The multiset of warning **codes** differs: rsvelte warns where upstream does
 not, or stays silent where upstream warns. This is a semantic bug — a user sees
 noise they cannot suppress, or misses a diagnostic they should have seen.
 
-Not every entry is equally bad. Of the 81 entries that still diverge, **20 are
-under-warnings** — rsvelte stays silent where upstream warns — and **61 are
+Not every entry is equally bad. Of the 80 entries that still diverge, **20 are
+under-warnings** — rsvelte stays silent where upstream warns — and **60 are
 over-warnings**, noise the user cannot suppress. No entry diverges in both
 directions at once. A missing diagnostic and an extra one fail
 differently, and the ratchet count alone does not distinguish them:
 
-Partition of `warning-known-failures.<target>.json` by direction: `20 + 61`
+Partition of `warning-known-failures.<target>.json` by direction: `20 + 60`
 
 **73 of the 83 pre-existing entries arrived with the wave-2 enrolment (#3130)**,
 which took the corpus from 37 corpus sources to 104. The remaining per-code
-incidences total 82 across 81 entries (one entry differs on two codes):
-`css_unused_selector` 48, `state_referenced_locally` 21,
+incidences total 81 across 80 entries (one entry differs on two codes):
+`css_unused_selector` 48, `state_referenced_locally` 20,
 `non_reactive_update` 8, `component_name_lowercase` 1,
 `a11y_consider_explicit_label` 4. `css_unused_selector` is half the file and the
 burn-down target; it is the one that is neither over- nor under-warning in a
@@ -80,6 +80,11 @@ The instance-script visitor now starts from the instance scope built in phase
 1 rather than the module/root scope. This restores the missing
 `state_referenced_locally` warning when an instance prop shadows a same-named
 module export, as in melt-ui's `motion.svelte`.
+
+The `state_referenced_locally` eligibility check now agrees with upstream
+`should_proxy` for logical and conditional `$state` initializers. Those
+expressions can produce proxyable values, so LayerChart's two later reads of a
+state initialized with `selected ?? fallback` no longer produce noise.
 
 The file was 171 entries before this branch was rebased onto `main`, and this is
 the second re-measurement against a moving `main`: the first removed **81 and

--- a/compatibility/warning-known-failures.server-dev.json
+++ b/compatibility/warning-known-failures.server-dev.json
@@ -27,7 +27,6 @@
 	"huly/plugins/text-editor-resources/src/components/extension/table/TableNodeView.svelte",
 	"huly/plugins/view-resources/src/components/RelationshipTable.svelte",
 	"joy-of-code/src/lib/ui/header/preferences/dyslexic.svelte",
-	"layerchart/docs/src/examples/components/Treemap/nested-filter.svelte",
 	"mathesar/mathesar_ui/src/components/breadcrumb/BreadcrumbSelector.svelte",
 	"musicat/src/lib/settings/InfoPopup.svelte",
 	"musicat/src/lib/your-music/Scrapbook.svelte",

--- a/compatibility/warning-known-failures.server.json
+++ b/compatibility/warning-known-failures.server.json
@@ -27,7 +27,6 @@
 	"huly/plugins/text-editor-resources/src/components/extension/table/TableNodeView.svelte",
 	"huly/plugins/view-resources/src/components/RelationshipTable.svelte",
 	"joy-of-code/src/lib/ui/header/preferences/dyslexic.svelte",
-	"layerchart/docs/src/examples/components/Treemap/nested-filter.svelte",
 	"mathesar/mathesar_ui/src/components/breadcrumb/BreadcrumbSelector.svelte",
 	"musicat/src/lib/settings/InfoPopup.svelte",
 	"musicat/src/lib/your-music/Scrapbook.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/identifier.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/identifier.rs
@@ -300,7 +300,9 @@ fn visit_identifier_inner(
                 BindingKind::State => {
                     binding.reassigned || {
                         // Also warn if the initial $state() call has an argument that won't be proxied
-                        // We approximate: check if initial_node_type is a primitive type
+                        // Match should_proxy's non-proxyable expression kinds. Logical
+                        // and conditional expressions deliberately fall through to true
+                        // upstream because either branch may produce a proxyable value.
                         binding.initial_node_type.as_deref().is_some_and(|t| {
                             matches!(
                                 t,
@@ -308,8 +310,6 @@ fn visit_identifier_inner(
                                     | "TemplateLiteral"
                                     | "BinaryExpression"
                                     | "UnaryExpression"
-                                    | "ConditionalExpression"
-                                    | "LogicalExpression"
                             )
                         })
                     }

--- a/crates/rsvelte_core/tests/state_referenced_locally_should_proxy.rs
+++ b/crates/rsvelte_core/tests/state_referenced_locally_should_proxy.rs
@@ -1,0 +1,45 @@
+//! `state_referenced_locally` uses the same non-proxyable expression classes as
+//! the client transform's `should_proxy` decision.
+
+use rsvelte_core::{CompileOptions, GenerateMode, Warning, compile};
+
+fn state_reference_warnings(src: &str) -> Vec<Warning> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+    .into_iter()
+    .filter(|warning| warning.code == "state_referenced_locally")
+    .collect()
+}
+
+#[test]
+fn logical_and_conditional_state_initializers_remain_proxyable() {
+    let warnings = state_reference_warnings(
+        r#"<script>
+    const left = $state({ value: 1 });
+    const right = $state({ value: 2 });
+    const logical = $state(left ?? right);
+    const conditional = $state(logical ? logical : right);
+    const result = $state(logical ? conditional.value : []);
+</script>"#,
+    );
+
+    assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+}
+
+#[test]
+fn binary_state_initializer_remains_non_proxyable() {
+    let warnings = state_reference_warnings(
+        "<script>\nconst count = $state(1 + 2);\nconst doubled = count * 2;\n</script>",
+    );
+
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].message.contains("`count`"));
+}


### PR DESCRIPTION
## Summary
- align phase-2 state warning eligibility with upstream should_proxy
- keep logical and conditional initializers proxyable
- add negative and positive regression coverage
- shrink all warning ratchets from 81 to 80

## Validation
- rustfmt --check on changed Rust files
- JSON parsing for all four warning ratchets
- git diff --check

Local Rust builds/tests were intentionally not run due the current machine-load constraint; CI is the execution oracle.