### PR TITLE
fix(fmt): a markup expression is not at statement position, so its head keeps no parens

### DIFF
--- a/.changeset/markup-cast-head-parens.md
+++ b/.changeset/markup-cast-head-parens.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+Stop parenthesizing the head of a markup `as`/`satisfies` cast: `{type as X}` no longer becomes `{(type) as X}`.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -991,6 +991,15 @@ after `trim()` but differing leading whitespace → **indent-only**; one side bl
 equal after swapping quote characters → **quote-style**; equal after removing all
 whitespace → **intra-line-ws**; anything else → **other**.
 
+**The table below is the wave-2 enrolment measurement, over a population of 765 —
+it is NOT a partition of the current 549.** Its `n` column sums to **766**, one
+more than the 765 the paragraph above claims, so it was already inconsistent with
+its own stated population before this ratchet shrank. What each of its rows would
+be against the current 549 is **unmeasured**: re-deriving it needs every entry's
+first differing line, which lives only in the CI report. The live partition is the
+`Partition of …` line above, which `known-failures-md-check.mjs` verifies; this
+table is kept for the per-cluster descriptions, not for its counts.
+
 | n | cluster | what the first differing line looks like |
 |---|---|---|
 | 386 | **20 — breaks-later** | rsvelte keeps on one line what the oracle has already broken (`{#each …sort( (a,b) => {` vs a wrapped form) |
@@ -1018,8 +1027,12 @@ separate product bug and was fixed by #3629. These two entries remain because
 gate 9 intentionally compares the shipped native CSS path rather than replacing
 it with `--no-native-css`; #3628 records that decision and the engine boundary.
 
-**624 of 765 (82%) are cluster 20 or 21 — one question, where a line breaks** —
-and that is the burndown target, not the tail. Nothing here is an oracle bug: the
+**472 of 549 (86%) are cluster 20 or 21 — one question, where a line breaks** —
+and that is the burndown target, not the tail. That is the live `Partition of …`
+line above (258 + 214), the one the doc check verifies. The figure this sentence
+carried until #4062, *624 of 765 (82%)*, was the wave-2 table's population, and it
+did not agree with that table either — its own rows give 386 + 239 = 625.
+Nothing here is an oracle bug: the
 `oracle-invalid` classification already carries those and is a pass, not a ratchet
 entry.
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -902,7 +902,7 @@ Svelte structure, oxc for embedded JS, and PostCSS for embedded CSS) and require
 embedded CSS by default, so the ratchet intentionally includes CSS-engine parity
 as well as Svelte-structure parity. The ratchet may only shrink.
 
-**Current baseline: `fmt-known-failures.json`, 550 entries.** The 789-entry
+**Current baseline: `fmt-known-failures.json`, 549 entries.** The 789-entry
 split this paragraph used to give (22 pre-enrolment + 766 expanded population + 1
 pattern-corpus repro) no longer holds: 239 entries left the ratchet in the
 2026-09-01 re-baseline, and the CI report the baseline is derived from carries a
@@ -927,17 +927,24 @@ An id that carries two clusters' divergences at once is filed under its dominant
 one (see *Multiple clusters per id*), so the per-cluster counts below remain a
 partition of the ratchet rather than an over-count:
 
-Partition of `fmt-known-failures.json` by cluster: `258 + 214 + 15 + 47 + 14 + 1 + 1`
+Partition of `fmt-known-failures.json` by cluster: `258 + 214 + 15 + 47 + 13 + 1 + 1`
 
-**The partition is now the mechanical rule applied to all 550 entries**, where it
+**The partition is now the mechanical rule applied to all 549 entries**, where it
 used to be the hand-diagnosed Clusters 1-12 (23 entries) plus the mechanical
 Clusters 20-27 over the rest. The hand-diagnosed sections below are kept — their
 diagnoses did not stop being true — but their ids are now counted inside the
 mechanical buckets, because the CI report names an entry's first differing line
 and not the cluster a human filed it under. The addends are, in order:
 20 breaks-later 258, 21 breaks-earlier 214, 22 intra-line-ws 15,
-23 indent-only 47, 24 other 14, 25 extra-line 1, 26 missing-line 1;
+23 indent-only 47, 24 other 13, 25 extra-line 1, 26 missing-line 1;
 27 quote-style is now empty.
+
+`svelte-inspect-value/packages/svelte/src/lib/CustomLine.svelte` left
+**24 — other** in #4062: its only differing line was
+`type={(type) as unknown as ValueType}` against the oracle's `type={type as …}`,
+which no rule above matches (not a prefix, not whitespace- or quote-equal). It is
+the one entry that fix moves, out of 34,686 real components whose output was
+diffed across the change.
 
 ### Wave-2 enrolment (#3130) — Clusters 20-27
 

--- a/compatibility/fmt-known-failures.json
+++ b/compatibility/fmt-known-failures.json
@@ -475,7 +475,6 @@
 	"svelte-gantt/packages/svelte-gantt/src/modules/dependencies/Dependency.svelte",
 	"svelte-inspect-value/apps/docs/src/components/theming/DefineTheme.svelte",
 	"svelte-inspect-value/packages/svelte/src/doclib/examples/BasicEditable.svelte",
-	"svelte-inspect-value/packages/svelte/src/lib/CustomLine.svelte",
 	"svelte-inspect-value/packages/svelte/src/lib/components/Key.svelte",
 	"svelte-inspect-value/packages/svelte/src/lib/components/Preview.svelte",
 	"svelte-inspect-value/packages/svelte/src/lib/components/StringView.svelte",

--- a/crates/rsvelte_formatter/src/expression/format_core.rs
+++ b/crates/rsvelte_formatter/src/expression/format_core.rs
@@ -373,25 +373,19 @@ pub(super) fn format_expr_core(
                 )
         );
 
-    // Detect an object literal that is the HEAD of a larger expression — the
-    // object of a member access or callee of a call (`{ … }[key]`, `{ … }.foo`,
-    // `{ … }()`). OXC parenthesizes the leading object because at statement
-    // position a bare `{` would start a block, so it emits `({ … })[key]`. In a
-    // mustache/attribute value the expression is in expression position, so
-    // prettier-plugin-svelte keeps no parens (`{ … }[key]`). `strip_outer_parens`
-    // can't help here because the formatted string ends with `]`/`.`/`)` of the
-    // postfix, not the wrapper `)`. Flag it so the leading pair is stripped below.
-    let leading_object_head = !use_const_wrapper
+    // Detect a head OXC parenthesizes only because the `(expr);` wrapper puts it
+    // at statement position — a leading object literal (`{ … }[key]`, `{ … }.foo`,
+    // `{ … } as T`), where a bare `{` would start a block, or a declaration-name
+    // identifier under an `as`/`satisfies` chain (`(type) as T`), where the
+    // statement would read as `type X = …`. In a mustache/attribute value the
+    // expression is in expression position, so prettier-plugin-svelte keeps no
+    // parens. `strip_outer_parens` can't help: the formatted string ends with the
+    // postfix's `]`/`.`/`)` or the type annotation, not the wrapper `)`.
+    let statement_position_head = !use_const_wrapper
         && matches!(
             parser_ret.program.body.first(),
             Some(oxc_ast::ast::Statement::ExpressionStatement(stmt))
-                if expr_has_object_head(&stmt.expression)
-        );
-    let object_type_assertion = !use_const_wrapper
-        && matches!(
-            parser_ret.program.body.first(),
-            Some(oxc_ast::ast::Statement::ExpressionStatement(stmt))
-                if expr_is_object_type_assertion(&stmt.expression)
+                if expr_head_parenthesized_at_statement_position(&stmt.expression)
         );
 
     let mut js = options.js.clone();
