### PR TITLE
ci(oxfmt): the auto-update job resolves a workspace whose submodule it never checked out

### DIFF
--- a/.github/workflows/auto-update-oxfmt.yml
+++ b/.github/workflows/auto-update-oxfmt.yml
@@ -53,6 +53,13 @@ jobs:
           submodules: false
           token: ${{ secrets.GH_PAT || github.token }}
 
+      # `crates/rsvelte_lint_types` is its own Cargo workspace and path-depends
+      # on this submodule, so the oxc-rev sync step's `cargo update
+      # --manifest-path crates/rsvelte_lint_types/Cargo.toml` cannot even load
+      # the manifest without it. Same step the `Lint-types lockfile` job runs.
+      - name: Checkout corsa-bind submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/corsa-bind
+
       - uses: ./.github/actions/setup-node-pnpm
 
       # Needed to regenerate Cargo.lock against the new oxc rev (see the oxc-rev


### PR DESCRIPTION
## What broke

`Auto-update oxfmt` has been **failing on `main`** (run 33497570014, `57f985c24`).
It is a P0 blocker for the compatibility-zero campaign, which requires every
`main` workflow to succeed.

```
error: failed to load manifest for dependency `corsa_client`

Caused by:
  failed to read `/home/runner/work/rsvelte/rsvelte/submodules/corsa-bind/src/core/corsa_client/Cargo.toml`

Caused by:
  No such file or directory (os error 2)
```

The job checks out with `submodules: false`, and its oxc-rev sync step runs

```sh
cargo update --manifest-path crates/rsvelte_lint_types/Cargo.toml "${lint_types_oxc_pkgs[@]}"
```

`crates/rsvelte_lint_types` is its own Cargo workspace and path-depends on
`submodules/corsa-bind`, so cargo cannot even load the manifest.

It only fires when the oxc rev actually moves (the whole block is inside
`if [ "${OLD_SHA}" != "${OXC_SHA}" ]`), which is why the four preceding runs
were green.

## The fix

The same shallow init `ci.yml`'s `Lint-types lockfile` job already carries
(`ci.yml:140-141`). `submodules/corsa-bind` is public, so it clones with no
credentials.

## Measurement

Reproduced locally rather than argued from the code. `cargo metadata --no-deps`
loads the same manifests the failing `cargo update` does, with no network:

| | exit | stderr |
|---|---|---|
| `submodules/corsa-bind` present | **0** | — |
| moved aside | **101** | `failed to load manifest for dependency \`corsa_client\`` … `No such file or directory` |

The directory was moved, not deleted, and restored; `git status --short` is
clean apart from the workflow file.

## What was not measured

Whether the job now completes end to end — that needs an oxfmt release newer
than the pinned one plus a moved oxc rev, which is exactly the condition that
was never exercised. Everything up to and including the failing command is
covered by the control above.

## Blast radius

Grepped `.github/workflows/` for every workflow that touches
`crates/rsvelte_lint_types`: three do, and the other two (`ci.yml`,
`type-aware-lint.yml`) already init the submodule. This was the only one
missing it. No other `cargo update --manifest-path` site exists in the tree.
