### PR TITLE
chore(gates): a partition's own restatements are checked against it

### DIFF
--- a/scripts/compat-corpus/known-failures-md-check.mjs
+++ b/scripts/compat-corpus/known-failures-md-check.mjs
@@ -514,6 +514,79 @@ for (const { doc, key, prefix, label } of PARTITIONS) {
 	}
 }
 
+// ---- 2b. a partition's own restatements must not go stale ---------------------
+// The header count and the partition line are both checked against the JSON, and
+// the numbers restating them a few lines down are not — so a section can read
+// `45 entries` / `Partition …: \`45\`` above `- **48 — the generated JS differs.**`
+// and pass. Both restatements are derivable from the partition line, so both are
+// checked here; nothing else in the prose is, because nothing else is derivable.
+for (const doc of new Set(PARTITIONS.map((p) => p.doc))) {
+	const body = docText(doc);
+	if (body === null) continue;
+	const lines = body.split('\n');
+	for (let i = 0; i < lines.length; i++) {
+		const partition = partitionLines(lines[i].trim())[0];
+		if (!partition) continue;
+		const terms = partition.expression
+			.split('+')
+			.map((t) => t.trim())
+			.filter(Boolean);
+
+		// (a) A bullet list immediately below restates the addends, one per bullet.
+		// Triggered by shape, so a doc that puts its clusters in a table or in prose
+		// is not required to grow one — but a doc that has the list has it checked.
+		// A `NxM` addend covers M clusters at once and has no one-bullet form, so
+		// those partitions are left to the sum check above.
+		if (!terms.some((t) => t.includes('x'))) {
+			let j = i + 1;
+			while (j < lines.length && lines[j].trim() === '') j++;
+			if (j < lines.length && /^\s*-\s/.test(lines[j])) {
+				const bullets = [];
+				for (; j < lines.length; j++) {
+					const line = lines[j];
+					if (/^\s*-\s/.test(line)) {
+						const m = line.match(/\d[\d,]*/);
+						bullets.push(m ? m[0].replace(/,/g, '') : 'no-number');
+					} else if (line.trim() === '') {
+						let k = j;
+						while (k < lines.length && lines[k].trim() === '') k++;
+						if (k < lines.length && /^\s*-\s/.test(lines[k])) {
+							j = k - 1;
+							continue;
+						}
+						break;
+					} else if (/^\s+\S/.test(line)) {
+						continue; // a continuation line of the bullet above
+					} else break;
+				}
+				const want = terms.map((t) => t.replace(/,/g, '')).sort();
+				const got = [...bullets].sort();
+				if (want.join(' ') !== got.join(' ')) {
+					fail(
+						`${doc}:${i + 1}: the bullets under \`${partition.key}\`'s partition read ` +
+							`[${got.join(', ')}] but the partition is \`${partition.expression}\`.\n` +
+							`    The addends and the bullets restating them are the same claim; one of them is stale.`,
+					);
+				}
+			}
+		}
+
+		// (b) `All remaining N arrived …` states the whole population, which is the
+		// partition's sum. Only this phrasing: `remaining 20` a few sections down
+		// means the residue after an attributed cluster, which is a different number.
+		const end = lines.findIndex((l, at) => at > i && /^### /.test(l));
+		const section = lines.slice(i + 1, end === -1 ? lines.length : end).join('\n');
+		for (const m of section.matchAll(/(?:All|Every one of the) remaining \*{0,2}([\d,]+)/g)) {
+			const stated = Number(m[1].replace(/,/g, ''));
+			if (stated !== partition.sum) {
+				fail(
+					`${doc}:${i + 1}: the section says "remaining ${m[1]}" but its partition sums to ${partition.sum}.`,
+				);
+			}
+		}
+	}
+}
+
 // ---- 3. doc-specific reconciliations that no generic rule can derive ----------
 const knownFailuresMd = docText('known-failures.md') ?? '';
 const clientDevLen = JSON.parse(


### PR DESCRIPTION
rsvelte-72 が `#4150` の衝突解決中に見つけた盲点です。`known-failures-md-check.mjs` はヘッダの `N entries` と `Partition of …: \`N\`` を JSON と突き合わせますが、**その数字を数行下で言い直している箇条書きと散文は誰も読んでいません**。実際に、この状態でチェッカが通りました:

```
### Client dev (`known-failures.client-dev.json`, 45 entries)     ← 照合される
Partition of `known-failures.client-dev.json` by verdict: `45`    ← 照合される

- **48 — the generated JS differs.**                              ← 誰も読まない
All remaining 48 arrived with the wave-2 enrolment …              ← 誰も読まない
```

**照合される数字と照合されない数字が、見た目で区別できない**のが本体です。どちらも partition から**導出できる**ので、両方を検査するようにしました。

## (a) partition 直下の箇条書き

addend を 1 つずつ言い直している箇条書きがあれば、その先頭の整数の多重集合が addend と一致すること。**形で発火する**ので、クラスタを表や散文で書いているドキュメントに箇条書きを生やすことは要求しません（現状 31 partition のうち 4 つが該当し、4 つとも一致）。`NxM` の addend は M クラスタを 1 項でまとめる形で 1 箇条書きに対応しないので、その partition は既存の合計検査に任せます。

## (b) `All remaining N arrived …`

その節の全体数を述べている唯一の言い回しなので、partition の合計と一致すること。**この言い回しに限定**しています — 数節下の `remaining 20` は「帰属済みクラスタを引いた残差」で別の数、`All 13 arrived with the wave-2 enrolment` は「かつて到着した数」の履歴的記述です。全 12 箇所の `remaining N` を数え、この言い回しに当たるのは 2 箇所（どちらも一致）でした。

## 陽性対照

2 つの欠陥を**別々に**入れ、両方が名指しで赤になることを確認しました:

```
[known-failures-md-check] known-failures.md:230: the bullets under `known-failures.client-dev.json`'s
    partition read [51] but the partition is `48`.
[known-failures-md-check] known-failures.md:230: the section says "remaining 51" but its partition sums to 48.
MD_EXIT_WITH_DEFECT=1
```

戻して `git diff` が空、素の実行が `MD_EXIT=0`（`49 declared ratchets across 35 docs match their JSON; 30 cluster partitions add up.`）。

ラチェット JSON は 1 バイトも触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmNuq3boYDqe9CWwSfxi8