@@ -481,7 +475,7 @@ pub(super) fn format_expr_core(
                 inner = stripped;
             }
             format!("({inner})")
-        } else if leading_object_head || object_type_assertion {
+        } else if statement_position_head {
             // Strip the leading `( … )` pair OXC wrapped around the head object,
             // keeping the postfix or type operator verbatim.
             strip_leading_paren_pair(s).unwrap_or_else(|| s.to_string())
@@ -493,14 +487,60 @@ pub(super) fn format_expr_core(
     Ok(result)
 }
 
-fn expr_is_object_type_assertion(expr: &oxc_ast::ast::Expression) -> bool {
+/// Innermost operand of a non-empty `as`/`satisfies` chain, mirroring the chain
+/// OXC walks in `needs_parens_in_cast_chain` — a `!` in the chain stops it there
+/// too, so the two must skip the same node kinds or the strip below fires where
+/// OXC added no parens.
+fn as_satisfies_chain_operand<'a>(
+    expr: &'a oxc_ast::ast::Expression<'a>,
+) -> Option<&'a oxc_ast::ast::Expression<'a>> {
     use oxc_ast::ast::Expression as E;
 
-    match expr {
-        E::TSAsExpression(expr) => matches!(expr.expression, E::ObjectExpression(_)),
-        E::TSSatisfiesExpression(expr) => matches!(expr.expression, E::ObjectExpression(_)),
-        _ => false,
+    let mut cur = match expr {
+        E::TSAsExpression(_) | E::TSSatisfiesExpression(_) => expr,
+        _ => return None,
+    };
+    loop {
+        cur = match cur {
+            E::TSAsExpression(e) => &e.expression,
+            E::TSSatisfiesExpression(e) => &e.expression,
+            operand => return Some(operand),
+        };
     }
+}
+
+/// An identifier OXC parenthesizes as the operand of a statement-position
+/// `as`/`satisfies` chain, because the statement would otherwise read as the
+/// head of a declaration (`type X = …`, `using x = …`, `interface X {}`).
+fn is_declaration_head_name(name: &str) -> bool {
+    matches!(
+        name,
+        "await"
+            | "component"
+            | "hook"
+            | "interface"
+            | "let"
+            | "module"
+            | "type"
+            | "using"
+            | "yield"
+    )
+}
+
+/// Whether OXC wraps this expression's HEAD in parens purely because the
+/// `(expr);` wrapper puts it at statement position. A template expression sits
+/// in expression position, where prettier-plugin-svelte — the oxfmt oracle —
+/// keeps the head bare, so the leading pair is stripped below.
+fn expr_head_parenthesized_at_statement_position(expr: &oxc_ast::ast::Expression) -> bool {
+    use oxc_ast::ast::Expression as E;
+
+    if expr_has_object_head(expr) {
+        return true;
+    }
+    matches!(
+        as_satisfies_chain_operand(expr),
+        Some(E::Identifier(id)) if is_declaration_head_name(&id.name)
+    )
 }
 
 /// AST gate for [`reflow_flat_as_satisfies_unions`]: does the program contain
@@ -694,11 +734,13 @@ fn try_flatten_union_block(
     Some((flat_line, n))
 }
 
-/// Returns `true` when `expr` is a member access or call whose left-most leaf
-/// (walking down `.object` / `.callee`) is an object literal — i.e. the shape
-/// `{ … }[key]` / `{ … }.foo` / `{ … }()` that OXC parenthesizes at statement
-/// position but prettier keeps bare in expression position. A bare object (with
-/// no postfix) returns `false`: that case is handled by `strip_outer_parens`.
+/// Returns `true` when `expr` is a postfix wrapper — a member access, a call, or
+/// an `as`/`satisfies`/`!` type operator — whose left-most leaf (walking down
+/// `.object` / `.callee` / `.expression`) is an object literal: the shapes
+/// `{ … }[key]` / `{ … }.foo` / `{ … }()` / `{ … } as T` / `{ … }!` that OXC
+/// parenthesizes at statement position but prettier keeps bare in expression
+/// position. A bare object (with no postfix) returns `false`: that case is
+/// handled by `strip_outer_parens`.
 fn expr_has_object_head(expr: &oxc_ast::ast::Expression) -> bool {
     use oxc_ast::ast::{ChainElement, Expression as E};
     // The top node must be a postfix wrapper, not a bare object.
@@ -708,7 +750,10 @@ fn expr_has_object_head(expr: &oxc_ast::ast::Expression) -> bool {
         | E::PrivateFieldExpression(_)
         | E::CallExpression(_)
         | E::TaggedTemplateExpression(_)
-        | E::ChainExpression(_) => expr,
+        | E::ChainExpression(_)
+        | E::TSAsExpression(_)
+        | E::TSSatisfiesExpression(_)
+        | E::TSNonNullExpression(_) => expr,
         _ => return false,
     };
     loop {
@@ -719,6 +764,9 @@ fn expr_has_object_head(expr: &oxc_ast::ast::Expression) -> bool {
             E::PrivateFieldExpression(m) => &m.object,
             E::CallExpression(c) => &c.callee,
             E::TaggedTemplateExpression(t) => &t.tag,
+            E::TSAsExpression(e) => &e.expression,
+            E::TSSatisfiesExpression(e) => &e.expression,
+            E::TSNonNullExpression(e) => &e.expression,
             E::ChainExpression(ch) => match &ch.expression {
                 ChainElement::CallExpression(c) => &c.callee,
                 ChainElement::ComputedMemberExpression(m) => &m.object,

--- a/crates/rsvelte_formatter/tests/markup_cast_head_parens.rs
+++ b/crates/rsvelte_formatter/tests/markup_cast_head_parens.rs
@@ -1,0 +1,1242 @@
+//! #4062 — a markup expression is formatted through a `(expr);` wrapper, so
+//! OXC parenthesizes any head it would have to disambiguate at STATEMENT
+//! position. A template expression sits in expression position, where
+//! prettier-plugin-svelte (the oxfmt `svelte: true` oracle) keeps the head bare.
+//!
+//! Every expected value below is the oxfmt oracle's own output for that cell,
+//! not a hand-written guess. Two families, crossed with five markup host slots:
+//!
+//!   A  head identifier NAME x expression shape.  The reported symptom was
+//!      `{type as X}` -> `{(type) as X}`, but the axis is the NAME, not
+//!      "identifier": `foo as X` was already correct. OXC parenthesizes only
+//!      `await` / `component` / `hook` / `interface` / `let` / `module` /
+//!      `type` / `using` / `yield`, and only as the operand of an
+//!      `as`/`satisfies` chain (a `!` in the chain stops it).
+//!   B  operand KIND x type operator.  Covers the object-literal head reached
+//!      through `as`/`satisfies`/`!` (`{ a: 1 }!`, `{ a: 1 }.a as T`).
+//!
+//! Both families carry cells that were ALREADY correct before the fix (neutral
+//! names, `!`-broken chains, parenthesized subexpressions), so a regression that
+//! strips a paren that is genuinely load-bearing fails here too.
+//!
+//! Two cells the oracle accepts are absent: `accessor satisfies T` and
+//! `declare satisfies T`, which rsvelte rejects before reaching this decision —
+//! a separate defect, unmoved by this fix.
+
+use rsvelte_formatter::{FormatOptions, format};
+
+/// (input markup, expected markup) for one expression, per host slot. A quoted
+/// single-interpolation attribute value normalizes to the unquoted form, so its
+/// two templates differ; every other slot round-trips its own shape.
+const HOSTS: &[(&str, &str)] = &[
+    (
+        "<button title={E}>x</button>",
+        "<button title={E}>x</button>",
+    ),
+    ("<p>{E}</p>", "<p>{E}</p>"),
+    ("{#if E}<p>y</p>{/if}", "{#if E}<p>y</p>{/if}"),
+    (
+        "<button title=\"{E}\">x</button>",
+        "<button title={E}>x</button>",
+    ),
+    ("<button {...E}>x</button>", "<button {...E}>x</button>"),
+];
+
+fn check(family: &str, axis_a: &str, axis_b: &str, expr: &str, expected_expr: &str) -> Vec<String> {
+    let mut failures = Vec::new();
+    for (input_tpl, output_tpl) in HOSTS {
+        let markup = input_tpl.replace('E', expr);
+        let want_markup = output_tpl.replace('E', expected_expr);
+        let src = format!("<script lang=\"ts\"></script>\n\n{markup}\n");
+        let want = format!("<script lang=\"ts\"></script>\n\n{want_markup}\n");
+        match format(&src, &FormatOptions::default()) {
+            Ok(got) => {
+                if got != want {
+                    failures.push(format!(
+                        "{family}/{axis_a}/{axis_b} in {input_tpl}\n  expected: {want:?}\n  actual:   {got:?}"
+                    ));
+                    continue;
+                }
+                // The formatter must be a fixed point on its own output.
+                match format(&got, &FormatOptions::default()) {
+                    Ok(again) if again == got => {}
+                    Ok(again) => failures.push(format!(
+                        "{family}/{axis_a}/{axis_b} in {input_tpl} is not idempotent\n  once:  {got:?}\n  twice: {again:?}"
+                    )),
+                    Err(e) => failures.push(format!(
+                        "{family}/{axis_a}/{axis_b} in {input_tpl} failed to re-format: {e:?}"
+                    )),
+                }
+            }
+            Err(e) => failures.push(format!(
+                "{family}/{axis_a}/{axis_b} in {input_tpl} failed to format: {e:?}"
+            )),
+        }
+    }
+    failures
+}
+
+fn report(family: &str, cells: &[(&str, &str, &str, &str)]) {
+    let mut failures = Vec::new();
+    for (axis_a, axis_b, expr, expected) in cells {
+        failures.extend(check(family, axis_a, axis_b, expr, expected));
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} cells diverge from the oxfmt oracle:\n{}",
+        failures.len(),
+        cells.len() * HOSTS.len(),
+        failures.join("\n")
+    );
+}
+
+/// The exact reproduction from the issue, kept verbatim so the report stays
+/// searchable: the attribute name and the identifier are both `type`.
+#[test]
+fn issue_4062_repro() {
+    let src = "<script lang=\"ts\">\n\tlet { type }: { type: 'a' | 'b' } = $props();\n</script>\n\n<button type={type as 'a' | 'b'}>x</button>\n";
+    let out = format(src, &FormatOptions::default()).expect("format ok");
+    assert!(
+        out.contains("<button type={type as \"a\" | \"b\"}>x</button>"),
+        "operand must not be parenthesized:\n{out}"
+    );
+}
+
+/// Family A: head identifier NAME x expression shape.
+#[test]
+fn declaration_name_head_matches_oracle() {
+    report("A", A_CELLS);
+}
+
+/// Family B: operand KIND x type operator.
+#[test]
+fn type_operator_operand_matches_oracle() {
+    report("B", B_CELLS);
+}
+
+/// name, shape, source expression, oracle-formatted expression.
+const A_CELLS: &[(&str, &str, &str, &str)] = &[
+    ("type", "bare", "type", "type"),
+    ("type", "as", "type as string", "type as string"),
+    (
+        "type",
+        "as_union",
+        "type as 'a' | 'b'",
+        "type as \"a\" | \"b\"",
+    ),
+    (
+        "type",
+        "as_as",
+        "type as any as string",
+        "type as any as string",
+    ),
+    (
+        "type",
+        "satisfies",
+        "type satisfies string",
+        "type satisfies string",
+    ),
+    (
+        "type",
+        "as_satisfies",
+        "type as any satisfies string",
+        "type as any satisfies string",
+    ),
+    ("type", "src_paren_as", "(type) as string", "type as string"),
+    ("type", "nonnull", "type!", "type!"),
+    ("type", "nonnull_as", "type! as string", "type! as string"),
+    (
+        "type",
+        "as_nonnull",
+        "(type as string)!",
+        "(type as string)!",
+    ),
+    ("type", "member_as", "type.p as string", "type.p as string"),
+    ("type", "as_member", "(type as any).p", "(type as any).p"),
+    (
+        "type",
+        "as_in_call",
+        "f(type as string)",
+        "f(type as string)",
+    ),
+    (
+        "type",
+        "as_in_array",
+        "[type as string]",
+        "[type as string]",
+    ),
+    (
+        "type",
+        "as_in_cond",
+        "type as any ? 1 : 2",
+        "(type as any) ? 1 : 2",
+    ),
+    ("module", "bare", "module", "module"),
+    ("module", "as", "module as string", "module as string"),
+    (
+        "module",
+        "as_union",
+        "module as 'a' | 'b'",
+        "module as \"a\" | \"b\"",
+    ),
+    (
+        "module",
+        "as_as",
+        "module as any as string",
+        "module as any as string",
+    ),
+    (
+        "module",
+        "satisfies",
+        "module satisfies string",
+        "module satisfies string",
+    ),
+    (
+        "module",
+        "as_satisfies",
+        "module as any satisfies string",
+        "module as any satisfies string",
+    ),
+    (
+        "module",
+        "src_paren_as",
+        "(module) as string",
+        "module as string",
+    ),
+    ("module", "nonnull", "module!", "module!"),
+    (
+        "module",
+        "nonnull_as",
+        "module! as string",
+        "module! as string",
+    ),
+    (
+        "module",
+        "as_nonnull",
+        "(module as string)!",
+        "(module as string)!",
+    ),
+    (
+        "module",
+        "member_as",
+        "module.p as string",
+        "module.p as string",
+    ),
+    (
+        "module",
+        "as_member",
+        "(module as any).p",
+        "(module as any).p",
+    ),
+    (
+        "module",
+        "as_in_call",
+        "f(module as string)",
+        "f(module as string)",
+    ),
+    (
+        "module",
+        "as_in_array",
+        "[module as string]",
+        "[module as string]",
+    ),
+    (
+        "module",
+        "as_in_cond",
+        "module as any ? 1 : 2",
+        "(module as any) ? 1 : 2",
+    ),
+    ("using", "bare", "using", "using"),
+    ("using", "as", "using as string", "using as string"),
+    (
+        "using",
+        "as_union",
+        "using as 'a' | 'b'",
+        "using as \"a\" | \"b\"",
+    ),
+    (
+        "using",
+        "as_as",
+        "using as any as string",
+        "using as any as string",
+    ),
+    (
+        "using",
+        "satisfies",
+        "using satisfies string",
+        "using satisfies string",
+    ),
+    (
+        "using",
+        "as_satisfies",
+        "using as any satisfies string",
+        "using as any satisfies string",
+    ),
+    (
+        "using",
+        "src_paren_as",
+        "(using) as string",
+        "using as string",
+    ),
+    ("using", "nonnull", "using!", "using!"),
+    (
+        "using",
+        "nonnull_as",
+        "using! as string",
+        "using! as string",
+    ),
+    (
+        "using",
+        "as_nonnull",
+        "(using as string)!",
+        "(using as string)!",
+    ),
+    (
+        "using",
+        "member_as",
+        "using.p as string",
+        "using.p as string",
+    ),
+    ("using", "as_member", "(using as any).p", "(using as any).p"),
+    (
+        "using",
+        "as_in_call",
+        "f(using as string)",
+        "f(using as string)",
+    ),
+    (
+        "using",
+        "as_in_array",
+        "[using as string]",
+        "[using as string]",
+    ),
+    (
+        "using",
+        "as_in_cond",
+        "using as any ? 1 : 2",
+        "(using as any) ? 1 : 2",
+    ),
+    ("component", "bare", "component", "component"),
+    (
+        "component",
+        "as",
+        "component as string",
+        "component as string",
+    ),
+    (
+        "component",
+        "as_union",
+        "component as 'a' | 'b'",
+        "component as \"a\" | \"b\"",
+    ),
+    (
+        "component",
+        "as_as",
+        "component as any as string",
+        "component as any as string",
+    ),
+    (
+        "component",
+        "satisfies",
+        "component satisfies string",
+        "component satisfies string",
+    ),
+    (
+        "component",
+        "as_satisfies",
+        "component as any satisfies string",
+        "component as any satisfies string",
+    ),
+    (
+        "component",
+        "src_paren_as",
+        "(component) as string",
+        "component as string",
+    ),
+    ("component", "nonnull", "component!", "component!"),
+    (
+        "component",
+        "nonnull_as",
+        "component! as string",
+        "component! as string",
+    ),
+    (
+        "component",
+        "as_nonnull",
+        "(component as string)!",
+        "(component as string)!",
+    ),
+    (
+        "component",
+        "member_as",
+        "component.p as string",
+        "component.p as string",
+    ),
+    (
+        "component",
+        "as_member",
+        "(component as any).p",
+        "(component as any).p",
+    ),
+    (
+        "component",
+        "as_in_call",
+        "f(component as string)",
+        "f(component as string)",
+    ),
+    (
+        "component",
+        "as_in_array",
+        "[component as string]",
+        "[component as string]",
+    ),
+    (
+        "component",
+        "as_in_cond",
+        "component as any ? 1 : 2",
+        "(component as any) ? 1 : 2",
+    ),
+    ("hook", "bare", "hook", "hook"),
+    ("hook", "as", "hook as string", "hook as string"),
+    (
+        "hook",
+        "as_union",
+        "hook as 'a' | 'b'",
+        "hook as \"a\" | \"b\"",
+    ),
+    (
+        "hook",
+        "as_as",
+        "hook as any as string",
+        "hook as any as string",
+    ),
+    (
+        "hook",
+        "satisfies",
+        "hook satisfies string",
+        "hook satisfies string",
+    ),
+    (
+        "hook",
+        "as_satisfies",
+        "hook as any satisfies string",
+        "hook as any satisfies string",
+    ),
+    ("hook", "src_paren_as", "(hook) as string", "hook as string"),
+    ("hook", "nonnull", "hook!", "hook!"),
+    ("hook", "nonnull_as", "hook! as string", "hook! as string"),
+    (
+        "hook",
+        "as_nonnull",
+        "(hook as string)!",
+        "(hook as string)!",
+    ),
+    ("hook", "member_as", "hook.p as string", "hook.p as string"),
+    ("hook", "as_member", "(hook as any).p", "(hook as any).p"),
+    (
+        "hook",
+        "as_in_call",
+        "f(hook as string)",
+        "f(hook as string)",
+    ),
+    (
+        "hook",
+        "as_in_array",
+        "[hook as string]",
+        "[hook as string]",
+    ),
+    (
+        "hook",
+        "as_in_cond",
+        "hook as any ? 1 : 2",
+        "(hook as any) ? 1 : 2",
+    ),
+    ("foo", "bare", "foo", "foo"),
+    ("foo", "as", "foo as string", "foo as string"),
+    (
+        "foo",
+        "as_union",
+        "foo as 'a' | 'b'",
+        "foo as \"a\" | \"b\"",
+    ),
+    (
+        "foo",
+        "as_as",
+        "foo as any as string",
+        "foo as any as string",
+    ),
+    (
+        "foo",
+        "satisfies",
+        "foo satisfies string",
+        "foo satisfies string",
+    ),
+    (
+        "foo",
+        "as_satisfies",
+        "foo as any satisfies string",
+        "foo as any satisfies string",
+    ),
+    ("foo", "src_paren_as", "(foo) as string", "foo as string"),
+    ("foo", "nonnull", "foo!", "foo!"),
+    ("foo", "nonnull_as", "foo! as string", "foo! as string"),
+    ("foo", "as_nonnull", "(foo as string)!", "(foo as string)!"),
+    ("foo", "member_as", "foo.p as string", "foo.p as string"),
+    ("foo", "as_member", "(foo as any).p", "(foo as any).p"),
+    ("foo", "as_in_call", "f(foo as string)", "f(foo as string)"),
+    ("foo", "as_in_array", "[foo as string]", "[foo as string]"),
+    (
+        "foo",
+        "as_in_cond",
+        "foo as any ? 1 : 2",
+        "(foo as any) ? 1 : 2",
+    ),
+    ("namespace", "bare", "namespace", "namespace"),
+    (
+        "namespace",
+        "as",
+        "namespace as string",
+        "namespace as string",
+    ),
+    (
+        "namespace",
+        "as_union",
+        "namespace as 'a' | 'b'",
+        "namespace as \"a\" | \"b\"",
+    ),
+    (
+        "namespace",
+        "as_as",
+        "namespace as any as string",
+        "namespace as any as string",
+    ),
+    (
+        "namespace",
+        "satisfies",
+        "namespace satisfies string",
+        "namespace satisfies string",
+    ),
+    (
+        "namespace",
+        "as_satisfies",
+        "namespace as any satisfies string",
+        "namespace as any satisfies string",
+    ),
+    (
+        "namespace",
+        "src_paren_as",
+        "(namespace) as string",
+        "namespace as string",
+    ),
+    ("namespace", "nonnull", "namespace!", "namespace!"),
+    (
+        "namespace",
+        "nonnull_as",
+        "namespace! as string",
+        "namespace! as string",
+    ),
+    (
+        "namespace",
+        "as_nonnull",
+        "(namespace as string)!",
+        "(namespace as string)!",
+    ),
+    (
+        "namespace",
+        "member_as",
+        "namespace.p as string",
+        "namespace.p as string",
+    ),
+    (
+        "namespace",
+        "as_member",
+        "(namespace as any).p",
+        "(namespace as any).p",
+    ),
+    (
+        "namespace",
+        "as_in_call",
+        "f(namespace as string)",
+        "f(namespace as string)",
+    ),
+    (
+        "namespace",
+        "as_in_array",
+        "[namespace as string]",
+        "[namespace as string]",
+    ),
+    (
+        "namespace",
+        "as_in_cond",
+        "namespace as any ? 1 : 2",
+        "(namespace as any) ? 1 : 2",
+    ),
+    ("satisfies", "bare", "satisfies", "satisfies"),
+    (
+        "satisfies",
+        "as",
+        "satisfies as string",
+        "satisfies as string",
+    ),
+    (
+        "satisfies",
+        "as_union",
+        "satisfies as 'a' | 'b'",
+        "satisfies as \"a\" | \"b\"",
+    ),
+    (
+        "satisfies",
+        "as_as",
+        "satisfies as any as string",
+        "satisfies as any as string",
+    ),
+    (
+        "satisfies",
+        "satisfies",
+        "satisfies satisfies string",
+        "satisfies satisfies string",
+    ),
+    (
+        "satisfies",
+        "as_satisfies",
+        "satisfies as any satisfies string",
+        "satisfies as any satisfies string",
+    ),
+    (
+        "satisfies",
+        "src_paren_as",
+        "(satisfies) as string",
+        "satisfies as string",
+    ),
+    ("satisfies", "nonnull", "satisfies!", "satisfies!"),
+    (
+        "satisfies",
+        "nonnull_as",
+        "satisfies! as string",
+        "satisfies! as string",
+    ),
+    (
+        "satisfies",
+        "as_nonnull",
+        "(satisfies as string)!",
+        "(satisfies as string)!",
+    ),
+    (
+        "satisfies",
+        "member_as",
+        "satisfies.p as string",
+        "satisfies.p as string",
+    ),
+    (
+        "satisfies",
+        "as_member",
+        "(satisfies as any).p",
+        "(satisfies as any).p",
+    ),
+    (
+        "satisfies",
+        "as_in_call",
+        "f(satisfies as string)",
+        "f(satisfies as string)",
+    ),
+    (
+        "satisfies",
+        "as_in_array",
+        "[satisfies as string]",
+        "[satisfies as string]",
+    ),
+    (
+        "satisfies",
+        "as_in_cond",
+        "satisfies as any ? 1 : 2",
+        "(satisfies as any) ? 1 : 2",
+    ),
+    ("of", "bare", "of", "of"),
+    ("of", "as", "of as string", "of as string"),
+    ("of", "as_union", "of as 'a' | 'b'", "of as \"a\" | \"b\""),
+    ("of", "as_as", "of as any as string", "of as any as string"),
+    (
+        "of",
+        "satisfies",
+        "of satisfies string",
+        "of satisfies string",
+    ),
+    (
+        "of",
+        "as_satisfies",
+        "of as any satisfies string",
+        "of as any satisfies string",
+    ),
+    ("of", "src_paren_as", "(of) as string", "of as string"),
+    ("of", "nonnull", "of!", "of!"),
+    ("of", "nonnull_as", "of! as string", "of! as string"),
+    ("of", "as_nonnull", "(of as string)!", "(of as string)!"),
+    ("of", "member_as", "of.p as string", "of.p as string"),
+    ("of", "as_member", "(of as any).p", "(of as any).p"),
+    ("of", "as_in_call", "f(of as string)", "f(of as string)"),
+    ("of", "as_in_array", "[of as string]", "[of as string]"),
+    (
+        "of",
+        "as_in_cond",
+        "of as any ? 1 : 2",
+        "(of as any) ? 1 : 2",
+    ),
+    ("async", "bare", "async", "async"),
+    (
+        "async",
+        "src_paren_as",
+        "(async) as string",
+        "async as string",
+    ),
+    ("async", "nonnull", "async!", "async!"),
+    (
+        "async",
+        "nonnull_as",
+        "async! as string",
+        "async! as string",
+    ),
+    (
+        "async",
+        "member_as",
+        "async.p as string",
+        "async.p as string",
+    ),
+    ("accessor", "bare", "accessor", "accessor"),
+    ("accessor", "as", "accessor as string", "accessor as string"),
+    (
+        "accessor",
+        "as_union",
+        "accessor as 'a' | 'b'",
+        "accessor as \"a\" | \"b\"",
+    ),
+    (
+        "accessor",
+        "as_as",
+        "accessor as any as string",
+        "accessor as any as string",
+    ),
+    (
+        "accessor",
+        "as_satisfies",
+        "accessor as any satisfies string",
+        "accessor as any satisfies string",
+    ),
+    (
+        "accessor",
+        "src_paren_as",
+        "(accessor) as string",
+        "accessor as string",
+    ),
+    ("accessor", "nonnull", "accessor!", "accessor!"),
+    (
+        "accessor",
+        "nonnull_as",
+        "accessor! as string",
+        "accessor! as string",
+    ),
+    (
+        "accessor",
+        "as_nonnull",
+        "(accessor as string)!",
+        "(accessor as string)!",
+    ),
+    (
+        "accessor",
+        "member_as",
+        "accessor.p as string",
+        "accessor.p as string",
+    ),
+    (
+        "accessor",
+        "as_member",
+        "(accessor as any).p",
+        "(accessor as any).p",
+    ),
+    (
+        "accessor",
+        "as_in_call",
+        "f(accessor as string)",
+        "f(accessor as string)",
+    ),
+    (
+        "accessor",
+        "as_in_array",
+        "[accessor as string]",
+        "[accessor as string]",
+    ),
+    (
+        "accessor",
+        "as_in_cond",
+        "accessor as any ? 1 : 2",
+        "(accessor as any) ? 1 : 2",
+    ),
+    ("global", "bare", "global", "global"),
+    ("global", "as", "global as string", "global as string"),
+    (
+        "global",
+        "as_union",
+        "global as 'a' | 'b'",
+        "global as \"a\" | \"b\"",
+    ),
+    (
+        "global",
+        "as_as",
+        "global as any as string",
+        "global as any as string",
+    ),
+    (
+        "global",
+        "satisfies",
+        "global satisfies string",
+        "global satisfies string",
+    ),
+    (
+        "global",
+        "as_satisfies",
+        "global as any satisfies string",
+        "global as any satisfies string",
+    ),
+    (
+        "global",
+        "src_paren_as",
+        "(global) as string",
+        "global as string",
+    ),
+    ("global", "nonnull", "global!", "global!"),
+    (
+        "global",
+        "nonnull_as",
+        "global! as string",
+        "global! as string",
+    ),
+    (
+        "global",
+        "as_nonnull",
+        "(global as string)!",
+        "(global as string)!",
+    ),
+    (
+        "global",
+        "member_as",
+        "global.p as string",
+        "global.p as string",
+    ),
+    (
+        "global",
+        "as_member",
+        "(global as any).p",
+        "(global as any).p",
+    ),
+    (
+        "global",
+        "as_in_call",
+        "f(global as string)",
+        "f(global as string)",
+    ),
+    (
+        "global",
+        "as_in_array",
+        "[global as string]",
+        "[global as string]",
+    ),
+    (
+        "global",
+        "as_in_cond",
+        "global as any ? 1 : 2",
+        "(global as any) ? 1 : 2",
+    ),
+    ("declare", "bare", "declare", "declare"),
+    ("declare", "as", "declare as string", "declare as string"),
+    (
+        "declare",
+        "as_union",
+        "declare as 'a' | 'b'",
+        "declare as \"a\" | \"b\"",
+    ),
+    (
+        "declare",
+        "as_as",
+        "declare as any as string",
+        "declare as any as string",
+    ),
+    (
+        "declare",
+        "as_satisfies",
+        "declare as any satisfies string",
+        "declare as any satisfies string",
+    ),
+    (
+        "declare",
+        "src_paren_as",
+        "(declare) as string",
+        "declare as string",
+    ),
+    ("declare", "nonnull", "declare!", "declare!"),
+    (
+        "declare",
+        "nonnull_as",
+        "declare! as string",
+        "declare! as string",
+    ),
+    (
+        "declare",
+        "as_nonnull",
+        "(declare as string)!",
+        "(declare as string)!",
+    ),
+    (
+        "declare",
+        "member_as",
+        "declare.p as string",
+        "declare.p as string",
+    ),
+    (
+        "declare",
+        "as_member",
+        "(declare as any).p",
+        "(declare as any).p",
+    ),
+    (
+        "declare",
+        "as_in_call",
+        "f(declare as string)",
+        "f(declare as string)",
+    ),
+    (
+        "declare",
+        "as_in_array",
+        "[declare as string]",
+        "[declare as string]",
+    ),
+    (
+        "declare",
+        "as_in_cond",
+        "declare as any ? 1 : 2",
+        "(declare as any) ? 1 : 2",
+    ),
+];
+
+/// operand kind, type operator, source expression, oracle-formatted expression.
+const B_CELLS: &[(&str, &str, &str, &str)] = &[
+    ("ident", "none", "foo", "foo"),
+    ("ident", "as", "foo as string", "foo as string"),
+    (
+        "ident",
+        "satisfies",
+        "foo satisfies string",
+        "foo satisfies string",
+    ),
+    ("ident", "nonnull", "foo!", "foo!"),
+    (
+        "ident",
+        "as_as",
+        "foo as any as string",
+        "foo as any as string",
+    ),
+    ("ident", "nonnull_as", "foo! as string", "foo! as string"),
+    ("member", "none", "foo.p", "foo.p"),
+    ("member", "as", "foo.p as string", "foo.p as string"),
+    (
+        "member",
+        "satisfies",
+        "foo.p satisfies string",
+        "foo.p satisfies string",
+    ),
+    ("member", "nonnull", "foo.p!", "foo.p!"),
+    (
+        "member",
+        "as_as",
+        "foo.p as any as string",
+        "foo.p as any as string",
+    ),
+    (
+        "member",
+        "nonnull_as",
+        "foo.p! as string",
+        "foo.p! as string",
+    ),
+    ("computed", "none", "foo['p']", "foo[\"p\"]"),
+    (
+        "computed",
+        "as",
+        "foo['p'] as string",
+        "foo[\"p\"] as string",
+    ),
+    (
+        "computed",
+        "satisfies",
+        "foo['p'] satisfies string",
+        "foo[\"p\"] satisfies string",
+    ),
+    ("computed", "nonnull", "foo['p']!", "foo[\"p\"]!"),
+    (
+        "computed",
+        "as_as",
+        "foo['p'] as any as string",
+        "foo[\"p\"] as any as string",
+    ),
+    (
+        "computed",
+        "nonnull_as",
+        "foo['p']! as string",
+        "foo[\"p\"]! as string",
+    ),
+    ("call", "none", "f()", "f()"),
+    ("call", "as", "f() as string", "f() as string"),
+    (
+        "call",
+        "satisfies",
+        "f() satisfies string",
+        "f() satisfies string",
+    ),
+    ("call", "nonnull", "f()!", "f()!"),
+    (
+        "call",
+        "as_as",
+        "f() as any as string",
+        "f() as any as string",
+    ),
+    ("call", "nonnull_as", "f()! as string", "f()! as string"),
+    ("str", "none", "'a'", "\"a\""),
+    ("str", "as", "'a' as string", "\"a\" as string"),
+    (
+        "str",
+        "satisfies",
+        "'a' satisfies string",
+        "\"a\" satisfies string",
+    ),
+    ("str", "nonnull", "'a'!", "\"a\"!"),
+    (
+        "str",
+        "as_as",
+        "'a' as any as string",
+        "\"a\" as any as string",
+    ),
+    ("str", "nonnull_as", "'a'! as string", "\"a\"! as string"),
+    ("num", "none", "1", "1"),
+    ("num", "as", "1 as string", "1 as string"),
+    (
+        "num",
+        "satisfies",
+        "1 satisfies string",
+        "1 satisfies string",
+    ),
+    ("num", "nonnull", "1!", "1!"),
+    ("num", "as_as", "1 as any as string", "1 as any as string"),
+    ("num", "nonnull_as", "1! as string", "1! as string"),
+    ("object", "none", "{ a: 1 }", "{ a: 1 }"),
+    ("object", "as", "{ a: 1 } as string", "{ a: 1 } as string"),
+    (
+        "object",
+        "satisfies",
+        "{ a: 1 } satisfies string",
+        "{ a: 1 } satisfies string",
+    ),
+    ("object", "nonnull", "{ a: 1 }!", "{ a: 1 }!"),
+    (
+        "object",
+        "as_as",
+        "{ a: 1 } as any as string",
+        "{ a: 1 } as any as string",
+    ),
+    (
+        "object",
+        "nonnull_as",
+        "{ a: 1 }! as string",
+        "{ a: 1 }! as string",
+    ),
+    ("object_member", "none", "{ a: 1 }.a", "{ a: 1 }.a"),
+    (
+        "object_member",
+        "as",
+        "{ a: 1 }.a as string",
+        "{ a: 1 }.a as string",
+    ),
+    (
+        "object_member",
+        "satisfies",
+        "{ a: 1 }.a satisfies string",
+        "{ a: 1 }.a satisfies string",
+    ),
+    ("object_member", "nonnull", "{ a: 1 }.a!", "{ a: 1 }.a!"),
+    (
+        "object_member",
+        "as_as",
+        "{ a: 1 }.a as any as string",
+        "{ a: 1 }.a as any as string",
+    ),
+    (
+        "object_member",
+        "nonnull_as",
+        "{ a: 1 }.a! as string",
+        "{ a: 1 }.a! as string",
+    ),
+    ("array", "none", "[1, 2]", "[1, 2]"),
+    ("array", "as", "[1, 2] as string", "[1, 2] as string"),
+    (
+        "array",
+        "satisfies",
+        "[1, 2] satisfies string",
+        "[1, 2] satisfies string",
+    ),
+    ("array", "nonnull", "[1, 2]!", "[1, 2]!"),
+    (
+        "array",
+        "as_as",
+        "[1, 2] as any as string",
+        "[1, 2] as any as string",
+    ),
+    (
+        "array",
+        "nonnull_as",
+        "[1, 2]! as string",
+        "[1, 2]! as string",
+    ),
+    ("binary", "none", "a + b", "a + b"),
+    ("binary", "as", "a + b as string", "(a + b) as string"),
+    (
+        "binary",
+        "satisfies",
+        "a + b satisfies string",
+        "(a + b) satisfies string",
+    ),
+    ("binary", "nonnull", "a + b!", "a + b!"),
+    (
+        "binary",
+        "as_as",
+        "a + b as any as string",
+        "(a + b) as any as string",
+    ),
+    (
+        "binary",
+        "nonnull_as",
+        "a + b! as string",
+        "(a + b!) as string",
+    ),
+    ("ternary", "none", "a ? b : c", "a ? b : c"),
+    (
+        "ternary",
+        "as",
+        "a ? b : c as string",
+        "a ? b : (c as string)",
+    ),
+    (
+        "ternary",
+        "satisfies",
+        "a ? b : c satisfies string",
+        "a ? b : (c satisfies string)",
+    ),
+    ("ternary", "nonnull", "a ? b : c!", "a ? b : c!"),
+    (
+        "ternary",
+        "as_as",
+        "a ? b : c as any as string",
+        "a ? b : (c as any as string)",
+    ),
+    (
+        "ternary",
+        "nonnull_as",
+        "a ? b : c! as string",
+        "a ? b : (c! as string)",
+    ),
+    ("template", "none", "`x${a}y`", "`x${a}y`"),
+    ("template", "as", "`x${a}y` as string", "`x${a}y` as string"),
+    (
+        "template",
+        "satisfies",
+        "`x${a}y` satisfies string",
+        "`x${a}y` satisfies string",
+    ),
+    ("template", "nonnull", "`x${a}y`!", "`x${a}y`!"),
+    (
+        "template",
+        "as_as",
+        "`x${a}y` as any as string",
+        "`x${a}y` as any as string",
+    ),
+    (
+        "template",
+        "nonnull_as",
+        "`x${a}y`! as string",
+        "`x${a}y`! as string",
+    ),
+    ("unary", "none", "!a", "!a"),
+    ("unary", "as", "!a as string", "!a as string"),
+    (
+        "unary",
+        "satisfies",
+        "!a satisfies string",
+        "!a satisfies string",
+    ),
+    ("unary", "nonnull", "!a!", "!a!"),
+    (
+        "unary",
+        "as_as",
+        "!a as any as string",
+        "!a as any as string",
+    ),
+    ("unary", "nonnull_as", "!a! as string", "!a! as string"),
+    ("optchain", "none", "a?.p", "a?.p"),
+    ("optchain", "as", "a?.p as string", "a?.p as string"),
+    (
+        "optchain",
+        "satisfies",
+        "a?.p satisfies string",
+        "a?.p satisfies string",
+    ),
+    ("optchain", "nonnull", "a?.p!", "a?.p!"),
+    (
+        "optchain",
+        "as_as",
+        "a?.p as any as string",
+        "a?.p as any as string",
+    ),
+    (
+        "optchain",
+        "nonnull_as",
+        "a?.p! as string",
+        "a?.p! as string",
+    ),
+    ("newx", "none", "new Foo()", "new Foo()"),
+    ("newx", "as", "new Foo() as string", "new Foo() as string"),
+    (
+        "newx",
+        "satisfies",
+        "new Foo() satisfies string",
+        "new Foo() satisfies string",
+    ),
+    ("newx", "nonnull", "new Foo()!", "new Foo()!"),
+    (
+        "newx",
+        "as_as",
+        "new Foo() as any as string",
+        "new Foo() as any as string",
+    ),
+    (
+        "newx",
+        "nonnull_as",
+        "new Foo()! as string",
+        "new Foo()! as string",
+    ),
+    ("src_paren", "none", "(foo)", "foo"),
+    ("src_paren", "as", "(foo) as string", "foo as string"),
+    (
+        "src_paren",
+        "satisfies",
+        "(foo) satisfies string",
+        "foo satisfies string",
+    ),
+    ("src_paren", "nonnull", "(foo)!", "foo!"),
+    (
+        "src_paren",
+        "as_as",
+        "(foo) as any as string",
+        "foo as any as string",
+    ),
+    (
+        "src_paren",
+        "nonnull_as",
+        "(foo)! as string",
+        "foo! as string",
+    ),
+];


### PR DESCRIPTION
Fixes #4062.

## What the issue reported, and what is actually true

`{type as X}` formats to `{(type) as X}`. Two of the issue's three "Notes" turned out to be hypotheses rather than facts, and one of them is the root cause:

1. **"the identifier should be left as-is"** — but `{foo as string}` was already correct. The axis is the identifier's **name**, not "is it an identifier". `type` is one of a small set OXC treats specially.
2. **"the same `x as T` inside `<script>` is delegated to oxfmt and formatted correctly"** — the `<script>` output is not "correct because it is delegated". At statement position `(type) as string;` is what the oracle emits too, because a statement starting with `type` would read as a type-alias declaration. That distinction *is* the bug.

## Root cause

`format_expr_core` formats a markup expression by wrapping it as `(expr\n);` and handing it to `oxc_formatter` — i.e. at **ExpressionStatement** position. `oxc_formatter`'s `parentheses/expression.rs` parenthesizes an identifier named `await` / `component` / `hook` / `interface` / `let` / `module` / `type` / `using` / `yield` when it is the innermost operand of an `as`/`satisfies` chain whose parent is an `ExpressionStatement`, because the statement would otherwise read as the head of a declaration (`type X = …`, `using x = …`). A template expression sits in *expression* position, where prettier-plugin-svelte keeps the head bare.

That is the same class the file already handles for a leading object literal (`({ … })[key]` → `{ … }[key]`), and the fix joins them: one predicate, one strip.

The measured trigger set is `type` / `module` / `using` / `component` / `hook`. The other four names in OXC's list are unreachable here — `await` takes the existing const-wrapper path, and `let` / `interface` / `yield` are rejected as markup expressions by both compilers.

## The fix

One file, `crates/rsvelte_formatter/src/expression/format_core.rs`:

- `expr_has_object_head` now also descends `as` / `satisfies` / `!`, so an object literal reached through a type operator is caught (`{ a: 1 }!`, `{ a: 1 }.a as T` — both previously wrong).
- new `as_satisfies_chain_operand` + `is_declaration_head_name` detect the declaration-name head, mirroring OXC's own chain walk (a `!` in the chain stops it in OXC, so it stops here too).
- the two separate flags that fed the same `strip_leading_paren_pair` branch collapse into one `statement_position_head`.

## Grid, measured against the oxfmt oracle

Oracle: `node_modules/.bin/oxfmt` 0.64.0 with `scripts/fixtures/fmt-corpus.oxfmtrc.json` (`svelte: true`). 1455 cells over four axes:

| axis | values |
|---|---|
| A · head identifier name | 13 — the 5 that trigger, plus **8 controls** (`foo`, `namespace`, `satisfies`, `of`, `async`, `accessor`, `global`, `declare`) |
| A · expression shape | 15 — `n`, `n as T`, `n as 'a'\|'b'`, `n as any as T`, `n satisfies T`, `n as any satisfies T`, `(n) as T`, `n!`, `n! as T`, `(n as T)!`, `n.p as T`, `(n as any).p`, `f(n as T)`, `[n as T]`, `n as any ? 1 : 2` |
| B · operand kind | 16 — ident / member / computed / call / string / number / object / `{a:1}.a` / array / binary / ternary / arrow / template / unary / optional chain / `new` / `(foo)` |
| B · type operator | 6 — none, `as T`, `as 'a'\|'b'`, `satisfies T`, `!`, `as any as T`, `! as T` |
| host slot | 5 — attribute value, mustache, `{#if}` header, quoted attribute, spread |

**Positive control (measured, not asserted).** The fix was reverted, rebuilt in release, and the same 1455 cells were run through both binaries:

| | match | mismatch | oracle-reject | rsvelte-reject | non-idempotent |
|---|---|---|---|---|---|
| ablated | 1205 | **190** | 50 | 10 | 0 |
| fixed | 1395 | **0** | 50 | 10 | 0 |

190 cells mismatch → match, **0 cells in the other direction**. The 190 decompose exactly as 5 names × 6 `as`/`satisfies` shapes × 5 hosts (150) plus 8 object-head classes × 5 hosts (40).

The controls moved nothing: every cell for the 8 neutral names, and every `!`-broken / already-parenthesized / nested shape (`n!`, `n! as T`, `(n as T)!`, `n.p as T`, `(n as any).p`, `f(n as T)`, `[n as T]`, `n as any ? 1 : 2`), matched before **and** after — so no paren that is genuinely load-bearing is being stripped.

The same 190/0 split reproduces at the Rust test level: with the fix ablated, `declaration_name_head_matches_oracle` reports **150 of 915** cells diverging, `type_operator_operand_matches_oracle` reports **40 of 480**, and `issue_4062_repro` fails.

## Idempotency

Every cell's output is re-formatted and required to be a fixed point, in the test and in both arms of the CLI measurement. 0 non-idempotent cells in either arm.

## Hard gates (tolerance-free)

| gate | result |
|---|---|
| `crates/rsvelte_formatter/tests/svelte_dev_corpus.rs` | `svelte.dev@fa53d1446916: 1103/1103 pass, 0 fail, 0 unparseable` |
| `crates/rsvelte_fmt/tests/svelte_dev_markdown.rs` | `svelte.dev@fa53d1446916: 644/644 pass, 0 fail` |
| `cargo test --release -p rsvelte_formatter -p rsvelte_fmt` | all suites pass, 0 failures |
| `cargo fmt --all --check` | clean |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean, **whole workspace** |

## Blast radius on real code, and the `fmt-known-failures.json` count

Ran the ablated and fixed binaries over every corpus source and diffed their outputs — no oracle needed, so this measures exactly what the change moves:

| population | compared | output differs | OK↔error either direction |
|---|---|---|---|
| `.svelte` files under `submodules/` | 34,686 | **1** | 0 |
| ` ```svelte ` blocks in `submodules/**/*.md` | 5,636 | **0** | 0 |
| `compatibility/pattern-corpus/**/*.svelte` | 1,341 | **0** | 0 |

The single file is `svelte-inspect-value/packages/svelte/src/lib/CustomLine.svelte`:

```
- <OneLineView type={(type) as unknown as ValueType} {...props} />
+ <OneLineView type={type as unknown as ValueType} {...props} />
```

It is a **listed `compatibility/fmt-known-failures.json` entry**, and with the fix its whole-file output is byte-identical to the oxfmt oracle (verified with the gate's own invocation: `rsvelte-fmt . -c fmt-corpus.oxfmtrc.json --oxfmt-bin …` vs `oxfmt -c fmt-corpus.oxfmtrc.json`).

So **`fmt-known-failures.json` should shrink 550 → 549**, and the two-sided ratchet will fail until it is re-baselined. All 550 entries resolve to real files under `submodules/` (543) or `compatibility/pattern-corpus/` (7) — both fully covered by the sweep above — so this is the only entry that can move. **I have deliberately not touched the ratchet**; the re-baseline is the integrator's to make.

## Not fixed here (filed separately, each with both sides measured)

- #4083 — `rsvelte_core::parse` rejects `{accessor satisfies T}` / `{declare satisfies T}`; official accepts. Those two cells are excluded from the grid test with an in-file comment.
- #4084 — `rsvelte_core::parse` rejects `{<T>() => x}`; official accepts. Same entry point as #4083, different mechanism.
- #4085 — a `{@render}` tag glued to a preceding inline run is measured from column 0, so lines over `printWidth` are left unbroken. Byte-identical before and after this fix.
