### PR TITLE
ci: a comparison must not report an environment failure under its own name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1148,6 +1148,7 @@ jobs:
       # node_modules. No Rust build; the lint-severity step below is the only one
       # that needs a submodule.
       - name: Install dependencies
+        id: flags-env
         run: pnpm install --frozen-lockfile
 
       - name: Check --update-baseline / --update-warning-baseline compose
@@ -1159,25 +1160,25 @@ jobs:
       - name: Check the output-parseability gate
         # A failing step skips every unguarded step after it, and a skipped
         # check reads exactly like a passing one. Run regardless.
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
         run: node scripts/dev/test-corpus-parse-gate.mjs
 
       - name: Check mutation baseline provenance
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
         run: node scripts/dev/test-mutation-baseline-provenance.mjs
 
       # `codeIdentity` decides the `code-mismatch` / `comment-mismatch` split
       # that this gate and the shape matrix ratchet on, so a reduction that
       # deletes real code makes a code regression report as comment noise.
       - name: Check the code/comment classifier's string handling
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
         run: node scripts/dev/test-code-identity-strings.mjs
 
       # The lint gate's rewrite floor and its compared population. Both linters
       # are stubbed, so this runs without the lint submodules, the dist-lint
       # build or the eslint oracle that the Lint parity job needs.
       - name: Check the lint gate's population floor
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
         run: node scripts/dev/test-lint-verify-population-floor.mjs
 
       # The deliberate-divergence claim behind lint-severity's 56 exit-code
@@ -1185,34 +1186,34 @@ jobs:
       # one-time measurement until it runs. It needs the real oracle, so this is
       # the one step here that checks out a submodule.
       - name: Checkout svelte submodule (shallow)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
         run: git submodule update --init --depth 1 submodules/svelte
 
       - name: Install Svelte compiler dependencies
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
         run: pnpm --dir submodules/svelte install --frozen-lockfile
 
       - name: Check the lint-severity exit attribution
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
         run: node scripts/dev/test-lint-severity-exit-attribution.mjs
 
       # The ratchet-doc count parser. Lives here rather than in Corpus Compat so
       # it runs without the corpus: it needs no submodules and no build.
       - name: Check the known-failures doc count parser
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
         run: node scripts/dev/test-known-failures-md-check.mjs
 
       # A recorded deliberate divergence is a decision not to close, so it has to
       # be held by a test; this reads the doc, not the corpus.
       - name: Check every deliberate divergence is pinned
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
         run: node scripts/dev/deliberate-divergences-check.mjs
 
       # The CSS-prune sweep's comparison key. Same reason it lives here: the
       # comparator is a pure module, so it needs neither the NAPI binding nor
       # submodules that the sweep itself does.
       - name: Check the CSS-prune sweep compares warnings
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
         run: node scripts/dev/test-css-prune-sweep-warning-verdict.mjs
 
   release-comment:
@@ -1352,6 +1353,18 @@ jobs:
       - name: Run upstream_issues index guard tests
         if: ${{ !cancelled() }}
         run: node scripts/ci/test-check-upstream-issues.mjs
+
+      # A guarded step that measures the environment rather than the code: the
+      # `!cancelled()` shape it enforces was itself the source of a red
+      # `Shape matrix parity` caused by a missing `node_modules`.
+      - name: Check no comparison can report an environment failure
+        if: ${{ !cancelled() }}
+        run: node scripts/ci/step-environment-guard.mjs
+
+      - name: Run step environment guard tests
+        if: ${{ !cancelled() }}
+        run: node scripts/ci/test-step-environment-guard.mjs
+
   prereq-coverage-guard:
     name: Prerequisite coverage guard
     runs-on: ubuntu-latest

--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -229,6 +229,7 @@ jobs:
           mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node
 
       - name: Collect corpus
+        id: corpus-env
         run: node scripts/compat-corpus/collect.mjs
 
       # The public `parse()` AST — a different export from `compile()`, and the
