### PR TITLE
fix(client): a compound assignment's binary right-hand side keeps its parentheses

### DIFF
--- a/.changeset/compound-assignment-rhs-parens.md
+++ b/.changeset/compound-assignment-rhs-parens.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Keep the parentheses around a compound assignment's binary right-hand side. `s += 'a' + x + 'b'` expanded to `$.set(s, $.get(s) + 'a' + x + 'b')`, which evaluates differently from `$.get(s) + ('a' + x + 'b')` whenever the operands mix types.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2866,11 +2866,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 25 entries)
+### Client (`known-failures.client.json`, 23 entries)
 
-Partition of `known-failures.client.json` by verdict: `24 + 1`
+Partition of `known-failures.client.json` by verdict: `22 + 1`
 
-- **24 — the generated JS differs** (`js` / `code-differs`).
+- **22 — the generated JS differs** (`js` / `code-differs`).
 - **1 — the generated CSS differs.**
 
 The error classes this section used to carry are gone: the run behind this
@@ -2916,6 +2916,16 @@ body and cannot see an outer declaration. A 104,439-unit sweep moved 2 units, on
 TypeScript first — `compile_module` parses plain JS, so all 923 `.svelte.(js|ts)` units had
 been erroring identically in both arms and the first run's `MOVED 0` was arithmetically
 forced.
+
+Two entries left this target and `client-dev` because a compound assignment's binary
+right-hand side lost its parentheses. Expanding `s += <rhs>` to
+`$.set(s, $.get(s) + <rhs>)` needs `<rhs>` parenthesized when it is itself a binary
+expression, and the difference is a **value** rather than a spelling: `1 + (2 + '3')` is
+`'123'` and `1 + 2 + '3'` is `'33'`. The predicate deciding it was a character scan whose
+"starts and ends with a quote, so it is a string literal" early return also matches
+`'a' + x + 'b'` — the closing quote now has to be the one that opens the text. The two ids
+are `svelte-maplibre-gl/…/Geolocate.svelte` and `svelte-spa-router/test/app/src/App.svelte`;
+the repro is `crates/rsvelte_core/tests/compound_assignment_rhs_parens.rs`.
 
 Two entries left this target and `client-dev` on two `$.mutate` decisions that answer
 differently depending on the HOST the write is written in. `musicat/…/Scrollbar.svelte`
@@ -3008,7 +3018,7 @@ the emitted default was the getter function rather than the store's value. Hashi
 client (entry, target) outputs before and after reports **2** changed units over 1 id,
 `match -> MISMATCH = 0`; the other two ids of that cluster do not move and stay listed.
 
-Every one of the remaining 25 arrived with the wave-2 enrolment (#3130) and is described
+Every one of the remaining 23 arrived with the wave-2 enrolment (#3130) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3115,15 +3125,15 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 39 entries)
+### Client dev (`known-failures.client-dev.json`, 37 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `39`
+Partition of `known-failures.client-dev.json` by verdict: `37`
 
-- **39 — the generated JS differs.**
+- **37 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 39 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 37 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -28,8 +28,6 @@
 	"svelte-bits/src/lib/components/library/TextAnimations/VariableProximity/VariableProximity.svelte",
 	"svelte-lexical/demos/qalam/src/lib/notesStore.svelte.ts",
 	"svelte-lexical/packages/svelte-lexical/src/lib/core/NestedComposer.svelte",
-	"svelte-maplibre-gl/src/content/examples/geolocate/Geolocate.svelte",
-	"svelte-spa-router/test/app/src/App.svelte",
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte",
 	"svelte/packages/svelte/tests/snapshot/samples/delegated-locally-declared-shadowed/index.svelte",
 	"svelteui/packages/svelteui-demos/src/demos/core/Modal/ModalForm.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -17,8 +17,6 @@
 	"primo/src/lib/builder/ui/Button.svelte",
 	"svelte-bits/src/lib/components/library/TextAnimations/RotatingText/RotatingText.svelte",
 	"svelte-bits/src/lib/components/library/TextAnimations/VariableProximity/VariableProximity.svelte",
-	"svelte-maplibre-gl/src/content/examples/geolocate/Geolocate.svelte",
-	"svelte-spa-router/test/app/src/App.svelte",
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte",
 	"svelteui/packages/svelteui-demos/src/demos/core/Modal/ModalForm.svelte",
 	"syntaxfm-website/src/routes/(site)/guests/+page.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -4871,6 +4871,22 @@ fn compound_op_to_binary(op: AssignmentOperator) -> &'static str {
     }
 }
 
+/// Whether a string / template literal opening `text` is closed by its LAST
+/// byte, i.e. the whole text is that one literal.
+fn ends_own_quote(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let quote = bytes[0];
+    let mut i = 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i += 2,
+            b if b == quote => return i == bytes.len() - 1,
+            _ => i += 1,
+        }
+    }
+    false
+}
+
 /// Check if the RHS expression of a compound assignment needs parentheses
 /// for correct precedence when expanded. Simple expressions (identifiers,
 /// literals, function calls, member expressions) don't need them.
@@ -4893,11 +4909,10 @@ fn needs_compound_parens(expr: &str, _op: &str) -> bool {
         return false;
     }
 
