### PR TITLE
fix(css): a render site belongs to the snippet it renders, not to every snippet of that name

### DIFF
--- a/.changeset/snippet-render-site-identity.md
+++ b/.changeset/snippet-render-site-identity.md
@@ -1,0 +1,26 @@
+---
+"@rsvelte/compiler": patch
+---
+
+A `{#snippet}`'s render sites are keyed by the snippet it renders, not by that snippet's name
+
+Upstream fills `SnippetBlock.metadata.sites` in one pass over `analysis.snippet_renderers`
+(`2-analyze/index.js:847`): a renderer whose callee resolves to a local snippet is a site of
+that block NODE, one that resolves to nothing gets `node.metadata.snippets =
+analysis.snippets` and so is a site of every snippet in the component, and one that resolves
+outside it — a prop, an import — is a site of none. rsvelte keyed that map by the snippet's
+name, so two `{#snippet row()}` in different scopes merged and each was given the other's
+ancestors; and it had no notion of an unresolved renderer, so `{@render f()}` with `f` an
+ordinary local, `<Comp {...spread}>` and `<Comp foo={row} />` contributed nothing. A
+component is now kept `resolved` when an expression attribute is an identifier naming a
+snippet, as upstream does, rather than being unresolved for any non-literal.
+
+The registration for a snippet declared directly inside a component tested
+`context.path.last()`, but `visit_node` pushes the node before dispatching, so inside the
+SnippetBlock visitor that is the snippet itself and the branch had never run. Nothing
+noticed while a missing site meant "unknown, stay conservative"; a real `svelte.dev`
+component starts losing a CSS rule the moment an empty site set becomes an answer.
+
+The same upstream rule is ported a second time in `2_analyze/css_scoping.rs`, which still
+keys by name and whose `{@render}` arm does not follow the tag into the snippet at all;
+that half is unfixed and is `compatibility/GATES.md#two-ports-inventory` row 27.

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -6690,7 +6690,7 @@ and a renderer that resolves outside the component (a prop, an import) is a site
 |---|---|---|
 | built by | `2_analyze/visitors/{render_tag,snippet_block,shared/component}.rs` | `css_scoping.rs:1432` `collect_render_site_ancestors`, its own template walk |
 | read by | `3_transform/css.rs` `effective_parents` — pruning and scoping | `css_scoping.rs` `subtree_has_matching_subject` — ancestor scoping |
-| a `{#snippet}` passed as an *attribute* (`<Comp foo={row} />`) | yes | yes (`attribute_snippet_names:1415`) |
+| a `{#snippet}` passed as an *attribute* (`<Comp foo={row} />`) | yes, since #4115's port-A fix | yes (`attribute_snippet_names:1415`) |
 | an **unresolved** renderer is a site of every snippet | yes | **no** |
 | resolves the callee through the scope chain | yes (`render_tag.rs:58`) | **no** — `get_render_tag_callee_name` returns the identifier's text |
 
@@ -6707,7 +6707,7 @@ this subtree holds no matching subject, so `.wrap` never receives its scope clas
 question, two answers, in the same output** — the CSS text and the template disagree about
 whether that `<span>` is inside `.wrap`.
 
-**Measured residue.** A 64-cell grid (snippet shape × render-site shape × `client`/`server`)
+**Measured residue.** A 70-cell grid (snippet shape × render-site shape × `client`/`server`)
 leaves **30 cells** diverging after port A was made faithful, and the *direction* splits: on 24
 rsvelte scopes **fewer** elements than official (port B's `RenderTag` arm computes a name, tests
 the map, and does nothing — `css_scoping.rs:2462`), and on 6 it scopes **more**, because port B
@@ -6715,6 +6715,12 @@ still keys by name and merges two same-named snippets in different scopes. That 
 **the same defect port A was just fixed for**: fixing one port of a decision does not narrow the
 other, and reporting the aggregate (`30 cells, all verdict JS`) hid the sign — the two directions
 were only separated by counting scope classes on each side.
+
+**The asymmetry runs both ways.** `attribute_snippet_names` (`css_scoping.rs:1415`) has no
+counterpart anywhere else in the tree: until the port-A fix, port B was the **more** faithful of
+the two on `<Comp foo={row} />`, and port A treated any non-literal attribute as making the
+component unresolved. A second port is not reliably the degraded one, so "fix the port the bug
+was reported against" is not a rule — read both before deciding which one moves.
 
 **Why closing port B is not a transcription.** Upstream walks the tree while reading another part
 of it; `propagate_ancestor_scoping` holds `&mut Fragment`, so Rust cannot take the immutable

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -6675,6 +6675,69 @@ probe is the 11-input structural round trip described above, which is not in the
 the open half of this row.**
 
 
