### PR TITLE
Fix each item member mutation transforms

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -861,6 +861,59 @@ fn reactive_each_collection_still_invalidates_inner_signals() {
 }
 
 #[test]
+fn each_item_member_mutation_is_transformed_before_sequence_marking() {
+    let result = crate::compiler::compile(
+        "<script>let list = [{ v: 0 }];</script>{#each list as item}<button onclick={() => (item.v = 1)}>x</button>{/each}",
+        crate::compiler::CompileOptions {
+            filename: Some("each-member-mutation.svelte".to_string()),
+            runes: Some(false),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(
+        result.js.code.contains("$.get(item).v = 1"),
+        "the reactive each item read must be transformed:\n{}",
+        result.js.code
+    );
+    assert!(
+        result.js.code.contains("$.invalidate_inner_signals"),
+        "the member mutation must invalidate the collection dependency:\n{}",
+        result.js.code
+    );
+}
+
+#[test]
+fn event_parameter_shadows_each_item_member_mutation() {
+    let result = crate::compiler::compile(
+        "<script>let list = [{ v: 0 }];</script>{#each list as item}<button onclick={(item) => (item.v = 1)}>x</button>{/each}",
+        crate::compiler::CompileOptions {
+            filename: Some("each-member-mutation-shadowed.svelte".to_string()),
+            runes: Some(false),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(
+        result.js.code.contains("(item) => (item.v = 1)"),
+        "the event parameter must remain a plain local write:\n{}",
+        result.js.code
+    );
+    assert!(
+        !result.js.code.contains("$.get(item).v = 1"),
+        "the shadowing parameter must not read the each item:\n{}",
+        result.js.code
+    );
+    assert!(
+        !result.js.code.contains("$.invalidate_inner_signals"),
+        "the shadowing parameter must not invalidate the each collection:\n{}",
+        result.js.code
+    );
+}
+
+#[test]
 fn event_handler_identifier_stays_unwrapped_with_source_span() {
     let result = crate::compiler::compile(
         "<script>function run() {} let value = 0; switch (value) { case 1: break; }</script><button onclick={run}>run</button>",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -5366,12 +5366,27 @@ pub(crate) fn preserve_each_mutation_sequence(
     let Some(root_name) = original_root_name else {
         return result;
     };
-    let is_each_item = context.state.each_binding_context.iter().rev().any(|each| {
-        each.item_name == root_name || each.destructured_update_paths.contains_key(root_name)
-    });
+    let is_each_item = !context.state.shadowed_prop_names.contains(root_name)
+        && context.state.each_binding_context.iter().rev().any(|each| {
+            each.item_name == root_name || each.destructured_update_paths.contains_key(root_name)
+        });
 
     if is_each_item {
-        b::sequence(vec![result])
+        // A one-element sequence is treated by the recursive transform walk as a
+        // synthesized, already-transformed node. Apply the each-item read/mutate
+        // transform before adding that marker; otherwise `item.v = 1` is frozen
+        // inside the sequence and never becomes `$.get(item).v = 1` (nor gains
+        // its legacy invalidation tail). Parameters and block locals are recorded
+        // in `shadowed_prop_names`, so a nested `(item) => item.v = 1` remains a
+        // write to the local parameter rather than the enclosing each item.
+        use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::apply_transforms_to_expression;
+
+        let transformed = apply_transforms_to_expression(&result, context);
+        if matches!(transformed, JsExpr::Sequence(_)) {
+            transformed
+        } else {
+            b::sequence(vec![transformed])
+        }
     } else {
         result
     }


### PR DESCRIPTION
Fixes the 30 `each-collection × mutate-property` shape-matrix divergences without changing compatibility baselines.

The assignment converter marked each-item mutations with a synthesized one-element sequence before applying the each-item transform. The recursive walker intentionally treats that shape as already transformed, so member writes stayed as `item.v = 1` and lost legacy collection invalidation. This applies the transform before adding the marker and preserves nested parameter/local shadowing.

Adds focused regression coverage for both the mutation and a shadowing event parameter.

Validation: targeted rustfmt and `git diff --check`. Per repository guidance, no local Rust build/test was run on this loaded host; CI is the execution oracle.