@@ -241,7 +242,7 @@ jobs:
       - name: Verify public parse() AST parity (ratchet)
         # A failing step skips every unguarded step after it, and a skipped
         # comparison reads exactly like a passing one. Run regardless.
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.corpus-env.outcome == 'success' }}
         run: node scripts/compat-corpus/parse-ast-verify.mjs --comment-owners
 
       # Asserts a PROPERTY of the transform rather than comparing its output, so
@@ -249,7 +250,7 @@ jobs:
       # `b::getter_call` and 7,888 of 27,566 corpus units violate it while the
       # output gate still scores 0 divergences. Hard gate, no ratchet.
       - name: Transform idempotency (client identifier transforms)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.corpus-env.outcome == 'success' }}
         env:
           RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT: '1'
         run: node scripts/compat-corpus/idempotency-verify.mjs
@@ -260,7 +261,7 @@ jobs:
       # carrying the shape is already listed for two unrelated divergences.
       # Hard gate, no ratchet.
       - name: Signal discipline (client write lowerings)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.corpus-env.outcome == 'success' }}
         env:
           RSVELTE_ASSERT_SIGNAL_DISCIPLINE: '1'
         run: node scripts/compat-corpus/signal-discipline-verify.mjs
@@ -269,11 +270,11 @@ jobs:
         # The parse-AST and idempotency checks are independent gates. Keep
         # compiling after either fails so the output, diagnostic, and
         # parseability reports below still expose their own regressions.
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.corpus-env.outcome == 'success' }}
         run: node scripts/compat-corpus/compile.mjs
 
       - name: Verify esrap round-trip, comments, and source maps
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.corpus-env.outcome == 'success' }}
         run: node scripts/compat-corpus/esrap-verify.mjs
 
       - name: Verify (oxfmt-normalized outputs must be identical)
@@ -282,7 +283,7 @@ jobs:
         # the only retained artifact that records the parser error for each
         # known-unparseable output; skipping this step leaves that burn-down
         # with ids but no generated-code location.
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.corpus-env.outcome == 'success' }}
         run: node scripts/compat-corpus/verify.mjs
 
       # Gate 3 (#2281): the corpus entries as a SEED set, not a test set. Runs
@@ -291,7 +292,7 @@ jobs:
       # deterministic sample; main gets the full sweep, which is what the
       # two-sided ratchet needs to judge a stale entry.
       - name: Mutation fuzz parity (ratchet against mutation-known-failures.json)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.corpus-env.outcome == 'success' }}
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             node scripts/compat-corpus/mutate-corpus.mjs --full
@@ -312,20 +313,20 @@ jobs:
         # This is an independent compatibility surface. Keep it observable when
         # an earlier compiler gate fails; otherwise its report and the concrete
         # error behind a `map-missing` entry are never produced.
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.corpus-env.outcome == 'success' }}
         run: node scripts/compat-corpus/svelte2tsx-compile.mjs
 
       # One invocation, two ratchets: TSX text parity against official
       # svelte2tsx, and structural validity of the source map each side returns.
       - name: Verify svelte2tsx (oxfmt-normalized TSX + source maps)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.corpus-env.outcome == 'success' }}
         run: node scripts/compat-corpus/svelte2tsx-verify.mjs
 
       # Synthetic combinatorial sweep of unused-CSS pruning — catches
       # per-sibling-traversal prune bugs the happy-path corpus can't (issue
       # #1700). Reuses the binding staged above; shrink-only ratchet.
       - name: Verify CSS-prune sweep (no new divergences)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.corpus-env.outcome == 'success' }}
         run: node scripts/compat-corpus/css-prune-sweep.mjs --check
 
       # The expected/actual trees cluster.mjs reads are not uploaded (too large),
@@ -497,6 +498,7 @@ jobs:
       # The oracle is the pinned real eslint-plugin-svelte; deps install into an
       # isolated package so the comparison never drifts from what users run.
       - name: Install lint oracle (real eslint-plugin-svelte)
+        id: lint-env
         run: npm --prefix scripts/compat-corpus/lint-oracle install --no-package-lock
 
       # Before the collected corpus: these patterns are committed, so the step