+#### 27. Where in the DOM is a `{#snippet}` body rendered? — [D], both ports still live
+
+**Upstream** answers once. `SnippetBlock.metadata.sites` is filled in a single pass over
+`analysis.snippet_renderers` (`2-analyze/index.js:847`): a renderer whose callee resolves to a
+local snippet is a site of **that block node** (`binding.initial`), a renderer that resolves to
+nothing gets `node.metadata.snippets = analysis.snippets` and so is a site of **every** snippet,
+and a renderer that resolves outside the component (a prop, an import) is a site of **none**.
+`get_ancestor_elements` (`css-prune.js:845`) then reads that one set.
+
+**rsvelte answers twice, and the two are not even subsets of each other.**
+
+| | port A | port B |
+|---|---|---|
+| built by | `2_analyze/visitors/{render_tag,snippet_block,shared/component}.rs` | `css_scoping.rs:1432` `collect_render_site_ancestors`, its own template walk |
+| read by | `3_transform/css.rs` `effective_parents` — pruning and scoping | `css_scoping.rs` `subtree_has_matching_subject` — ancestor scoping |
+| a `{#snippet}` passed as an *attribute* (`<Comp foo={row} />`) | yes | yes (`attribute_snippet_names:1415`) |
+| an **unresolved** renderer is a site of every snippet | yes | **no** |
+| resolves the callee through the scope chain | yes (`render_tag.rs:58`) | **no** — `get_render_tag_callee_name` returns the identifier's text |
+
+**Discriminating input, and both answers are observable in ONE compile:**
+
+```svelte
+{#snippet row()}<span>x</span>{/snippet}
+<div class="wrap">{@render row()}</div>
+<style>.wrap span { color: red; }</style>
+```
+
+Port A says the selector is used, so the emitted CSS is byte-identical to official's. Port B says
+this subtree holds no matching subject, so `.wrap` never receives its scope class. **One upstream
+question, two answers, in the same output** — the CSS text and the template disagree about
+whether that `<span>` is inside `.wrap`.
+
+**Measured residue.** A 64-cell grid (snippet shape × render-site shape × `client`/`server`)
+leaves **30 cells** diverging after port A was made faithful, and the *direction* splits: on 24
+rsvelte scopes **fewer** elements than official (port B's `RenderTag` arm computes a name, tests
+the map, and does nothing — `css_scoping.rs:2462`), and on 6 it scopes **more**, because port B
+still keys by name and merges two same-named snippets in different scopes. That second half is
+**the same defect port A was just fixed for**: fixing one port of a decision does not narrow the
+other, and reporting the aggregate (`30 cells, all verdict JS`) hid the sign — the two directions
+were only separated by counting scope classes on each side.
+
+**Why closing port B is not a transcription.** Upstream walks the tree while reading another part
+of it; `propagate_ancestor_scoping` holds `&mut Fragment`, so Rust cannot take the immutable
+borrow of a *different* snippet body from inside that walk. The port needs the decision lifted
+into a prior immutable pass. **Same algorithm, different number of passes** — a reason to deviate
+that this file's other rows do not have.
+
+**Not [M].** Nothing compares the two ports to each other; the grid compares each to official, so
+both ports failing the same way would score green. `is_resolved_snippet` was briefly a third
+implementation of the neighbouring "does this callee resolve" question (`render_tag.rs` private,
+`shared/snippets.rs` public); the two were read side by side, found to agree on all four
+conditions in the same order, and merged into one — an inventory entry that was retired rather
+than added.
+
+**One more thing a reader of `css-prune.js` needs.** Its two neighbouring walkers treat
+`SnippetBlock` **oppositely**: `get_ancestor_elements` (:845) `break`s the lexical path walk at
+one and continues from the render sites, while `get_descendant_elements` (:907) has no
+`SnippetBlock` case at all — the `_` catch-all calls `context.next()`, so it *does* descend into a
+lexically nested snippet body, and only `RenderTag` is special-cased. A port that carries the
+`break` intuition into the descending walker prunes real descendants; one that carries the
+descending intuition upward invents ancestors.
+
+
 ### Adding a row, and closing one
 
 **Finding a candidate.** Start from *one upstream function*, not from a rsvelte symbol. Grep the

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
@@ -3045,7 +3045,8 @@ fn g_ancestor_elements(
     ancestors
 }
 
