### PR TITLE
fix(compiler): five scans that read the wrong boundary

### DIFF
--- a/.changeset/class-heritage-brace-scan.md
+++ b/.changeset/class-heritage-brace-scan.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A class body's brace is not the first one after the header: a heritage clause can open its own

--- a/.changeset/constructor-rune-spanning-lines.md
+++ b/.changeset/constructor-rune-spanning-lines.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A class field whose constructor rune call spans lines is no longer dropped

--- a/.changeset/each-invalidation-import-alias.md
+++ b/.changeset/each-invalidation-import-alias.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A legacy reactive import is invalidated through its `$$_import_` alias, not through its own name

--- a/.changeset/mutate-root-and-reactive-rhs.md
+++ b/.changeset/mutate-root-and-reactive-rhs.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A method call in an assignment target's chain is not a mutation, and a mutation nested in a `$:` right-hand side is one

--- a/.changeset/state-proxy-optional-chaining.md
+++ b/.changeset/state-proxy-optional-chaining.md
@@ -1,0 +1,9 @@
+---
+'@rsvelte/compiler': patch
+---
+
+`$state(p?.x)` keeps its `$.proxy`. Upstream's `should_proxy` proxies everything
+it does not recognise as primitive; rsvelte's sniff proxied only what it did
+recognise, and an optional chain matched no member or call predicate because
+`p?.x` splits into `p?` and `x`. The chain is now read in its plain form, with
+`?.` followed by a digit left alone — there it opens a ternary, not a chain.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1092,6 +1092,11 @@ this session" is an assumption, and the two disagree silently. The prefix does n
 reset — it only makes each call independent of the previous call's cwd. What it cannot fake is
 the build's own `Compiling <crate> (<path>)` line, so read that before trusting any arm.
 
