### PR TITLE
fix(css): a snippet handed to a component is scoped from that component

### DIFF
--- a/.changeset/snippet-prop-css-scope.md
+++ b/.changeset/snippet-prop-css-scope.md
@@ -1,0 +1,10 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Scope a `{#snippet}`'s body from the ancestors of every place the snippet is
+used, not only from its `{@render}` tags. Upstream's `analysis.snippet_renderers`
+holds a component alongside each render tag, so a snippet handed to a component
+as a prop still has that component's position as one of its sites; rsvelte
+collected only the render tags, so an element in such a snippet was scoped as if
+it had no ancestor and lost its scope class

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2847,11 +2847,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 43 entries)
+### Client (`known-failures.client.json`, 42 entries)
 
-Partition of `known-failures.client.json` by verdict: `42 + 1`
+Partition of `known-failures.client.json` by verdict: `41 + 1`
 
-- **42 — the generated JS differs** (`js` / `code-differs`).
+- **41 — the generated JS differs** (`js` / `code-differs`).
 - **1 — the generated CSS differs.**
 
 The error classes this section used to carry are gone: the run behind this
@@ -2912,11 +2912,11 @@ everywhere". Divergences this target keeps on purpose — because reproducing
 upstream's bytes would emit invalid JavaScript — are recorded in
 [`deliberate-divergences.md`](#deliberate-divergences), each pinned by a test.
 
-### Server (`known-failures.server.json`, 10 entries)
+### Server (`known-failures.server.json`, 9 entries)
 
-Partition of `known-failures.server.json` by verdict: `8 + 2`
+Partition of `known-failures.server.json` by verdict: `7 + 2`
 
-- **8 — the generated JS differs.**
+- **7 — the generated JS differs.**
 - **2 — a recorded deliberate divergence, not a burndown target.**
   `pattern/issues/dollar-function-parameter.svelte` and
   `threlte/packages/extras/src/lib/hooks/useViewport.svelte.ts`. A `$`-prefixed
@@ -2949,19 +2949,19 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-### Server dev (`known-failures.server-dev.json`, 10 entries)
+### Server dev (`known-failures.server-dev.json`, 9 entries)
 
 The `server-dev` target is the server transform with `dev: true`. It separately
 ratchets server-only development instrumentation: component metadata, element
 locations, dynamic-element validation, snippet validation, and injected CSS.
 
-Partition of `known-failures.server-dev.json` by verdict: `8 + 2`
+Partition of `known-failures.server-dev.json` by verdict: `7 + 2`
 
 The trailing **2** is the same deliberate divergence as on `server` — the
 `$`-prefixed function parameter — carried on both targets because the server
 transform runs on both.
 
-- **8 — the generated JS differs.**
+- **7 — the generated JS differs.**
 - **2 — the same recorded deliberate divergence as on `server`.**
 
 All 13 arrived with the wave-2 enrolment (#3130); this target was at 0 before
@@ -2970,15 +2970,15 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 57 entries)
+### Client dev (`known-failures.client-dev.json`, 56 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `57`
+Partition of `known-failures.client-dev.json` by verdict: `56`
 
-- **57 — the generated JS differs.**
+- **56 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 57 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 56 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -54,6 +54,5 @@
 	"syntaxfm-website/src/routes/(site)/guests/+page.svelte",
 	"threlte/packages/extras/src/lib/hooks/useGamepad/useGamepad.svelte.ts",
 	"trakt-web/projects/client/src/lib/components/select/SegmentedSelect.svelte",
-	"trakt-web/projects/client/src/lib/sections/navbar/_internal/NavbarHeader.svelte",
-	"trakt-web/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.svelte"
+	"trakt-web/projects/client/src/lib/sections/navbar/_internal/NavbarHeader.svelte"
 ]

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -40,6 +40,5 @@
 	"svelteui/packages/svelteui-demos/src/demos/core/Modal/ModalForm.svelte",
 	"syntaxfm-website/src/routes/(site)/guests/+page.svelte",
 	"trakt-web/projects/client/src/lib/components/select/SegmentedSelect.svelte",
