### PR TITLE
Track asserted prop member mutation locations

### DIFF
--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -93,8 +93,6 @@
 	"huly/plugins/process-resources/src/components/criterias/CriteriasEditor.svelte",
 	"huly/plugins/process-resources/src/components/settings/ParamsEditor.svelte",
 	"huly/plugins/process-resources/src/components/settings/ProcessAttributeEditor.svelte",
-	"huly/plugins/process-resources/src/components/settings/ResultCriteriaEditor.svelte",
-	"huly/plugins/process-resources/src/components/settings/SubProcessEditor.svelte",
 	"huly/plugins/questions-resources/src/components/OrderingQuestionDataEditor.svelte",
 	"huly/plugins/recruit-resources/src/components/CreateApplication.svelte",
 	"huly/plugins/recruit-resources/src/components/OptimizeSkills.svelte",

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -398,6 +398,11 @@ collector. The collector now crosses that assertion only when its closing
 parenthesis is followed by a mutation operator. The six verified entries are
 retired without suppressing the distinct computed- and mid-chain-assertion
 shapes that remain.
+The remaining computed and mid-chain TypeScript assertion shapes are now
+collected too. The scanner finds the assertion wrapper with the shared
+JavaScript-aware bracket matcher, then resumes the member chain after `)`, so
+nested parentheses in a type cannot terminate the target early. This retires
+the two corresponding client-dev entries.
 The two threlte `bush.svelte` files destructure `[$gltf, $texture1]` in an
 `{:then}` clause while an unrelated top-level `gltf` store exists. The lexical
 store scan ignored the await scope and synthesized a root `$gltf` subscription;

--- a/compatibility/pattern-corpus/issues/prop-mutation-location-duplicate-words.svelte
+++ b/compatibility/pattern-corpus/issues/prop-mutation-location-duplicate-words.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	export let filter;
 	export let step = { params: null };
+	export let result = {};
 
 	const targets = new Set();
 
@@ -16,6 +17,8 @@
 
 	let params = step.params;
 	(step.params as any) = params;
+	(result as any)[params] = true;
+	(step.params as any)._id = params;
 </script>
 
 <button onclick={clean}>clean</button>

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_mutation_validation_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_mutation_validation_ast.rs
@@ -413,4 +413,18 @@ mod tests {
 
         assert!(output.ends_with(", 4, 0);"));
     }
