### PR TITLE
fix(svelte2tsx): the dts heritage rewrite reconstructed three positions by scanning text

### DIFF
--- a/.changeset/dts-interface-heritage-comment.md
+++ b/.changeset/dts-interface-heritage-comment.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/svelte2tsx": patch
+---
+
+Emit parseable TypeScript from `--mode dts` when an interface's heritage clause carries a comment.
+
+The `interface X extends Y { … }` → `type X = Y & { … }` rewrite reconstructed three positions by scanning raw text — a backward walk to the `extends` keyword that skipped whitespace but not comments, a `find(',')` for the separator between entries, and a `find('{')` for the body. A comment defeated all three: `extends` survived (`type X extends …`), and a `,` or `{` written inside a comment took the operator into the comment's body. All three now come from spans, as upstream's does. The trailing ` & ` moves with them, so the join now spells `Y &  {` like official instead of `Y  & {`.

--- a/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
@@ -759,6 +759,7 @@ fn find_line_comment_start(line: &[u8]) -> Option<usize> {
 pub(super) fn rewrite_interface_to_type_dts(
     iface: &oxc_ast::ast::TSInterfaceDeclaration<'_>,
     raw_content: &str,
+    comments: &[oxc_ast::ast::Comment],
     offset: u32,
     str: &mut MagicString<'_>,
 ) {
@@ -766,78 +767,80 @@ pub(super) fn rewrite_interface_to_type_dts(
     let iface_kw_start = iface.span.start;
     let iface_kw_end = iface_kw_start + 9; // "interface".len()
     if (iface_kw_end as usize) <= raw_content.len()
-        && &raw_content[iface_kw_start as usize..iface_kw_end as usize] == "interface"
+        && &raw_content.as_bytes()[iface_kw_start as usize..iface_kw_end as usize] == b"interface"
     {
         str.overwrite(iface_kw_start + offset, iface_kw_end + offset, "type");
     }
 
     let extends = &iface.extends;
-    if extends.is_empty() {
-        // No extends: insert `=` immediately before the body's `{`.
+    let Some(first_heritage) = extends.first() else {
+        // No extends: insert `=` immediately before the body's `{`. Upstream
+        // reaches that brace with `indexOf('{')`, which a comment holding one
+        // sends into the comment's text; the body span is the same position
+        // without the scan.
         let body_start = iface.body.span.start;
         if (body_start as usize) <= raw_content.len() {
             str.append_left(body_start + offset, "=");
         }
-    } else {
-        {
-            // 2. `extends` -> `=`. The `extends` token sits between `iface.id`
-            //    (or its type-parameter list) and the first heritage entry.
-            let first_heritage = &extends[0];
-            let first_start = first_heritage.span.start as usize;
-            // Walk back from the heritage entry through whitespace, then
-            // expect "extends" right before. The OXC AST doesn't expose the
-            // keyword span directly.
-            let bytes = raw_content.as_bytes();
-            let mut p = first_start;
-            while p > 0 {
-                let prev = bytes[p - 1];
-                if prev == b' ' || prev == b'\t' || prev == b'\n' || prev == b'\r' {
-                    p -= 1;
-                } else {
-                    break;
-                }
-            }
-            // p is now just past "extends" (or at the closing `>` of generics
-            // if no `extends` token — but `iface.extends` is non-empty so
-            // `extends` must exist).
-            let extends_end = p;
-            if extends_end >= 7 {
-                // A comment may sit between `extends` and the heritage entry, so
-                // `extends_end - 7` can land inside a multi-byte char. The keyword
-                // is ASCII, so compare bytes rather than slicing the `str`.
-                let prev_kw = &raw_content.as_bytes()[extends_end - 7..extends_end];
-                if prev_kw == b"extends" {
-                    str.overwrite(
-                        u32_index(extends_end - 7) + offset,
-                        u32_index(extends_end) + offset,
-                        "=",
-                    );
-                }
-            }
+        return;
+    };
 
-            // 3. Replace each `,` between heritage entries with ` &`.
-            let mut prev_end = first_heritage.span.end;
-            for entry in extends.iter().skip(1) {
-                let entry_start = entry.span.start;
-                if entry_start > prev_end {
-                    let between = &raw_content[prev_end as usize..entry_start as usize];
-                    if let Some(comma_off) = between.find(',') {
-                        let comma_abs = prev_end + u32_index(comma_off);
-                        str.overwrite(comma_abs + offset, comma_abs + 1 + offset, " &");
-                    }
-                }
-                prev_end = entry.span.end;
-            }
-
-            // 4. Append ` & ` immediately before the body's `{`.
-            let last_extends_end = extends.last().unwrap().span.end;
-            let after = &raw_content[last_extends_end as usize..];
-            if let Some(brace_off) = after.find('{') {
-                let brace_abs = last_extends_end + u32_index(brace_off);
-                str.append_left(brace_abs + offset, " & ");
-            }
-        }
+    // 2. `extends` -> `=`. Upstream takes the position from the heritage
+    //    CLAUSE, which starts at the keyword; OXC's heritage span starts at the
+    //    type, so the keyword is the first code token after the interface head.
+    let head_end = iface
+        .type_parameters
+        .as_ref()
+        .map_or(iface.id.span.end, |params| params.span.end);
+    if let Some(kw) =
+        extends_keyword_start(raw_content, comments, head_end, first_heritage.span.start)
+    {
+        str.overwrite(kw + offset, kw + 7 + offset, "="); // "extends".len()
     }
+
+    // 3. Each gap between two heritage entries becomes ` & `. Upstream
+    //    overwrites the whole gap rather than locating the `,` in it, so a
+    //    comment there is dropped instead of surviving around the operator.
+    let mut prev_end = first_heritage.span.end;
+    for entry in extends.iter().skip(1) {
+        if entry.span.start > prev_end {
+            str.overwrite(prev_end + offset, entry.span.start + offset, " & ");
+        }
+        prev_end = entry.span.end;
+    }
+
+    // 4. ` & ` joins the last entry to the body. The anchor is that entry's
+    //    end, not the body's `{`: everything between them is source the
+    //    rewrite must not step over.
+    str.append_left(prev_end + offset, " & ");
+}
+
+/// Byte offset of the `extends` keyword between an interface's head and its
+/// first heritage entry, or `None` if the region does not hold one.
+///
+/// The region can only contain whitespace, comments and the keyword, and the
+/// parser has already located the comments — so this consumes trivia it is
+/// given rather than re-deciding where a comment ends.
+fn extends_keyword_start(
+    raw_content: &str,
+    comments: &[oxc_ast::ast::Comment],
+    from: u32,
+    to: u32,
+) -> Option<u32> {
+    const KEYWORD: &[u8] = b"extends";
+    let bytes = raw_content.as_bytes();
+    let end = (to as usize).min(bytes.len());
+    let mut i = (from as usize).min(end);
+    loop {
+        while i < end && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        let Some(comment) = comments.iter().find(|c| c.span.start as usize == i) else {
+            break;
+        };
+        i = (comment.span.end as usize).min(end);
+    }
+    (i + KEYWORD.len() <= end && &bytes[i..i + KEYWORD.len()] == KEYWORD).then_some(i as u32)
 }
 
 #[cfg(test)]

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -343,7 +343,13 @@ pub fn process_instance_script(
                                     });
                                 }
                                 if is_dts_mode {
-                                    rewrite_interface_to_type_dts(iface, raw_content, offset, str);
+                                    rewrite_interface_to_type_dts(
+                                        iface,
+                                        raw_content,
+                                        &program.comments,
+                                        offset,
+                                        str,
+                                    );
                                 }
                             }
                             _ => {}