@@ -505,65 +507,65 @@ jobs:
       - name: Verify adversarial lint parity (ratchet against lint-adversarial-known-failures.json)
         # A failing step skips every unguarded step after it, and a skipped
         # comparison reads exactly like a passing one. Run regardless.
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.lint-env.outcome == 'success' }}
         run: node scripts/compat-corpus/lint-adversarial.mjs
 
       # The report gate above compares diagnostics; a rule's autofix is a
       # separate output that no other gate reads.
       - name: Verify adversarial lint autofix parity (ratchet against lint-adversarial-fix-known-failures.json)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.lint-env.outcome == 'success' }}
         run: node scripts/compat-corpus/lint-adversarial-fix.mjs
 
       # The step above enables one rule per pattern, so it says nothing about
       # `--fix` on the config users run — all 74 rules editing one file at once.
       - name: Verify whole-config lint autofix parity (ratchet against lint-adversarial-fix-all-known-failures.json)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.lint-env.outcome == 'success' }}
         run: node scripts/compat-corpus/lint-adversarial-fix-all.mjs
 
       # And a suggestion is neither a report nor a fix, so it is outside both
       # of the steps above.
       - name: Verify adversarial lint suggestion parity (ratchet against lint-adversarial-suggest-known-failures.json)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.lint-env.outcome == 'success' }}
         run: node scripts/compat-corpus/lint-adversarial-suggest.mjs
 
       # The start position is compared by the report gate; the END is not, and a
       # rule can underline the wrong region while agreeing about everything else.
       - name: Verify adversarial lint end-position parity (ratchet against lint-adversarial-end-known-failures.json)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.lint-env.outcome == 'success' }}
         run: node scripts/compat-corpus/lint-adversarial-end.mjs
 
       # Same sources, different project manifests: the adversarial corpus
       # declares @sveltejs/kit for its whole tree, so it cannot vary the one
       # input that decides whether five SvelteKit-gated rules run at all.
       - name: Verify lint environment parity (ratchet against lint-env-known-failures.json)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.lint-env.outcome == 'success' }}
         run: node scripts/compat-corpus/lint-env.mjs
 
       # Every gate above configures all shared rules to "warn" on both sides, so
       # the set a user gets with NO config is a constant none of them can vary.
       - name: Verify lint default-preset parity (ratchet against lint-preset-known-failures.json)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.lint-env.outcome == 'success' }}
         run: node scripts/compat-corpus/lint-preset.mjs
 
       # And the step above reads the two presets' declared TABLES. What a run
       # emits under them — each finding's severity and the process exit code —
       # is what this one compares, with no rule configuration on either side.
       - name: Verify lint default-configuration parity (ratchet against lint-severity-known-failures.json)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.lint-env.outcome == 'success' }}
         run: node scripts/compat-corpus/lint-severity.mjs
 
       # Whether a rule runs at all in a given Svelte mode. A wrong flag is
       # invisible to every finding-level gate unless the corpus happens to hold a
       # file in the mode the flag wrongly excludes.
       - name: Verify lint rule conditions (ratchet against lint-conditions-known-failures.json)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.lint-env.outcome == 'success' }}
         run: node scripts/compat-corpus/lint-conditions.mjs
 
       - name: Collect lint corpus
         run: node scripts/compat-corpus/lint-collect.mjs --ci
 
       - name: Verify lint parity (ratchet against lint-known-failures.json)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.lint-env.outcome == 'success' }}
         run: node scripts/compat-corpus/lint-verify.mjs
 
   check-parity:
@@ -755,6 +757,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build rsvelte NAPI binding
+        id: matrix-env
         run: |
           cargo build --release -p rsvelte_napi --lib
           mkdir -p .corpus-cache
@@ -767,7 +770,7 @@ jobs:
       - name: Shape matrix parity (ratchet against matrix-known-failures.json)
         # A failing step skips every unguarded step after it, and a skipped
         # comparison reads exactly like a passing one. Run regardless.
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.matrix-env.outcome == 'success' }}
         run: node scripts/compat-corpus/matrix/run.mjs
 
       # The only gate here that RUNS the compiled output instead of reading it.