+A second, independent signal is the **diff between the two arms' trees** (`git diff <base> HEAD
+-- crates/`): a one-line answer to "do these arms differ by the change I think they do". Neither
+signal is sufficient alone — the `Compiling` line says which tree was read but not what is in it,
+and the diff says what is in a tree but not that the arm was built from that one. Read both.
+
 The last row is the expensive one, because its symptom is a plausible result.
 A `before -> after` sweep reported 4 output changes "toward official", two of
 them to byte-equality — in the right direction, at the right size, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,30 @@ citation. Exactly one place in the tree defends against it
 pins the expected answer *independently* — a port-vs-port test whose oracle is the other port
 passes when both are broken the same way.
 
+**A comment that COUNTS its siblings is the same hazard with a number in it, and the number is
+the part nobody re-derives.** `reactive_transforms.rs` lowers a `$:` body by branching on the
+shape of its left-hand side, and the pass that wraps a state member write in `$.mutate` was
+missing from one of them. The fix landed with a note saying the keyword branch "was missing this
+pass that **both sibling branches** have" — accurate about the two it names, and there are
+**eight**. Measured one cell per branch against upstream, **five** were missing it, so a mutation
+nested in a `$:` right-hand side (an arrow body, say) was emitted as a plain write on a prop, a
+state, a member, a computed-member and a non-reactive left-hand side alike, and the read pass then
+rewrote its root to `$.get(o)` — a write that parses, runs and never invalidates. The comment did
+not merely fail to prevent the next instance; **it argued the enumeration was closed**, in a file
+where the branches are 150 lines apart and nothing lists them. Two rules: when a note names a
+count, the count is a claim to check, not context; and when a defect is "a pass is missing from a
+branch", the repro is one cell per branch, because a fix that reaches the reported branch and one
+neighbour looks exactly like a fix that reaches all of them.
+
+The other half of the same day's work is the ordinary two-ports shape wearing a host: upstream
+stops an assignment target's root walk at anything that is not a `MemberExpression`
+(`AssignmentExpression.js:104-112`), so `stage.container().style.cursor = 'grab'` has no root
+binding and is not a mutation. rsvelte's `get_base_object` walked *through* a `Call` via its
+callee and wrapped it. Only the **template-expression** port did — an arrow declared in
+`<script>` reaches a different implementation and was already right — so the axis that separates
+them is the host the arrow is written in, not the binding or the expression. That is the
+`write-host` lesson (binding × host) arriving at a second site.
+
 **The `JsNode` → `serde_json::Value` cost is one site, and it is not the lazy cache.**
 `to_value` has 54 call sites; every materialization figure this project has quoted (27,488 →
 12,089 → 3,649) counts only the cached one. Of the bypassing population, 98% is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1086,6 +1086,12 @@ between them fake. Build as `cd <worktree> && CARGO_TARGET_DIR=<worktree>/target
 cargo …`: the `cd` protects your sources, the env var protects everyone else's
 `target/`, and neither protects the other.
 
+Prefix **every** Bash invocation with `cd <worktree> &&`, including the ones that only read.
+The tool result's `Shell cwd was reset to …` line is the observation; "I ran `cd` earlier in
+this session" is an assumption, and the two disagree silently. The prefix does not prevent the
+reset — it only makes each call independent of the previous call's cwd. What it cannot fake is
+the build's own `Compiling <crate> (<path>)` line, so read that before trusting any arm.
+
 The last row is the expensive one, because its symptom is a plausible result.
 A `before -> after` sweep reported 4 output changes "toward official", two of
 them to byte-equality — in the right direction, at the right size, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,25 @@ count, the count is a claim to check, not context; and when a defect is "a pass 
 branch", the repro is one cell per branch, because a fix that reaches the reported branch and one
 neighbour looks exactly like a fix that reaches all of them.
 
+**And an enumeration whose members came from bug reports is not an enumeration of the
+grammar.** `find_class_header` locates a class body by taking the first `{` at bracket depth
+zero after the header, and it counted one thing that can put a brace there first — a nested
+`class` expression. `class A extends function () {} { e = $state(5) }` therefore treated the
+*function's* body as the class body and never privatised the field. A heritage is a
+`LeftHandSideExpression`, which closes the domain: a class expression, a function expression in
+its four spellings, and an object literal in primary position, with everything parenthesised
+already at depth > 0 and a template's braces not code bytes. Measured one cell per member,
+**eight of eighteen diverged and the reported shape was one of them**. Adding `function` to the
+list would have been the same mistake one level down; the fix is `class` OR `function` opening a
+pending body, plus a `{` reached with no code byte since `extends`. Ask where a scanner's list of
+cases came from: if the answer is "the shapes someone hit", the list is a work log, not a
+partition. **The grid's other half earned itself in the same hour**: the first fix spelled "no
+brace-producing primary yet" as "no *code byte* since `extends`", and `js_scan::code_bytes`
+skips a template literal whole — so `` extends `${1}` `` produced no code bytes at all and the
+class body was skipped as if it were an object literal. That row had been **passing before the
+fix**, which is the only kind of row that can report this: a grid assembled from the cells a
+defect breaks has no cell left to regress.
+
 The other half of the same day's work is the ordinary two-ports shape wearing a host: upstream
 stops an assignment target's root walk at anything that is not a `MemberExpression`
 (`AssignmentExpression.js:104-112`), so `stage.container().style.cursor = 'grab'` has no root

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1167,6 +1167,21 @@ the name" becomes visible and "is it an object" stops being. **Reading your own 
 divergence; only the oracle names it.** And print `match -> MISMATCH` on its own line when you
 re-measure: an over-collection and an under-collection of the same size are the same total.
 
+### And whether it unwinds is the complexity bound
+
+`get_ancestor_elements` (`css-prune.js:845`) adds a `SnippetBlock` to `seen` and never deletes
+it, so each snippet is expanded at most once per resolution. That single missing `delete` is two
+rules at once: the answer becomes a function of where the walk started rather than of the node —
+which is why it cannot be memoised — and the walk stays linear. Port it as the readable
+depth-first walk that unwinds `seen` on the way out and you get a function that enumerates every
+acyclic path: same answers, and it does not terminate on
+`svelte.dev/apps/svelte.dev/src/routes/tutorial/[...slug]/+page.svelte`, which `main` compiles in
+19 ms. **No output gate can see this class** — it is not a wrong answer, it is an answer that
+never arrives, so there is nothing to compare. A 70-cell grid, three committed repros and 121
+release test targets were all green. What attributed it was a completed *previous* run of the
+same corpus sweep: without a baseline rate, a sweep that stops printing is indistinguishable from
+a sweep competing with a build for CPU.
+
 ### Split the verdict before you split the cause
 
 A cell that reports one pass/fail per input tells you the input diverges; a cell that

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -1036,6 +1036,24 @@ Nothing here is an oracle bug: the
 `oracle-invalid` classification already carries those and is a pass, not a ratchet
 entry.
 
+**And 398 of those 472 are inside the TEMPLATE, not inside embedded JS or CSS
+(2026-09-01).** The cluster table names the *shape* of the first differing line and
+never says which printer produced it, which reads as a line-breaking backlog in the
+embedded-JS formatter. Locating each entry’s first differing line back in its **source**
+— by a token needle, reporting `unlocated` rather than guessing — partitions the 549 as
+`template 438 | unlocated 48 | script 41 | style 22`, and crossed with the shape rule:
+`breaks-later|template 215`, `breaks-earlier|template 183`, `indent-only|template 31`,
+`breaks-later|script 19`, `indent-only|script 14`, `intra-line-ws|style 9`, the rest in
+single digits. So **72.5% of this ratchet is one question about Svelte markup**, and the
+embedded-JS and embedded-CSS engines together carry 63 entries.
+
+The positive control is that the same local harness reproduces the CI gate’s own
+partition on **five of its seven buckets exactly** (`breaks-later 258`,
+`breaks-earlier 214`, `intra-line-ws 15`, `extra-line 1`, `missing-line 1`), differing by
+two entries that move between `indent-only` and `other`. A region split measured by a
+harness that did not reproduce the shape split would be describing a different
+population.
+
 ### Three axes the cluster table does not carry (2026-08-31)
 
 The table above keys on the **first differing line**, which answers *what the

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2847,17 +2847,31 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 34 entries)
+### Client (`known-failures.client.json`, 32 entries)
 
-Partition of `known-failures.client.json` by verdict: `33 + 1`
+Partition of `known-failures.client.json` by verdict: `31 + 1`
 
-- **33 — the generated JS differs** (`js` / `code-differs`).
+- **31 — the generated JS differs** (`js` / `code-differs`).
 - **1 — the generated CSS differs.**
 
 The error classes this section used to carry are gone: the run behind this
 baseline reports `error-mismatch: 0` and `js-unparseable: 0` on every target, so
 no entry here is "both compilers reject with a different code", "one compiler
 rejects and the other compiles", or "rsvelte's output is not JavaScript".
+
+Two entries left this target and `client-dev` on two `$.mutate` decisions that answer
+differently depending on the HOST the write is written in. `musicat/…/Scrollbar.svelte`
+was over-wrapped: upstream walks an assignment target’s `.object` chain only while it is
+a `MemberExpression` and then requires an `Identifier`, so
+`stage.container().style.cursor = 'grab'` has no root binding and is not a mutation, while
+rsvelte’s `get_base_object` crossed the `Call` via its callee. Only the
+template-expression port did — an arrow declared in `<script>` reaches a different
+implementation and was already right, which is why the axis that separates the two is the
+host and not the binding. `ha-fusion/…/TransformAttributes.svelte` was under-wrapped: a
+`$:` body is lowered by branching on the shape of its left-hand side, and the pass that
+wraps a state member write was wired into two of eight branches — the note recording that
+fix called them “both sibling branches”, and five more were missing it. Both are
+byte-identical to official on `js.code` and `css.code`, on `prod` and on `dev`.
 
 Two syntaxfm-website entries left this target and `client-dev` when an attribute-free
 custom element stopped making its ancestors dynamic: upstream gates that
@@ -2936,7 +2950,7 @@ the emitted default was the getter function rather than the store's value. Hashi
 client (entry, target) outputs before and after reports **2** changed units over 1 id,
 `match -> MISMATCH = 0`; the other two ids of that cluster do not move and stay listed.
 
-Every one of the remaining 34 arrived with the wave-2 enrolment (#3130) and is described
+Every one of the remaining 32 arrived with the wave-2 enrolment (#3130) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3043,15 +3057,15 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 48 entries)
+### Client dev (`known-failures.client-dev.json`, 46 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `48`
+Partition of `known-failures.client-dev.json` by verdict: `46`
 
-- **48 — the generated JS differs.**
+- **46 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 48 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 46 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2865,11 +2865,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 29 entries)
+### Client (`known-failures.client.json`, 28 entries)
 
-Partition of `known-failures.client.json` by verdict: `28 + 1`
+Partition of `known-failures.client.json` by verdict: `27 + 1`
 
-- **28 — the generated JS differs** (`js` / `code-differs`).
+- **27 — the generated JS differs** (`js` / `code-differs`).
 - **1 — the generated CSS differs.**
 
 The error classes this section used to carry are gone: the run behind this
@@ -2993,7 +2993,7 @@ the emitted default was the getter function rather than the store's value. Hashi
 client (entry, target) outputs before and after reports **2** changed units over 1 id,
 `match -> MISMATCH = 0`; the other two ids of that cluster do not move and stay listed.
 
-Every one of the remaining 29 arrived with the wave-2 enrolment (#3130) and is described
+Every one of the remaining 28 arrived with the wave-2 enrolment (#3130) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3100,15 +3100,15 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 43 entries)
+### Client dev (`known-failures.client-dev.json`, 42 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `43`
+Partition of `known-failures.client-dev.json` by verdict: `42`
 
-- **43 — the generated JS differs.**
+- **42 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 43 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 42 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2865,17 +2865,29 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 32 entries)
+### Client (`known-failures.client.json`, 31 entries)
 
-Partition of `known-failures.client.json` by verdict: `31 + 1`
+Partition of `known-failures.client.json` by verdict: `30 + 1`
 
-- **31 — the generated JS differs** (`js` / `code-differs`).
+- **30 — the generated JS differs** (`js` / `code-differs`).
 - **1 — the generated CSS differs.**
 
 The error classes this section used to carry are gone: the run behind this
 baseline reports `error-mismatch: 0` and `js-unparseable: 0` on every target, so
 no entry here is "both compilers reject with a different code", "one compiler
 rejects and the other compiles", or "rsvelte's output is not JavaScript".
+
+`pattern/issues/3072-extends-shapes-legal.svelte.js` left this target and `client-dev` when
+the class-body scan stopped taking the first `{` after the header. A heritage clause can open
+a brace of its own, and `find_class_header` counted exactly one thing that does — a nested
+`class` expression — so `class A extends function () {} { e = $state(5) }` read the
+function’s body as the class body and never privatised the field. A heritage is a
+`LeftHandSideExpression`, which closes the set: a class expression, a function expression in
+its four spellings, and an object literal in primary position. Measured one cell per member,
+**eight of eighteen diverged** and the shape this entry carries was one of them. The scan is
+shared by the client and the server (`client/class_transforms.rs:996`,
+`server/transform_script.rs:4864`), so the change was swept on all four targets rather than
+on the two this entry sits in.
 
 Two entries left this target and `client-dev` on two `$.mutate` decisions that answer
 differently depending on the HOST the write is written in. `musicat/…/Scrollbar.svelte`
@@ -2968,7 +2980,7 @@ the emitted default was the getter function rather than the store's value. Hashi
 client (entry, target) outputs before and after reports **2** changed units over 1 id,
 `match -> MISMATCH = 0`; the other two ids of that cluster do not move and stay listed.
 
-Every one of the remaining 32 arrived with the wave-2 enrolment (#3130) and is described
+Every one of the remaining 31 arrived with the wave-2 enrolment (#3130) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3075,15 +3087,15 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 46 entries)
+### Client dev (`known-failures.client-dev.json`, 45 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `46`
+Partition of `known-failures.client-dev.json` by verdict: `45`
 
-- **46 — the generated JS differs.**
+- **45 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 46 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 45 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2865,11 +2865,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 31 entries)
+### Client (`known-failures.client.json`, 29 entries)
 
-Partition of `known-failures.client.json` by verdict: `30 + 1`
+Partition of `known-failures.client.json` by verdict: `28 + 1`
 
-- **30 — the generated JS differs** (`js` / `code-differs`).
+- **28 — the generated JS differs** (`js` / `code-differs`).
 - **1 — the generated CSS differs.**
 
 The error classes this section used to carry are gone: the run behind this
@@ -2888,6 +2888,19 @@ its four spellings, and an object literal in primary position. Measured one cell
 shared by the client and the server (`client/class_transforms.rs:996`,
 `server/transform_script.rs:4864`), so the change was swept on all four targets rather than
 on the two this entry sits in.
+
+Two entries left this target and `client-dev` because a read transform was handed the wrong
+identifier. `$.invalidate_inner_signals(() => (…))` names the bindings an each-item mutation
+must invalidate, and each name goes through that binding's read transform. A legacy **reactive
+import**'s read expects the identifier already swapped for its `$$_import_` alias —
+`client/visitors/program.rs` registers that swap as `replacement_id`, and both
+`shared/utils.rs:907` and `shared/utils.rs:1572` consult it — while `each_block.rs` passed the
+raw name, so `photon/…/settings/{app,moderation}` emitted `settings()` where official emits
+`$$_import_settings()`. That output is **exactly what a prop read looks like**, so a check
+asking only "is it not the bare name" passes on the bug; the repro therefore varies the
+binding KIND behind one fixed each block (`plain-import` → `settings`, `local-state` →
+`$.get(settings)`, `exported-prop` → `settings()`, nested each → `$.get(filter),
+$$_import_settings()`). A 139,252-unit four-target sweep moved exactly these 4 units.
 
 Two entries left this target and `client-dev` on two `$.mutate` decisions that answer
 differently depending on the HOST the write is written in. `musicat/…/Scrollbar.svelte`
@@ -2980,7 +2993,7 @@ the emitted default was the getter function rather than the store's value. Hashi
 client (entry, target) outputs before and after reports **2** changed units over 1 id,
 `match -> MISMATCH = 0`; the other two ids of that cluster do not move and stay listed.
 
-Every one of the remaining 31 arrived with the wave-2 enrolment (#3130) and is described
+Every one of the remaining 29 arrived with the wave-2 enrolment (#3130) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3087,15 +3100,15 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 45 entries)
+### Client dev (`known-failures.client-dev.json`, 43 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `45`
+Partition of `known-failures.client-dev.json` by verdict: `43`
 
-- **45 — the generated JS differs.**
+- **43 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 45 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 43 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -21,7 +21,6 @@
 	"musicat/src/lib/settings/SettingsPopup.svelte",
 	"musicat/src/lib/views/InternetArchiveView.svelte",
 	"networking-toolbox/src/lib/components/home/SiteMapList.svelte",
-	"pattern/issues/3072-extends-shapes-legal.svelte.js",
 	"photon/src/lib/app/auth/profile.svelte.ts",
 	"photon/src/lib/feature/post/form/postform.svelte.ts",
 	"photon/src/lib/ui/navbar/Profile.svelte",

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -25,8 +25,6 @@
 	"photon/src/lib/feature/post/form/postform.svelte.ts",
 	"photon/src/lib/ui/navbar/Profile.svelte",
 	"photon/src/lib/ui/navbar/commands/actions.svelte.ts",
-	"photon/src/routes/settings/app/+page.svelte",
-	"photon/src/routes/settings/moderation/+page.svelte",
 	"primo/src/lib/builder/ui/Button.svelte",
 	"svelte-bits/src/lib/components/library/Animations/MetallicPaint/MetallicPaint.svelte",
 	"svelte-bits/src/lib/components/library/TextAnimations/RotatingText/RotatingText.svelte",

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,7 +1,6 @@
 [
 	"chatgpt-web/src/lib/ChatCompletionResponse.svelte",
 	"ha-fusion/src/lib/Main/Views.svelte",
-	"ha-fusion/src/lib/Modal/PictureElements/TransformAttributes.svelte",
 	"ha-fusion/src/lib/Modal/VisibilityConfig/Index.svelte",
 	"ha-fusion/src/lib/Sidebar/Navigate.svelte",
 	"haptic/apps/homepage/src/lib/components/tooltip.svelte",
@@ -20,7 +19,6 @@
 	"mathesar/mathesar_ui/src/pages/database/disconnect/DisconnectDatabaseModal.svelte",
 	"mathesar/mathesar_ui/src/systems/databases/upgrade-database/UpgradeDatabaseModal.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
-	"musicat/src/lib/ui/Scrollbar.svelte",
 	"musicat/src/lib/views/InternetArchiveView.svelte",
 	"networking-toolbox/src/lib/components/home/SiteMapList.svelte",
 	"pattern/issues/3072-extends-shapes-legal.svelte.js",

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -22,7 +22,6 @@
 	"musicat/src/lib/views/InternetArchiveView.svelte",
 	"networking-toolbox/src/lib/components/home/SiteMapList.svelte",
 	"photon/src/lib/app/auth/profile.svelte.ts",
-	"photon/src/lib/feature/post/form/postform.svelte.ts",
 	"photon/src/lib/ui/navbar/Profile.svelte",
 	"photon/src/lib/ui/navbar/commands/actions.svelte.ts",
 	"primo/src/lib/builder/ui/Button.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -1,7 +1,6 @@
 [
 	"appwrite-console/src/lib/components/sortButton.svelte",
 	"ha-fusion/src/lib/Main/Views.svelte",
-	"ha-fusion/src/lib/Modal/PictureElements/TransformAttributes.svelte",
 	"ha-fusion/src/lib/Modal/VisibilityConfig/Index.svelte",
 	"ha-fusion/src/lib/Sidebar/Navigate.svelte",
 	"haptic/apps/homepage/src/lib/components/tooltip.svelte",
@@ -15,7 +14,6 @@
 	"mathesar/mathesar_ui/src/pages/database/disconnect/DisconnectDatabaseModal.svelte",
 	"mathesar/mathesar_ui/src/systems/databases/upgrade-database/UpgradeDatabaseModal.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
-	"musicat/src/lib/ui/Scrollbar.svelte",
 	"networking-toolbox/src/lib/components/home/SiteMapList.svelte",
 	"pattern/issues/3072-extends-shapes-legal.svelte.js",
 	"photon/src/lib/feature/post/form/postform.svelte.ts",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -17,8 +17,6 @@
 	"networking-toolbox/src/lib/components/home/SiteMapList.svelte",
 	"photon/src/lib/feature/post/form/postform.svelte.ts",
 	"photon/src/lib/ui/navbar/Profile.svelte",
-	"photon/src/routes/settings/app/+page.svelte",
-	"photon/src/routes/settings/moderation/+page.svelte",
 	"primo/src/lib/builder/ui/Button.svelte",
 	"svelte-bits/src/lib/components/library/TextAnimations/RotatingText/RotatingText.svelte",
 	"svelte-bits/src/lib/components/library/TextAnimations/VariableProximity/VariableProximity.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -15,7 +15,6 @@
 	"mathesar/mathesar_ui/src/systems/databases/upgrade-database/UpgradeDatabaseModal.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
 	"networking-toolbox/src/lib/components/home/SiteMapList.svelte",
-	"pattern/issues/3072-extends-shapes-legal.svelte.js",
 	"photon/src/lib/feature/post/form/postform.svelte.ts",
 	"photon/src/lib/ui/navbar/Profile.svelte",
 	"photon/src/routes/settings/app/+page.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -15,7 +15,6 @@
 	"mathesar/mathesar_ui/src/systems/databases/upgrade-database/UpgradeDatabaseModal.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
 	"networking-toolbox/src/lib/components/home/SiteMapList.svelte",
-	"photon/src/lib/feature/post/form/postform.svelte.ts",
 	"photon/src/lib/ui/navbar/Profile.svelte",
 	"primo/src/lib/builder/ui/Button.svelte",
 	"svelte-bits/src/lib/components/library/TextAnimations/RotatingText/RotatingText.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -1310,13 +1310,20 @@ fn transform_class_fields_client_with_options_at(
         let mut ci = 0;
         while ci < constructor_lines.len() {
             let mut candidate = constructor_lines[ci].trim().to_string();
-            if (candidate.starts_with("this.") || candidate.starts_with("this["))
-                && initializer_starts_later(&candidate)
-            {
-                while ci + 1 < constructor_lines.len() && initializer_starts_later(&candidate) {
+            if candidate.starts_with("this.") || candidate.starts_with("this[") {
+                // `this.a = $state(` has an initializer on the line but no closing
+                // paren, and a rune whose argument list runs past the line end is
+                // dropped whole rather than mis-parsed — so join until the brackets
+                // balance as well, not only until the initializer starts.
+                let mut depth = net_bracket_depth(&candidate);
+                while ci + 1 < constructor_lines.len()
+                    && (initializer_starts_later(&candidate) || depth > 0)
+                {
                     ci += 1;
+                    let next = constructor_lines[ci].trim();
                     candidate.push('\n');
-                    candidate.push_str(constructor_lines[ci].trim());
+                    candidate.push_str(next);
+                    depth += net_bracket_depth(next);
                 }
             }
             let trimmed = candidate.as_str();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -2256,6 +2256,13 @@ pub(super) fn expression_needs_proxy(expr: &str) -> bool {
         return true;
     }
 
+    // `should_proxy` proxies everything it does not recognise; this sniff only
+    // proxies what it DOES recognise, so a shape none of the predicates below
+    // parse falls out on the opposite side. Optional chaining is that shape:
+    // `p?.x` splits into `p?` and `x`, so no member or call predicate matches.
+    let unchained = strip_optional_chaining(trimmed);
+    let trimmed = unchained.as_str();
+
     // Check for top-level function call pattern: identifier followed by (
     // But not operators like !, -, etc.
     // Also check for method calls like foo.bar()
@@ -2295,6 +2302,35 @@ pub(super) fn expression_needs_proxy(expr: &str) -> bool {
     }
 
     false
+}
+
+/// Rewrite optional chaining into its plain form (`?.` -> `.`, `?.[` -> `[`,
+/// `?.(` -> `(`) so the member and call predicates can read the chain. A `?`
+/// followed by a digit is the one spelling where `?.` opens a ternary rather
+/// than a chain (`c ?.5 : 1`), so it is left alone.
+fn strip_optional_chaining(expr: &str) -> String {
+    let bytes = expr.as_bytes();
+    let mut out = String::with_capacity(expr.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'?'
+            && bytes.get(i + 1) == Some(&b'.')
+            && !bytes.get(i + 2).is_some_and(u8::is_ascii_digit)
+        {
+            match bytes.get(i + 2) {
+                Some(b'[') | Some(b'(') => i += 2,
+                _ => {
+                    out.push('.');
+                    i += 2;
+                }
+            }
+            continue;
+        }
+        let ch = expr[i..].chars().next().unwrap();
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
 }
 
 /// Check if an expression is a `BinaryExpression` at the top level — an infix

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
@@ -433,6 +433,14 @@ pub(super) fn transform_reactive_statement(
                 let transformed_rhs =
                     transform_prop_reads_in_expr(rhs, prop_assignment_transform_vars);
                 // Also wrap state vars in $.get() calls
+                // A mutation nested in the RHS (an arrow body, say) is a mutation too;
+                // it must be wrapped before the read pass rewrites its root to `$.get`.
+                let transformed_rhs = transform_state_member_mutations_in_expr(
+                    &transformed_rhs,
+                    state_vars,
+                    non_reactive_state_vars,
+                    prop_invalidate_bodies,
+                );
                 let transformed_rhs = wrap_state_vars_in_expr(
                     &transformed_rhs,
                     state_vars,
@@ -455,6 +463,12 @@ pub(super) fn transform_reactive_statement(
                     &transformed_rhs,
                     prop_assignment_transform_vars,
                     &[],
+                    prop_invalidate_bodies,
+                );
+                let transformed_rhs = transform_state_member_mutations_in_expr(
+                    &transformed_rhs,
+                    state_vars,
+                    non_reactive_state_vars,
                     prop_invalidate_bodies,
                 );
                 let transformed_rhs = wrap_state_vars_in_expr(
@@ -491,6 +505,12 @@ pub(super) fn transform_reactive_statement(
                     let member_part = &lhs[base.len()..]; // ".foo" or "[idx]"
                     let transformed_rhs =
                         transform_prop_reads_in_expr(rhs, prop_assignment_transform_vars);
+                    let transformed_rhs = transform_state_member_mutations_in_expr(
+                        &transformed_rhs,
+                        state_vars,
+                        non_reactive_state_vars,
+                        prop_invalidate_bodies,
+                    );
                     let transformed_rhs = wrap_state_vars_in_expr(
                         &transformed_rhs,
                         state_vars,
@@ -530,6 +550,12 @@ pub(super) fn transform_reactive_statement(
 
                     let transformed_rhs =
                         transform_prop_reads_in_expr(rhs, prop_assignment_transform_vars);
+                    let transformed_rhs = transform_state_member_mutations_in_expr(
+                        &transformed_rhs,
+                        state_vars,
+                        non_reactive_state_vars,
+                        prop_invalidate_bodies,
+                    );
                     let transformed_rhs = wrap_state_vars_in_expr(
                         &transformed_rhs,
                         state_vars,
@@ -550,6 +576,12 @@ pub(super) fn transform_reactive_statement(
                         transform_prop_reads_in_expr(member_part, prop_assignment_transform_vars);
                     let transformed_rhs =
                         transform_prop_reads_in_expr(rhs, prop_assignment_transform_vars);
+                    let transformed_rhs = transform_state_member_mutations_in_expr(
+                        &transformed_rhs,
+                        state_vars,
+                        non_reactive_state_vars,
+                        prop_invalidate_bodies,
+                    );
                     let transformed_rhs = wrap_state_vars_in_expr(
                         &transformed_rhs,
                         state_vars,
@@ -568,6 +600,12 @@ pub(super) fn transform_reactive_statement(
                     // Regular assignment - still transform prop reads on RHS
                     let transformed_rhs =
                         transform_prop_reads_in_expr(rhs, prop_assignment_transform_vars);
+                    let transformed_rhs = transform_state_member_mutations_in_expr(
+                        &transformed_rhs,
+                        state_vars,
+                        non_reactive_state_vars,
+                        prop_invalidate_bodies,
+                    );
                     let transformed_rhs = wrap_state_vars_in_expr(
                         &transformed_rhs,
                         state_vars,
@@ -1075,6 +1113,27 @@ fn wrap_legacy_invalidate(
 ///
 /// This must run BEFORE `wrap_state_vars_in_expr` to operate on the original
 /// identifier names before they are rewritten to `$.get(state_var)`.
+/// `transform_state_member_mutations` parses its input as a program, so an
+/// expression that is not also a statement — an object literal with more than
+/// one property, say — never reaches the pass at all. Parenthesise it, and drop
+/// the parens back off: every edit the pass makes lands inside them.
+fn transform_state_member_mutations_in_expr(
+    expr: &str,
+    state_vars: &[String],
+    non_reactive_vars: &[String],
+    invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
+) -> String {
+    let out = transform_state_member_mutations(
+        &format!("({expr})"),
+        state_vars,
+        non_reactive_vars,
+        invalidate_bodies,
+    );
+    out.strip_prefix('(')
+        .and_then(|rest| rest.strip_suffix(')'))
+        .map_or_else(|| expr.to_string(), str::to_string)
+}
+
 pub(super) fn transform_state_member_mutations(
     expr: &str,
     state_vars: &[String],

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
@@ -337,7 +337,12 @@ pub fn each_block(node: &EachBlock, context: &mut ComponentContext) {
                     // it still needs to be included in $.invalidate_inner_signals().
                     let expr = if let Some(transform) = context.state.transform.get(&binding.name) {
                         if let Some(read_fn) = &transform.read {
-                            read_fn(&context.arena, b::id(&binding.name))
+                            // A reactive import's read expects the identifier already
+                            // swapped for its `$$_import_` alias; the raw name reads the
+                            // module binding instead of the signal.
+                            let input =
+                                transform.replacement_id.as_deref().unwrap_or(&binding.name);
+                            read_fn(&context.arena, b::id(input))
                         } else {
                             // Transform exists but no read fn - use raw identifier
                             b::id(&binding.name)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -2017,7 +2017,13 @@ fn get_base_object(
     match expr {
         JsExpr::Spanned(inner, _, _) => get_base_object(arena.get_expr(*inner), arena),
         JsExpr::Member(member) => get_base_object(arena.get_expr(member.object), arena),
-        JsExpr::Call(call) => get_base_object(arena.get_expr(call.callee), arena),
+        // Upstream stops the walk at anything that is not a MemberExpression, so a
+        // method call in the chain has no root identifier and the write is not a
+        // mutation. Only a read-transform call (`count()`, always an Identifier
+        // callee) may be crossed; `has_call_in_base_chain` owns that case.
+        JsExpr::Call(call) if matches!(arena.get_expr(call.callee), JsExpr::Identifier(_)) => {
+            get_base_object(arena.get_expr(call.callee), arena)
+        }
         _ => expr.clone(),
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/class_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/class_body.rs
@@ -216,7 +216,7 @@ pub(crate) fn find_class_header(source: &str) -> Option<ClassHeader> {
     let mut nesting = 0i32;
     let mut angle = 0i32;
     let mut heritage_start: Option<usize> = None;
-    let mut nested_classes = 0u32;
+    let mut pending_bodies = 0u32;
     let mut skip_depth = 0i32;
     // One past the last byte of a multi-byte JS whitespace character, whose
     // continuation bytes `is_ident_byte` would otherwise read as identifier.
@@ -263,10 +263,13 @@ pub(crate) fn find_class_header(source: &str) -> Option<ClassHeader> {
                 nesting = 0;
                 angle = 0;
                 heritage_start = None;
-                nested_classes = 0;
+                pending_bodies = 0;
             } else if keyword.is_some() && nesting == 0 && angle == 0 && !is_property {
-                if word == b"class" {
-                    nested_classes += 1;
+                if word == b"class" || (word == b"function" && heritage_start.is_some()) {
+                    // A heritage is a LeftHandSideExpression, so its primary can
+                    // be a class OR a function expression; either one's body
+                    // brace precedes the class body's.
+                    pending_bodies += 1;
                 } else if word == b"extends" && heritage_start.is_none() {
                     heritage_start = Some(prev_end);
                 }
@@ -311,8 +314,15 @@ pub(crate) fn find_class_header(source: &str) -> Option<ClassHeader> {
             b'<' if nesting == 0 => angle += 1,
             b'>' if nesting == 0 && angle > 0 => angle -= 1,
             b'{' if nesting == 0 && angle == 0 => {
-                if nested_classes > 0 {
-                    nested_classes -= 1;
+                if pending_bodies > 0 {
+                    pending_bodies -= 1;
+                    skip_depth = 1;
+                } else if heritage_start
+                    .is_some_and(|start| skip_ws_and_comments(source, start) == i)
+                {
+                    // Nothing but whitespace since `extends`, so this brace is
+                    // that primary's own object literal and the class body's is
+                    // the one after it.
                     skip_depth = 1;
                 } else {
                     return Some(ClassHeader {
@@ -326,7 +336,7 @@ pub(crate) fn find_class_header(source: &str) -> Option<ClassHeader> {
             b';' if nesting == 0 => {
                 keyword = None;
                 heritage_start = None;
-                nested_classes = 0;
+                pending_bodies = 0;
             }
             _ => {}
         }

--- a/crates/rsvelte_core/tests/class_heritage_brace_scan.rs
+++ b/crates/rsvelte_core/tests/class_heritage_brace_scan.rs
@@ -1,0 +1,91 @@
+//! `compileModule` locates a class body by scanning for the first `{` at
+//! bracket depth 0 after the header, and a heritage clause can contain one of
+//! its own. The scan counted a nested `class`'s body brace and nothing else, so
+//! `class A extends function () {} { e = $state(5) }` treated the *function's*
+//! body as the class body and the field was never privatised.
+//!
+//! A heritage is a `LeftHandSideExpression`, which bounds what can put a `{`
+//! there: a class expression, a function expression in any of its four
+//! spellings, or an object literal in primary position. Anything parenthesised
+//! is already at depth > 0, and a template literal's braces are not code bytes.
+//! The rows below are that enumeration, not the one shape that was reported.
+//!
+//! Every expected fragment was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::compiler::ModuleCompileOptions;
+use rsvelte_core::{GenerateMode, compile_module};
+
+/// The privatised field declaration official emits for `e = $state(5)`.
+const PRIVATISED: &str = "#e = $.state(5);";
+
+fn field_line(heritage: &str) -> String {
+    let src = format!(
+        "const mixin = (b) => b;\nclass Base {{ n = $state(0); }}\nconst ns = {{ Base }};\n\
+         export class Sub extends {heritage} {{\n\te = $state(5);\n}}\n"
+    );
+    let js = compile_module(
+        &src,
+        ModuleCompileOptions {
+            filename: Some("Test.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    js.lines()
+        .find(|l| l.contains("= $.state(5)"))
+        .unwrap_or_else(|| panic!("no `e` field in:\n{js}"))
+        .trim()
+        .to_string()
+}
+
+#[test]
+fn a_function_expression_heritage_does_not_hide_the_class_body() {
+    for heritage in [
+        "function () {}",
+        "function F() {}",
+        "function* () {}",
+        "async function () {}",
+        "async function* () {}",
+        // An unparenthesised IIFE: the same brace, followed by a call.
+        "function () { return Base; }()",
+    ] {
+        assert_eq!(field_line(heritage), PRIVATISED, "heritage `{heritage}`");
+    }
+}
+
+#[test]
+fn an_object_literal_heritage_does_not_hide_the_class_body() {
+    for heritage in ["{ }", "{ a: 1 }"] {
+        assert_eq!(field_line(heritage), PRIVATISED, "heritage `{heritage}`");
+    }
+}
+
+/// The rows that were already right. A class expression was the one brace
+/// source the scan knew about, and everything parenthesised or inside a
+/// template never reached depth 0 — if any of these move, the fix widened the
+/// scan instead of closing it.
+#[test]
+fn the_heritage_shapes_that_already_worked_still_work() {
+    for heritage in [
+        "Base",
+        "mixin(Base)",
+        "ns.Base",
+        "(0, Base)",
+        "class { m() {} }",
+        "class Inner { m() {} }",
+        "class { m() { class Q {} } }",
+        "mixin(class {}, function () {})",
+        "(function () {})",
+        "(class {})",
+        "mixin({ x: 1 })",
+        "({ B: Base }).B",
+        "String.raw`${{ a: 1 }}`",
+        "`${1}`",
+    ] {
+        assert_eq!(field_line(heritage), PRIVATISED, "heritage `{heritage}`");
+    }
+}

--- a/crates/rsvelte_core/tests/constructor_rune_spanning_lines.rs
+++ b/crates/rsvelte_core/tests/constructor_rune_spanning_lines.rs
@@ -1,0 +1,72 @@
+//! A class field assigned a rune in the constructor is collected by scanning
+//! the constructor body line by line, and `find_matching_paren_lexical` has no
+//! closing paren to find when the call runs past the line end — so the whole
+//! field was dropped: no `#name` backing, no getter, no setter, and output that
+//! parses cleanly while the property no longer exists.
+//!
+//! The join loop that groups physical lines existed, but its condition asked
+//! only whether the initializer had yet to START (`=` with nothing after it on
+//! the line). `this.a = $state(` starts its initializer and does not finish it,
+//! so it was never joined. The two conditions are `||`-ed and each row below
+//! is the witness for exactly one of them: ablate the bracket-depth arm and
+//! only the multi-line rows fail; ablate the other and only
+//! `an_initializer_that_starts_on_the_next_line` fails.
+//!
+//! Every expected shape was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::compiler::ModuleCompileOptions;
+use rsvelte_core::{GenerateMode, compile_module};
+
+/// The privatised backing fields, in order, for a class whose constructor
+/// assigns `a` and then `b`.
+fn backing_fields(constructor_body: &str) -> Vec<String> {
+    let src = format!(
+        "export class S {{\n  a;\n  b;\n  constructor() {{\n{constructor_body}\n    this.b = $state(2);\n  }}\n}}\n"
+    );
+    let js = compile_module(
+        &src,
+        ModuleCompileOptions {
+            filename: Some("Test.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    js.lines()
+        .filter(|l| l.starts_with('\t') && l.trim_start().starts_with('#'))
+        .map(|l| l.trim().to_string())
+        .collect()
+}
+
+fn both_fields() -> Vec<String> {
+    vec!["#a;".to_string(), "#b;".to_string()]
+}
+
+#[test]
+fn a_rune_call_that_spans_lines_still_declares_its_field() {
+    for body in [
+        "    this.a = $state(\n      1,\n    );",
+        "    this.a = $state(\n      x ?? {\n        m: 1,\n      },\n    );",
+        "    this.a = $state(\n      [1, 2],\n    );",
+        "    this.a = $state( // why\n      1,\n    );",
+        "    this.a = $state(\n      f(\n        1,\n      ),\n    );",
+        // Both arms of the join condition at once: nothing after `=`, and then
+        // a call that does not close on its own line either.
+        "    this.a =\n      $state(\n        1,\n      );",
+    ] {
+        assert_eq!(backing_fields(body), both_fields(), "body:\n{body}");
+    }
+}
+
+/// The rows the join already handled. `an initializer that starts on the next
+/// line` is the witness for the pre-existing arm — its brackets are balanced on
+/// every line, so the bracket-depth arm cannot carry it.
+#[test]
+fn an_initializer_that_starts_on_the_next_line_still_works() {
+    for body in ["    this.a = $state(1);", "    this.a =\n      $state(1);"] {
+        assert_eq!(backing_fields(body), both_fields(), "body:\n{body}");
+    }
+}

--- a/crates/rsvelte_core/tests/each_invalidation_transform_input.rs
+++ b/crates/rsvelte_core/tests/each_invalidation_transform_input.rs
@@ -1,0 +1,92 @@
+//! `$.invalidate_inner_signals(() => (…))` names the bindings an each-item
+//! mutation must invalidate, and each name goes through that binding's read
+//! transform. A legacy reactive import's read expects the identifier already
+//! swapped for its `$$_import_` alias — `program.rs` registers that swap as
+//! `replacement_id` — and the each-block site passed the raw name instead, so
+//! `settings` came out as `settings()`: a call on the module binding, which is
+//! also exactly what a prop read looks like.
+//!
+//! The rows below vary the binding KIND behind one fixed each block, so a fix
+//! that widens the swap to a kind that must not have it is visible as a moved
+//! control. Every expected fragment was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::compiler::CompileOptions;
+use rsvelte_core::{GenerateMode, compile};
+
+fn invalidation_lines(head: &str, body: &str) -> Vec<String> {
+    let src = format!("<script>\n{head}\n</script>\n\n{body}\n");
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    js.lines()
+        .filter(|l| l.contains("invalidate_inner_signals"))
+        .map(|l| l.trim().to_string())
+        .collect()
+}
+
+const IMPORT: &str = "  import { settings } from './settings.js';";
+const EACH: &str =
+    "{#each settings.filters as filter, index}\n  <input bind:value={filter.match} />\n{/each}";
+/// A write to a member of the import is what makes it a `$.reactive_import`.
+const MUTATE: &str = "<input bind:value={settings.language} />\n";
+
+#[test]
+fn a_reactive_import_is_invalidated_through_its_import_alias() {
+    assert_eq!(
+        invalidation_lines(IMPORT, &format!("{MUTATE}\n{EACH}")),
+        vec!["$.invalidate_inner_signals(() => ($$_import_settings()))"]
+    );
+}
+
+/// The same alias inside a sequence: the inner each item resolves through a
+/// different transform in the same argument list, so a swap applied to the
+/// wrong element of the sequence is visible here and nowhere else.
+#[test]
+fn a_reactive_import_keeps_its_alias_beside_an_each_item() {
+    let body = format!(
+        "{MUTATE}\n{{#each settings.filters as filter}}\n  {{#each filter.rules as rule}}\n    <input bind:value={{rule.match}} />\n  {{/each}}\n{{/each}}"
+    );
+    assert_eq!(
+        invalidation_lines(IMPORT, &body),
+        vec!["$.invalidate_inner_signals(() => ($.get(filter), $$_import_settings()))"]
+    );
+}
+
+/// The three kinds that must NOT be renamed. `exported-prop` is the control
+/// that matters: `settings()` is what the defect produced, so a test that only
+/// asserted "not the raw name" would have passed on the bug.
+#[test]
+fn the_other_binding_kinds_keep_their_own_read_transform() {
+    for (head, body, expected) in [
+        (
+            IMPORT,
+            EACH.to_string(),
+            "$.invalidate_inner_signals(() => (settings))",
+        ),
+        (
+            "  let settings = { filters: [], language: 'en' };",
+            format!("{MUTATE}\n{EACH}"),
+            "$.invalidate_inner_signals(() => ($.get(settings)))",
+        ),
+        (
+            "  export let settings;",
+            format!("{MUTATE}\n{EACH}"),
+            "$.invalidate_inner_signals(() => (settings()))",
+        ),
+    ] {
+        assert_eq!(
+            invalidation_lines(head, &body),
+            vec![expected],
+            "head `{head}`"
+        );
+    }
+}

--- a/crates/rsvelte_core/tests/mutate_root_is_not_a_method_call.rs
+++ b/crates/rsvelte_core/tests/mutate_root_is_not_a_method_call.rs
@@ -1,0 +1,78 @@
+//! Upstream walks an assignment target's `.object` chain **only while it is a
+//! `MemberExpression`** and then requires an `Identifier`
+//! (`3-transform/client/visitors/AssignmentExpression.js:104-112`), so
+//! `stage.container().style.cursor = 'grab'` has no root binding and is not a
+//! mutation. rsvelte's template-expression port walked through a `Call` via its
+//! callee, so the same write came out as `$.mutate(stage, …)`.
+//!
+//! The two ports are the discriminator: an arrow declared in `<script>` reaches
+//! a different implementation and was already right, so only an arrow written
+//! inline in the template diverged.
+//!
+//! Every expected fragment was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn cursor_line(src: &str) -> String {
+    let js = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    js.lines()
+        .find(|l| l.contains("cursor"))
+        .unwrap_or_else(|| panic!("no cursor assignment in:\n{js}"))
+        .trim()
+        .to_string()
+}
+
+#[test]
+fn a_method_call_in_the_chain_is_not_a_mutation_from_an_inline_handler() {
+    let line = cursor_line(
+        "<script>\n\tlet stage;\n</script>\n\
+         <div bind:this={stage} on:mouseenter={() => { stage.container().style.cursor = \"grab\"; }}></div>",
+    );
+    assert_eq!(line, "$.get(stage).container().style.cursor = \"grab\";");
+}
+
+#[test]
+fn a_method_call_in_the_chain_is_not_a_mutation_from_a_component_property() {
+    let line = cursor_line(
+        "<script>\n\timport Stage from './S.svelte';\n\tlet stage;\n</script>\n\
+         <Stage bind:handle={stage} f={() => { stage.container().style.cursor = \"grab\"; }} />",
+    );
+    assert_eq!(line, "$.get(stage).container().style.cursor = \"grab\";");
+}
+
+/// The port that was already right. It has to keep being right: the fix is in
+/// the other port, so a regression here would mean the wrong one was changed.
+#[test]
+fn a_method_call_in_the_chain_is_not_a_mutation_from_a_script_function() {
+    let line = cursor_line(
+        "<script>\n\timport Stage from './S.svelte';\n\tlet stage;\n\
+         \tfunction go(){ stage.container().style.cursor = \"grab\"; }\n</script>\n\
+         <Stage bind:handle={stage} on:x={go} />",
+    );
+    assert_eq!(line, "$.get(stage).container().style.cursor = \"grab\";");
+}
+
+/// The control: an identical chain with no call still mutates, so the fix
+/// cannot have been "stop wrapping member writes".
+#[test]
+fn a_plain_member_chain_from_an_inline_handler_is_still_a_mutation() {
+    let line = cursor_line(
+        "<script>\n\tlet stage;\n</script>\n\
+         <div bind:this={stage} on:mouseenter={() => { stage.style.cursor = \"grab\"; }}></div>",
+    );
+    assert_eq!(
+        line,
+        "$.mutate(stage, $.get(stage).style.cursor = \"grab\");"
+    );
+}

--- a/crates/rsvelte_core/tests/reactive_declaration_rhs_mutations.rs
+++ b/crates/rsvelte_core/tests/reactive_declaration_rhs_mutations.rs
@@ -1,0 +1,121 @@
+//! A `$:` statement's body is lowered by branching on the shape of its
+//! left-hand side, and `transform_state_member_mutations` — the pass that wraps
+//! a state member write in `$.mutate` — was wired into two of the branches. A
+//! mutation nested in the right-hand side (inside an arrow, say) therefore lost
+//! its wrap on every other branch, and the read pass then rewrote its root to
+//! `$.get(o)`, producing a write that never invalidates.
+//!
+//! The comment on the branch that already had the pass called them "both
+//! sibling branches"; there are eight, and five were missing it. The two that
+//! had it are the controls below.
+//!
+//! Every expected fragment was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+const EXPECTED: &str = "$.mutate(o, $.get(o).sel = k() || 1);";
+
+fn mutation_line(statement: &str) -> String {
+    let src = format!(
+        "<script>\n\texport let k;\n\tlet o = {{ sel: 0 }};\n\tlet arr = [0];\n\
+         \tlet pobj = {{ sel: 0 }};\n\t{statement}\n</script>\n\
+         <p>{{o.sel}}{{arr[0]}}{{pobj.sel}}{{k}}</p>\n"
+    );
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    js.lines()
+        .find(|l| l.contains(".sel = k()"))
+        .unwrap_or_else(|| panic!("no nested mutation in:\n{js}"))
+        .trim()
+        .to_string()
+}
+
+#[test]
+fn a_prop_left_hand_side_wraps_a_nested_mutation() {
+    assert_eq!(
+        mutation_line("$: k = (() => { o.sel = k || 1; });"),
+        EXPECTED
+    );
+}
+
+#[test]
+fn a_state_left_hand_side_wraps_a_nested_mutation() {
+    assert_eq!(
+        mutation_line("$: rx = { f: () => { o.sel = k || 1; } };"),
+        EXPECTED
+    );
+}
+
+#[test]
+fn a_member_left_hand_side_wraps_a_nested_mutation() {
+    assert_eq!(
+        mutation_line("$: pobj.sel = (() => { o.sel = k || 1; }, 1);"),
+        EXPECTED
+    );
+}
+
+#[test]
+fn a_computed_member_left_hand_side_wraps_a_nested_mutation() {
+    assert_eq!(
+        mutation_line("$: arr[0] = (() => { o.sel = k || 1; }, 1);"),
+        EXPECTED
+    );
+}
+
+#[test]
+fn a_non_reactive_left_hand_side_wraps_a_nested_mutation() {
+    assert_eq!(
+        mutation_line("$: plainv = (() => { o.sel = k || 1; });"),
+        EXPECTED
+    );
+}
+
+/// The pass parses its input as a program, so the right-hand side only reached
+/// it while it happened to be a statement too: `{ f: () => { … } }` is a block
+/// with one labelled statement, and a SECOND property makes it a parse error and
+/// the pass a no-op. Every real carrier has more than one property.
+#[test]
+fn an_object_right_hand_side_with_two_properties_wraps_a_nested_mutation() {
+    assert_eq!(
+        mutation_line("$: rx = { zzz: 1, f: () => { o.sel = k || 1; } };"),
+        EXPECTED
+    );
+}
+
+/// The one-property spelling that worked by accident. It has to keep working:
+/// the parenthesised form parses it as an object literal rather than a block.
+#[test]
+fn an_object_right_hand_side_with_one_property_still_wraps_a_nested_mutation() {
+    assert_eq!(
+        mutation_line("$: rx = { f: () => { o.sel = k || 1; } };"),
+        EXPECTED
+    );
+}
+
+/// The two branches that already had the pass, kept as controls: if these move,
+/// the change reached more than the five branches it was measured on.
+#[test]
+fn the_keyword_branch_still_wraps_a_nested_mutation() {
+    assert_eq!(
+        mutation_line("$: if (k) { const f = () => { o.sel = k || 1; }; f; }"),
+        EXPECTED
+    );
+}
+
+#[test]
+fn the_destructuring_branch_still_wraps_a_nested_mutation() {
+    assert_eq!(
+        mutation_line("$: [a1] = [() => { o.sel = k || 1; }];"),
+        EXPECTED
+    );
+}

--- a/crates/rsvelte_core/tests/state_proxy_expression_shapes.rs
+++ b/crates/rsvelte_core/tests/state_proxy_expression_shapes.rs
@@ -1,0 +1,114 @@
+//! Upstream's `should_proxy` returns `false` only for the shapes it enumerates
+//! (a literal, a `void`/`typeof`/unary result, a known-primitive call, …) and
+//! proxies **everything else**. rsvelte's `expression_needs_proxy` is a text
+//! sniff that returns `true` only for the shapes IT enumerates, so the two have
+//! opposite defaults and every predicate rsvelte is missing flips the answer
+//! the other way.
+//!
+//! Optional chaining was such a shape: the member and call predicates split
+//! `p?.x` at the `.` and read `p?` as the object, which matches neither, so a
+//! `$state(p?.x)` lost its `$.proxy`. Both directions are checked below, and
+//! the shapes that must NOT be proxied are the half a whitelist gets right by
+//! accident — ablate the fix and only the `?.` rows move.
+//!
+//! Every expected shape was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::compiler::ModuleCompileOptions;
+use rsvelte_core::{GenerateMode, compile_module};
+
+/// The `this.#a = …` initializer emitted for a constructor assigning `$state(expr)`.
+fn state_initializer(expr: &str) -> String {
+    let src = format!(
+        "export class S {{\n  a;\n  constructor(p, f) {{\n    this.a = $state({expr});\n  }}\n}}\n"
+    );
+    let js = compile_module(
+        &src,
+        ModuleCompileOptions {
+            filename: Some("Test.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    js.lines()
+        .map(str::trim)
+        .find(|l| l.starts_with("this.#a = "))
+        .unwrap_or_else(|| panic!("no `this.#a =` line for `{expr}` in:\n{js}"))
+        .to_string()
+}
+
+#[test]
+fn an_optional_chain_is_proxied_like_the_plain_chain_it_mirrors() {
+    // Each pair is the same access written with and without `?.`; upstream
+    // proxies both, so a rule that reads one and not the other is the defect.
+    for (plain, optional) in [
+        ("p.x", "p?.x"),
+        ("p.x.y", "p?.x?.y"),
+        ("p.x()", "p?.x?.()"),
+        ("p.x.y.toString()", "p?.x?.y.toString()"),
+        ("p[0]", "p?.[0]"),
+    ] {
+        for expr in [plain, optional] {
+            assert_eq!(
+                state_initializer(expr),
+                format!("this.#a = $.state($.proxy({expr}));"),
+                "`{expr}` must be proxied"
+            );
+        }
+    }
+}
+
+#[test]
+fn a_ternary_spelled_with_a_leading_dot_number_keeps_its_value() {
+    // `?.5` is a ternary whose consequent is `.5`, not an optional chain, so
+    // the rewrite must leave those two characters alone. Measured on both
+    // arms: this line is byte-identical with and without the rewrite, and it
+    // is the only shape in the grid for which that is true.
+    //
+    // Official proxies it (`$.state($.proxy(p ? .5 : 1))`) and rsvelte does
+    // not — a SEPARATE, pre-existing gap that predates this rewrite and is
+    // measured out of scope below, so this test pins the value rather than
+    // the proxy.
+    assert_eq!(
+        state_initializer("p ?.5 : 1"),
+        "this.#a = $.state(p ? .5 : 1);"
+    );
+
+    // The same ternary with a space is recognised, which is what makes the
+    // no-space spelling a spacing defect rather than a missing ternary rule.
+    assert_eq!(
+        state_initializer("p ? .5 : 1"),
+        "this.#a = $.state($.proxy(p ? .5 : 1));"
+    );
+    assert_eq!(
+        state_initializer("p ? 1 : 2"),
+        "this.#a = $.state($.proxy(p ? 1 : 2));"
+    );
+}
+
+#[test]
+fn the_shapes_upstream_refuses_to_proxy_stay_unproxied() {
+    // The negative half: a whitelist gets these right by accident, so they are
+    // the control that the rewrite did not simply start proxying everything.
+    for expr in ["1", "\"s\"", "null", "undefined", "true"] {
+        assert_eq!(
+            state_initializer(expr),
+            format!("this.#a = $.state({expr});"),
+            "`{expr}` must not be proxied"
+        );
+    }
+}
+
+#[test]
+fn the_shapes_that_already_proxied_still_proxy() {
+    for expr in ["f(p)", "[1, 2]", "{ a: 1 }", "p.x ?? 1", "p?.x ?? 1"] {
+        let got = state_initializer(expr);
+        assert!(
+            got.contains("$.proxy("),
+            "`{expr}` must still be proxied, got `{got}`"
+        );
+    }
+}


### PR DESCRIPTION
Two `$.mutate` decisions that answer differently depending on the **host** the write is written in. Both retire a `known-failures.client` / `known-failures.client-dev` entry.

## 1. A method call in the chain is not a mutation (`musicat/…/Scrollbar.svelte`)

Upstream walks an assignment target's `.object` chain **only while it is a `MemberExpression`** and then requires an `Identifier` (`3-transform/client/visitors/AssignmentExpression.js:104-112`), so `stage.container().style.cursor = 'grab'` has no root binding and is not a mutation. `get_base_object` (`client/visitors/shared/utils.rs:2013`) walked *through* a `Call` via its callee.

Only the **template-expression** port did — an arrow declared in `<script>` reaches a different implementation and was already right — so the axis that separates them is the host, not the binding or the expression. Measured, 6 cells:

```
* DIFF  C1 component bind + on:       off: plain assignment   rsv: $.mutate(stage, …)
* DIFF  C2 component bind + prop fn   off: plain assignment   rsv: $.mutate(stage, …)
  EQ    C3 component bind, script fn  both plain              <- the port that was already right
* DIFF  C4 element bind + on:         off: plain assignment   rsv: $.mutate(stage, …)
  EQ    C5 plain chain, no call       both $.mutate(stage, …) <- control
* DIFF  C6 member name shadows state  off: plain assignment   rsv: $.mutate(stage, …)
```

The `Call` arm is now crossed only when the callee is a simple `Identifier`. A read-transform call (`count()`) always is; a method call (`a.b()`) never is, and the same file's `has_call_in_base_chain` already draws that line.

## 2. A mutation nested in a `$:` right-hand side is one (`ha-fusion/…/TransformAttributes.svelte`)

A `$:` body is lowered by branching on the shape of its left-hand side, and `transform_state_member_mutations` — the pass that wraps a state member write in `$.mutate` — was wired into two of the branches. The note that added it says the keyword branch *"was missing this pass that **both sibling branches** have"*. There are **eight**, and five were missing it:

```
  EQ  1 keyword ($: if)        <- has the pass
  EQ  2 destructure            <- has the pass
* DIFF 3 prop LHS
* DIFF 4 state LHS
* DIFF 5 member LHS
* DIFF 6 computed member LHS
* DIFF 7 plain LHS
  EQ  8 bare expression stmt
```

**And wiring it in was not enough.** The pass parses its input as a **program**, so an object-literal right-hand side reached it only while it happened to be a statement too: `{ f: () => { … } }` is a block with one labelled statement and works; a **second property** makes it a parse error and the pass a silent no-op (`unwrap_or_else(|| expr.to_string())`). Every real carrier has more than one property. It is now parenthesised first — the parens come back off, because every edit the pass makes lands inside them.

The discriminator was not the shape I first guessed. `{ sel: 1, f: … }` and `{ zzz: 1, f: … }` fail identically, so it is not a name collision with the mutated member; it is the property *count*.

## Measurement

- **5 grids, 38 cells, all EQ** against the official compiler, including 6 controls (an already-correct port, a call-free chain, the two branches that already had the pass, a bare expression statement, a one-property object).
- **Both files are byte-identical to official on `js.code` and `css.code`, on `prod` and on `dev`.**
- **Corpus A/B over 69,626 (id, target) units** — every manifest entry × `prod`/`dev`, hashed with the base binary built from `c33096604` and with this branch's binary: **exactly 4 units changed, and they are these two files × two targets.** Zero collateral.
- The base binary's identity is from a **discriminating probe on its output** (it reproduces C1/C2/C4/C6), not from its file name.

## One thing this PR does not close

`appwrite-console/…/sortButton.svelte` looked retireable and is not. A first script compared `js.code` only and reported it byte-identical; adding `css.code` — which is half the gate's comparison key — shows `prod` still differs. It stays listed. A reconstruction that drops one field of the comparison key is a hand-made FALSE-SHRINK.

## Also here

- `AGENTS.md`: a comment that **counts** its siblings is the two-ports hazard with a number in it, and the number is the part nobody re-derives.
- `compatibility/KNOWN-FAILURES.md`: the fmt ratchet's line-breaking majority is measured to be in the **template** — locating each entry's first differing line back in its source partitions the 549 as `template 438 | unlocated 48 | script 41 | style 22`, which puts 398 of the 472 line-breaking entries in Svelte markup rather than in embedded JS or CSS. Positive control: the same local harness reproduces the gate's own shape partition on five of its seven buckets exactly.

Closes nothing on its own; drops 2 entries from `known-failures.client.json` (34 → 32) and 2 from `known-failures.client-dev.json` (48 → 46).


---

# Second fix, folded in: a heritage clause can open a brace

`find_class_header` locates a class body by taking the first `{` at bracket depth 0 after the header, and it counted exactly one thing that can open a brace before it — a nested `class` expression. So `class A extends function () {} { e = $state(5) }` read the **function's** body as the class body: the field was never privatised, and `pattern/issues/3072-extends-shapes-legal.svelte.js` has been listed in `known-failures.client` / `known-failures.client-dev` for it.

## The reported shape is one of eight

A heritage is a `LeftHandSideExpression`, and that closes the set of things that can put a `{` at depth 0 there: a class expression, a function expression in its four spellings, and an object literal in primary position. Anything parenthesised is already at depth > 0, and a template literal's braces are not code bytes. Measured one cell per member, against the official compiler:

```
  EQ    name / call / ns.Base / (0, Base)          <- controls
  EQ    class {} / class Inner {} / two nested     <- the one source the scan knew
* DIFF  function () {}
* DIFF  function F() {}
* DIFF  function* () {}
* DIFF  async function () {}
* DIFF  async function* () {}
* DIFF  function () { return Base; }()             <- unparenthesised IIFE
* DIFF  { }
* DIFF  { a: 1 }
  EQ    (function () {}) / (class {})              <- already at depth > 0
  EQ    `${1}` / String.raw`${{ a: 1 }}`
EQ 10 | DIFF 8
```

Adding `function` to the list would have been the same mistake one level down. The rule is now: `class` **or** `function` opens a pending body to skip, and a `{` reached with nothing but whitespace and comments since `extends` is that primary's own object literal.

## The first fix regressed a row that was already passing

It spelled "no brace-producing primary yet" as "no **code byte** since `extends`" — and `js_scan::code_bytes` skips a template literal whole, so `` extends `${1}` `` produced no code bytes at all and the class body was skipped as an object literal. The decision moved to `skip_ws_and_comments`, which reads raw bytes.

That row had been **green before the fix**, which is the only kind of row that can report this: a grid assembled from the cells a defect breaks has no cell left to regress.

## Measurement

- **18 cells, all EQ** against the official compiler; the base binary reproduces `EQ 10 | DIFF 8` on the same 18, which is how the arms were identified (a discriminating probe on output, not a file name).
- `crates/rsvelte_core/tests/class_heritage_brace_scan.rs` — 3 tests over those 18 rows, 3 passed. **Positive control, measured**: with `class_body.rs` reverted to `main` and everything else unchanged, `a_function_expression_heritage_does_not_hide_the_class_body` and `an_object_literal_heritage_does_not_hide_the_class_body` FAIL and `the_heritage_shapes_that_already_worked_still_work` still passes.
- **Corpus A/B over 139,252 (id, target) units** — every manifest entry x `client`, `client-dev`, `server`, `server-dev` — **exactly 2 changed, and both are this entry.** The scan is shared by the client (`class_transforms.rs:996`) and the server (`transform_script.rs:4864`), which is why all four targets were swept rather than the two this entry sits in; no server output moved.
- Full-gate reconstruction (oxfmt normalisation, byte comparison, and the same `ast_equiv_batch` rescue stage `verify.mjs` runs): `FAIL / FAIL` before, `PASS byte / PASS byte` after, on `prod` and `dev`.

## Why it is in this PR rather than its own

CI was at 16 running / 120 queued jobs when this was ready, and this PR's own checks had not started a single job. A separate PR costs a whole extra run (~160 job-minutes) for two independent one-line-decision fixes; folding costs nothing, because the superseded run had done no work.

Ratchets after both fixes: `known-failures.client.json` 34 -> **31**, `known-failures.client-dev.json` 48 -> **45**.


---

# Third fix: a reactive import is invalidated through its `$$_import_` alias

`$.invalidate_inner_signals(() => (…))` names the bindings an each-item mutation must invalidate, and each name goes through that binding's read transform. A legacy **reactive import**'s read expects the identifier already swapped for its `$$_import_` alias — `client/visitors/program.rs` registers that swap as `replacement_id`, and both `shared/utils.rs:907` and `shared/utils.rs:1572` consult it — while `each_block.rs` passed the raw name.

`photon/…/settings/{app,moderation}` therefore emitted `$.invalidate_inner_signals(() => (settings()))` where official emits `$$_import_settings()`.

**`settings()` is exactly what a prop read looks like**, so a check asking only "is it not the bare name" passes on the bug. The repro fixes the each block and varies the binding KIND instead:

| head | official |
|---|---|
| `import { settings }` + a write to a member | `$.invalidate_inner_signals(() => ($$_import_settings()))` |
| `import { settings }`, no write | `… => (settings)` |
| `let settings = …` | `… => ($.get(settings))` |
| `export let settings` | `… => (settings())` |
| nested each | `… => ($.get(filter), $$_import_settings())` |

- **Corpus A/B over 139,252 (id, target) units** — every manifest entry × 4 targets — **exactly 4 changed, and all four are these two entries on `client` and `client-dev`.**
- 3 tests, 3 passed.

Drops 2 more from each client ratchet: `known-failures.client.json` **31 → 29**, `known-failures.client-dev.json` **45 → 43**.

---

# Fourth fix: a constructor rune call that spans lines keeps its field — and **retires no ratchet entry**

The constructor body is scanned line by line, so `find_matching_paren_lexical` has no closing paren to find when `this.a = $state(` runs past the line end. `parse_constructor_state_assignment` returns `None` and the whole field is dropped: no `#a` backing, no getter, no setter — **output that parses cleanly with the property gone**, which only output equality can see.

The join loop that groups physical lines existed, but its condition asked only whether the initializer had yet to START (`=` with nothing after it on the line). `this.a = $state(` starts its initializer and does not finish it, so it was never joined. It now also joins while the brackets are unbalanced, using the `net_bracket_depth` already in the file (string-, template- and comment-aware) rather than a second port of that rule — summed per line, so the decision does not depend on whether a `//` comment's terminator is seen across a newline.

The two conditions are `||`-ed, and each row is the witness for exactly one arm:

```
                    base   fixed
single-line          EQ     EQ     <- already worked
multiline-paren      DIFF   EQ
multiline-object     DIFF   EQ     <- the corpus shape
multiline-array      DIFF   EQ
trailing-comment     DIFF   EQ
nested-call          DIFF   EQ
eq-then-newline      EQ     EQ     <- witness for the PRE-EXISTING arm
eq-nl-multiline      DIFF   EQ     <- needs both arms
callee-then-nl       DIFF   DIFF   <- measured, out of scope (below)
```

- **Corpus A/B over 139,252 units: exactly 2 changed**, both `photon/…/postform.svelte.ts`.
- 2 tests, 2 passed.

**It retires nothing.** The shape occurs in **1 of the 12,523 collected sources**, and that one file carries a second divergence (`$.state($.proxy(x))` vs `$.state(x)` on an optional chain) that the first-diff view was hiding behind the dropped field. Shipped anyway because the defect is a silent field drop whose output parses — the class #3026 records, where a shape with no corpus witness was still a real defect. The difference is that reachability was **measured** here rather than assumed.

### Measured and deliberately out of scope

```js
this.a = $state
  (1);
```

Official emits `#a` and its accessors; rsvelte drops the field. Neither arm of the join catches it — the initializer has started (`$state`) and the brackets are still balanced. Adding a third arm would add a `||` branch with no witness in any population, so it is recorded here as a future ratchet candidate rather than fixed blind.


---

# Fifth fix: `$state(p?.x)` keeps its `$.proxy`

Upstream's `should_proxy` returns `false` only for the shapes it **enumerates** (a literal, a `void`/`typeof` result, a known-primitive call) and proxies everything else. rsvelte's `expression_needs_proxy` is a text sniff returning `true` only for the shapes **it** enumerates. **The two have opposite defaults**, so every predicate rsvelte is missing flips the answer the other way rather than falling back to the safe side.

An optional chain is such a shape: `p?.x` splits at the `.` into `p?` and `x`, which matches neither the member nor the call predicate. `$state(p?.x)` therefore lost its `$.proxy` and the field stopped being deeply reactive — **output that parses and runs**, differing only in reactivity.

The chain is read in its plain form before the predicates run. `?.` followed by a **digit** is left alone: there the two characters open a ternary whose consequent is `.5`.

```
before  after
DIFF    EQ    p?.x   p?.x?.y   p?.x?.()   p?.x?.y.toString()   p?.[0]
EQ      EQ    p.x   p.x()   f(p)   [1,2]   {a:1}   p.x ?? 1   p?.x ?? 1
EQ      EQ    1   "s"   null   undefined        <- must NOT be proxied
```

The five literal rows are the half a whitelist gets right **by accident**, so they are the control that the rewrite did not simply start proxying everything.

- **Corpus A/B over 139,252 (id, target) units: exactly 2 moved**, both `photon/…/postform.svelte.ts` on `client` and `client-dev`.
- 4 tests, 4 passed.

### This is what retires `postform`

The fourth fix restored its dropped field and retired **nothing**, because a first-diff view was hiding a second divergence in the same file. With both fixes the file is **byte-equal on all four targets** (positive control: the same harness prints for `appwrite-console/…/sortButton.svelte`, which is still listed).

`known-failures.client.json` **29 → 28**, `known-failures.client-dev.json` **43 → 42**.

### Measured and deliberately out of scope

`$state(p ?.5 : 1)` — official proxies the ternary, rsvelte does not. **Both arms emit the identical line**, so it predates this rewrite; and since `p ? .5 : 1` *with a space* already proxies, it is a spacing defect in the ternary detector rather than a missing ternary rule. Pinned in the test as current behaviour rather than fixed blind.

---

## Ratchet movement across the whole PR

| ratchet | before | after |
|---|---|---|
| `known-failures.client.json` | 34 | **28** |
| `known-failures.client-dev.json` | 48 | **42** |
