### PR TITLE
Accept quoted expression event handlers

### DIFF
--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -281,7 +281,6 @@
 	"svelteui/packages/svelteui-core/src/components/Tabs/Tab/Tab.svelte",
 	"svelteui/packages/svelteui-core/src/components/Tabs/Tabs.svelte",
 	"svelteui/packages/svelteui-demos/src/demos/core/Modal/ModalForm.svelte",
-	"svelty-picker/src/routes/+layout.svelte",
 	"svelvet/src/lib/components/Drawer/DrawerAnchor.svelte",
 	"svelvet/src/lib/components/Drawer/DrawerNode.svelte",
 	"svelvet/src/lib/components/Edge/Edge.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -246,7 +246,6 @@
 	"svelteui/packages/svelteui-core/src/components/Tabs/Tab/Tab.svelte",
 	"svelteui/packages/svelteui-core/src/components/Tabs/Tabs.svelte",
 	"svelteui/packages/svelteui-demos/src/demos/core/Modal/ModalForm.svelte",
-	"svelty-picker/src/routes/+layout.svelte",
 	"svelvet/src/lib/components/Drawer/DrawerAnchor.svelte",
 	"svelvet/src/lib/components/Drawer/DrawerNode.svelte",
 	"svelvet/src/lib/components/Resizer/Resizer.svelte",

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -27,19 +27,19 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-## Client (`known-failures.client.json`, 285 entries)
+## Client (`known-failures.client.json`, 284 entries)
 
-Partition of `known-failures.client.json` by verdict: `237 + 4 + 7 + 37 + 0`
+Partition of `known-failures.client.json` by verdict: `237 + 4 + 6 + 37 + 0`
 
 - **237 — the generated JS differs** (`js` / `code-differs`).
 - **4 — both compilers reject the entry with a different error code.**
-- **7 — one compiler rejects and the other compiles.**
+- **6 — one compiler rejects and the other compiles.**
 - **37 — the generated CSS differs.**
 - **0 — rsvelte's output is not JavaScript**, ratcheted in full in
   [`parse-known-failures.md`](parse-known-failures.md) and listed here too
   because unparseable output is necessarily byte-different.
 