@@ -775,7 +778,7 @@ jobs:
       # either passes or does not, so a text comparison can be green while the
       # warning is disarmed — which is the state #2540 shipped in.
       - name: await_waterfall runtime parity
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.matrix-env.outcome == 'success' }}
         run: node scripts/compat-corpus/await-waterfall-runtime.mjs
 
       - name: Upload matrix artifacts on failure

--- a/.github/workflows/lsp-benchmark.yml
+++ b/.github/workflows/lsp-benchmark.yml
@@ -69,6 +69,7 @@ jobs:
       # official measured 9.7 s. Raising it publishes the figure instead of losing
       # the run; the gap itself is tracked separately.
       - name: Run LSP benchmark
+        id: benchmark-run
         run: >-
           node scripts/bench-lsp/run.mjs
           --project submodules/bits-ui
@@ -80,7 +81,10 @@ jobs:
         timeout-minutes: 45
 
       - name: Validate LSP benchmark report
-        if: always()
+        # `always()` so a failing *validation* never hides behind a skip. It
+        # still needs the run to have produced a report: without the outcome
+        # test, a build failure is reported as "the report is invalid".
+        if: ${{ always() && steps.benchmark-run.outcome == 'success' }}
         run: |
           node --input-type=module <<'NODE'
           import assert from "node:assert/strict";

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -151,6 +151,44 @@ both worth knowing before it is merged, and neither visible in a diff.
 
 ---
 
+### A named blind-spot class: the environment failure wearing a verdict's name
+
+**A comparison step guarded so that it cannot be silently skipped will instead run without
+the environment it needs, and its failure is reported under the comparison's name.** The
+guard is right; what it did not say is that *setup* is also "an unguarded step after the
+failing one".
+
+`corpus-compat.yml` opens `shape-matrix` with a doc-count check, then checks out the Svelte
+submodule, installs, and builds the binding — all unguarded — and closes with two steps
+carrying `if: ${{ !cancelled() }}`, whose comment reads *"A failing step skips every unguarded
+step after it, and a skipped comparison reads exactly like a passing one. Run regardless."*
+On #4140 the doc-count check failed, every setup step was skipped, and the two comparisons ran
+anyway: `matrix/run.mjs` died on `Cannot find package 'acorn'` and the waterfall runtime gate
+on `official compiler missing`. What reached the branch header was
+**`Shape matrix parity (generated inputs): FAILURE`** — read by two people in succession as a
+divergence verdict, on a job where the matrix had never run at all. Fixing *a skipped
+comparison reads as a pass* had introduced *an environment failure reads as a divergence*:
+the same defect with the sign reversed.
+
+It is a class, not an instance. Counting, per job, the unguarded steps preceding the first
+`!cancelled()` step: `corpus` 13, `fmt-parity` 12, `shape-matrix` 11, `lsp-corpus` 10,
+`lsp-fixtures-current` 9, `lint-parity` 8, `lsp-benchmark` 9. Any of those failing — a doc
+check, or a `pnpm install` that hit a network blip — produces a red parity verdict whose cause
+is not parity.
+
+The defence is a precondition rather than the removal of the guard, because the guard's own
+reason still holds: a comparison runs on `!cancelled() && steps.<setup>.outcome == 'success'`,
+so it is skipped exactly when its environment is absent — and the job is already red from the
+real cause, so nothing is swallowed. `scripts/ci/step-environment-guard.mjs` enforces it, with
+`test-step-environment-guard.mjs` as the control set: the rule has to reject the #4140 shape
+**and** accept a sibling check guarded for the reason `!cancelled()` was written for, since a
+rule that requires a sibling check's outcome puts the original bug straight back.
+
+The generalisable question, asked of any `if:` on a CI step: **what else does this condition
+let through, and under whose name does that arrive?**
+
+---
+
 ### Reading the corpus in one sentence
 
 The collected corpus samples the *marginal* distribution of published Svelte code. That is

