### PR TITLE
docs: five lessons about what a measurement and a reconstructed gate report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1176,6 +1176,127 @@ edge, so a change under `crates/rsvelte_projection/src/svelte2tsx/` reaches it a
 changeset naming only `@rsvelte/svelte2tsx` fails `check-core-consumer-changesets.mjs`.
 Name every consumer the checker lists, not the one whose directory you edited.
 
+### A reconstruction of a gate misses in a direction, and the direction is the stage it dropped
+
+A gate's verdict is a pipeline, and a local reconstruction of it drops stages. Which way the
+reconstruction is wrong follows from **what kind of stage went missing**: dropping a *rescue*
+stage — the corpus gate's `ast_equiv_batch` pass over every byte-different output, or the
+oxfmt normalization before it — makes the reconstruction **stricter** than the gate, while
+dropping a *judging* stage makes it **looser**. #4152 is the strict direction: a reconstruction
+that stopped at the normalized byte comparison reported two entries as still diverging, both on
+comment placement, which the AST comparator does not represent — so the gate retired them and
+the local answer had said to keep them. That is the opposite of the usual reconstruction hazard
+and equally wrong.
+
+The asymmetry makes one side of the fidelity question free. **A stricter reconstruction that
+reports zero needs no fidelity argument at all** — a zero under a stricter comparison is a zero
+under the gate's. It is only a **non-zero** from a stricter reconstruction that is not a
+finding: it is a list of candidates to ask the gate about, every one of which can be a false
+positive. Both halves landed on the same day, on the same tree: two false positives from a
+strict reconstruction, and a 135,592-pair `compile()` sweep over raw output hashes that needed
+no gate confirmation for exactly this reason.
+
+The instrument that reproduced the gate needed **its own positive control**, and the first
+version of it failed one: `ast_equiv_batch` reads its two sides as **file paths**, not as
+content, and reports `{verdict: "equivalent"}` rather than a boolean. Handed strings and read
+for `.equivalent`, it rescued **0 of 81** candidates and printed a clean, plausible table. Four
+pairs the gate had *already named* as passing were run through it first; they came back FAIL,
+which is the only reason the two bugs were found. **Reconstruct a gate against cases the gate
+has already ruled on, before running it on cases it has not.**
+
+### `pipestatus` protects the verdict; nothing protects the denominator
+
+The truncation table above is about reading a *verdict* through a stage that can drop it. There
+is a second, independent hazard with the same shape: reading a *population* through one. A run
+of `cargo test --lib --test a --test b …` for 64 targets printed 41 `running` lines, and the
+`--lib` unit tests — 1,952 of them, the very targets that had been added because "a `--test`
+list does not run the lib" — produced **no line at all**. `PIPESTATUS[0]` was cargo's and was
+0, so the verdict was read correctly; the denominator was not read at all.
+
+The generalisable half is about workarounds. **A workaround for a known trap is itself a change
+that has to be checked.** Knowing the trap and adding `--lib` does not entail that `--lib` ran;
+the two feel like one event because they are one intention. The check is one line: look in the
+output for a fingerprint only the workaround can produce — here, a four-digit `running` count.
+
+### An enumerated concern gets one item crossed off and reads as answered
+
+"That `loc` change reaches phase 3's comment decision **and** the source map, so 'only `parse()`
+output moves' is an assumption until measured" — a two-item list. The answer came back as a
+135,592-pair sweep with **0** differing, and the sweep hashed `js.code + css.code`. Generated
+text carries the comment decision; **nothing in that hash carries the map**. The measurement
+answered one of the two and was remembered as answering the concern.
+
+It is not a memory failure, it is an output-format one: a result of "0" has the same shape as
+an answer to the whole question, and an unmeasured mechanism prints as nothing at all. **Carry
+an enumerated concern as columns, one per mechanism, and print `UNMEASURED` where there is no
+carrier** — a blank and a zero are indistinguishable, and only one of them is a result.
+
+### A classifier that stops at the first matching predicate puts its own source order in the key
+
+A ratchet key derived by classification inherits whatever decides the classification. A rule
+that walks a table of rewrites and returns the first one that suffices assigns a label by the
+order the table was written, so **reordering the table relabels the ratchet** — and two
+divergences of the same mechanism land in different buckets depending on which predicate was
+added first. It showed up as 2 rows of a known union-ordering class sitting inside a generic
+label, invisible because the generic predicate came first. Collect **every** individually
+sufficient predicate; one hit is that label, two or more is an explicit `multiple`. Then the
+table can be sorted without moving a single entry.
+
+### A port that answers "is this an each-block binding" by name answers a different question
+
+Upstream's `build_bind_this` passes each-context variables into the getter and setter, and its
+test is `owner.type === 'EachBlock' && scope === binding.scope` — a question about the
+binding's **scope**. rsvelte matched the identifier's **name** against the block's item, index
+and destructured names. The two agree on every shape anyone thinks to write down and part
+company on `{@const}`: a const declared in an each body is declared in that block's scope, so
+upstream passes it, and passes it even when its initializer mentions no each variable at all
+(`{@const k = 7}`). A grid of 12 bind targets isolates it — 7 agree, 5 diverge, and 4 of the 5
+are a `{@const}`, the fifth an each index inside a template literal, which the hand-written
+walker had no arm for. Both are the same defect: **a name test needs an enumeration and a scope
+test does not**, so every shape the enumerator's author did not think of is a silent miss.
+
+### Nothing is always spelled as something, and the two ends of a measurement spell it differently
+
+The truncation table records tools that manufacture a datum — `|| echo 0`, a `comm` against an
+empty set, a JSON-stringified options bag the API ignores. The reporting end has the same
+failure and a different spelling. Collected on one day:
+
+| where the emptiness is | what it looks like instead |
+|---|---|
+| a mechanism nobody measured | a row that is simply not printed, beside rows that read `0` |
+| a gate stage the reconstruction lacks | the verdict that stage would have overturned (`MISMATCH`) |
+| a workflow run that never started | no check line at all, which reads as "not required here" |
+| a cancelled shard under a rollup | `FAILURE`, indistinguishable from a real regression |
+
+Two of these fake a **value** and two fake a **verdict**, and that is the useful split: a faked
+value is caught by printing the carrier beside the number (`mechanism | carrier | result`, with
+`UNMEASURED` where there is no carrier), a faked verdict only by asking what produced it.
+
+### Report a measurement as `mechanism | carrier | population | result`, and the mistakes cannot hide
+
+Three failures of the same family landed in one afternoon, and each one is a different column
+of that row going unwritten:
+
+| what was measured | what the question was | the column that was blank |
+|---|---|---|
+| the ratchet — the ids that fail today | did anything that passes today break | **population** (the set is the complement of the question's) |
+| `js.code + css.code` over 135,592 pairs | a `loc` change reaching phase 3 comments **and** the source map | **carrier** (nothing in that hash carries a map) |
+| the corpus manifest, 33,898 components | 58 samples under `packages/svelte/tests/sourcemaps` | **population** (same mechanism, disjoint inputs) |
+
+None of the three is visible as "measured / not measured", and all three produce a `0` that
+reads as an answer. Writing the population out loud is what makes the first one self-evident —
+"the ids that fail today" names its own unsuitability the moment it is a field rather than an
+assumption. And a mechanism with no carrier must print `UNMEASURED` rather than an empty cell:
+a blank and a zero are the same pixel.
+
+**`n passed` is a complete output that answers a different question, which is worse than a
+truncated one.** `cargo test --test sourcemaps_gate` reports `4 passed; 1 ignored`, and the
+ignored one is the ratchet-regeneration helper while the gate itself is among the four — but
+the same line would print if the arrangement were reversed. Nothing is missing from that output,
+so re-reading it more carefully cannot help; only a different operation can — **read the names
+of the tests that ran, not the count**, and where a suite prints its own denominators
+(`770/770 official segments`, `0/1634 out of range`) run it with `--nocapture` so those appear.
+
 ### Working with Subagents
 
 Use the `Agent` tool for substantial work — feature implementation, multi-file refactors, broad code exploration, or anything likely to consume meaningful context.


### PR DESCRIPTION
`AGENTS.md` のみ。今日 4 セッションで独立に踏んだ形を 5 節。

1. **再構成したゲートは、落とした段の種類が決める向きに外れる。** 救済段（`ast_equiv_batch`、oxfmt）を落とせば本物より厳しく、判定段を落とせば緩い。非対称なので片側は無料 — **厳しい再構成の 0 は忠実度の議論を要らない**が、非ゼロは所見ではなく「ゲートに聞く候補リスト」。`#4152` で 2 件の偽陽性、同じ日に 135,592 ペアの 0 が無料で通った。器械自体の較正は**ゲートが既に判定済みのケース**で先に打つ（最初の版は 81 件中 0 件しか救済せず、`ast_equiv_batch` が 2 つの側を**内容ではなくファイルパス**として読むこと、判定フィールドが `verdict` であることが、その 4 ペアでだけ分かった）。

2. **`PIPESTATUS` は判定を守るが、分母は誰も守らない。** 64 ターゲットの実行が `running` 行 41 本で、`--lib` の 1,952 本が 1 行も出ていなかった。**罠の回避策は、それ自体が検査を要する変更**で、検査は 1 行 — 回避策にしか出せない指紋を出力に探す。

3. **列挙された懸念は、1 項目に答えると答えたことになる。** 「`loc` はコメント判定**と**ソースマップに効く」に対し `js.code + css.code` を 135,592 ペア測って 0。マップの carrier がハッシュに入っていない。`mechanism | carrier | population | result` で報告し、carrier の無い機構は空欄ではなく `UNMEASURED` と印字する。**空欄と 0 は同じピクセル。** 同じ族が同日に 3 回出て、欠けた列は population / carrier / population だった。

4. **最初に当たった述語で決める分類器は、ラチェットのキーに自分のソース順を入れる。** 表を並べ替えるとラベルが動く。個別に十分な述語を**全部**集め、1 つならそのラベル、2 つ以上は明示的な `multiple`。

5. **構造的性質を名前比較で近似した移植は、構造テストが要求しない列挙を要求する。** 上流の `build_bind_this` は binding の**スコープ**が each block のものかを問い、移植は識別子の**名前**を item / index / 分解名と突き合わせていた。`{@const}` で割れる — each 本体の const はそのスコープに宣言されるので、初期化子が each 変数を一切参照しなくても上流は渡す。**列挙者が思い付かなかった形は黙って落ちる。**

最後に、4 つの「空の見え方」を 1 表に。2 つが値を偽装し、2 つが判定を偽装する — 前者は carrier 列で捕まり、後者は「何がそれを出したか」を問うまで捕まらない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmNuq3boYDqe9CWwSfxi8
