### PR TITLE
fix(svelte2tsx): a `<style>` inside an HTML comment is not a start tag

### DIFF
--- a/.changeset/s2t-style-in-comment.md
+++ b/.changeset/s2t-style-in-comment.md
@@ -1,0 +1,11 @@
+---
+'@rsvelte/compiler': patch
+---
+
+svelte2tsx: a `<style>` written inside an HTML comment no longer opens a style element
+
+The fallback scanner that blanks style tags the parser did not capture searched the source for
+`<style` with no regard for comments, so a comment mentioning `<style>` was treated as a start
+tag and everything up to the file's real `</style>` was blanked — taking the attributes of every
+element in between. Upstream's `findNextVerbatimElement` matches a comment before either verbatim
+tag and skips it; the scan now does the same.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -5998,12 +5998,49 @@ The svelte2tsx output-parity corpus (`scripts/compat-corpus/svelte2tsx-*`) compa
 rsvelte's svelte2tsx port against **official `svelte2tsx`** byte-for-byte (after
 oxfmt normalization). The ratchet may only shrink.
 
-**Current baseline: `svelte2tsx-known-failures.json`, 36 entries.**
+**Current baseline: `svelte2tsx-known-failures.json`, 35 entries.**
 
-Partition of `svelte2tsx-known-failures.json` by verdict: `34 + 2`
+Partition of `svelte2tsx-known-failures.json` by verdict: `33 + 2`
 
-- **34 — the emitted TSX differs** (`ts-mismatch`).
-- **2 — one side rejects and the other compiles** (`error-mismatch`).
+- **33 — the emitted TSX differs** (`ts-mismatch`).
+- **2 — one side rejects and the other compiles** (`error-mismatch`). Both are
+  `cnblocks`'s `(app)/veil/` components, and the rejecting side is **official**:
+  a UTF-8 BOM together with a `<script>` block and markup makes `svelte2tsx`
+  throw from `magic-string`, reduced and filed as
+  `upstream_issues/svelte2tsx-bom-crashes-on-any-component-with-a-script.md`.
+
+Attribution of `svelte2tsx-known-failures.json`:
+
+| n | target | cluster |
+|---|---|---|
+| 2 | `upstream_issues/svelte2tsx-bom-crashes-on-any-component-with-a-script.md` | official throws on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it |
+
+The remaining 33 carry no target yet: every one measured so far is an rsvelte
+defect, so the end state for them is elimination rather than attribution. The
+classification below is the input to that work.
+
+### The 33 `ts-mismatch` entries, measured 2026-09-01
+
+Both implementations run directly on the 33 listed sources with the options
+`svelte2tsx-compile.mjs` passes (`{filename, isTsFile, mode:'ts', namespace:'html',
+version:'5'}`); the key is the first differing line after blank-line normalization.
+Read it the way the paragraphs above tell you to read every first-differing-line
+key: it is a **symptom**, so a mechanism can span rows and two mechanisms can
+share one.
+
+| n | first differing line |
+|---|---|
+| 5 | official has reached `async () => {` while rsvelte is still emitting an `import` — the instance/module statement order |
+| 3 | `App.Error` on official against `any` on rsvelte, in a `+error.svelte`'s `$$ComponentProps` typedef |
+| 3 | `* @type {{` against `* @typedef {{` |
+| 2 | `return { props: {` — a JSDoc comment placed after the brace |
+| 2 | the props object's entries, from a wider `return { props: {…}` line |
+| 2 | `;` against `function $$render() {` |
+| 1 | store declarations emitted in a different order |
+| 1 | `ensureTransition(fade(…))` against `ensureTransition(fade)(…)` |
+| 1 | `function $$render/*Ωignore_startΩ*/<T>/*Ωignore_endΩ*/()` against a bare `;` |
+| 1 | a dev-mode `__sveltets_2_any` assignment rsvelte adds to a typed declaration |
+| 13 | one entry each |
 
 ### Wave-2 enrolment (#3130)
 