--- a/scripts/ci/step-environment-guard.mjs
+++ b/scripts/ci/step-environment-guard.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// Fail when a step that runs `if: ${{ !cancelled() }}` could run without the
+// environment it needs.
+//
+// `!cancelled()` exists here for a real reason: a failing step skips every
+// unguarded step after it, and a skipped comparison reads exactly like a
+// passing one. But *setup* is also "an unguarded step after it". So when a
+// doc-count check at the head of the job fails, `pnpm install` and the cargo
+// build are skipped and the comparison runs anyway — against no `node_modules`
+// and no binding. What lands in the branch header is
+// `Shape matrix parity: FAILURE`, caused by `Cannot find package 'acorn'`.
+//
+// Measured on #4140: two reviewers in a row read that red as a divergence
+// verdict before the job log was readable. Fixing "a skipped comparison reads
+// as a pass" had introduced "an environment failure reads as a divergence" —
+// the same defect wearing the other sign.
+//
+// The rule: a guarded `run:` step in a job that has any earlier unguarded step
+// which can fail must also require that step's outcome, so it is skipped when
+// the environment is missing. The job is already red from the real cause, so
+// nothing is silently swallowed.
+//
+// Exit codes: 0 = clean, 2 = violations found, 1 = internal/parse error.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_WORKFLOW_DIR = join(HERE, '..', '..', '.github', 'workflows');
+
+const EXIT_CLEAN = 0;
+const EXIT_ERROR = 1;
+const EXIT_VIOLATIONS = 2;
+
+const GUARDS = ['!cancelled()', 'always()'];
+
+/**
+ * A step that only checks out the repository cannot leave a *partial*
+ * environment behind: if it fails there is no tree, and every later step fails
+ * on its own. Requiring its outcome would be noise.
+ */
+const isCheckout = (step) => /actions\/checkout@/.test(step.uses ?? '');
+
+/**
+ * What counts as "the environment". The distinction matters: `!cancelled()`
+ * exists so that a failing SIBLING CHECK does not skip the checks after it, and
+ * requiring a sibling check's outcome would put that bug straight back. Only a
+ * step that installs, builds, or fetches can leave a half-made environment for
+ * the next step to fail inside.
+ */
+const SETUP_RUN = /\b(pnpm install|npm install|npm ci|yarn install|cargo build|cargo run|git submodule|collect\.mjs|pnpm run build|pnpm --filter|make )\b/;
+const isSetup = (step) =>
+	(step.uses !== null && !isCheckout(step)) || SETUP_RUN.test(step.run ?? '');
+
+/**
+ * Parse the workflow far enough to see jobs, steps, and the three keys this
+ * guard reads. A YAML dependency would buy nothing: the shapes here are
+ * two-space-indented block mappings, and the guard has to report line numbers.
+ *
+ * @param {string} text
+ */
+export function parseJobs(text) {
+	const lines = text.split('\n');
+	/** @type {{name: string, steps: any[]}[]} */
+	const jobs = [];
+	let job = null;
+	let step = null;
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		const jobHeader = line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+		if (jobHeader) {
+			job = { name: jobHeader[1], steps: [] };
+			jobs.push(job);
+			step = null;
+			continue;
+		}
+		if (!job) continue;
+		const stepHeader = line.match(/^ {6}- (name|uses|run|if|id): ?(.*)$/);
+		if (stepHeader) {
+			step = { line: i + 1, name: null, uses: null, run: null, if: null, id: null };
+			step[stepHeader[1]] = stepHeader[2];
+			job.steps.push(step);
+			continue;
+		}
+		if (!step) continue;
+		const key = line.match(/^ {8}(name|uses|run|if|id): ?(.*)$/);
+		if (key) step[key[1]] = key[2];
+	}
+	return jobs;
+}
+
+/**
+ * @param {{name: string, steps: any[]}[]} jobs
+ * @param {string} file
+ */
+export function violations(jobs, file) {
+	const out = [];
+	for (const job of jobs) {
+		// An unguarded step that is not a checkout is one whose failure leaves a
+		// half-built environment behind.
+		const fragile = job.steps.filter(
+			(s) => !GUARDS.some((g) => (s.if ?? '').includes(g)) && isSetup(s),
+		);
+		if (!fragile.length) continue;
+		for (const s of job.steps) {
+			const guard = s.if ?? '';
+			if (!GUARDS.some((g) => guard.includes(g))) continue;
+			// Only a step that *does* something can be misread as a verdict. An
+			// artifact upload guarded by `!cancelled()` is the intended shape:
+			// its whole point is to run when the job is failing.
+			if (s.run === null) continue;
+			// Anything before this step that is still unguarded.
+			const before = fragile.filter((f) => f.line < s.line);
+			if (!before.length) continue;
+			if (/steps\.[A-Za-z0-9_-]+\.outcome\s*==\s*'success'/.test(guard)) continue;
+			out.push(
+				`${file}:${s.line}  ${job.name}: \`${(s.name ?? s.run).slice(0, 60)}\` runs on ` +
+					`${GUARDS.find((g) => guard.includes(g))} with ${before.length} unguarded setup step(s) before it ` +
+					`(last: \`${(before.at(-1).name ?? before.at(-1).uses ?? '').slice(0, 50)}\`) and no ` +
+					`\`steps.<id>.outcome == 'success'\` precondition — an environment failure would be ` +
+					'reported under this step\'s name',
+			);
+		}
+	}
+	return out;
+}
+
+export function run(dir = DEFAULT_WORKFLOW_DIR) {
+	const found = [];
+	for (const f of readdirSync(dir).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml')).sort()) {
+		found.push(...violations(parseJobs(readFileSync(join(dir, f), 'utf8')), f));
+	}
+	return found;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+	try {
+		const found = run(process.argv[2] ?? DEFAULT_WORKFLOW_DIR);
+		if (found.length) {
+			for (const v of found) console.error(v);
+			console.error(
+				`\n[step-environment-guard] ${found.length} step(s) could report an environment ` +
+					'failure under a comparison\'s name. Give the environment step an `id:` and add ' +
+					"`&& steps.<id>.outcome == 'success'` to the guard.",
+			);
+			process.exit(EXIT_VIOLATIONS);
+		}
+		console.log('[step-environment-guard] every `!cancelled()` run step requires its environment. ✓');
+		process.exit(EXIT_CLEAN);
+	} catch (error) {
+		console.error(`[step-environment-guard] ${error?.stack ?? error}`);
+		process.exit(EXIT_ERROR);
+	}
+}