@@ -369,7 +375,13 @@ pub fn process_instance_script(
                     // breaks .d.ts generation. Mirrors
                     // `processInstanceScriptContent.ts::transformInterfacesToTypes`.
                     if is_dts_mode {
-                        rewrite_interface_to_type_dts(iface, raw_content, offset, str);
+                        rewrite_interface_to_type_dts(
+                            iface,
+                            raw_content,
+                            &program.comments,
+                            offset,
+                            str,
+                        );
                     }
                 }
                 oxc::Statement::TSTypeAliasDeclaration(type_alias) => {

--- a/crates/rsvelte_projection/tests/svelte2tsx_bind_multibyte_boundary_4072.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_bind_multibyte_boundary_4072.rs
@@ -69,18 +69,20 @@ fn reported_repro_file() {
 }
 
 /// Same class, a different site, found by sweeping the crate for byte-offset
-/// `str` slices rather than by a report: `rewrite_interface_to_type_dts` walks
-/// back from the first heritage entry over whitespace and reads the seven bytes
-/// before it as the `extends` keyword. A comment between `extends` and the entry
-/// puts those seven bytes inside the comment text, so a multi-byte char there is
-/// sliced mid-character. `--mode dts` only (`svelte-package`), which is why
+/// `str` slices rather than by a report: `rewrite_interface_to_type_dts` used to
+/// walk back from the first heritage entry over whitespace and read the seven
+/// bytes before it as the `extends` keyword, so a comment between the two put
+/// those bytes inside the comment's text and a multi-byte char there was sliced
+/// mid-character. `--mode dts` only (`svelte-package`), which is why
 /// `rsvelte-check` never reached it.
 ///
-/// The comment also defeats the keyword walk itself, so neither case rewrites
-/// `extends` — a separate, output-level divergence from upstream, which takes
-/// the position from `heritageClauses[0].getStart()` and never scans. The two
-/// cases must therefore agree with each other: that is what says the multi-byte
-/// char is not special, without pinning the wrong output as correct.
+/// That slice is gone — #4077 replaced all three of the function's text scans
+/// with spans, and `svelte2tsx_dts_interface_heritage_4077.rs` is where those
+/// live. What is still only here is the **multi-byte** comment: these rows say
+/// that a `/*日本*/` in the slot behaves exactly like the `/*hi*/` beside it,
+/// which is what would go red if byte arithmetic ever returned to the site.
+/// Both expectations are official's own output, so they no longer have to be
+/// stated as "the two agree with each other".
 mod dts_interface_extends {
     use rsvelte_projection::svelte2tsx::{Svelte2TsxMode, Svelte2TsxOptions, svelte2tsx};
 
@@ -99,28 +101,28 @@ mod dts_interface_extends {
             .code
     }
 
-    /// `/*日本*/` is 10 bytes, so the seven before its end land inside `日`.
+    /// `/*日本*/` is 10 bytes — the width that put the old `- 7` inside `日`.
     #[test]
     fn multibyte_comment_between_extends_and_its_heritage_entry() {
         let out = dts("日本");
         assert!(
-            out.contains("type A extends /*日本*/B  & { b: string }"),
+            out.contains("type A = /*日本*/B &  { b: string }"),
             "output:\n{out}"
         );
     }
 
-    /// The ASCII control: same shape, the boundary is never crossed.
+    /// The ASCII control: same shape, no boundary to cross.
     #[test]
     fn ascii_comment_between_extends_and_its_heritage_entry() {
         let out = dts("hi");
         assert!(
-            out.contains("type A extends /*hi*/B  & { b: string }"),
+            out.contains("type A = /*hi*/B &  { b: string }"),
             "output:\n{out}"
         );
     }
 
-    /// No comment: the walk finds the keyword and the rewrite lands, which is
-    /// what keeps the two rows above from reading as "this path never fires".
+    /// No comment: the row that keeps the two above from reading as "this path
+    /// never fires".
     #[test]
     fn no_comment_still_rewrites_extends() {
         let opts = Svelte2TsxOptions {

--- a/crates/rsvelte_projection/tests/svelte2tsx_dts_interface_heritage_4077.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_dts_interface_heritage_4077.rs
@@ -1,0 +1,122 @@
+//! #4077: `--mode dts` rewrites `interface X extends Y { … }` into
+//! `type X = Y & { … }` with three raw text scans, and a comment defeats every
+//! one of them — producing TypeScript that does not parse.
+//!
+//! Upstream (`processInstanceScriptContent.ts::transformInterfacesToTypes`) is
+//! entirely span-based: the keyword position comes from `heritageClauses[0]`
+//! (a TypeScript heritage clause starts AT `extends`), the gap between two
+//! entries is overwritten whole, and ` & ` is appended at the clause's end.
+//! OXC's `TSInterfaceHeritage` span starts at the type instead, which is why
+//! rsvelte reconstructed those positions by scanning — a backward walk that
+//! skips whitespace but not comments, a `find(',')` and a `find('{')`.
+//!
+//! Each test below is the discriminating case for ONE of those three scans, so
+//! reverting one does not turn the others red. Each expectation is official's
+//! own output, captured from the pinned `submodules/language-tools` build.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxMode, Svelte2TsxOptions, svelte2tsx};
+
+/// The rewritten declaration line, which is where all three scans land.
+fn dts_line(declaration: &str) -> String {
+    let src = format!(
+        "<script lang=\"ts\">\n  interface B {{ a: string }}\n  interface C {{ c: string }}\n  {declaration}\n  export let x: Iface;\n</script>\n\n{{x}}\n"
+    );
+    let opts = Svelte2TsxOptions {
+        filename: "Comp.svelte".to_string(),
+        is_ts_file: true,
+        mode: Svelte2TsxMode::Dts,
+        ..Default::default()
+    };
+    let code = svelte2tsx(&src, opts)
+        .expect("svelte2tsx should not fail")
+        .code;
+    code.lines()
+        .find(|line| line.contains("Iface") && !line.contains("InstanceType"))
+        .unwrap_or_else(|| panic!("no Iface line in:\n{code}"))
+        .to_string()
+}
+
+/// Scan 1 — the `extends` keyword. A comment between `extends` and the entry
+/// stopped the backward walk, so `extends` survived and `type X extends …` is
+/// not TypeScript.
+#[test]
+fn a_comment_before_the_heritage_entry_still_rewrites_extends() {
+    assert_eq!(
+        dts_line("interface Iface extends /*c*/B { b: string }"),
+        "  type Iface = /*c*/B &  { b: string }"
+    );
+}
+
+/// Same scan, line comment: the walk stops one character earlier and the
+/// keyword is equally invisible to it.
+#[test]
+fn a_line_comment_before_the_heritage_entry_still_rewrites_extends() {
+    assert_eq!(
+        dts_line("interface Iface extends //c\n  B { b: string }"),
+        "  type Iface = //c"
+    );
+}
+
+/// Scan 2 — the separator between two entries. `find(',')` over the raw gap
+/// takes a comma written inside a comment, splicing ` &` into the comment body.
+#[test]
+fn a_comma_inside_a_comment_between_entries_is_not_the_separator() {
+    assert_eq!(
+        dts_line("interface Iface extends B /*,*/, C { b: string }"),
+        "  type Iface = B & C &  { b: string }"
+    );
+}
+
+/// Scan 3 — the anchor for the trailing ` & `. `find('{')` from the last entry
+/// takes a brace written inside a comment, splicing ` & ` into the comment.
+#[test]
+fn a_brace_inside_a_trailing_comment_is_not_the_body() {
+    assert_eq!(
+        dts_line("interface Iface extends B /*{*/ { b: string }"),
+        "  type Iface = B &  /*{*/ { b: string }"
+    );
+}
+
+/// The comment-free controls. Every scan above fires here too, so these are
+/// what say a fix repaired the comment cases rather than moving the common one
+/// — and the two-entry row is the one that pins the separator's spacing.
+mod controls {
+    use super::dts_line;
+
+    #[test]
+    fn single_heritage_entry() {
+        assert_eq!(
+            dts_line("interface Iface extends B { b: string }"),
+            "  type Iface = B &  { b: string }"
+        );
+    }
+
+    #[test]
+    fn two_heritage_entries() {
+        assert_eq!(
+            dts_line("interface Iface extends B, C { b: string }"),
+            "  type Iface = B & C &  { b: string }"
+        );
+    }
+
+    #[test]
+    fn no_heritage_clause() {
+        assert_eq!(
+            dts_line("interface Iface { b: string }"),
+            "  type Iface ={ b: string }"
+        );
+    }
+
+    /// rsvelte is deliberately NOT byte-equal here. Upstream reaches the body's
+    /// `{` with `str.original.indexOf('{', …)`, which a comment holding a brace
+    /// sends into the comment's text — official emits `type Iface /*={*/ {`,
+    /// which does not parse. The body span is the same position with no scan,
+    /// so rsvelte emits `/*{*/ ={`. Matching would mean reproducing the bug.
+    #[test]
+    fn a_brace_in_a_comment_does_not_move_the_equals_of_a_bodyless_rewrite() {
+        assert_eq!(
+            dts_line("interface Iface /*{*/ { b: string }"),
+            "  type Iface /*{*/ ={ b: string }"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #4077.

## The defect

Upstream's `transformInterfacesToTypes` is entirely span-based
(`processInstanceScriptContent.ts:413-447`): the `extends` position comes from
`heritageClauses[0].getStart()` — a TypeScript heritage clause **starts at the keyword** — the gap
between two entries is overwritten whole, and ` & ` is appended at the clause's end.

OXC's `TSInterfaceHeritage` span starts at the **type**, not the keyword, so rsvelte rebuilt all
three positions by reading raw bytes: a backward walk that skipped whitespace but not comments, a
`find(',')` for the separator, and a `find('{')` for the body. A comment defeats every one of
them, and two of the three splice the operator into the comment's own body:

| source | rsvelte before |
|---|---|
| `interface I extends /*c*/B {}` | `type I extends /*c*/B  & {}` |
| `interface I extends B /*,*/, C {}` | `type I = B/* &*/ , C  & {}` |
| `interface I extends B /*{*/ {}` | `type I = B/* & {*/ {}` |

None of that is TypeScript. All three positions now come from spans. The keyword is the first
code token after the interface head, found by consuming the trivia **the parser already located**
(`program.comments`) rather than by adding a scan — the shape that caused this in the first place.

## The whitespace difference recorded on #4075 is the same site

`B &  {` (official) vs `B  & {` (rsvelte) is scan 3: rsvelte appended ` & ` before the body's `{`,
upstream appends it at the last entry's **end**. It is not comment-dependent — it fired on **every**
extends-bearing interface. Moving the anchor settles it, which is why the comment-free controls in
the new test file are load-bearing rather than decorative.

## Measurement

202 cells — 6 interface shapes (1/2/3 heritage entries, generic entry, generic interface, no
heritage) × 4 comment slots (after the name, after `extends`, between entries, before the body) ×
5 comment kinds (`/*c*/`, `/*,*/`, `/*{*/`, `/*extends*/`, `//c`) × `dts`/`ts`, plus a comment-free
control per shape — against the pinned official svelte2tsx, with `ts.createSourceFile`
`parseDiagnostics` counted on **both** sides:

| | before | after |
|---|---|---|
| byte-equal | 110 | **200** |
| differ | 92 | **2** |
| rsvelte unparseable | 32 | **0** |
| official unparseable | 2 | 2 |
| panics | 0 | 0 |

**`mode: 'ts'` is the control**: 0 of its 101 cells ever diverged, before or after. The whole class
is `dts`-only.

The 32 unparseable cells were not one bug — they were the three scans, in the proportion
25 / 2 / 5 (`extends` keyword / comma-in-a-comment / brace-in-a-comment).

### The 2 remaining differences run the other way, and stay

Upstream reaches a bodyless interface's `{` with `str.original.indexOf('{', node.getStart())`,
which a comment holding a brace sends into the comment's text:

```
source    interface I /*{*/ { b: string }
official  type I /*={*/ { b: string }     <- 1 parse diagnostic
rsvelte   type I /*{*/ ={ b: string }     <- 0
```

rsvelte takes the position from the body span and is correct. Matching would mean reproducing an
upstream bug, so `controls::a_brace_in_a_comment_does_not_move_the_equals_of_a_bodyless_rewrite`
pins rsvelte's answer instead of official's.

## What the gates could not see — measured, not argued

- The corpus svelte2tsx-parity gate compiles with `mode: 'ts'`
  (`scripts/compat-corpus/svelte2tsx-compile.mjs:113`). **No corpus gate reaches `mode: 'dts'`.**
- The fixture suite *does* reach this code — `transforms-interfaces-dts` covers `extends`,
  `extends A, B` and a generic `extends`. It cannot see either half, and both were checked by
  reverting the fix and re-running rather than by reading the harness:

  | reverted | fixture suite |
  |---|---|
  | the `extends` keyword fix | `PASS: transforms-interfaces-dts`, **256/256** — no fixture writes a comment there |
  | the ` & ` anchor fix | `PASS: transforms-interfaces-dts`, **256/256** — the comparison falls back to whitespace-collapsed equality (`tests/common/svelte2tsx.rs:156,173`) |

  The checked-in expected output carries official's spacing (`type Bar2 = Bar1 &  {`), so that
  fixture had been passing on the *collapsed* comparison and now passes byte-exactly.

**No pattern-corpus repro is added on purpose.** That corpus reaches svelte2tsx only through the
`mode: 'ts'` gate, so a file there would measure nothing about this defect. The new Rust test file
is the gate.

## Verification

| check | result |
|---|---|
| `cargo test --no-fail-fast -p rsvelte_projection -p rsvelte_check` | exit 0 — 90 test binaries `ok`, 0 `FAILED` |
| `RSVELTE_REQUIRE_PREREQS=1 … --test svelte2tsx_fixtures` | 256/256, 0 failed, 0 skipped |
| `cargo fmt --check` | exit 0 |
| `cargo clippy --all-targets --all-features -- -D warnings` | exit 0, 0 warning/error lines |

### Positive controls

One scan reverted at a time, each producing a distinct signature — so a regression in any one of
the three is detected on its own:

| reverted scan | tests red |
|---|---|
| `extends` keyword | **2** — both `extends` rows. The separator and brace rows stay green. |
| entry separator | **1** — the comma-in-a-comment row. |
| trailing ` & ` anchor | **5** — its own row plus **both comment-free controls**, because this scan fires on every extends-bearing shape. |

## Interaction with #4075 (please merge #4075 first)

This branch is cut from `origin/main`, so it does not contain #4075. The two touch the same
function and #4077's fix **subsumes** #4075's `hoistable_types` half: the `extends_end - 7` slice
that #4075 made boundary-safe is deleted here, so `interface A extends /*日本*/B` compiles on this
branch with no `#4075` present — byte-identical to official, no panic.

On rebase, expect:

1. A conflict in `hoistable_types.rs` — resolve in favour of this branch (the byte slice is gone).
2. Two of #4075's tests to need updating. They deliberately pinned the *unrewritten* output
   ("the two cases must agree with each other … without pinning the wrong output as correct"), and
   that output is now correct. Both inputs measured against official on this branch:

   | #4075 test | new expectation |
   |---|---|
   | `multibyte_comment_between_extends_and_its_heritage_entry` | `type A = /*日本*/B &  { b: string }` |
   | `ascii_comment_between_extends_and_its_heritage_entry` | `type A = /*hi*/B &  { b: string }` |

   Both are byte-equal to official. `no_comment_still_rewrites_extends` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ayf2LfKqP7yEEtWjunZ7DF
