### PR TITLE
test(lsp): measure the projection round-trip at the positions the corpus gate requests

### DIFF
--- a/crates/rsvelte_language_server/src/tsgo_overlay.rs
+++ b/crates/rsvelte_language_server/src/tsgo_overlay.rs
@@ -2048,6 +2048,171 @@ mod tests {
         );
     }
 
+    // Measures, not asserts: how many of the positions the LSP corpus gate
+    // requests survive `map_source_position` -> `map_generated_position`
+    // unchanged. `forward-none` is the correct answer where a position has no TS
+    // projection (a `<style>` body, markup text), so an equality assertion here
+    // would pin correct behaviour; only `moved` is a defect class. Measured on
+    // submodules/melt-ui 2026-09-01: positions=12043 identity=9344 moved=1239
+    // forward_none=1460 reverse_none=0, all 43 files preprocess_status=Identity.
+    // `ROUNDTRIP_ROOT` selects another corpus repo; `ROUNDTRIP_OUT` writes one
+    // `<file>\t<line>:<col>\t<class>` row per position.
+    #[test]
+    #[ignore]
+    fn projection_roundtrip_identity_measure() {
+        let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let root = repo.join(
+            std::env::var("ROUNDTRIP_ROOT").unwrap_or_else(|_| "submodules/melt-ui".to_string()),
+        );
+        let mut files = Vec::new();
+        fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+            let Ok(entries) = fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if path.is_dir() {
+                    if name != "node_modules" && !name.starts_with('.') {
+                        walk(&path, out);
+                    }
+                } else if name.ends_with(".svelte") {
+                    out.push(path);
+                }
+            }
+        }
+        walk(&root, &mut files);
+        files.sort();
+        assert!(
+            !files.is_empty(),
+            "no .svelte files under {}",
+            root.display()
+        );
+
+        let mut overlay = TsgoOverlay::build(&root, None).unwrap();
+        let (mut positions, mut identity, mut forward_none, mut reverse_none, mut moved) =
+            (0usize, 0usize, 0usize, 0usize, 0usize);
+        let mut open_failed = 0usize;
+        let mut by_status: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+        let mut sample: Vec<String> = Vec::new();
+        let mut classes: Vec<String> = Vec::new();
+        for file in &files {
+            let text = fs::read_to_string(file).unwrap();
+            let rel = file.strip_prefix(&root).unwrap().display().to_string();
+            if overlay.open_or_update(file, &text, 0).is_err() {
+                open_failed += 1;
+                continue;
+            }
+            let shadow_path = overlay.shadow_path_for(file).unwrap();
+            let status = overlay
+                .entries
+                .get(&overlay.lookup_source_path(file))
+                .map(|entry| format!("{:?}/identity={}", entry.preprocess_status, entry.identity))
+                .unwrap_or_else(|| "missing".to_string());
+            *by_status.entry(status).or_default() += 1;
+            for (line, line_text) in text.split('\n').enumerate() {
+                for (column, position) in identifier_probe_positions(line_text) {
+                    let _ = column;
+                    positions += 1;
+                    let source = Position::new(line as u32, position);
+                    let Some(generated) = overlay.map_source_position(file, source) else {
+                        forward_none += 1;
+                        classes.push(format!(
+                            "{}\t{}:{}\tforward-none",
+                            rel, source.line, source.character
+                        ));
+                        continue;
+                    };
+                    let Some(back) = overlay.map_generated_position(&shadow_path, generated) else {
+                        reverse_none += 1;
+                        classes.push(format!(
+                            "{}\t{}:{}\treverse-none",
+                            rel, source.line, source.character
+                        ));
+                        continue;
+                    };
+                    if back == source {
+                        identity += 1;
+                        classes.push(format!(
+                            "{}\t{}:{}\tidentity",
+                            rel, source.line, source.character
+                        ));
+                    } else {
+                        classes.push(format!(
+                            "{}\t{}:{}\tmoved",
+                            rel, source.line, source.character
+                        ));
+                        moved += 1;
+                        if sample.len() < 20 {
+                            sample.push(format!(
+                                "{}  {}:{} -> gen {}:{} -> {}:{}",
+                                file.strip_prefix(&root).unwrap().display(),
+                                source.line,
+                                source.character,
+                                generated.line,
+                                generated.character,
+                                back.line,
+                                back.character
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        if let Ok(path) = std::env::var("ROUNDTRIP_OUT") {
+            fs::write(path, classes.join("\n") + "\n").unwrap();
+        }
+        println!("files={} open_failed={}", files.len(), open_failed);
+        println!(
+            "positions={positions} identity={identity} moved={moved} forward_none={forward_none} reverse_none={reverse_none}"
+        );
+        for (status, count) in &by_status {
+            println!("  entry status {status}: {count} files");
+        }
+        for line in &sample {
+            println!("  moved: {line}");
+        }
+    }
+
+    // Mirrors `identifierPositionIterator` in scripts/compat-lsp/suites.mjs: the
+    // gate requests the SECOND character of each identifier, never its start.
+    fn identifier_probe_positions(line: &str) -> Vec<(usize, u32)> {
+        let chars: Vec<char> = line.chars().collect();
+        let is_start = |c: char| c == '$' || c == '_' || c.is_alphabetic();
+        let is_continue = |c: char| c == '$' || c == '_' || c.is_alphanumeric();
+        let mut out = Vec::new();
+        let mut index = 0usize;
+        // UTF-16 column of each char index.
+        let mut utf16: Vec<u32> = Vec::with_capacity(chars.len() + 1);
+        let mut acc = 0u32;
+        for c in &chars {
+            utf16.push(acc);
+            acc += c.len_utf16() as u32;
+        }
+        utf16.push(acc);
+        while index < chars.len() {
+            if is_start(chars[index]) {
+                let start = index;
+                index += 1;
+                while index < chars.len() && is_continue(chars[index]) {
+                    index += 1;
+                }
+                let offset = if index - start > 1 { 1 } else { 0 };
+                out.push((start, utf16[start + offset]));
+            } else {
+                index += 1;
+            }
+        }
+        out
+    }
+
     #[test]
     fn build_is_diskless_and_discovers_project_components() {
         let workspace = TestWorkspace::new("build");


### PR DESCRIPTION
Adds one `#[ignore]`d measurement to `tsgo_overlay.rs`'s test module. No production code changes.

## Why

The LSP corpus gate folds every divergence into `compactCorpusObservation`'s digest, so the ratchet key cannot say **which** positions the `.svelte` ↔ `.svelte.tsx` mapping moves. This runs the projection round-trip — `map_source_position` → `map_generated_position` — over the positions the gate actually requests (`identifierPositionIterator` yields the **second** character of each identifier, never its start, which is precisely the class a token-start fallback mishandles) and prints the split.

## It measures, it does not assert

`forward-none` is the *correct* answer wherever a position has no TS projection — a `<style>` body, markup text — so an equality assertion here would pin correct behaviour. Only `moved` is a defect class. When `moved` reaches 0 this can become an assertion; the header comment says so.

The mechanism behind `moved` is in `map_generated_position`: when the `exact_map` segment lookup misses, the fallback returns `closest_source_token`'s token **start**, which loses the offset inside the token. That is why a hover range comes back zero-width at the line start (`71:29 → gen 77:0 → 71:1`).

## What it measured

`submodules/melt-ui`, 43 files, identical in debug and release:

```
positions=12043 identity=9344 moved=1239 forward_none=1460 reverse_none=0
all 43 files preprocess_status=Identity, identity=false
```

Joined against a full `--suites corpus --corpus-repos melt-ui` run (72,258/72,258 compared, 23,508 divergent requests, exit 0 so `transportTimeouts` = 0), this **falsifies the projection as the sole cause** of the gate's divergences: over the 9,344 positions that round-trip *exactly*, `textDocument/hover` still diverges at 1,425, `definition` at 1,408 and `completion` at 4,773.

It is one of six mechanisms behind the hover divergences, and the smallest but one — 148 of 2,876 open-phase hover divergences (5.1%). Two of the others are now filed: #4095 (CSS hover is a name-only stub, 1,109 / 38.6%) and #4097 (hover returns null on a `.svelte` module specifier and on a component tag name, 259). The largest, 42.1%, is tsgo's quickinfo text differing from tsc's, measured by asking both backends the same position on the same plain `.ts` file.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` (whole workspace, via the pre-commit hook): exit 0.
- `cargo fmt --all --check`: clean.
- `cargo test -p rsvelte_language_server --lib -- --ignored projection_roundtrip_identity_measure`: passes in debug and in release, with byte-identical output.
- The test is `#[ignore]`d, so no CI job's runtime changes.

## Reproducing the classification

The commit message records it: patch `record()` in `scripts/compat-lsp/verify.mjs` to append one JSONL row per corpus divergence — `{id, method, pos, phase, differences}` plus `JSON.stringify` of both responses — behind an env var, and join it against this test's `ROUNDTRIP_OUT` file on `<file>|<line>:<col>`. That patch is deliberately not committed; the gate should not write a 100 MB artifact on every run.