--- a/compatibility/svelte2tsx-known-failures.json
+++ b/compatibility/svelte2tsx-known-failures.json
@@ -20,7 +20,6 @@
 	"sparrow-app/packages/@sparrow-workspaces/src/components/tabular-input/sub-component/BulkEditorMergeView.svelte",
 	"sparrow-app/packages/@sparrow-workspaces/src/features/tab-bar/components/tab/Tab.svelte",
 	"svelte-commerce/src/lib/components/form/textbox.svelte",
-	"svelte-commerce/src/lib/components/nav/mega-menu.svelte",
 	"svelte-inspect-value/packages/svelte/src/lib/components/Options.svelte",
 	"svelte-inspect-value/packages/svelte/src/routes/(app)/reference/+page.svelte",
 	"svelte-virtuallists/src/lib/VirtualListNew.svelte",

--- a/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
@@ -252,6 +252,24 @@ pub fn blank_style_tags(ast: &Root, source: &str, str: &mut MagicString<'_>) {
                 .iter()
                 .any(|&(s, e)| pos >= s && pos < e)
         };
+        // `findNextVerbatimElement` matches `(<!--[^]*?-->)` before either tag
+        // and skips it, so a commented-out `<style>` never opens an element.
+        let comment_ranges: Vec<(usize, usize)> = {
+            let mut ranges = Vec::new();
+            let mut at = 0usize;
+            while let Some(rel) = source[at..].find("<!--") {
+                let start = at + rel;
+                let Some(close) = source[start + 4..].find("-->") else {
+                    break;
+                };
+                let end = start + 4 + close + 3;
+                ranges.push((start, end));
+                at = end;
+            }
+            ranges
+        };
+        let is_inside_comment =
+            |pos: usize| -> bool { comment_ranges.iter().any(|&(s, e)| pos >= s && pos < e) };
 
         // Direct case-sensitive substring search over the original source.
         // The previous implementation called `source.to_lowercase()` once
@@ -267,7 +285,7 @@ pub fn blank_style_tags(ast: &Root, source: &str, str: &mut MagicString<'_>) {
                 search_from = abs_start + 1;
                 continue;
             }