--- a/scripts/ci/test-step-environment-guard.mjs
+++ b/scripts/ci/test-step-environment-guard.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+// Self-test for scripts/ci/step-environment-guard.mjs.
+//
+// The guard passing on the current tree proves nothing — the tree is what it
+// was written against, and the fix landed in the same commit. Every case below
+// is a control: the shape the guard must reject, paired with the near-miss it
+// must accept, so a rule that flags everything and a rule that flags nothing
+// both fail here.
+
+import { parseJobs, violations } from './step-environment-guard.mjs';
+
+let failures = 0;
+
+function check(name, fn) {
+	try {
+		fn();
+		console.log(`  ok   ${name}`);
+	} catch (err) {
+		failures++;
+		console.error(`  FAIL ${name}\n       ${err.message}`);
+	}
+}
+
+const assert = (cond, message) => {
+	if (!cond) throw new Error(message);
+};
+
+const found = (yaml) => violations(parseJobs(yaml), 'x.yml');
+
+const CHECKOUT = '      - uses: actions/checkout@abc # v7.0.1';
+
+// The #4140 shape: a doc check at the head of the job, setup after it, and the
+// comparison guarded by `!cancelled()`. The comparison runs with no
+// `node_modules` and reports the environment failure under its own name.
+const REGRESSION = `
+jobs:
+  shape-matrix:
+    steps:
+${CHECKOUT}
+      - name: Verify docs
+        run: node scripts/check.mjs
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+      - name: Shape matrix parity
+        if: \${{ !cancelled() }}
+        run: node scripts/matrix.mjs
+`;
+
+const FIXED = REGRESSION.replace(
+	'      - name: Install deps\n        run: pnpm install --frozen-lockfile',
+	'      - name: Install deps\n        id: env\n        run: pnpm install --frozen-lockfile',
+).replace("if: ${{ !cancelled() }}", "if: ${{ !cancelled() && steps.env.outcome == 'success' }}");
+
+check('flags a guarded comparison with unguarded setup before it', () => {
+	const v = found(REGRESSION);
+	assert(v.length === 1, `expected 1 violation, got ${v.length}`);
+	assert(/Shape matrix parity/.test(v[0]), `violation names the wrong step: ${v[0]}`);
+});
+
+check('accepts the same job once the guard requires the setup outcome', () => {
+	const v = found(FIXED);
+	assert(v.length === 0, `expected 0 violations, got ${v.length}: ${v[0]}`);
+});
+
+// The case `!cancelled()` was WRITTEN for. Requiring a sibling check's outcome
+// would restore the bug it fixed, so a rule that flags this is wrong — this is
+// the near-miss that separates "the environment is missing" from "an earlier
+// check found something".
+check('does not flag sibling checks that install nothing', () => {
+	const v = found(`
+jobs:
+  guards:
+    steps:
+${CHECKOUT}
+      - name: Check triggers
+        run: node scripts/ci/a.mjs
+      - name: Check pins
+        if: \${{ !cancelled() }}
+        run: node scripts/ci/b.mjs
+`);
+	assert(v.length === 0, `expected 0 violations, got ${v.length}: ${v[0]}`);
+});
+
+// An artifact upload guarded by `!cancelled()` is the intended shape: its whole
+// purpose is to run while the job is red.
+check('does not flag an artifact upload', () => {
+	const v = found(`
+jobs:
+  corpus:
+    steps:
+${CHECKOUT}
+      - name: Install deps
+        run: pnpm install
+      - name: Upload report
+        if: \${{ !cancelled() }}
+        uses: actions/upload-artifact@abc
+`);
+	assert(v.length === 0, `expected 0 violations, got ${v.length}: ${v[0]}`);
+});
+
+// A checkout cannot leave a partial environment: if it fails there is no tree.
+check('does not treat checkout alone as fragile setup', () => {
+	const v = found(`
+jobs:
+  guards:
+    steps:
+${CHECKOUT}
+      - name: Check something
+        if: \${{ !cancelled() }}
+        run: node scripts/ci/a.mjs
+`);
+	assert(v.length === 0, `expected 0 violations, got ${v.length}: ${v[0]}`);
+});
+
+// `always()` carries the same hazard as `!cancelled()` and must be covered by
+// the same rule; a guard that only knew the one spelling would miss
+// lsp-benchmark.yml's report validation.
+check('covers always() as well as !cancelled()', () => {
+	const v = found(`
+jobs:
+  benchmark:
+    steps:
+${CHECKOUT}
+      - name: Build server
+        run: cargo build --release -p x
+      - name: Validate report
+        if: always()
+        run: node -e ''
+`);
+	assert(v.length === 1, `expected 1 violation, got ${v.length}`);
+});
+
+// A `uses:` action other than checkout is setup by definition — setup-rust,
+// setup-node-pnpm and the caches all leave state a later step reads.
+check('treats a non-checkout action as setup', () => {
+	const v = found(`
+jobs:
+  corpus:
+    steps:
+${CHECKOUT}
+      - uses: ./.github/actions/setup-node-pnpm
+      - name: Compare
+        if: \${{ !cancelled() }}
+        run: node scripts/compare.mjs
+`);
+	assert(v.length === 1, `expected 1 violation, got ${v.length}`);
+});
+
+// A guarded step BEFORE the setup cannot be affected by it, so requiring the
+// outcome of a step that has not run yet would be meaningless.
+check('ignores a guarded step that precedes the setup', () => {
+	const v = found(`
+jobs:
+  corpus:
+    steps:
+${CHECKOUT}
+      - name: Early check
+        if: \${{ !cancelled() }}
+        run: node scripts/ci/a.mjs
+      - name: Install deps
+        run: pnpm install
+`);
+	assert(v.length === 0, `expected 0 violations, got ${v.length}: ${v[0]}`);
+});
+
+console.log(failures ? `\n${failures} failure(s)` : '\nall step-environment-guard controls pass');
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
`if: ${{ !cancelled() }}` on a comparison step exists so a failing sibling cannot skip it — *"a skipped comparison reads exactly like a passing one"*. What that comment does not say is that **setup is also "an unguarded step after the failing one."**