-Every one of the remaining 285 arrived with the wave-2 enrolment (#3130) and is described
+Every one of the remaining 284 arrived with the wave-2 enrolment (#3130) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -64,15 +64,15 @@ everywhere". Divergences this target keeps on purpose — because reproducing
 upstream's bytes would emit invalid JavaScript — are recorded in
 [`deliberate-divergences.md`](deliberate-divergences.md), each pinned by a test.
 
-## Server (`known-failures.server.json`, 75 entries)
+## Server (`known-failures.server.json`, 74 entries)
 
-Partition of `known-failures.server.json` by verdict: `62 + 4 + 9`
+Partition of `known-failures.server.json` by verdict: `62 + 4 + 8`
 
 - **62 — the generated JS differs.**
 - **4 — both compilers reject with a different error code.**
-- **9 — one compiler rejects and the other compiles.**
+- **8 — one compiler rejects and the other compiles.**
 
-All 75 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All 74 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it. The last pre-enrolment entry was #2308, from the `runed` / `svelte-toolbelt` enrolment:
 `watch.test.svelte.ts` writes `runs = runs + 1` and rsvelte **contracted** it to
 `runs += 1` (that direction, not the reverse). The `.svelte.(js|ts)` server path
@@ -90,35 +90,35 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Server dev (`known-failures.server-dev.json`, 75 entries)
+## Server dev (`known-failures.server-dev.json`, 74 entries)
 
 The `server-dev` target is the server transform with `dev: true`. It separately
 ratchets server-only development instrumentation: component metadata, element
 locations, dynamic-element validation, snippet validation, and injected CSS.
 
-Partition of `known-failures.server-dev.json` by verdict: `62 + 4 + 9`
+Partition of `known-failures.server-dev.json` by verdict: `62 + 4 + 8`
 
 - **62 — the generated JS differs.**
 - **4 — both compilers reject with a different error code.**
-- **9 — one compiler rejects and the other compiles.**
+- **8 — one compiler rejects and the other compiles.**
 
-All 75 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All 74 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it. Its counts now match `server`. The one extra entry was SoftShadows output
 that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-## Client dev (`known-failures.client-dev.json`, 322 entries)
+## Client dev (`known-failures.client-dev.json`, 321 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `277 + 4 + 7 + 34 + 0`
+Partition of `known-failures.client-dev.json` by verdict: `277 + 4 + 6 + 34 + 0`
 
 - **277 — the generated JS differs.**
 - **4 — both compilers reject with a different error code.**
-- **7 — one compiler rejects and the other compiles.**
+- **6 — one compiler rejects and the other compiles.**
 - **34 — the generated CSS differs** (three fewer than `client`).
 - **0 — rsvelte's output is not JavaScript.**
 
-All remaining 322 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 321 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 40 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 
@@ -407,7 +407,7 @@ No remaining first-difference cluster
 in the latest completed report contains more than two entries per target; the
 table records the tied largest signatures so the next pass starts from data.
 
-### The 20 entries where only one compiler rejects
+### The 19 entries where only one compiler rejects
 
 This is the class no amount of corpus growth found before, because it needs
 code that is *almost* legal. Split by direction, from the run's own
@@ -415,15 +415,16 @@ code that is *almost* legal. Split by direction, from the run's own
 
 - **10 under-rejections** — official rejects, rsvelte compiles: `js_parse_error`
   ×9, `css_expected_identifier` ×1.
-- **10 over-rejections** — rsvelte rejects, official compiles:
+- **9 over-rejections** — rsvelte rejects, official compiles:
   `store_invalid_scoped_subscription` ×3, `global_reference_invalid` ×3,
-  `expected_token` ×2, `reactive_declaration_cycle` ×1,
-  `attribute_invalid_event_handler` ×1.
+  `expected_token` ×2, `reactive_declaration_cycle` ×1.
 
 An over-rejection is the worse of the two for a drop-in replacement: it fails a
 build that upstream completes. The nine `dollar_prefix_invalid` entries that
 used to be the largest single one are gone — `main` fixed them, and they were
-the whole of the drop from 19 over-rejections to 10.
+the whole of the drop from 19 over-rejections to 10. The quoted single-expression
+event attribute fix then removed one more entry (four target-pairs) for
+`attribute_invalid_event_handler`.
 
 ## Hard-cluster warnings for future work
 

--- a/compatibility/known-failures.server-dev.json
+++ b/compatibility/known-failures.server-dev.json
@@ -50,7 +50,6 @@
 	"svelte-commerce/src/lib/theme/sections/tile-grid.svelte",
 	"svelte-french-toast/src/routes/+page.svelte",
 	"sveltepress/packages/theme-default/src/components/NavItem.svelte",
-	"svelty-picker/src/routes/+layout.svelte",
 	"threlte/apps/docs/src/examples/geometry/random-placement/basic-random/assets/bush.svelte",
 	"threlte/apps/docs/src/examples/xr/vr-button/assets/bush.svelte",
 	"trakt-web/projects/client/src/lib/components/avatar-pill/AvatarPill.svelte",

--- a/compatibility/known-failures.server.json
+++ b/compatibility/known-failures.server.json
@@ -50,7 +50,6 @@
 	"svelte-commerce/src/lib/theme/sections/tile-grid.svelte",
 	"svelte-french-toast/src/routes/+page.svelte",
 	"sveltepress/packages/theme-default/src/components/NavItem.svelte",
-	"svelty-picker/src/routes/+layout.svelte",
 	"threlte/apps/docs/src/examples/geometry/random-placement/basic-random/assets/bush.svelte",
 	"threlte/apps/docs/src/examples/xr/vr-button/assets/bush.svelte",
 	"trakt-web/projects/client/src/lib/components/avatar-pill/AvatarPill.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -6539,6 +6539,22 @@ mod tests {
     }
 
     #[test]
+    fn quoted_lone_expression_is_an_event_handler() {
+        analyze(r#"<button onclick="{handler}">click</button>"#);
+
+        for source in [
+            r#"<button onclick="handler">click</button>"#,
+            r#"<button onclick="before {handler}">click</button>"#,
+        ] {
+            assert!(matches!(
+                try_analyze(source),
+                Err(AnalysisError::ValidationWithCode { ref code, .. })
+                    if code == "attribute_invalid_event_handler"
+            ));
+        }
+    }
+
+    #[test]
     fn meta_property_name_slots_are_not_global_conflicts() {
         let analysis = analyze(
             "<script>const url = import.meta.url; function ctor() { return new.target; }</script>",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/attribute.rs
@@ -213,19 +213,25 @@ pub fn validate_slot_attribute(
 
 /// Check if an attribute is an expression attribute.
 pub fn is_expression_attribute(attribute: &AttributeNode<'_>) -> bool {
-    use crate::ast::template::AttributeValue;
-
-    matches!(&attribute.value, AttributeValue::Expression(_))
+    match &attribute.value {
+        AttributeValue::Expression(_) => true,
+        AttributeValue::Sequence(parts) => {
+            parts.len() == 1 && matches!(parts[0], AttributeValuePart::ExpressionTag(_))
+        }
+        AttributeValue::True(_) => false,
+    }
 }
 
 /// Get the expression tag from an attribute value.
 pub fn get_attribute_expression<'b, 'a>(
     attribute: &'b AttributeNode<'a>,
 ) -> Option<&'b ExpressionTag<'a>> {
-    use crate::ast::template::AttributeValue;
-
     match &attribute.value {
         AttributeValue::Expression(expr) => Some(expr),
+        AttributeValue::Sequence(parts) if parts.len() == 1 => match &parts[0] {
+            AttributeValuePart::ExpressionTag(expr) => Some(expr),
+            AttributeValuePart::Text(_) => None,
+        },
         _ => None,
     }
 }
@@ -256,7 +262,7 @@ pub fn record_event_attribute_arrow(context: &mut VisitorContext, attribute: &At
     if !is_event_attribute(attribute) {
         return;
     }
-    if let AttributeValue::Expression(tag) = &attribute.value
+    if let Some(tag) = get_attribute_expression(attribute)
         && tag.expression.as_node().node_type() == Some("ArrowFunctionExpression")
         && let Some(start) = tag.expression.as_node().start()
     {


### PR DESCRIPTION
## Summary

- align Phase 2's expression-attribute predicate with upstream's Svelte 5 compatibility form
- extract quoted lone expressions for event warnings and dev assignment exemptions
- keep rejecting literal and mixed-string event handlers
- retire the svelty-picker failure from all four compiler-output ratchets

## Verification

- `rustfmt --edition 2024 --check` on the changed Rust files
- JSON baselines are sorted, unique, and parse successfully
- `git diff --check`
- direct official-compiler check: quoted lone expression succeeds; literal and mixed strings report `attribute_invalid_event_handler`

Rust tests were not run locally per the repository host-load constraint; CI is the Rust execution oracle.