-	"trakt-web/projects/client/src/lib/sections/navbar/_internal/NavbarHeader.svelte",
-	"trakt-web/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.svelte"
+	"trakt-web/projects/client/src/lib/sections/navbar/_internal/NavbarHeader.svelte"
 ]

--- a/compatibility/known-failures.server-dev.json
+++ b/compatibility/known-failures.server-dev.json
@@ -7,6 +7,5 @@
 	"svelte-commerce/src/lib/theme/sections/tile-grid.svelte",
 	"sveltepress/packages/theme-default/src/components/NavItem.svelte",
 	"threlte/packages/extras/src/lib/hooks/useViewport.svelte.ts",
-	"trakt-web/projects/client/src/lib/components/select/SegmentedSelect.svelte",
-	"trakt-web/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.svelte"
+	"trakt-web/projects/client/src/lib/components/select/SegmentedSelect.svelte"
 ]

--- a/compatibility/known-failures.server.json
+++ b/compatibility/known-failures.server.json
@@ -7,6 +7,5 @@
 	"svelte-commerce/src/lib/theme/sections/tile-grid.svelte",
 	"sveltepress/packages/theme-default/src/components/NavItem.svelte",
 	"threlte/packages/extras/src/lib/hooks/useViewport.svelte.ts",
-	"trakt-web/projects/client/src/lib/components/select/SegmentedSelect.svelte",
-	"trakt-web/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.svelte"
+	"trakt-web/projects/client/src/lib/components/select/SegmentedSelect.svelte"
 ]

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
@@ -1408,6 +1408,23 @@ fn get_snippet_block_name(snippet: &template::SnippetBlock) -> Option<String> {
     snippet.expression.identifier_name().map(String::from)
 }
 
+/// The snippet names a component may render because they were passed to it as
+/// an attribute value. Upstream's `analysis.snippet_renderers` holds a component
+/// alongside every `{@render}` tag, so a snippet reached only through a prop
+/// still has the component's position as one of its sites.
+fn attribute_snippet_names(attributes: &[template::Attribute]) -> Vec<String> {
+    let mut names = Vec::new();
+    for attribute in attributes {
+        if let template::Attribute::Attribute(node) = attribute
+            && let template::AttributeValue::Expression(tag) = &node.value
+            && let Some(name) = tag.expression.identifier_name()
+        {
+            names.push(name.to_string());
+        }
+    }
+    names
+}
+
 /// Mapping from snippet name to the list of ancestor chains at each render site.
 type SnippetAncestorMap = FxHashMap<String, Vec<Vec<ElementInfo>>>;
 