## What happened on #4140

A doc-count check sits at the head of `shape-matrix`. It failed. Every unguarded step after it — the Svelte submodule checkout, `pnpm install`, the cargo build — was skipped. The two steps carrying `!cancelled()` ran anyway:

```
checkout                         ✓
known-failures-md-check          ##[error] exit 1    ← the real failure
  (submodule / setup-rust / setup-node-pnpm / pnpm install / cargo build … all SKIPPED)
matrix/run.mjs                   ##[error] exit 1    Cannot find package 'acorn'
await-waterfall-runtime.mjs      ##[error] exit 2    [waterfall] official compiler missing
```

What reached the branch header was **`Shape matrix parity (generated inputs): FAILURE`**, for a job in which the matrix never ran. Two people read it in succession as a divergence verdict and started reasoning about a #4117 × #4118 interaction; the run was still `in_progress`, so `gh run view --log-failed` refused the log.

Fixing *a skipped comparison reads as a pass* had introduced *an environment failure reads as a divergence* — the same defect with the sign reversed.

## It is a class

Unguarded steps preceding the first `!cancelled()` step, per job:

| job | count |
|---|---|
| `corpus-compat.yml` `corpus` | 13 |
| `fmt-parity` | 12 |
| `shape-matrix` | 11 |
| `lsp-corpus` | 10 |
| `lsp-fixtures-current` | 9 |
| `lint-parity` | 8 |
| `lsp-benchmark.yml` `benchmark` | 9 |