-            if is_already_blanked(abs_start) {
+            if is_already_blanked(abs_start) || is_inside_comment(abs_start) {
                 search_from = abs_start + 1;
                 continue;
             }

--- a/crates/rsvelte_projection/tests/style_tag_inside_a_comment.rs
+++ b/crates/rsvelte_projection/tests/style_tag_inside_a_comment.rs
@@ -1,0 +1,61 @@
+//! `findNextVerbatimElement` (`utils/htmlxparser.ts:76-99`) matches a comment
+//! before either verbatim tag and skips it, so a `<style>` written inside an
+//! HTML comment never opens a style element. The fallback scanner in
+//! `blank_style_tags` was the one scan here that did not, so it blanked from
+//! the comment to the real `</style>` and took every attribute in between.
+
+use rsvelte_projection::svelte2tsx::{
+    Svelte2TsxMode, Svelte2TsxNamespace, Svelte2TsxOptions, SvelteVersion, svelte2tsx,
+};
+
+fn opts() -> Svelte2TsxOptions {
+    Svelte2TsxOptions {
+        filename: "a.svelte".to_string(),
+        is_ts_file: true,
+        mode: Svelte2TsxMode::Ts,
+        namespace: Svelte2TsxNamespace::Html,
+        version: SvelteVersion::V5,
+        ..Svelte2TsxOptions::default()
+    }
+}
+
+const ELEMENT: &str = "<li\n\tclass=\"hoverable\"\n\tonmousemove={() => { go() }}\n>x</li>\n";
+const STYLE: &str = "<style>\n\t.hoverable { color: red }\n</style>\n";
+
+#[test]
+fn a_commented_style_tag_does_not_swallow_the_markup_after_it() {
+    let source = format!("<!-- the rule is in <style>. -->\n{ELEMENT}{STYLE}");
+    let out = svelte2tsx(&source, opts()).expect("svelte2tsx").code;
+    assert!(
+        out.contains("\"class\":`hoverable`"),
+        "the element's attributes survive:\n{out}"
+    );
+    assert!(
+        out.contains("\"onmousemove\""),
+        "the event handler survives:\n{out}"
+    );
+}
+
+#[test]
+fn a_real_style_tag_is_still_blanked() {
+    let source = format!("{ELEMENT}{STYLE}");
+    let out = svelte2tsx(&source, opts()).expect("svelte2tsx").code;
+    assert!(
+        !out.contains("color: red"),
+        "the CSS is not carried into the TSX:\n{out}"
+    );
+    assert!(
+        out.contains("\"class\":`hoverable`"),
+        "the element is unaffected:\n{out}"
+    );
+}
+
+#[test]
+fn a_commented_style_tag_with_no_real_style_block_is_inert() {
+    let source = format!("<!-- see <style>. -->\n{ELEMENT}");
+    let out = svelte2tsx(&source, opts()).expect("svelte2tsx").code;
+    assert!(
+        out.contains("\"class\":`hoverable`"),
+        "the element's attributes survive:\n{out}"
+    );
+}

--- a/upstream_issues/README.md
+++ b/upstream_issues/README.md
@@ -111,6 +111,7 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `svelte-scss-line-comment-hides-an-animation-name-from-keyframe-scoping.md` | sveltejs/svelte | #4048 | unrecorded |
 | `svelte-server-treats-a-dollar-parameter-as-a-store.md` | sveltejs/svelte | #4048 | unrecorded |
 | `svelte-snippet-name-colliding-with-an-import.md` | sveltejs/svelte | #3567 | unrecorded |
+| `svelte2tsx-bom-crashes-on-any-component-with-a-script.md` | sveltejs/language-tools (svelte2tsx) | #4048 | unrecorded |
 | `svelte2tsx-shorthand-style-directive-modifier.md` | sveltejs/language-tools (svelte2tsx) | #3567, #3578 | unrecorded |
 | `svelte2tsx-transposes-an-unclosed-start-tag.md` | sveltejs/language-tools (svelte2tsx) | — | unrecorded |
 | `tsgo-lsp-completion-item-omits-the-typescript-kind.md` | microsoft/typescript-go (`tsgo --lsp`) | — | unrecorded |

--- a/upstream_issues/svelte2tsx-bom-crashes-on-any-component-with-a-script.md
+++ b/upstream_issues/svelte2tsx-bom-crashes-on-any-component-with-a-script.md
@@ -1,0 +1,51 @@
+# `svelte2tsx` throws on any component that starts with a UTF-8 BOM
+
+**Repository**: `sveltejs/language-tools` (`packages/svelte2tsx`)
+**Measured**: 2026-09-01, `submodules/language-tools` at the pinned revision, driven through
+`packages/svelte2tsx/index.js` with the options `scripts/compat-corpus/svelte2tsx-compile.mjs`
+passes: `{ filename, isTsFile, mode: 'ts', namespace: 'html', version: '5' }`.
+
+## Summary
+
+A component whose source begins with a UTF-8 BOM (`U+FEFF`) and contains **both** a `<script>`
+block and markup makes `svelte2tsx` throw from `magic-string`:
+
+```
+Cannot split a chunk that has already been edited (2:9 – ">…
+```
+
+Either half alone is fine. Removing the BOM from the same source is fine. The `<script>` may be
+`lang="ts"` or plain JavaScript.
+
+## Reduction
+
+```js
+const { svelte2tsx } = await import('packages/svelte2tsx/index.js');
+const opts = { filename: 'a.svelte', isTsFile: true, mode: 'ts', namespace: 'html', version: '5' };
+const BOM = '﻿';
+```
+
+| input | official `svelte2tsx` |
+|---|---|
+| `BOM + '<script lang="ts">\n\tlet a = 1;\n</script>\n\n<div>{a}</div>\n'` | **throws** `Cannot split a chunk that has already been edited (2:9 – ">…` |
+| `BOM + '<script>\n\tlet a = 1;\n</script>\n\n<div>{a}</div>\n'` | **throws**, same message |
+| the first input **without** the BOM | ok |
+| `BOM + '<div>x</div>\n'` (no script) | ok |
+| `BOM + '<script lang="ts">\n\tlet a = 1;\n</script>\n'` (no markup) | ok |
+
+A larger real input reports a different magic-string message from the same cause
+(`Cannot move a selection inside itself`), preceded by svelte2tsx's own
+`Error leaving node {…}` dump — so the message alone does not identify the class.
+
+## Real-world instances
+
+`cnblocks/src/routes/(app)/veil/+page.svelte` and
+`cnblocks/src/routes/(app)/veil/+layout.svelte` (both begin with a BOM) are the two
+`error-mismatch` entries in `compatibility/svelte2tsx-known-failures.json`: official rejects them,
+rsvelte's port converts them.
+
+## Why this is filed rather than matched
+
+rsvelte's `svelte2tsx` port produces TSX for these inputs. Reproducing the crash would mean
+porting a `magic-string` bookkeeping fault, so the two entries stay listed and are attributed
+here.


### PR DESCRIPTION
`blank_style_tags` のフォールバック走査だけが `<style` をコメント非対応で探していた。
`<!-- the rule is in <style>. -->` が style 要素を開き、ファイル下方の実 `</style>` までを
blank するので、**間にある要素の属性名と値が全部空になる**。

```
official: { svelteHTML.createElement("li", { "class":`hoverable`,"onmousemove":() => { go() },});
rsvelte : { svelteHTML.createElement("li", { "":``,"":,});
```

上流は `findNextVerbatimElement`（`utils/htmlxparser.ts:76-99`）が `(<!--[^]*?-->)` を先に当てて
`startsWith('<!--')` で捨てる。同じ rsvelte のファイルにある他 2 つの走査
（`blank_style_content` / `verbatim_style_ranges`）は既にコメントをタグより先に消費しており、
doc コメントに「tag-looking text inside comments and script bodies is opaque」と書いてある —
**入口走査だけが取り残されていた**という、この repo が何度も踏んでいる形。

## 再現に必要な 3 条件

`<style>` を含む HTML コメント **と** 実 `<style>` ブロックの両方。片方だけでは発火しない。

## 測定

- `crates/rsvelte_projection/tests/style_tag_inside_a_comment.rs` 3 本。
  **陽性対照**: 判定を `false && …` に潰すと狙った 1 本だけが赤、対照 2 本は緑のまま。
- `svelte2tsx_fixtures` 緑。`rsvelte_projection` の clippy `-D warnings` 緑。
- `svelte2tsx-known-failures.json` の 36 件全部を、修正済み binding で両実装に直接かけて再分類:
  **`svelte-commerce/.../mega-menu.svelte` の 1 件だけ**が `ts-mismatch` → `ALREADY-PASSES` に動き、
  他 35 件の判定は 1 つも変わらない。two-sided ratchet なので同じ PR で 36 → 35 に縮めた。

## 併せて DoD-3

- `error-mismatch` 2 件（cnblocks `(app)/veil/`）の帰属先を新規起票した:
  `upstream_issues/svelte2tsx-bom-crashes-on-any-component-with-a-script.md`。
  **UTF-8 BOM + `<script>` + markup** で official svelte2tsx が magic-string から throw する
  （rsvelte は通る）。最小化済み、3 つの陰性対照つき。
- `KNOWN-FAILURES.md` に `Attribution of \`svelte2tsx-known-failures.json\`:` を追加（2/35）。
  残り 33 件は実測して first-differing-line で分類し、**それが症状であって原因ではない**ことを
  明記した上で表にした。
