### PR TITLE
ci(corpus): a ratchet entry is only observable while the gate is red

### DIFF
--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -334,8 +334,12 @@ jobs:
         if: failure()
         run: node scripts/compat-corpus/cluster.mjs > compatibility/cluster.txt || true
 
-      - name: Upload report on failure
-        if: failure()
+      # Uploaded on a PASSING run too: a ratchet entry is a divergence we ship,
+      # and the only per-entry record of what diverges lives here. Gating this on
+      # `failure()` means the accepted entries are observable only while the gate
+      # is red, which is exactly when nobody is attributing them.
+      - name: Upload report
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: corpus-report
@@ -405,8 +409,8 @@ jobs:
       - name: Verify formatter parity (ratchet, byte-identical)
         run: node scripts/compat-corpus/fmt-verify.mjs
 
-      - name: Upload fmt report on failure
-        if: failure()
+      - name: Upload fmt report
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: corpus-fmt-report


### PR DESCRIPTION
`corpus-report` と `corpus-fmt-report` は `if: failure()` で、**ゲートが赤いときにしかアップロードされません**。

ratchet に載っているエントリは「出荷している乖離」であり、P3（#4048）はその一件ずつに帰属先を要求します。ところが **その乖離が何であるかの記録はこの成果物にしかありません** — `report.json` の `failures` と `fmt-report.json` の `failures[].detail` が、受理済みエントリの first-differing-line を持つ唯一の場所です。ゲートが緑のあいだは生成されるのにアップロードされないので、**帰属作業をしようとした瞬間にデータが無い**。

いま実際に詰まりました: `fmt-known-failures.json` の 549 件を機構ごとに分類しようとして、直近 8 回の `main` の Corpus Compat run のどれにも `corpus-fmt-report` が無いことが分かりました（全部緑だったので）。

■ 変更

2 つの `upload-artifact` を `if: failure()` → `if: ${{ !cancelled() }}` に。

■ 何が増えるか（測定済みでない部分は書きません）

- `corpus-report`: `report.json` + `esrap-report.json` + `report-s2t.json` + `manifest.json` + `cluster.txt`。`manifest.json` が 34k 行のパス配列で最大です。`cluster.txt` は `Cluster failures` が `if: failure()` のままなので緑の run では生成されず、`if-no-files-found: ignore` が吸収します。
- `corpus-fmt-report`: `fmt-report.json` + `fmt/meta.json`。
- 保持は 14 日のまま。

`Cluster failures` を緑の run でも回すことは**していません**: `verify.mjs` は合格した run で `expected/` と `actual/` を削除するので、その時点で `cluster.mjs` が読む木はもう存在しません。緑の run で欲しいのは `report.json` のほうで、それは削除対象に入っていません（`artifacts.mjs` の `RECLAIMABLE` は `corpus:clean` が回収する集合であって、verify の自動削除は `OUTPUT_TREES` だけです）。

Refs #4048