-    // String literals
-    if (trimmed.starts_with('"') && trimmed.ends_with('"'))
-        || (trimmed.starts_with('\'') && trimmed.ends_with('\''))
-        || (trimmed.starts_with('`') && trimmed.ends_with('`'))
-    {
+    // A string literal — but only when the closing quote is the one that opens
+    // it. `'a' + x + 'b'` also starts and ends with a quote, and returning here
+    // dropped the parens the expansion needs.
+    if matches!(trimmed.as_bytes().first(), Some(b'"' | b'\'' | b'`')) && ends_own_quote(trimmed) {
         return false;
     }
 

--- a/crates/rsvelte_core/tests/compound_assignment_rhs_parens.rs
+++ b/crates/rsvelte_core/tests/compound_assignment_rhs_parens.rs
@@ -1,0 +1,81 @@
+//! Expanding `s += <rhs>` to `$.set(s, $.get(s) + <rhs>)` needs the right-hand
+//! side parenthesized whenever it is itself a binary expression, and the
+//! difference is a value rather than a spelling: `1 + (2 + '3')` is `'123'` and
+//! `1 + 2 + '3'` is `'33'`.
+//!
+//! The predicate deciding that was a character scan with a "starts and ends with
+//! a quote, so it is a string literal" early return, which `'a' + x + 'b'` and
+//! `` `a${x}` + x + `b${x}` `` also satisfy. The rows below that keep no parens
+//! are the controls: a single literal, an escaped quote inside one, and a bare
+//! identifier still have to come out unparenthesized.
+//!
+//! Every expected fragment was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn set_line(script: &str) -> String {
+    let src = format!("<script>\n{script}\n</script>\n<p>{{s}}</p>\n");
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    js.lines()
+        .filter(|l| l.contains("$.set(s"))
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[test]
+fn a_binary_rhs_that_begins_and_ends_with_a_quote_is_parenthesized() {
+    assert_eq!(
+        set_line("let s = $state(''); function f(x){ s += 'a' + x + 'b'; }"),
+        "$.set(s, $.get(s) + ('a' + x + 'b'));"
+    );
+    assert_eq!(
+        set_line("let s = $state(''); function f(x){ s += `a${x}` + x + `b${x}`; }"),
+        "$.set(s, $.get(s) + (`a${x}` + x + `b${x}`));"
+    );
+}
+
+#[test]
+fn a_binary_rhs_that_only_begins_with_a_quote_was_already_parenthesized() {
+    assert_eq!(
+        set_line("let s = $state(''); function f(x){ s += 'a' + x; }"),
+        "$.set(s, $.get(s) + ('a' + x));"
+    );
+    assert_eq!(
+        set_line("let s = $state(0); function f(x){ s -= 1 + x; }"),
+        "$.set(s, $.get(s) - (1 + x));"
+    );
+}
+
+/// A right-hand side that really is one literal must stay unparenthesized — the
+/// control a fix that simply deleted the early return would fail.
+#[test]
+fn a_single_literal_rhs_keeps_no_parentheses() {
+    assert_eq!(
+        set_line("let s = $state(''); function f(x){ s += 'a'; }"),
+        "$.set(s, $.get(s) + 'a');"
+    );
+    assert_eq!(
+        set_line("let s = $state(''); function f(x){ s += `a${x}b`; }"),
+        "$.set(s, $.get(s) + `a${x}b`);"
+    );
+    assert_eq!(
+        set_line("let s = $state(''); function f(x){ s += 'a\\'b'; }"),
+        "$.set(s, $.get(s) + 'a\\'b');"
+    );
+    assert_eq!(
+        set_line("let s = $state(''); function f(x){ s += x; }"),
+        "$.set(s, $.get(s) + x);"
+    );
+}


### PR DESCRIPTION
`s += <rhs>` を `$.set(s, $.get(s) + <rhs>)` に展開するとき、RHS が二項式なら括弧が要ります。**これは見た目ではなく値の差**です:

```js
1 + (2 + '3')   // '123'
1 + 2 + '3'     // '33'
```

判定していた `needs_compound_parens`（`client/ast_state_transform.rs`）は文字走査で、その中に

```rust
if (trimmed.starts_with('\'') && trimmed.ends_with('\'')) || ... { return false; }
```

という早期 return がありました。**`'a' + x + 'b'` も `` `a${x}` + x + `b${x}` `` も先頭と末尾が引用符**なのでこれに当たり、括弧が落ちます。閉じ引用符が開き引用符に対応するものかを、エスケープを見ながら確かめる形に直しました。

## グリッド

16 セル（`$state` / 非 `$state` × `+=` / `-=` / `*=` / `||=` × RHS の形）で乖離は **1 セル**でした:

```
* DIFF  $state += binary
    off: $.set(s, $.get(s) + ('a' + x + 'b'));
    rsv: $.set(s, $.get(s) + 'a' + x + 'b');
EQ 15 | DIFF 1
```

`$state` かつ `+=` かつ RHS が二項、の**3 条件の積**です。`'a' + x`（末尾が識別子）は元から正しく、`-= 1 + x` も正しく、非 `$state` の `+=` はこの経路を通らない。**積で張らなければ 1 セルも当たりません。**

修正後は 16/16 EQ です。

## 実コーパス

`known-failures.client.json` の 34 件のうち 2 件（`svelte-maplibre-gl/…/Geolocate.svelte` と `svelte-spa-router/test/app/src/App.svelte`）がこの形です。**ローカルの sweep で退役 id を決め打ちはしません** — #4152 で、ゲートの最終段（バイト差のある出力すべてに対する AST 比較）を持たないローカル再構成が**退役できる entry を「残る」と報告する**ことが分かったので、退役する id は CI に名指しさせます。

## pin テスト

`crates/rsvelte_core/tests/compound_assignment_rhs_parens.rs` — 乖離 2 行、既に正しかった 2 行、そして**対照 4 行**（単一リテラル / 単一テンプレート / エスケープ入りリテラル `'a\'b'` / 素の識別子）。対照は「早期 return を単に消すと落ちる」行です。期待値はすべて official（`submodules/svelte/packages/svelte/src/compiler/index.js`）の実出力から取っています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmNuq3boYDqe9CWwSfxi8