@@ -1453,6 +1470,9 @@ fn collect_render_sites_in_node(
             }
         }
         TemplateNode::Component(comp) => {
+            for name in attribute_snippet_names(&comp.attributes) {
+                map.entry(name).or_default().push(ancestors.clone());
+            }
             collect_render_sites_in_fragment(&comp.fragment, ancestors, map);
         }
         TemplateNode::IfBlock(if_block) => {
@@ -1494,9 +1514,15 @@ fn collect_render_sites_in_node(
             collect_render_sites_in_fragment(&frag.fragment, ancestors, map);
         }
         TemplateNode::SvelteComponent(comp) => {
+            for name in attribute_snippet_names(&comp.attributes) {
+                map.entry(name).or_default().push(ancestors.clone());
+            }
             collect_render_sites_in_fragment(&comp.fragment, ancestors, map);
         }
         TemplateNode::SvelteSelf(comp) => {
+            for name in attribute_snippet_names(&comp.attributes) {
+                map.entry(name).or_default().push(ancestors.clone());
+            }
             collect_render_sites_in_fragment(&comp.fragment, ancestors, map);
         }
         TemplateNode::SlotElement(slot) => {

--- a/crates/rsvelte_core/tests/css_snippet_render_site_scope_4113.rs
+++ b/crates/rsvelte_core/tests/css_snippet_render_site_scope_4113.rs
@@ -1,0 +1,126 @@
+//! A `{#snippet}`'s body is scoped from the ancestors of the places the snippet
+//! is used, and upstream counts a component the snippet is passed to as one of
+//! those places (`analysis.snippet_renderers` holds a `Component` next to every
+//! `{@render}` tag). rsvelte collected only the `{@render}` tags, so a snippet
+//! reached solely through a prop was scoped as if it had no ancestor at all.
+//!
+//! Every expectation is the official compiler's output for the same source,
+//! measured across all three targets, which agree on every row.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn out(src: &str, generate: GenerateMode, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate,
+            dev,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+struct Row {
+    name: &'static str,
+    src: &'static str,
+    a: bool,
+    b: bool,
+}
+
+const ROWS: &[Row] = &[
+    // The defect: the snippet is never `{@render}`ed here, only handed to `<C>`.
+    Row {
+        name: "snippet passed as a component prop, nested rule",
+        src: "<script>\n\timport C from \"./C.svelte\";\n</script>\n{#snippet s()}\n\t<span class=\"b\"></span>\n{/snippet}\n<div class=\"a\"><C icon={s} /></div>\n<style>\n\t.a { .b { color: red } }\n</style>\n",
+        a: true,
+        b: true,
+    },
+    Row {
+        name: "snippet passed as a component prop, nested rule with an inner :global",
+        src: "<script>\n\timport C from \"./C.svelte\";\n</script>\n{#snippet s()}\n\t<span class=\"b\"><i></i></span>\n{/snippet}\n<div class=\"a\"><C icon={s} /></div>\n<style>\n\t.a {\n\t\t.b {\n\t\t\tcolor: red;\n\t\t\t:global(i) { color: blue }\n\t\t}\n\t}\n</style>\n",
+        a: true,
+        b: true,
+    },
+    // Controls that already passed: the fix must not move them.
+    Row {
+        name: "snippet rendered with {@render}, nested rule",
+        src: "{#snippet s()}\n\t<span class=\"b\"></span>\n{/snippet}\n<div class=\"a\">{@render s()}</div>\n<style>\n\t.a { .b { color: red } }\n</style>\n",
+        a: true,
+        b: true,
+    },
+    Row {
+        name: "a snippet nobody uses scopes nothing in its body",
+        src: "{#snippet s()}\n\t<span class=\"b\"></span>\n{/snippet}\n<div class=\"a\"></div>\n<style>\n\t.a { .b { color: red } }\n</style>\n",
+        a: true,
+        b: false,
+    },
+    Row {
+        name: "a rule that names only the snippet's own subject",
+        src: "{#snippet s()}\n\t<span class=\"b\"></span>\n{/snippet}\n{@render s()}\n<style>\n\t.b { color: red }\n</style>\n",
+        a: false,
+        b: true,
+    },
+    Row {
+        name: "the parent selector matches no element in the markup",
+        src: "{#snippet s()}\n\t<span class=\"b\"></span>\n{/snippet}\n{@render s()}\n<style>\n\t.a .b { color: red }\n</style>\n",
+        a: false,
+        b: false,
+    },
+    Row {
+        name: "plain nesting, no snippet",
+        src: "<div class=\"a\"><span class=\"b\"></span></div>\n<style>\n\t.a { .b { color: red } }\n</style>\n",
+        a: true,
+        b: true,
+    },
+    Row {
+        name: "plain nesting, flat descendant selector",
+        src: "<div class=\"a\"><span class=\"b\"></span></div>\n<style>\n\t.a .b { color: red }\n</style>\n",
+        a: true,
+        b: true,
+    },
+    Row {
+        name: "an {#each} body is not a snippet",
+        src: "<div class=\"a\">{#each [1] as i}<span class=\"b\"></span>{/each}</div>\n<style>\n\t.a { .b { color: red } }\n</style>\n",
+        a: true,
+        b: true,
+    },
+    Row {
+        name: "the snippet is declared inside the parent it is rendered in",
+        src: "<div class=\"a\">{#snippet s()}<span class=\"b\"></span>{/snippet}{@render s()}</div>\n<style>\n\t.a { .b { color: red } }\n</style>\n",
+        a: true,
+        b: true,
+    },
+];
+
+#[test]
+fn a_snippet_reached_only_through_a_component_prop_is_scoped_from_that_component() {
+    let targets = [
+        ("server", GenerateMode::Server, false),
+        ("client", GenerateMode::Client, false),
+        ("client-dev", GenerateMode::Client, true),
+    ];
+    let mut failures = Vec::new();
+    for row in ROWS {
+        for (tname, generate, dev) in targets {
+            let code = out(row.src, generate, dev);
+            for (class, want) in [("a", row.a), ("b", row.b)] {
+                // The scope class survives into client output inside a template
+                // string as well as a server `class="…"`, so match the token pair.
+                let present = code.contains(&format!("{class} svelte-"));
+                if present != want {
+                    failures.push(format!(
+                        "{} [{tname}] .{class}: want scoped={want}, got={present}",
+                        row.name
+                    ));
+                }
+            }
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}


### PR DESCRIPTION
`{#snippet}` の本体は「その snippet が使われる場所」の祖先から scope されます。上流は
`analysis.snippet_renderers` に **`{@render}` タグとコンポーネントの両方**を入れ、
`index.js:847-854` で `snippet.metadata.sites.add(node)` します
（コンポーネントが renderer になる規則は `visitors/shared/component.js:30-68` — 属性の値が
識別子で、その binding の `initial` が `SnippetBlock` なら `node.metadata.snippets` に入る）。
`css-prune.js:836` の `get_ancestor_elements` はその `sites` から祖先を集めます。

rsvelte の `collect_render_sites_in_node` は **`TemplateNode::RenderTag` だけ**を site として
登録していたので、**コンポーネントの prop でしか参照されない snippet** の中の要素は
「祖先を持たないルート」として扱われ、scope class を落としていました。

## 変更

`Component` / `SvelteComponent` / `SvelteSelf` の属性から識別子名を拾い、同じ祖先チェーンを
その名前の site として登録します（`attribute_snippet_names` 1 関数 + 3 アーム）。

## 陽性対照

`crates/rsvelte_core/tests/css_snippet_render_site_scope_4113.rs` は 10 行 × 3 target = 60 セル。
修正を `git stash` で外すと **予測どおり 6 セルだけ赤**:

```
snippet passed as a component prop, nested rule [server|client|client-dev] .b: want scoped=true, got=false
snippet passed as a component prop, nested rule with an inner :global [server|client|client-dev] .b: want scoped=true, got=false
```

対照 8 行（`{@render}` 経由 / 一度も使われない snippet / subject だけの規則 / 親が markup に無い /
素の入れ子 2 種 / `{#each}` / 親の中で宣言した snippet）は**両アームで緑**です。期待値はすべて
official の同じソースに対する実出力を測って入れています。

## 回帰

CSS スイート 53 本 + `compiler_fixtures` + `ssr` + `--lib`（1947 テスト）= **57 スイート、EXIT=0**。

## ratchet

`known-failures.{server,server-dev}.json` の 3 件がこの形です:

- `networking-toolbox/src/lib/components/home/SiteMapList.svelte`
- `trakt-web/…/select/SegmentedSelect.svelte`
- `trakt-web/…/plex/PlexSyncedServers.svelte`

**ratchet はこの PR では触っていません。** ローカルの `.corpus-cache/rsvelte.node` は provenance が
壊れており（`stagedAt 2026-08-31` に対し mtime が 2026-09-01 10:20 UTC）、どのツリーのバイナリか
言えないので、**CI の実測を見てから再導出**します。この 3 件が落ちるかどうかは CI が答えます。

## 分離した別欠陥

同じグリッドの残り 6 セル（flat な子孫セレクタの subject が snippet の中にいるとき**祖先**が
scope を落とす）は**別の機構**で、`subtree_has_matching_subject_inner` の `RenderTag` アームが
空実装であることが原因です。**#4115** に分けました。この PR では直りません。

Closes #4113