+
+    #[test]
+    fn locates_typescript_assertions_before_member_accesses() {
+        let source = "<script lang=\"ts\">\nexport let result;\nexport let step;\nlet key = 'done';\n(result as any)[key] = true;\n(step.params as any)._id = 'next';\n</script>";
+        let output = wrap_prop_mutation_validation_ast(
+            "result(result()[key] = true, true);\nstep(step().params._id = 'next', true);",
+            &[("result".to_string(), None), ("step".to_string(), None)],
+            source,
+        )
+        .unwrap();
+
+        assert!(output.contains("result()[key] = true, true), 5, 0)"));
+        assert!(output.contains("step().params._id = 'next', true), 6, 0)"));
+    }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -4007,19 +4007,13 @@ impl PropMutationSites {
             {
                 continue;
             }
-            let chain_start = skip_non_null_assertions(bytes, end);
-            if !starts_member_access(bytes, chain_start) {
-                continue;
-            }
-            if let Some((after, chain)) = scan_member_chain_names(source, chain_start)
-                && let Some(value_start) =
-                    mutation_value_start(source, skip_ts_asserted_assignment_target(source, after))
-                        .or_else(|| {
-                            // A PREFIX update (`--p.deep.c`) has its operator before
-                            // the identifier; the site's position stays the identifier.
-                            let head = source[..start].trim_end();
-                            (head.ends_with("++") || head.ends_with("--")).then_some(after)
-                        })
+            if let Some((after, chain)) = scan_prop_mutation_target(source, start, end)
+                && let Some(value_start) = mutation_value_start(source, after).or_else(|| {
+                    // A PREFIX update (`--p.deep.c`) has its operator before
+                    // the identifier; the site's position stays the identifier.
+                    let head = source[..start].trim_end();
+                    (head.ends_with("++") || head.ends_with("--")).then_some(after)
+                })
             {
                 let (line, column) =
                     crate::compiler::phases::phase3_transform::utils::locate_in_source(
@@ -4207,41 +4201,70 @@ fn skip_non_null_assertions(bytes: &[u8], mut pos: usize) -> usize {
     pos
 }
 
-/// Advance from a member chain through a parenthesized TypeScript assertion
-/// when that asserted expression is the assignment target:
-/// `(step.params as any) = params`.
-///
-/// The generated JavaScript no longer carries the assertion, so failing to
-/// collect this source site makes the location matcher fall back to the first
-/// `step.params` read in the file. We stop at the first closing parenthesis
-/// followed by an actual mutation operator; parentheses inside the type are
-/// therefore harmless.
-fn skip_ts_asserted_assignment_target(source: &str, pos: usize) -> usize {
-    let mut cursor = skip_whitespace_chars(source, pos);
-    let tail = &source[cursor..];
-    let keyword_len =
-        if tail.starts_with("as") && tail[2..].chars().next().is_some_and(char::is_whitespace) {
-            2
-        } else if tail.starts_with("satisfies")
-            && tail[9..].chars().next().is_some_and(char::is_whitespace)
-        {
-            9
-        } else {
-            return pos;
-        };
-    cursor += keyword_len;
-
+/// Scan a prop mutation target, including a TypeScript assertion that wraps
+/// either the root or an intermediate member chain:
+/// `(result as any)[key] = value` and `(step.params as any)._id = value`.
+fn scan_prop_mutation_target(
+    source: &str,
+    root_start: usize,
+    root_end: usize,
+) -> Option<(usize, Option<Vec<String>>)> {
     let bytes = source.as_bytes();
-    while cursor < bytes.len() && !matches!(bytes[cursor], b'\n' | b';') {
-        if bytes[cursor] == b')' {
-            let candidate = skip_whitespace_chars(source, cursor + 1);
-            if is_mutation_operator(source, candidate) {
-                return candidate;
-            }
+    let chain_start = skip_non_null_assertions(bytes, root_end);
+    let (mut after, mut chain, mut saw_member) = if starts_member_access(bytes, chain_start) {
+        let (after, chain) = scan_member_chain_names(source, chain_start)?;
+        (after, chain, true)
+    } else {
+        (chain_start, Some(Vec::new()), false)
+    };
+
+    if let Some(assertion_end) = parenthesized_ts_assertion_end(source, root_start, after) {
+        after = skip_whitespace_chars(source, assertion_end);
+        if starts_member_access(bytes, after) {
+            let (tail_end, tail_chain) = scan_member_chain_names(source, after)?;
+            chain = match (chain, tail_chain) {
+                (Some(mut head), Some(tail)) => {
+                    head.extend(tail);
+                    Some(head)
+                }
+                _ => None,
+            };
+            after = tail_end;
+            saw_member = true;
         }
-        cursor += 1;
     }
-    pos
+
+    saw_member.then_some((after, chain))
+}
+
+/// Return the byte after the closing parenthesis when `root_start..expression_end`
+/// is wrapped in a TypeScript `as` or `satisfies` assertion.
+fn parenthesized_ts_assertion_end(
+    source: &str,
+    root_start: usize,
+    expression_end: usize,
+) -> Option<usize> {
+    let (open, ch) = source[..root_start]
+        .char_indices()
+        .rev()
+        .find(|(_, ch)| !ch.is_whitespace())?;
+    if ch != '(' {
+        return None;
+    }
+    let close =
+        crate::compiler::phases::phase1_parse::utils::find_matching_bracket(source, open + 1, '(')?;
+    if expression_end > close {
+        return None;
+    }
+    let assertion = source[expression_end..close].trim_start();
+    let has_keyword = ["as", "satisfies"].into_iter().any(|keyword| {
+        assertion.strip_prefix(keyword).is_some_and(|tail| {
+            tail.chars()
+                .next()
+                .is_some_and(|ch| ch.is_whitespace() && !tail.trim().is_empty())
+        })
+    });
+    has_keyword.then_some(close + 1)
 }
 
 /// Whether a member access — plain, computed or optional — starts at `pos`.


### PR DESCRIPTION
## Summary

- resume prop mutation target scanning after parenthesized TypeScript assertions
- support assertions around a root before computed access and around an intermediate member chain
- extend the constructed repro and retire two verified client-dev failures

## Root cause

The source-site collector expected the member access to begin directly after the prop identifier and stopped when `as any` appeared inside a parenthesized target. The generated JavaScript erases the assertion, so matching fell back to an unrelated earlier read.

The scanner now uses the shared JavaScript-aware bracket matcher to find the assertion wrapper's true closing parenthesis, then resumes member-chain collection after it.

## Verification

- targeted `rustfmt --check`
- baseline JSON sorted and duplicate-free (292 entries, down by 2)
- `git diff --check`
- official Svelte dev compile confirms the extended fixture's new mutation positions at lines 20 and 21

Local Rust execution was intentionally skipped per repository operating constraints; CI is the execution oracle.