-/// Port of `get_descendant_elements`.
+/// Port of `get_descendant_elements`. It has no `Snippet` arm on purpose: upstream's walker
+/// descends into a lexically nested snippet body, where `get_ancestor_elements` breaks at one.
 fn g_descendant_elements(
     graph: &SGraph,
     node: usize,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -2391,9 +2391,15 @@ pub struct DomStructure {
     /// All elements in the template, with their relationships
     pub elements: Vec<CssDomElement>,
     pub general_siblings_linked: bool,
-    /// `{@render name(...)}` call sites, keyed by snippet name. A snippet-declared
-    /// element's real DOM ancestors are the union of its sites' ancestors.
-    pub snippet_render_sites: FxHashMap<String, Vec<CssRenderSite>>,
+    /// Render sites, keyed by the start of the snippet's NAME expression. Upstream
+    /// keys `SnippetBlock.metadata.sites` on the block node itself, and two
+    /// snippets in different scopes may share a name.
+    pub snippet_render_sites: FxHashMap<u32, Vec<CssRenderSite>>,
+    /// Sites of renderers that resolve to no specific declaration. Upstream's
+    /// `if (!resolved) node.metadata.snippets = analysis.snippets` makes such a
+    /// site one of EVERY snippet here — stronger than "unknown", so it must not
+    /// be modelled as one.
+    pub unresolved_render_sites: Vec<CssRenderSite>,
 }
 
 /// A `{@render}` call site: where the snippet body is spliced into the DOM.
@@ -2401,8 +2407,8 @@ pub struct DomStructure {
 pub struct CssRenderSite {
     /// Enclosing element index, `None` at the fragment root.
     pub parent_idx: Option<usize>,
-    /// Innermost `{#snippet}` the call site itself sits in, if any.
-    pub snippet_name: Option<String>,
+    /// Innermost `{#snippet}` the call site itself sits in, keyed as above.
+    pub snippet_start: Option<u32>,
 }
 
 /// Certainty level of sibling relationships.
@@ -2469,9 +2475,9 @@ pub struct CssDomElement {
     /// Whether this element has a dynamic tag name (svelte:element)
     /// When true, any type selector matches this element
     pub is_dynamic_tag: bool,
-    /// Innermost enclosing `{#snippet}` name — its real DOM ancestors are that
-    /// snippet's render sites, not its lexical `parent_idx`.
-    pub snippet_name: Option<String>,
+    /// Innermost enclosing `{#snippet}`, keyed by its name expression's start —
+    /// its real DOM ancestors are that snippet's render sites, not `parent_idx`.
+    pub snippet_start: Option<u32>,
     /// Set when the sibling walk stopped at something it could not enumerate, so
     /// the four lists above are a subset of the real siblings rather than all of
     /// them. A `{#if}` / `{#each}` / `{#await}` / `{#key}` branch does not set it:

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/const_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/const_tag.rs
@@ -32,7 +32,7 @@ pub fn visit(tag: &mut ConstTag, context: &mut VisitorContext) -> Result<(), Ana
         Some(FragmentOwnerType::EachBlock) => true,
         Some(FragmentOwnerType::AwaitBlock) => true,
         Some(FragmentOwnerType::KeyBlock) => true,
-        Some(FragmentOwnerType::SnippetBlock(_, _)) => true,
+        Some(FragmentOwnerType::SnippetBlock(_, _, _)) => true,
         Some(FragmentOwnerType::SvelteFragment) => true,
         Some(FragmentOwnerType::SvelteBoundary) => true,
         Some(FragmentOwnerType::Component) => true,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/declaration_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/declaration_tag.rs
@@ -57,7 +57,7 @@ pub fn visit(tag: &mut DeclarationTag, context: &mut VisitorContext) -> Result<(
                 | FragmentOwnerType::EachBlock
                 | FragmentOwnerType::AwaitBlock
                 | FragmentOwnerType::KeyBlock
-                | FragmentOwnerType::SnippetBlock(_, _)
+                | FragmentOwnerType::SnippetBlock(_, _, _)
                 | FragmentOwnerType::SvelteFragment
                 | FragmentOwnerType::SvelteBoundary
                 | FragmentOwnerType::Component

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/identifier.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/identifier.rs
@@ -628,7 +628,7 @@ fn check_const_tag_snippet_reference(
 
     for i in (0..stack.len()).rev() {
         match &stack[i] {
-            super::FragmentOwnerType::SnippetBlock(scope, sname) => {
+            super::FragmentOwnerType::SnippetBlock(scope, sname, _) => {
                 found_snippet = true;
                 snippet_scope = Some(*scope);
                 snippet_name = Some(sname.clone());

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -568,8 +568,9 @@ pub enum FragmentOwnerType {
     AwaitBlock,
     /// Inside a KeyBlock
     KeyBlock,
-    /// Inside a SnippetBlock (scope index, snippet name)
-    SnippetBlock(usize, String),
+    /// Inside a SnippetBlock (declaring scope index, snippet name, and the start
+    /// of its name expression — the identity upstream keys `metadata.sites` on).
+    SnippetBlock(usize, String, u32),
     /// Inside a SvelteFragment
     SvelteFragment,
     /// Inside a SvelteBoundary
@@ -664,13 +665,15 @@ impl<'a> VisitorContext<'a> {
         self.dom_element_stack.last().copied()
     }
 
-    /// Name of the innermost enclosing `{#snippet}`, if any.
-    pub fn current_snippet_name(&self) -> Option<String> {
+    /// The innermost enclosing `{#snippet}`, keyed by its name expression's
+    /// start. Upstream keys `metadata.sites` on the block node, so a name is not
+    /// an identity: two scopes may declare the same one.
+    pub fn current_snippet_key(&self) -> Option<u32> {
         self.fragment_owner_stack
             .iter()
             .rev()
             .find_map(|o| match o {
-                FragmentOwnerType::SnippetBlock(_, name) => Some(name.clone()),
+                FragmentOwnerType::SnippetBlock(_, _, key) => Some(*key),
                 _ => None,
             })
     }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -744,7 +744,7 @@ pub fn visit<'a, 'b: 'a>(
             has_content: !element.fragment.nodes.is_empty(),
             has_opaque_content,
             is_dynamic_tag: false,
-            snippet_name: context.current_snippet_name(),
+            snippet_start: context.current_snippet_key(),
             sibling_walk_incomplete: false,
             prev_is_opaque_boundary: false,
             prev_has_opaque_boundary: false,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/render_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/render_tag.rs
@@ -6,6 +6,7 @@
 
 use super::VisitorContext;
 use super::shared::fragment::mark_subtree_dynamic;
+use super::shared::snippets::is_resolved_snippet;
 use super::shared::utils::validate_opening_tag;
 use crate::ast::template::{ExpressionMetadata, RenderTag, TemplateNode};
 use crate::ast::typed_expr::JsNode;
@@ -85,20 +86,7 @@ pub fn visit(tag: &mut RenderTag, context: &mut VisitorContext) -> Result<(), An
     // In JavaScript: binding?.kind !== 'normal' - when binding is null, this returns true
     tag.metadata.dynamic = binding.is_none_or(|b| b.kind != BindingKind::Normal);
 
-    // Determine if we can unambiguously resolve this to a specific snippet declaration
-    // It's resolved if:
-    // - No binding (external/import)
-    // - Binding is an import
-    // - Binding is a prop/rest_prop/bindable_prop
-    // - Binding's initial value is a SnippetBlock
-    let _resolved = is_resolved_snippet(binding);
-
-    // If the callee is an identifier that unambiguously references a local snippet, track it
-    if let Some(_binding) = binding {
-        // Check if the binding's initial node is a SnippetBlock
-        // For now, we'll track snippet indices separately
-        // TODO: Link to actual snippet blocks when we have a proper index mapping
-    }
+    let resolved = callee_name.is_some() && is_resolved_snippet(binding);
 
     // Track this render tag in the analysis (for Phase 3)
     // In JavaScript: context.state.analysis.snippet_renderers.set(node, resolved);
@@ -110,19 +98,26 @@ pub fn visit(tag: &mut RenderTag, context: &mut VisitorContext) -> Result<(), An
     // content, so mark this as an opaque boundary for sibling detection.
     context.analysis.css.has_opaque_elements = true;
 
-    if let Some(name) = callee_name {
-        let site = crate::compiler::phases::phase2_analyze::types::CssRenderSite {
-            parent_idx: context.current_parent_idx(),
-            snippet_name: context.current_snippet_name(),
-        };
-        context
-            .analysis
-            .css
-            .dom_structure
-            .snippet_render_sites
-            .entry(name.to_string())
-            .or_default()
-            .push(site);
+    // Upstream adds this site to `binding.initial`'s sites when the callee
+    // resolves to a local snippet, to EVERY snippet when it resolves to nothing,
+    // and to none at all when it resolves outside the component (a prop or an
+    // import) — `2-analyze/index.js:847`.
+    let site = crate::compiler::phases::phase2_analyze::types::CssRenderSite {
+        parent_idx: context.current_parent_idx(),
+        snippet_start: context.current_snippet_key(),
+    };
+    let snippet_key = binding.and_then(|b| {
+        if b.initial_node_type.as_deref() == Some("SnippetBlock") {
+            b.declaration_start
+        } else {
+            None
+        }
+    });
+    let dom = &mut context.analysis.css.dom_structure;
+    if let Some(key) = snippet_key {
+        dom.snippet_render_sites.entry(key).or_default().push(site);
+    } else if !resolved {
+        dom.unresolved_render_sites.push(site);
     }
 
     // Validate arguments - no spread elements allowed
@@ -159,28 +154,6 @@ pub fn visit(tag: &mut RenderTag, context: &mut VisitorContext) -> Result<(), An
 
     Ok(())
 }
-/// Check if a binding unambiguously resolves to a specific snippet declaration,
-/// or is external to the current component.
-///
-/// Corresponds to `is_resolved_snippet` in Svelte's visitors/shared/snippets.js.
-fn is_resolved_snippet(binding: Option<&crate::compiler::phases::phase2_analyze::Binding>) -> bool {
-    if binding.is_none() {
-        return true; // No binding = external/global
-    }
-
-    let binding = binding.unwrap();
-
-    // It's resolved if it's an import, prop, bindable prop, or directly bound
-    // to a `{#snippet ...}` block in the same component.
-    matches!(
-        binding.declaration_kind,
-        crate::compiler::phases::phase2_analyze::DeclarationKind::Import
-    ) || matches!(
-        binding.kind,
-        BindingKind::Prop | BindingKind::RestProp | BindingKind::BindableProp
-    ) || binding.initial_node_type.as_deref() == Some("SnippetBlock")
-}
-
 /// Get a string representation of a template node type.
 fn node_type_string(node: &TemplateNode) -> String {
     match node {

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -11,6 +11,7 @@ use super::super::super::errors;
 use super::super::VisitorContext;
 use super::super::attribute::visit_attribute_value_expressions;
 use super::fragment;
+use super::snippets::is_resolved_snippet;
 use super::utils::{
     validate_assignment_node, validate_attribute_name as validate_attribute_name_colon,
 };
@@ -61,17 +62,11 @@ pub fn visit_component<'a, 'b: 'a>(
         }
     }
 
-    // Determine which snippets this component might render. `resolved` is
-    // true when we can list those candidates exactly; if false, the official
-    // compiler treats every locally-defined snippet as a possible render
-    // target, so Phase 3 must not rely on the set being a precise list.
-    //
-    // We currently only resolve the easy cases — an expression attribute
-    // whose value is a literal can never reference a snippet, so it doesn't
-    // taint resolution. Identifier / member / call expressions, spreads,
-    // and bind directives all leave us with no static knowledge of which
-    // snippet the component will receive, so they fall back to "unresolved".
+    // Determine which snippets this component might render. `resolved` is true when
+    // we can list those candidates exactly; if false, upstream treats every snippet
+    // in the component as a possible target, so Phase 3 must not rely on the set.
     let mut resolved = true;
+    let mut attr_snippet_keys: Vec<u32> = Vec::new();
     for attr in &component.attributes {
         match attr {
             Attribute::SpreadAttribute(_) | Attribute::BindDirective(_) => {
@@ -79,10 +74,31 @@ pub fn visit_component<'a, 'b: 'a>(
             }
             Attribute::Attribute(a) => {
                 if let crate::ast::template::AttributeValue::Expression(expr_tag) = &a.value {
-                    let expr_type = expr_tag.expression.node_type().unwrap_or("");
-                    if expr_type != "Literal" {
-                        // Identifier / member / call etc. — could reference a
-                        // snippet binding we can't statically resolve here.
+                    // An identifier is resolvable: it either names a snippet here, or
+                    // comes from outside the component and so names none of ours.
+                    // Anything else that is not a literal leaves us with no static
+                    // knowledge of which snippet the component will receive.
+                    if let Some(name) = expr_tag.expression.identifier_name() {
+                        let binding_idx = context
+                            .analysis
+                            .root
+                            .get_binding(name, context.scope)
+                            .filter(|&i| {
+                                let declared = context.analysis.root.bindings[i].scope_index;
+                                context
+                                    .analysis
+                                    .root
+                                    .is_scope_ancestor_of(declared, context.scope)
+                            });
+                        let binding = binding_idx.map(|i| &context.analysis.root.bindings[i]);
+                        resolved &= is_resolved_snippet(binding);
+                        if let Some(b) = binding
+                            && b.initial_node_type.as_deref() == Some("SnippetBlock")
+                            && let Some(start) = b.declaration_start
+                        {
+                            attr_snippet_keys.push(start);
+                        }
+                    } else if expr_tag.expression.node_type().unwrap_or("") != "Literal" {
                         resolved = false;
                     }
                 }
@@ -112,6 +128,31 @@ pub fn visit_component<'a, 'b: 'a>(
         .analysis
         .snippet_renderers
         .insert(format!("Component@{}", component.start), resolved);
+
+    // Upstream `2-analyze/index.js:847`: an UNRESOLVED renderer is a site of every
+    // snippet in the component, which is stronger than "unknown". A resolved one is
+    // a site of the snippets its attributes name (its own children are registered by
+    // the SnippetBlock visitor, which `<svelte:self>` reaches and this does not).
+    let site = crate::compiler::phases::phase2_analyze::types::CssRenderSite {
+        parent_idx: context.current_parent_idx(),
+        snippet_start: context.current_snippet_key(),
+    };
+    if resolved {
+        let dom = &mut context.analysis.css.dom_structure;
+        for key in attr_snippet_keys {
+            dom.snippet_render_sites
+                .entry(key)
+                .or_default()
+                .push(site.clone());
+        }
+    } else {
+        context
+            .analysis
+            .css
+            .dom_structure
+            .unresolved_render_sites
+            .push(site);
+    }
 
     // Mark the subtree as dynamic
     super::super::shared::fragment::mark_subtree_dynamic(&context.path);

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
@@ -29,26 +29,32 @@ pub fn visit<'a, 'b: 'a>(
     validate_snippet(block, context)?;
 
     // A snippet declared directly inside a component is rendered by that
-    // component, so the component's position is one of its render sites.
+    // component, so the component's position is one of its render sites. This
+    // holds whether or not the component resolved: upstream's unresolved branch
+    // replaces `metadata.snippets` with EVERY snippet, which still contains this
+    // one. `<svelte:self>` / `<svelte:component>` never reach `visit_component`,
+    // so this is also the only site registration they get.
+    // `visit_node` pushes the node before dispatching, so `path.last()` is this
+    // SnippetBlock; the enclosing node is one further back.
     if matches!(
-        context.path.last(),
+        context.path.iter().rev().nth(1),
         Some(
             TemplateNode::Component(_)
                 | TemplateNode::SvelteComponent(_)
                 | TemplateNode::SvelteSelf(_)
         )
-    ) && let Some(name) = super::shared::snippets::get_snippet_name(block)
+    ) && let Some(key) = block.expression.start()
     {
         let site = super::super::types::CssRenderSite {
             parent_idx: context.current_parent_idx(),
-            snippet_name: context.current_snippet_name(),
+            snippet_start: context.current_snippet_key(),
         };
         context
             .analysis
             .css
             .dom_structure
             .snippet_render_sites
-            .entry(name)
+            .entry(key)
             .or_default()
             .push(site);
     }
@@ -87,8 +93,12 @@ pub fn visit<'a, 'b: 'a>(
     context
         .fragment_owner_stack
         .push(super::FragmentOwnerType::SnippetBlock(
+            // Pushed BEFORE `context.scope` is switched to the body scope below,
+            // so this is the DECLARING scope. Moving the push after the switch
+            // silently changes what every consumer of this variant resolves.
             context.scope,
             snippet_name,
+            block.expression.start().unwrap_or(block.start),
         ));
 
     // Reset parent_element to None for snippet body analysis

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
@@ -65,7 +65,7 @@ pub fn visit<'a, 'b: 'a>(
             has_content: !element.fragment.nodes.is_empty(),
             has_opaque_content: false,
             is_dynamic_tag: true,
-            snippet_name: context.current_snippet_name(),
+            snippet_start: context.current_snippet_key(),
             sibling_walk_incomplete: false,
             prev_is_opaque_boundary: false,
             prev_has_opaque_boundary: false,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -3553,52 +3553,48 @@ fn structural_ancestry_is_lexical(ctx: &CssContext) -> bool {
 /// outside the element's `{#snippet}` body, in which case the union of the
 /// parents of every `{@render}` site of that snippet (upstream
 /// `get_ancestor_elements` breaking the path walk at a `SnippetBlock`).
-/// `None` when a snippet's render sites are unknown, in which case callers must
-/// stay conservative rather than treat the ancestor set as empty.
+/// A snippet nothing renders has an empty set; a renderer that resolved to nothing
+/// is a site of every snippet. Neither is modelled as "unknown".
 fn effective_parents(ctx: &CssContext, el_idx: usize) -> Option<Vec<usize>> {
     let el = &ctx.dom_structure.elements[el_idx];
     let mut out = Vec::new();
-    let mut seen: FxHashSet<&str> = FxHashSet::default();
-    expand_effective_parents(
-        ctx,
-        el.parent_idx,
-        el.snippet_name.as_deref(),
-        &mut seen,
-        &mut out,
-    )?;
+    let mut seen: FxHashSet<u32> = FxHashSet::default();
+    expand_effective_parents(ctx, el.parent_idx, el.snippet_start, &mut seen, &mut out)?;
     out.sort_unstable();
     out.dedup();
     Some(out)
 }
 
-fn expand_effective_parents<'a>(
-    ctx: &'a CssContext,
+fn expand_effective_parents(
+    ctx: &CssContext,
     parent_idx: Option<usize>,
-    snippet: Option<&'a str>,
-    seen: &mut FxHashSet<&'a str>,
+    snippet: Option<u32>,
+    seen: &mut FxHashSet<u32>,
     out: &mut Vec<usize>,
 ) -> Option<()> {
     if let Some(p) = parent_idx
-        && ctx.dom_structure.elements[p].snippet_name.as_deref() == snippet
+        && ctx.dom_structure.elements[p].snippet_start == snippet
     {
         out.push(p);
         return Some(());
     }
     // The lexical walk left the snippet body (or hit the root): continue from
     // wherever the snippet is rendered.
-    let Some(name) = snippet else { return Some(()) };
-    if !seen.insert(name) {
+    let Some(key) = snippet else { return Some(()) };
+    if !seen.insert(key) {
         return Some(());
     }
-    let sites = ctx.dom_structure.snippet_render_sites.get(name)?;
-    for site in sites {
-        expand_effective_parents(
-            ctx,
-            site.parent_idx,
-            site.snippet_name.as_deref(),
-            seen,
-            out,
-        )?;
+    // Upstream reads `SnippetBlock.metadata.sites`, so a snippet nothing renders
+    // contributes no ancestors — an empty set is knowledge. A renderer that
+    // resolved to nothing is a site of every snippet, which is also knowledge and
+    // the other end of the same axis; neither is "unknown".
+    if let Some(sites) = ctx.dom_structure.snippet_render_sites.get(&key) {
+        for site in sites {
+            expand_effective_parents(ctx, site.parent_idx, site.snippet_start, seen, out)?;
+        }
+    }
+    for site in &ctx.dom_structure.unresolved_render_sites {
+        expand_effective_parents(ctx, site.parent_idx, site.snippet_start, seen, out)?;
     }
     Some(())
 }

--- a/crates/rsvelte_core/tests/snippet_render_sites_4115.rs
+++ b/crates/rsvelte_core/tests/snippet_render_sites_4115.rs
@@ -1,0 +1,180 @@
+//! Upstream keys `SnippetBlock.metadata.sites` on the block NODE, reached through
+//! `binding.initial`, and fills it in one pass over `analysis.snippet_renderers`
+//! (`2-analyze/index.js:847`): a renderer that resolves to a local snippet is a
+//! site of that one, a renderer that resolves to nothing is a site of EVERY
+//! snippet, and a renderer that resolves outside the component is a site of none.
+//!
+//! rsvelte keyed the same map by NAME and had no notion of an unresolved
+//! renderer, so two snippets sharing a name merged, and "no sites" was read as
+//! "unknown" (conservative) and then, briefly, as "never rendered" — the second
+//! of which deletes CSS the user wrote. Every expectation below is the official
+//! compiler's output for the same source, spelled out here rather than compared
+//! to it at run time.
+
+use rsvelte_core::{CompileOptions, CssMode, GenerateMode, compile};
+
+struct Out {
+    css: String,
+    warnings: Vec<String>,
+}
+
+fn build(source: &str) -> Out {
+    let result = compile(
+        source,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|e| panic!("compile: {e:?}"));
+    let css = result
+        .css
+        .map(|c| c.code)
+        .unwrap_or_default()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    Out {
+        warnings: result.warnings.iter().map(|w| w.code.clone()).collect(),
+        css,
+    }
+}
+
+fn is_pruned(out: &Out, selector: &str) -> bool {
+    out.css.contains(&format!("/* (unused) {selector}"))
+}
+
+/// Two `{#snippet row()}` in different scopes and a third passed to a component.
+/// Only the one rendered inside `.wrap` may lend its body `.wrap` as an ancestor.
+const SHADOWED: &str = "<script>\n\timport Comp from './Comp.svelte';\n</script>\n\
+     {#snippet row()}<span>outer</span>{/snippet}\n\
+     <div class=\"wrap\">{#snippet row()}<b>inner</b>{/snippet}{@render row()}</div>\n\
+     <Comp>{#snippet row()}<i>passed</i>{/snippet}</Comp>\n\
+     <style>\n\t.wrap span { color: red; }\n\t.wrap b { color: green; }\n\t.wrap i { color: blue; }\n</style>\n";
+
+#[test]
+fn a_render_site_belongs_to_one_snippet_node_not_to_every_snippet_of_that_name() {
+    let out = build(SHADOWED);
+    assert!(
+        is_pruned(&out, ".wrap span"),
+        "the OUTER `row` is shadowed at the render site and so is never rendered:\n{}",
+        out.css
+    );
+    assert!(
+        !is_pruned(&out, ".wrap b"),
+        "the INNER `row` is the one `{{@render row()}}` resolves to:\n{}",
+        out.css
+    );
+    assert!(
+        is_pruned(&out, ".wrap i"),
+        "the component-passed `row` renders at `<Comp>`, outside `.wrap`:\n{}",
+        out.css
+    );
+    assert_eq!(
+        out.warnings,
+        vec![
+            "css_unused_selector".to_string(),
+            "css_unused_selector".to_string()
+        ],
+        "exactly the two pruned rules warn"
+    );
+}
+
+/// `alias` is an ordinary local binding, so upstream cannot say which snippet
+/// `{@render alias()}` runs — `is_resolved_snippet` is false and the site is
+/// handed to every snippet. Reading that as "unknown" is a different answer, and
+/// reading it as "no sites" deletes the rule.
+const UNRESOLVED: &str = "<script>\n\tlet alias = row;\n</script>\n\
+     {#snippet row()}<span>x</span>{/snippet}\n\
+     <div class=\"aliased\">{@render alias()}</div>\n\
+     <div class=\"never\"></div>\n\
+     <style>\n\t.aliased span { color: red; }\n\t.never span { color: blue; }\n</style>\n";
+
+#[test]
+fn an_unresolved_renderer_is_a_site_of_every_snippet() {
+    let out = build(UNRESOLVED);
+    assert!(
+        !is_pruned(&out, ".aliased span"),
+        "`row` is rendered through an unresolvable callee, so `.aliased` is one of its sites:\n{}",
+        out.css
+    );
+    assert!(
+        is_pruned(&out, ".never span"),
+        "`.never` is a site of nothing — the control that separates this from \
+         'every selector is used':\n{}",
+        out.css
+    );
+}
+
+/// A snippet no renderer names has an empty site set, which is knowledge: its
+/// body contributes no ancestors at all. The control is the sibling that IS
+/// rendered, so a rule that prunes everything cannot pass.
+const ORPHANED: &str = "{#snippet shown()}<span>a</span>{/snippet}\n\
+     {#snippet orphan()}<b>b</b>{/snippet}\n\
+     <div class=\"wrap\">{@render shown()}</div>\n\
+     <style>\n\t.wrap span { color: red; }\n\t.wrap b { color: green; }\n</style>\n";
+
+#[test]
+fn a_snippet_nothing_renders_contributes_no_ancestors() {
+    let out = build(ORPHANED);
+    assert!(
+        is_pruned(&out, ".wrap b"),
+        "`orphan` is never rendered, so its `<b>` is not inside `.wrap`:\n{}",
+        out.css
+    );
+    assert!(
+        !is_pruned(&out, ".wrap span"),
+        "`shown` is rendered inside `.wrap`:\n{}",
+        out.css
+    );
+}
+
+/// Upstream keeps a component `resolved` when an expression attribute is an
+/// identifier that resolves to a snippet — it knows exactly which one. Treating
+/// every non-literal attribute as unresolved hands the component's position to
+/// every snippet, which is why the never-rendered sibling is needed to see it.
+const ATTR_PASSED: &str = "<script>\n\timport Comp from './Comp.svelte';\n</script>\n\
+     {#snippet row()}<b>y</b>{/snippet}\n\
+     {#snippet other()}<span>x</span>{/snippet}\n\
+     <div class=\"wrap\"><Comp foo={row} /></div>\n\
+     <style>\n\t.wrap span { color: red; }\n</style>\n";
+
+#[test]
+fn an_identifier_attribute_naming_a_snippet_keeps_the_component_resolved() {
+    let out = build(ATTR_PASSED);
+    assert!(
+        is_pruned(&out, ".wrap span"),
+        "`<Comp foo={{row}} />` renders `row`, never `other`, so `other`'s `<span>` \
+         is not inside `.wrap`:\n{}",
+        out.css
+    );
+}
+
+/// The registration for a snippet declared directly inside a component tested
+/// `path.last()`, but `visit_node` pushes the node *before* dispatching, so
+/// inside the SnippetBlock visitor that is the snippet itself and the branch was
+/// never taken. Nothing noticed while "no sites" meant "unknown, stay
+/// conservative"; the moment an empty set became an answer, the body stopped
+/// being inside the component. The assertion has to be the POSITIVE direction —
+/// a cell where official prunes cannot tell a registered site from a dead branch.
+const COMPONENT_PASSED: &str = "<script>\n\timport Comp from './Comp.svelte';\n</script>\n\
+     <div class=\"wrap\"><Comp>{#snippet row()}<span>x</span>{/snippet}</Comp></div>\n\
+     <style>\n\t.wrap span { color: red; }\n</style>\n";
+
+#[test]
+fn a_snippet_declared_inside_a_component_is_rendered_at_that_component() {
+    let out = build(COMPONENT_PASSED);
+    assert!(
+        !is_pruned(&out, ".wrap span"),
+        "`<Comp>`'s own position is the site of the snippet it was handed:\n{}",
+        out.css
+    );
+    assert!(
+        out.warnings.is_empty(),
+        "no rule is unused here: {:?}",
+        out.warnings
+    );
+}


### PR DESCRIPTION
Found while investigating #4115. **It does not close it** — #4115 is the `{@render}` arm of
`subtree_has_matching_subject_inner`, which is the *other* port of this decision and is
untouched here (see **What is left**). What follows are four defects in the port next to it,
one of which the investigation itself would have shipped.

Upstream decides where a `{#snippet}` body sits in the DOM in one place. `SnippetBlock.metadata.sites`
is filled by a single pass over `analysis.snippet_renderers` (`2-analyze/index.js:847`):

```js
for (const [node, resolved] of analysis.snippet_renderers) {
    if (!resolved) node.metadata.snippets = analysis.snippets;   // a site of EVERY snippet
    for (const snippet of node.metadata.snippets) snippet.metadata.sites.add(node);
}
```

A renderer whose callee resolves to a local snippet is a site of **that block node**
(`binding.initial`); one that resolves to nothing is a site of **every** snippet here; one that
resolves outside the component — a prop, an import — is a site of **none**.

rsvelte keyed that map by the snippet's **name** and had no notion of an unresolved renderer.
Four consequences, each fixed and pinned:

| | before | after |
|---|---|---|
| two `{#snippet row()}` in different scopes | one key, merged | keyed by the declaration's own position |
| a snippet nothing renders | `get(name)?` → `None` → "unknown", stay conservative | an empty site set is an *answer*: it contributes no ancestors |
| `{@render f()}`, `f` an ordinary local | not modelled | a site of every snippet, as upstream |
| `<Comp foo={row} />` | any non-literal attribute made the component unresolved | an identifier that names a snippet keeps it resolved |

## Measurement

A 70-cell grid — snippet shape × render-site shape × `client`/`server`, both directions on purpose
(cells where official **scopes** and cells where official **prunes**), plus error-parity cells for
inputs official rejects.

```
HEAD -> this branch, 70 cells
  moved 18
  toward-official (reached match)                6
  improved verdict but still not matching        6
  cells added after the first measurement        6   (all match)
  away-from-official                             0
  match -> MISMATCH = 0
```

Both numbers are given because they answer different questions: six cells now match official, and
six more stopped diverging on CSS text and warnings while still diverging on the template.

## What is left, and how much

The same upstream rule is ported **twice** here, and this PR fixes one port.
`compatibility/GATES.md#two-ports-inventory` row 27 has the detail. The residue is **30 of the 70
cells**, all in `2_analyze/css_scoping.rs`, and it is *not* one direction:

```
24 cells  rsvelte scopes FEWER elements than official
          — the `RenderTag` arm of `subtree_has_matching_subject_inner` computes a name,
            tests the map, and does nothing (css_scoping.rs:2462)
 6 cells  rsvelte scopes MORE
          — that port still keys by NAME, i.e. the very defect this PR fixes in the other port
```

**Fixing one port of a decision does not narrow the other.** The aggregate (`30 cells, all verdict
`JS``) hid the sign; the split only appears when you count scope classes on each side.

Port B is a separate PR because it is not a transcription: upstream walks the tree while reading
another part of it, and `propagate_ancestor_scoping` holds `&mut Fragment`, so Rust cannot take an
immutable borrow of a *different* snippet body from inside that walk. It needs the decision lifted
into a prior immutable pass — same algorithm, different number of passes.

**Two `compatibility/pattern-corpus` repros are already written** (`scratchpad`, and reproduced in
the port-B PR): one with three same-named `row` snippets to which official gives three *different*
verdicts, and one pinning the unresolved-renderer rule with a `.never span` control so that
"everything is used" cannot satisfy it. Both are byte-correct on CSS and warnings today and still
diverge on the template — i.e. they would **add** ratchet entries — so they land with port B. This
is recorded so the next person does not write them again.

## The corpus found what the grid could not

The grid was green on component-passed snippets and the whole corpus moved one file:
`svelte.dev/.../nav/Nav.svelte` began pruning `&.secondary` and raising a spurious
`css_unused_selector`. Four arms placed it — `HEAD 0 pruned / intermediate 1 / this branch 1` —
and the cause was a branch that had been **dead since before any of this**:

```rust
if matches!(context.path.last(), Some(TemplateNode::Component(_) | ...))
```

`visit_node` pushes the node *before* dispatching, so inside `snippet_block::visit` that
`last()` is the SnippetBlock itself and the test was never true. A snippet declared directly
inside a component registered **no** render site, in HEAD too — and nobody saw it, because "no
sites" then meant "unknown, stay conservative" and the conservative answer happened to be right.
Two errors cancelling: the moment an empty site set became a real answer, that snippet's body
stopped being inside its component.

**Three grid cells covered component-passed snippets and all three expected official to PRUNE**,
so not one of them required a site to have been registered. A conservative fallback makes the
negative cells pass, which is exactly why an all-negative family looks healthy. Cells whose
expected verdict is the *positive* one are now in the grid, and the pin test for this asserts
`.wrap span` is **not** pruned — a negative assertion cannot see a producer that never runs.

This is the generated-family blind spot recorded for #2535, with the roles reversed: this time
the generated family was mine and the collected corpus is what caught it.

## Corpus: byte-identical

Both arms swept over the whole collected corpus, 34,813 entries × 3 targets:

```
compared 104439 (entry,target) keys; present in only one arm: 0
  js     changed 0 keys / 0 ids
  css    changed 0 keys / 0 ids
  codes  changed 0 keys / 0 ids     (warning-known-failures.*)
  pos    changed 0 keys / 0 ids     (warning-position-known-failures.*)
  0 keys change position with an unchanged code set
```

No ratchet entry moves in either direction, so no baseline is touched. The zero is worth
something only because the sweep is demonstrably sensitive: within one arm, of the 32,846 ids
that compile on `client`, **99.9%** differ from `client-dev` and **0** are identical to
`server`.

Reading that control took a second pass. Its first form reported 1,966 ids where client and
server output were "identical" — all 1,966 of which were files that **fail to compile**, because
the sweep writes `ERR:<code>` into every target and the sentinel then agrees with itself. An
error sentinel written into both arms of a comparison makes them agree; exclude it before
reading any equality control, or the control reports the failure population as a defect in the
instrument meant to validate it.

**A corpus zero here is not evidence the fix is unnecessary.** It says these shapes — two
same-named snippets in different scopes, an unresolved renderer beside a never-rendered sibling —
do not occur in 34,813 published files, which is the standing argument for a generated grid and
for `pattern-corpus`. The one corpus file that *did* move during development moved because of a
defect introduced mid-way, and is back to byte-identical.

## Things that cost time here

**A field nobody writes reads as `None`, and `cargo check` passes.** The first version of the key
was `binding.initial_span`; `declare_binding` puts the span it is handed into
`declaration_start`, not `initial_span`, so the key was `None` for every snippet and no render
site would have been registered at all. It type-checks. Worse, a plausible reading of the
resulting grid was already waiting ("that residue belongs to the other port"). The key is now
probed directly, by a **one-arm flip** that needs no oracle — a rendered snippet and an orphaned
one must produce different output *in this compiler* if the key resolves at all. Comparing against
official instead would let "both agree" mean either "correct" or "the key is dead and the answer
collapsed onto the oracle's".

**A falling total can contain a regression.** An intermediate version of this fix modelled
"unresolved" as a `bool` and took the grid from 34 non-matching cells to 32 — an improvement by
count — while the cell *set* moved `toward 4 / away 6 / match -> MISMATCH = 2`, and all three
regressing shapes ran the same way: rsvelte dropped CSS official keeps and raised a spurious
`css_unused_selector`. Only a set diff separates those.

**"Correct" and "correct for the right reason" separate only under a third arm.** One cell passed
under that intermediate version and fails under this one, which reads as a regression until you
measure HEAD too: `HEAD CSS+WARN → intermediate match → this branch CSS+WARN`. The intermediate
registered zero sites for a name-keyed lookup, so a snippet that *is* rendered fell into the
"never rendered" arm and pruned correctly by accident. The third arm has to be the tree you are
changing — "returned to HEAD" is a statement about the merge base.

**"The answer is everything" is knowledge too.** A previous note in this repo says an empty set is
knowledge rather than ignorance. The same axis has a second end: upstream's `!resolved` branch
says a site belongs to *every* snippet, which is stronger than "unknown". A boolean records
neither end, and modelling one end with it regressed three shapes the flag never even fires on.

**A prediction disciplines the measurement; it does not restrict its scope.** The expected residue
was written to a file before building. It held exactly on its own population — and the two cells
it missed are cells added *after* it was written, one of which found a pre-existing defect. Adding
them was right; freezing the population to protect the prediction would not have been.


**A reduction that reproduces and a variant that does not are not symmetric evidence.** Chasing
the corpus file above, a *flat* selector (`.nav a.secondary`) reproduced in all six shapes tried
and the *nested* `&` form — which is what the real file actually uses — reproduced in none. That
reads as "the reduction drifted onto a different cause", and it was recorded that way, with the
test for it fixed in advance: *if one fix clears both, it was the same defect*. One fix cleared
both. What had failed to reproduce was the hand-written nested variant, not the reduction. The
positive result tells you about the defect; the negative one tells you only about that probe —
**including when the negative is the variant that looks more like the real input.**

**One invariant worth not tidying away.** `snippet_block.rs` pushes `FragmentOwnerType::SnippetBlock`
**before** switching `context.scope` to the body scope, so the scope it carries is the *declaring*
one. Moving that push after the switch silently changes what every consumer of the variant
resolves.

**Neighbouring walkers in `css-prune.js` treat `SnippetBlock` oppositely.** `get_ancestor_elements`
`break`s the lexical walk at one and continues from the render sites; `get_descendant_elements` has
no case for it at all, so its `_` catch-all descends into a lexically nested body. Carrying either
intuition into the other walker is wrong in a different direction.

**On the 363.** Measuring whether warning order can differ at all: 3,720 corpus keys carry ≥2
warnings and **363** of those are not in non-decreasing `(line, column)` order. That is an upper
bound on what an instrument that sorts could fail to see — **it is not the number of keys this
change reorders**, which is reported separately below. Do not quote the two as one number.

**The arm that produced these numbers predated the commit by four minutes.** The binding the grid
was measured with was built at 04:01; `shared/component.rs` has an mtime of 04:05 and the commit is
04:09. The edits in between were believed to be a comment and an empty block — *believed*, which is
not a measurement. The binding was rebuilt from the committed tree and all six steps re-run:

```
cells differing between the measured arm and the committed-source build: 0
```

`shasum` differs between the two `.dylib`s and proves nothing either way (the source did change);
the identity was taken on the **70 verdicts**, and the tree from the build log's
`Compiling rsvelte_core (…/fix-ce-traverse/…)` line. A difference of zero is not evidence the check
was unnecessary — it is the only reason the numbers above can be quoted at all.

## Testing

`cargo test -p rsvelte_core --release --lib --test validator --test ssr --test parser_fixtures
--test css_snippet_render_site_scope_4113 --test snippet_render_sites_4115`, unfiltered, on the
committed tree:

```
     Running unittests src/lib.rs           1951 passed; 0 failed; 1 ignored
     Running tests/css_snippet_render_site_scope_4113.rs     1 passed; 0 failed
     Running tests/parser_fixtures.rs                        3 passed; 0 failed
     Running tests/snippet_render_sites_4115.rs              5 passed; 0 failed
     Running tests/ssr.rs                                    2 passed; 0 failed
     Running tests/validator.rs                              3 passed; 0 failed
```

`css_snippet_render_site_scope_4113` is included deliberately: it pins **port B**'s output in the
same area, and this PR changes port A.

The 63 `css*` / `snippet*` suites were then run unfiltered on the same tree:

```
     Running lines            63   (= the 63 targets requested)
     test result lines        63
     299 passed; 0 failed;  FAILED / panicked / ^error: 0 lines   CARGO_EXIT=0
```

That re-run exists because the first one was read through a `grep` filter whose 41 `running` lines
could not be reconciled with the 64 targets asked for — and, separately, because `--lib` was added
to that invocation precisely to avoid the known "a `--test` list does not run the lib unit tests"
trap, yet its 1,952-test line was not in the log. **A workaround is itself a change that needs
checking**: "I added A to avoid trap T" does not entail "A took effect", and the check is one line —
look for A's own fingerprint in the output. `pipestatus` defends against a *truncated verdict*; it
says nothing about a *truncated population*.