A `pnpm install` that hits a network blip produces the same shape as the doc check did.

## The fix

Not removing the guard — its reason still holds. Each affected comparison now runs on

```yaml
if: ${{ !cancelled() && steps.<setup>.outcome == 'success' }}
```

so it is skipped exactly when its environment is absent. The job is already red from the real cause, so nothing is swallowed. Artifact uploads keep the bare guard: running while the job is red is their whole purpose.

Changed: `corpus` (11 steps, gated on `Collect corpus`), `lint-parity` (10, on the oracle install), `shape-matrix` (2, on the NAPI build), `ci.yml` `corpus-verify-flags` (10, on `Install dependencies`), and `lsp-benchmark`'s report validation (on the benchmark run — otherwise a build failure is reported as "the report is invalid").

## The guard, and why its control set is the interesting half

`scripts/ci/step-environment-guard.mjs` enforces the rule. The rule has to reject the #4140 shape **and accept** a sibling check guarded for the reason `!cancelled()` was written for — a rule that requires a *sibling check's* outcome puts the original bug straight back. The first version did exactly that: it flagged all 15 steps of `workflow-trigger-guard`, where every preceding step is a peer check that installs nothing. `test-step-environment-guard.mjs` pins both directions plus the artifact-upload, checkout-only, `always()`, and step-order cases.

```
$ node scripts/ci/step-environment-guard.mjs
[step-environment-guard] every `!cancelled()` run step requires its environment. ✓
$ node scripts/ci/test-step-environment-guard.mjs
  ok   flags a guarded comparison with unguarded setup before it
  ok   accepts the same job once the guard requires the setup outcome
  ok   does not flag sibling checks that install nothing
  ok   does not flag an artifact upload
  ok   does not treat checkout alone as fragile setup
  ok   covers always() as well as !cancelled()
  ok   treats a non-checkout action as setup
  ok   ignores a guarded step that precedes the setup
```

`compatibility/GATES.md` gets the class as a named blind spot, with the generalisable question: **what else does this `if:` let through, and under whose name does that arrive?**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmNuq3boYDqe9CWwSfxi8
