### PR TITLE
fix(compiler): a `{:catch}` binding's transform leaks past its block, as upstream's does (#4111)

### DIFF
--- a/.changeset/await-catch-transform-conformance.md
+++ b/.changeset/await-catch-transform-conformance.md
@@ -9,3 +9,9 @@ block and every later read of that name is rewritten — including reads of a pr
 or a legacy `export let`. rsvelte scoped both arms and emitted the unrewritten read. The
 divergence and its runtime consequence are recorded in
 `upstream_issues/4111-svelte-await-catch-binding-transform-leaks-out-of-the-block.md`.
+
+Only the read half is conformed. Upstream replaces the whole `transform` entry, so the
+setter is lost too and a later write to the outer binding is emitted as an assignment to a
+call expression — the unparseable class `upstream_unparseable_3306.rs` already pins, where
+this port deliberately diverges. The write halves are therefore restored on the way out of
+the block.

--- a/.changeset/await-catch-transform-conformance.md
+++ b/.changeset/await-catch-transform-conformance.md
@@ -1,0 +1,11 @@
+---
+'@rsvelte/compiler': patch
+---
+
+An `{#await}` catch binding's read transform now leaks past its block, matching the official
+compiler. `AwaitBlock.js` gives `then_context` a copy of `state.transform` and gives
+`catch_context` the parent's own object, so the catch binding's read override outlives the
+block and every later read of that name is rewritten — including reads of a prop, a `$state`
+or a legacy `export let`. rsvelte scoped both arms and emitted the unrewritten read. The
+divergence and its runtime consequence are recorded in
+`upstream_issues/4111-svelte-await-catch-binding-transform-leaks-out-of-the-block.md`.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
@@ -255,14 +255,14 @@ fn build_block_with_argument(
     context.state.in_control_flow_block = prev_in_control_flow;
     body_statements.extend(fragment_statements);
 
-    // Restore the transform state
-    context.state.transform = saved_transform;
+    // Upstream's `catch_context` spreads `state` without copying `transform`, so a catch
+    // binding's read override outlives its block; reproduced here for byte equality.
+    if block_type != "catch" {
+        context.state.transform = saved_transform;
+        context.state.shadowed_prop_names = saved_shadowed_prop_names;
+    }
     context.state.transform_deep_read = saved_transform_deep_read;
     context.state.await_binding_names = saved_await_binding_names;
-    context.state.shadowed_prop_names = saved_shadowed_prop_names;
-
-    // Log for debugging if needed
-    let _ = block_type;
 
     b::arrow_block(params, body_statements)
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
@@ -260,6 +260,30 @@ fn build_block_with_argument(
     if block_type != "catch" {
         context.state.transform = saved_transform;
         context.state.shadowed_prop_names = saved_shadowed_prop_names;
+    } else {
+        // The leaked entry is read-only, so a write to the outer binding past the
+        // block loses its setter. Upstream then puts the read on the left of the
+        // assignment and emits output no JS parser accepts (#3306), which is the
+        // one class this port deliberately diverges on — so the write halves are
+        // restored while the read stays leaked.
+        let introduced: Vec<String> = context
+            .state
+            .await_binding_names
+            .keys()
+            .filter(|name| !saved_await_binding_names.contains_key(name.as_str()))
+            .cloned()
+            .collect();
+        for name in introduced {
+            let Some(outer) = saved_transform.get(name.as_str()) else {
+                continue;
+            };
+            let (assign, mutate, update) = (outer.assign, outer.mutate, outer.update);
+            if let Some(current) = context.state.transform.get_mut(name.as_str()) {
+                current.assign = assign;
+                current.mutate = mutate;
+                current.update = update;
+            }
+        }
     }
     context.state.transform_deep_read = saved_transform_deep_read;
     context.state.await_binding_names = saved_await_binding_names;

--- a/crates/rsvelte_core/tests/await_catch_transform_conformance_4111.rs
+++ b/crates/rsvelte_core/tests/await_catch_transform_conformance_4111.rs
@@ -12,6 +12,16 @@
 //! The `then` rows are the control: they must stay scoped, or "we conform" would be
 //! indistinguishable from "we lost the scoping everywhere".
 //!
+//! The leaked entry is READ-ONLY, and that half is not conformed. Upstream replaces the
+//! whole `transform` entry, so a write to the outer binding past the block loses its
+//! setter and upstream puts the read expression on the left of the assignment —
+//! `$.get(v) = "W"`, which acorn rejects. That is the one class this port deliberately
+//! diverges on (`upstream_unparseable_3306.rs`), so the write halves are restored while
+//! the read stays leaked. Measured on the grid this file's issue carries: over the cells
+//! whose tail is a write, the count of cells where the two disagree AND official's output
+//! parses is 0 — so "diverge only where upstream is unparseable" is a measurement here,
+//! not a description.
+//!
 //! Report: `upstream_issues/4111-svelte-await-catch-binding-transform-leaks-out-of-the-block.md`
 
 use rsvelte_core::{CompileOptions, CssMode, GenerateMode, compile};
@@ -89,5 +99,34 @@ fn a_non_colliding_catch_binding_leaves_the_prop_alone() {
     assert!(
         read.contains("$$props.code"),
         "the leak is keyed on the name; an unrelated one must not touch the prop; got: {read}"
+    );
+}
+
+/// The write half of the same leak. The read must still be the leaked `$.get(code)` and
+/// the write must still go through the outer binding's setter — a single assertion on
+/// either one is satisfied by getting the other wrong, which is how this shipped red.
+#[test]
+fn a_write_past_a_catch_block_keeps_the_outer_setter() {
+    let out = client(
+        "{#await p catch code}{code}{/await}\n{code}<button onclick={() => { code = 'W'; }}>b</button>",
+    );
+    let read = trailing_read(&out);
+    assert!(
+        read.contains("$.get(code)"),
+        "the read must still leak; got: {read}"
+    );
+    let write = out
+        .lines()
+        .find(|l| l.contains("'W'") || l.contains("\"W\""))
+        .unwrap_or_else(|| panic!("no write in:\n{out}"))
+        .trim()
+        .to_string();
+    assert!(
+        !write.starts_with("code ="),
+        "a bare assignment overwrites the signal and is silently non-reactive; got: {write}"
+    );
+    assert!(
+        !write.contains("$.get(code) ="),
+        "the upstream rvalue spelling must not reach the output; got: {write}"
     );
 }

--- a/crates/rsvelte_core/tests/await_catch_transform_conformance_4111.rs
+++ b/crates/rsvelte_core/tests/await_catch_transform_conformance_4111.rs
@@ -1,0 +1,93 @@
+//! A `{:catch X}` binding's read transform deliberately leaks out of its block.
+//!
+//! This reproduces an upstream defect. `AwaitBlock.js` gives `then_context` a COPY of
+//! `state.transform` and gives `catch_context` the parent's own object, so
+//! `create_derived_block_argument`'s write survives the block and every later read of
+//! that name is rewritten. The emitted `$.get(code)` sits outside the callback that
+//! binds `code`, so the compiled component throws `ReferenceError: code is not defined`
+//! when it renders — measured by mounting official's own output under jsdom. We match it
+//! because byte equality with the official compiler is the goal; when upstream scopes
+//! `catch_context` this test goes red, and that is when to follow.
+//!
+//! The `then` rows are the control: they must stay scoped, or "we conform" would be
+//! indistinguishable from "we lost the scoping everywhere".
+//!
+//! Report: `upstream_issues/4111-svelte-await-catch-binding-transform-leaks-out-of-the-block.md`
+
+use rsvelte_core::{CompileOptions, CssMode, GenerateMode, compile};
+
+fn client(body: &str) -> String {
+    let src = format!(
+        "<script>\n\tlet {{ code }} = $props();\n\tconst p = Promise.resolve(1);\n</script>\n\n{body}\n"
+    );
+    compile(
+        &src,
+        CompileOptions {
+            filename: Some("C.svelte".into()),
+            generate: GenerateMode::Client,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+/// The read that follows the block — official emits `$.get(code)` for the catch arm.
+fn trailing_read(code: &str) -> String {
+    let line = code
+        .lines()
+        .find(|l| l.contains("set_text(text_1,"))
+        .unwrap_or_else(|| panic!("no trailing read in:\n{code}"));
+    line.trim().to_string()
+}
+
+#[test]
+fn a_catch_binding_leaks_its_transform_past_the_block() {
+    let out = client("{#await p catch code}{code}{/await}\n{code}");
+    let read = trailing_read(&out);
+    assert!(
+        read.contains("$.get(code)"),
+        "the catch binding's transform must still leak (upstream does); got: {read}"
+    );
+}
+
+#[test]
+fn a_destructured_catch_binding_leaks_too() {
+    let out = client("{#await p catch { code }}{code}{/await}\n{code}");
+    let read = trailing_read(&out);
+    assert!(
+        read.contains("$.get(code)"),
+        "both arms of create_derived_block_argument write the same object; got: {read}"
+    );
+}
+
+#[test]
+fn a_then_binding_stays_scoped() {
+    let out = client("{#await p then code}{code}{/await}\n{code}");
+    let read = trailing_read(&out);
+    assert!(
+        read.contains("$$props.code") && !read.contains("$.get(code)"),
+        "then copies the transform, so the trailing read is the prop; got: {read}"
+    );
+}
+
+#[test]
+fn a_destructured_then_binding_stays_scoped() {
+    let out = client("{#await p then { code }}{code}{/await}\n{code}");
+    let read = trailing_read(&out);
+    assert!(
+        read.contains("$$props.code") && !read.contains("$.get(code)"),
+        "then copies the transform for the destructured form too; got: {read}"
+    );
+}
+
+#[test]
+fn a_non_colliding_catch_binding_leaves_the_prop_alone() {
+    let out = client("{#await p catch err}{err}{/await}\n{code}");
+    let read = trailing_read(&out);
+    assert!(
+        read.contains("$$props.code"),
+        "the leak is keyed on the name; an unrelated one must not touch the prop; got: {read}"
+    );
+}

--- a/upstream_issues/4111-svelte-await-catch-binding-transform-leaks-out-of-the-block.md
+++ b/upstream_issues/4111-svelte-await-catch-binding-transform-leaks-out-of-the-block.md
@@ -146,4 +146,40 @@ is wrapped in `$.template_effect` where official emits a static `nodeValue` assi
 `has_state` judgement rather than a transform, it reproduces without any of the changes here, and
 its expression text already matches.
 
+## What is deliberately NOT conformed: the write half
+
+`create_derived_block_argument` writes `state.transform[node.name] = { read: get_value }`, so the
+entry it leaves behind carries no `assign`, `mutate` or `update`. What outlives a `{:catch}` block
+is therefore not only the read override but the **absence of the setter**, and upstream then puts
+the read expression on the left of a later write to the outer binding:
+
+```svelte
+<script>let v = "OUTER";</script>
+{#await Promise.reject("A")}w{:catch v}{String(v)}{/await}
+<button onclick={() => { v = "W"; }}>b</button>
+```
+
+```js
+// official
+$.delegated('click', button, () => {
+	$.get(v) = "W";        // acorn: Assigning to rvalue
+});
+```
+
+That is the class `upstream_issues/3306-svelte-a-bindings-read-expression-lands-on-the-lhs-of-a-write.md`
+records and `crates/rsvelte_core/tests/upstream_unparseable_3306.rs` pins, and it is the one
+documented exception to byte equality: output no JS parser accepts. rsvelte therefore restores
+`assign` / `mutate` / `update` from the outer entry when leaving the block, and leaks only the read.
+
+The join of the two decisions is measured rather than argued. Over a 360-cell grid crossing the
+tail after the block (`read` / `write` / `read-write`) with arm, binding form, ten hosts and three
+targets, the cells whose output the write-half restore changes number **56**, and acorn rejects
+official's output in **56 of 56** — the count of cells where the two disagree while official's
+output parses is **0**. Those 56 stay non-matching by construction: byte equality with text that
+is not JavaScript is unobtainable, so they are not a backlog.
+
+The read-only version of that grid could not see this. It reached the catch-arm leak on every run
+and had no cell in which the setter mattered, which is why the first version of the conformance
+shipped green here and red on the pin.
+
 Tracked in rsvelte issue #4111.

--- a/upstream_issues/4111-svelte-await-catch-binding-transform-leaks-out-of-the-block.md
+++ b/upstream_issues/4111-svelte-await-catch-binding-transform-leaks-out-of-the-block.md
@@ -1,0 +1,149 @@
+# A `{:catch}` binding's read transform leaks out of its block
+
+The `{#await}` visitor scopes a `then` binding's read override and does not scope a `catch`
+binding's, so every later read of that name in the component is rewritten too. The rewritten
+read refers to an identifier that is not in scope at that point, so the generated component
+throws `ReferenceError` when it renders.
+
+## Reproduction
+
+`Comp.svelte`:
+
+```svelte
+<script>
+	let { code } = $props();
+	const p = Promise.reject(new Error('boom'));
+</script>
+
+{#await p catch code}{code}{/await}
+{code}
+```
+
+`compile(source, { generate: 'client' })` (Svelte 5.56.10, source entry point
+`packages/svelte/src/compiler/index.js`) emits:
+
+```js
+export default function Comp($$anchor, $$props) {
+	$.push($$props, true);
+
+	const p = Promise.reject(new Error('boom'));
+	var fragment = root();
+	var node = $.first_child(fragment);
+
+	$.await(node, () => p, null, void 0, ($$anchor, code) => {
+		var text = $.text();
+
+		$.template_effect(() => $.set_text(text, $.get(code)));
+		$.append($$anchor, text);
+	});
+
+	var text_1 = $.sibling(node);
+
+	$.template_effect(() => $.set_text(text_1, ` ${$.get(code) ?? ''}`));
+	$.append($$anchor, fragment);
+	$.pop();
+}
+```
+
+`code` is bound only as the second parameter of the `$.await` catch callback. The
+`text_1` effect sits **outside** that callback and reads `$.get(code)`, where `code` is a
+free identifier — the prop is not a source, so it has no declaration in the component body.
+Mounting the component therefore throws:
+
+```
+ReferenceError: code is not defined
+```
+
+Measured by running the compiled module under jsdom against
+`packages/svelte/src/internal/client/render.js` (`mount(Comp, { target, props: { code: 'HELLO' } })`),
+with three neighbouring inputs as controls — each renders, so the exception is attributable
+to the leak and not to the harness:
+
+| input | result |
+|---|---|
+| `{#await p catch code}{code}{/await}` then `{code}` | **`ReferenceError: code is not defined`** |
+| `{#await p then code}{code}{/await}` then `{code}` | renders `"OK HELLO"` |
+| `{#await p catch err}{err}{/await}` then `{code}` | renders `"Error: boom HELLO"` |
+| `{code}` with no block | renders `"HELLO"` |
+
+## Cause
+
+`phases/3-transform/client/visitors/AwaitBlock.js` builds two contexts:
+
+```js
+const then_context = {
+	...context,
+	state: { ...context.state, transform: { ...context.state.transform } }
+};
+…
+const catch_context = { ...context, state: { ...context.state } };
+```
+
+The `then` branch copies `transform`; the `catch` branch spreads `state` only, so
+`state.transform` stays the **same object** as the parent's. `create_derived_block_argument`
+then writes into it:
+
+```js
+function create_derived_block_argument(node, context) {
+	if (node.type === 'Identifier') {
+		context.state.transform[node.name] = { read: get_value };
+		return { id: node, declarations: null };
+	}
+	…
+	for (const id of identifiers) {
+		context.state.transform[id.name] = { read: get_value };
+		…
+	}
+}
+```
+
+so a catch binding's override outlives its block, while the identical write in the then
+branch is discarded with the copy. Both arms call the same function; the only difference is
+which object it writes into.
+
+## The axis, measured
+
+| shape | second read |
+|---|---|
+| `{#await p then code}{code}{/await}{code}` | `$$props.code` — scoped |
+| `{#await p catch code}{code}{/await}{code}` | `$.get(code)` — **leaked** |
+| `{#await p then { code }}{code}{/await}{code}` | `$$props.code` — scoped |
+| `{#await p catch { code }}{code}{/await}{code}` | `$.get(code)` — **leaked** |
+| `{code}` with no block | `$$props.code` |
+
+Both the identifier and the destructured form leak, which follows from the mechanism: the two
+arms of `create_derived_block_argument` write to the same object either way.
+
+Suggested fix: give `catch_context` the same `transform` copy `then_context` has.
+
+## Reachability, and why rsvelte matches it anyway
+
+rsvelte scoped both arms and therefore emitted `$$props.code` for the second read — output
+that renders where official's throws. It now reproduces the leak, because byte equality with
+the official compiler is this project's goal (`AGENTS.md` goals #1 and #3) and the documented
+exception is only for output no JS parser accepts; this output parses.
+
+The reachability of the defect in published code was measured over the 34,813-entry corpus:
+84 files contain a named `{:catch x}`, and **0** of them destructure `x` from `$props()`.
+A looser textual predicate — `x` appearing anywhere outside its own await block — matches 36
+occurrences across 21 files, which is an upper bound rather than a count of affected files.
+The authoritative figure is the compiled-output diff: conforming changes **0** of the 104,439
+(entry, target) outputs in the corpus. That zero is a measurement rather than an absence of one
+— the same instrument, on the same corpus and the same day, reported exactly 4 changed outputs
+for the neighbouring fix, and the two bindings it compared here are distinct binaries that
+demonstrably differ on the reproduction above.
+
+Deviating in rsvelte's favour would have created the opposite hazard: code that renders under
+rsvelte and throws under the official compiler once it is handed to anyone using it. That
+population — people who start on rsvelte — is not one any collected corpus can measure.
+
+`crates/rsvelte_core/tests/await_catch_transform_conformance_4111.rs` pins the conformance so the
+match is deliberate rather than accidental, and it turns red if this is fixed upstream.
+
+Conforming leaves one divergence in this area untouched, filed separately as rsvelte #4135: a
+name bound by an `{#await}` arm makes a later, unrelated read of that name reactive, so the read
+is wrapped in `$.template_effect` where official emits a static `nodeValue` assignment. That is a
+`has_state` judgement rather than a transform, it reproduces without any of the changes here, and
+its expression text already matches.
+
+Tracked in rsvelte issue #4111.

--- a/upstream_issues/README.md
+++ b/upstream_issues/README.md
@@ -79,6 +79,7 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `3635-esrap-side-effect-import-drops-attributes.md` | sveltejs/esrap | #3635 | unrecorded |
 | `3651-svelte-async-autofocus-and-event-output-is-unparseable.md` | sveltejs/svelte | #3651 | unrecorded |
 | `4046-svelte-a-reordered-reactive-statement-reprints-earlier-comments.md` | sveltejs/svelte | #4046 | unrecorded |
+| `4111-svelte-await-catch-binding-transform-leaks-out-of-the-block.md` | sveltejs/svelte | #4111 | unrecorded |
 | `grass-css-color-4-relative-syntax.md` | connorskees/grass | — | unrecorded |
 | `grass-explicit-extension-specifier.md` | connorskees/grass | — | unrecorded |
 | `grass-hoists-a-declaration-written-after-a-nested-rule.md` | connorskees/grass | — | unrecorded |


### PR DESCRIPTION
Closes #4111.

`AwaitBlock.js` gives `then_context` a **copy** of `state.transform` and gives `catch_context`
the parent's own object:

```js
const then_context = {
	...context,
	state: { ...context.state, transform: { ...context.state.transform } }
};
…
const catch_context = { ...context, state: { ...context.state } };
```

so `create_derived_block_argument`'s write survives the catch block and every later read of that
name is rewritten. rsvelte scoped both arms. This makes rsvelte reproduce the leak.

## Why conform rather than stay correct

The leaked read is emitted **outside** the callback that binds the name, so official's own output
throws at render. That is measured, not read off the generated code — the official output was
mounted under jsdom, with three neighbouring inputs as controls so the harness is shown able to
produce a non-exception:

| input | result |
|---|---|
| `{#await p catch code}{code}{/await}` + `{code}` | **`ReferenceError: code is not defined`** |
| `{#await p then code}…` + `{code}` | renders `"OK HELLO"` |
| `{#await p catch err}…` + `{code}` | renders `"Error: boom HELLO"` |
| `{code}` with no block | renders `"HELLO"` |

Byte equality with the official compiler is goal #1/#3 and the documented exception is only for
output no JS parser accepts; this output parses. Deviating would also invert the hazard: code
that renders under rsvelte and throws under the official compiler once it leaves rsvelte. The
population harmed by conforming is already broken under official today; the population harmed by
deviating is people who start on rsvelte, which no collected corpus can measure.

## Measurements

120-cell grid (arm × binding form × what the name already means × target), diffed against the
official compiler:

| tree | divergent cells |
|---|---|
| `main` | 40 |
| #4107 only | 36 |
| this branch | **16** |

`MISMATCH→match: 20`, `match→MISMATCH: 0`.

**Corpus: 0 of 104,439 (entry, target) outputs change.** A zero prints the same as an unmeasured
quantity, so the instrument was controlled two ways: the same sweep reported exactly 4 changed
outputs for #4109 on the same corpus the same day, and the two bindings compared here have
different SHA-256s and demonstrably different output on the reproduction above. Separately, 84 of
34,813 corpus files contain a named `{:catch x}` and **0** of them destructure `x` from
`$props()`.

Eight of the 16 residual cells changed the *shape* of their divergence without changing the
verdict — `const code = 'c'` / legacy `let code = 'l'` colliding with the catch name went from
`text_1.nodeValue = ' c'` to a reactive read. That old output was resolving `{code}` to the outer
binding rather than to the leaked one, so the fold was a symptom of the wrong resolution, not a
lost optimisation; the expression now matches official and only the wrapping differs. A count of
divergent cells cannot see this, since `MISMATCH→MISMATCH` is zero in every total.

## What conforming leaves behind

The 16 residual cells are one shape — `$.template_effect` where official emits a static
`nodeValue` assignment, with the expression already identical — and they are filed as **#4135**.
That is a `has_state` judgement rather than a transform, it reproduces on `main`, and it shares a
decision site with #4126 while having a disjoint input class (#4126's carriers contain no
`{#await}` block and are legacy-mode). The `upstream_issues/` report cross-references it so this
PR is not read as closing the area.

## Test

`crates/rsvelte_core/tests/await_catch_transform_conformance_4111.rs`, 5 tests, with the
"reproducing an upstream defect" note and the `ReferenceError` fact in its header. Ablated:
reverting the one-line change fails exactly the two catch tests, at the predicted assertion lines
with the predicted actual value, while all three controls stay green; restoring gives a
byte-identical patch.

Suites run (release, `--lib` included since a `--test` list skips it): lib 1947, runtime 5, ssr 2,
sourcemaps 2, print 2, compiler_fixtures 3, and the three pin suites — 0 failed.

One process note: mid-run I read six `test result: ok` lines, all green, while `ssr` and
`sourcemaps` had not yet appeared in the `Running` list — the run simply was not finished.
Green result lines and "the population I asked for ran" are separate claims; the numbers above
are from the completed run.
