### PR TITLE
Fix generated comment ownership boundaries

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -370,6 +370,34 @@ fn erase_generated_effect_call_locs(
     }
 }
 
+/// Match the locations upstream assigns when it builds a legacy reactive
+/// effect: the call, callee, arrow shells, parameter lists and callback's outer
+/// block are generated, while expressions and statements copied into those
+/// shells retain their source locations.
+fn unlocate_legacy_pre_effect_wrapper(call: &mut CallExpression<'_>) {
+    call.span = SPAN;
+
+    let mut unlocator = SpanUnlocator;
+    unlocator.visit_expression(&mut call.callee);
+
+    for argument in &mut call.arguments {
+        let Argument::ArrowFunctionExpression(arrow) = argument else {
+            continue;
+        };
+        arrow.span = SPAN;
+        unlocator.visit_formal_parameters(&mut arrow.params);
+        if let Some(type_parameters) = &mut arrow.type_parameters {
+            unlocator.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(return_type) = &mut arrow.return_type {
+            unlocator.visit_ts_type_annotation(return_type);
+        }
+        if let ArrowFunctionBody::FunctionBody(body) = &mut arrow.body {
+            body.span = SPAN;
+        }
+    }
+}
+
 /// Rebuilds any `SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER(expr)` call — however
 /// deeply nested — into a one-element `SequenceExpression`. See the marker's doc
 /// comment and [`Cx::restore_single_target_destructure_sequences`].
@@ -1774,6 +1802,9 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
     /// as `() => (dep)`. Re-parsing that generated text yields a
     /// `ParenthesizedExpression`, which the printer drops (as esrap must, since
     /// acorn elides source parens); rebuild the sequence so the parens survive.
+    /// Re-parsing also gives locations to the generated call and arrow wrappers;
+    /// erase those while retaining the source-located statements in the effect
+    /// callback, matching the split upstream constructs directly.
     fn restore_legacy_pre_effect_deps(&self, stmts: &mut [Statement<'a>]) {
         for stmt in stmts {
             let Statement::ExpressionStatement(es) = stmt else {
@@ -1785,31 +1816,31 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
             if !is_dollar_call(&call.callee, "legacy_pre_effect") {
                 continue;
             }
-            let Some(Argument::ArrowFunctionExpression(arrow)) = call.arguments.first_mut() else {
-                continue;
-            };
-            let Some(body) = arrow.get_expression_mut() else {
-                continue;
-            };
-            // A multi-dependency thunk re-parses as `Paren(Sequence)`, which the
-            // printer already prints with the sequence's own parens.
-            let single = matches!(&*body, Expression::ParenthesizedExpression(p)
-                if !matches!(p.expression, Expression::SequenceExpression(_)));
-            if !single {
-                continue;
+            if let Some(Argument::ArrowFunctionExpression(arrow)) = call.arguments.first_mut()
+                && let Some(body) = arrow.get_expression_mut()
+            {
+                // A multi-dependency thunk re-parses as `Paren(Sequence)`, which
+                // the printer already prints with the sequence's own parens.
+                let single = matches!(&*body, Expression::ParenthesizedExpression(p)
+                    if !matches!(p.expression, Expression::SequenceExpression(_)));
+                if single {
+                    // `SPAN` mirrors upstream, where this node is builder-made
+                    // and so carries no `loc` for comment placement.
+                    body.replace_with(|e| {
+                        let Expression::ParenthesizedExpression(p) = e else {
+                            unreachable!()
+                        };
+                        Expression::SequenceExpression(SequenceExpression::boxed(
+                            SPAN,
+                            ArenaVec::from_value_in(p.unbox().expression, &self.ab),
+                            &self.ab,
+                        ))
+                    });
+                }
             }
-            // `SPAN` mirrors upstream, where this node is builder-made and so
-            // carries no `loc` for the printer to place comments against.
-            body.replace_with(|e| {
-                let Expression::ParenthesizedExpression(p) = e else {
-                    unreachable!()
-                };
-                Expression::SequenceExpression(SequenceExpression::boxed(
-                    SPAN,
-                    ArenaVec::from_value_in(p.unbox().expression, &self.ab),
-                    &self.ab,
-                ))
-            });
+
+            unlocate_legacy_pre_effect_wrapper(call);
+            es.span = SPAN;
         }
     }
 

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -3220,13 +3220,13 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     /// esrap's `ArrowFunctionExpression`: `[async ](params) => body`, wrapping an
     /// object concise body in parens so it isn't read as a block.
     fn arrow_function(&mut self, node: &ArrowFunctionExpression, ctx: &mut Context<DIRECT>) {
-        self.arrow_function_with_comment_body(node, false, ctx);
+        self.arrow_function_with_owned_comments(node, None, ctx);
     }
 
-    fn arrow_function_with_comment_body(
+    fn arrow_function_with_owned_comments(
         &mut self,
         node: &ArrowFunctionExpression,
-        comment_body: bool,
+        owned_comment_until: Option<u32>,
         ctx: &mut Context<DIRECT>,
     ) {
         if node.r#async {
@@ -3239,11 +3239,21 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         // esrap runs the params sequence until `(returnType ?? body).loc.start`,
         // so a comment ahead of a located body flushes inside a synthesized
         // arrow's empty parens.
-        let until = (!comment_body).then(|| {
-            node.return_type
-                .as_ref()
-                .map_or_else(|| node.body.span().start, |rt| rt.span().start)
-        });
+        let body_start = node
+            .return_type
+            .as_ref()
+            .map_or_else(|| node.body.span().start, |rt| rt.span().start);
+        // A comment-owning generated arrow can have an original-source body
+        // span, which is below `loc_base` and therefore cannot bound comments
+        // in the synthetic comment buffer. In that case the next call argument
+        // is the boundary upstream's generated arrow effectively gets. A
+        // located body (for example a header-comment carrier) remains the more
+        // precise boundary.
+        let until = if owned_comment_until.is_some() && !self.has_loc(body_start) {
+            owned_comment_until
+        } else {
+            Some(body_start)
+        };
         self.formal_parameters_with_this(&node.params, None, until, ctx);
         ctx.write_ascii(b')');
         if let Some(rt) = &node.return_type {
@@ -4421,7 +4431,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         if owns_comments
             && let Some(Expression::ArrowFunctionExpression(arrow)) = arg.as_expression()
         {
-            self.arrow_function_with_comment_body(arrow, true, ctx);
+            self.arrow_function_with_owned_comments(arrow, next, ctx);
         } else {
             self.print_argument(arg, ctx);
         }
@@ -4604,7 +4614,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             if owns_comments
                 && let Some(Expression::ArrowFunctionExpression(arrow)) = arg.as_expression()
             {
-                self.arrow_function_with_comment_body(arrow, true, ctx);
+                self.arrow_function_with_owned_comments(arrow, Some(call_end), ctx);
             } else {
                 self.print_argument(arg, ctx);
             }


### PR DESCRIPTION
## Summary

- bound comments owned by generated arrow arguments at the next call argument when their body has no comment-space location
- remove locations restored by reparsing the generated `$.legacy_pre_effect` shells while preserving source locations inside the callback
- fix the 32 new `comment-slot` matrix divergences (await script-tail and nested legacy-reactive shapes, client and client-dev)

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- existing focused regressions: `client_instance_script_tail_comments_stay_with_the_await_promise_thunk` and `client_a_nested_reactive_block_revives_the_tail_comment`

Rust tests were left to CI because local Rust execution is disabled on this host under load.
