### PR TITLE
fix(client): a `{const}` tag reads every template binding, not two kinds of them

### DIFF
--- a/.changeset/declaration-tag-template-reads.md
+++ b/.changeset/declaration-tag-template-reads.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A `{const}` / `{let}` tag now reads every template-scope binding through that binding's own read, not through a hand-written list of two kinds. Snippet parameters, `let:` bindings and `{@const}` bindings were read bare, so a value produced by one of them was frozen at its first-render value.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1127,6 +1127,37 @@ diagnosed as a defect and nearly deleted from three ports, because the npm build
 No gate compares generated code against the npm build (`test-wasm-compile-options.mjs` imports
 it only to ask whether an option *throws*), so the hazard is probes, not gates.
 
+### Generate an expected value from the oracle; do not back it out of the oracle's output
+
+A test's expected strings are a second implementation of the rule, written by hand, and the
+cheapest way to get them wrong is to infer them from a few outputs. Two instances on one day.
+A `$state(p ?.5 : 1)` row was typed as `$.state($.proxy(p ? 0.5 : 1))` from two neighbouring
+cells; official neither normalises `.5` to `0.5` nor leaves the ternary unproxied, so the
+hand-written row was wrong in two independent ways and the test failed for neither of the
+reasons it was written to check. And the span a `@typedef` tag occupies was inferred from
+official's output, giving a rule ("delete up to the next tag") that is **right in three of six
+cells**: `@typedef {X} T` ends at the name, while `@typedef {X} T<Id=(string)>` treats the
+angle-bracket text as the tag's *comment* and swallows the following `\n   * `. Printing
+TypeScript's own `tag.pos` / `tag.end` settles it; six outputs do not.
+
+So: **compile the inputs through the oracle and print the answers**, then paste those into the
+test — `submodules/svelte/.../compiler/index.js` for compiler output, and the oracle's own
+functions where they can be called directly. Back-inference gives you exactly as much
+confidence as the number of cells that happen to agree, which is why it fails on the
+interesting ones.
+
+**And the corrected rule was still wrong, for the reason the first one was.** `getLastLeadingDoc`
+(`tsAst.ts:143-160`) reads `tag.pos` / `tag.end`, which are **SourceFile-absolute**, and hands
+them to `nodeText.substring`, which is **node-relative** — so the slice is off by `node.pos` for
+every declaration that is not the first statement. Where the shifted slice happens to occur in
+the comment it deletes the wrong text; where it does not, `replace` silently no-ops and the tag
+survives. Porting the rule *correctly* therefore diverges on 2 real files while fixing 1
+(`match -> MISMATCH: 2`, `MISMATCH -> match: 1` over 738 moved units). The grid that produced
+the corrected rule had every declaration at the top of the script, so `node.pos` was 0 in every
+cell — **the constant it held fixed was the branch condition**. That is the same shape as a
+grid whose bindings all share one name, where a name-keyed test cannot see shadowing: adding an
+axis is not what finds these, moving a held constant is.
+
 ### A changed hash is not a fixed file, and five samples can be one sample
 
 Two independent measurements of a fix's blast radius converged on the same two
@@ -1192,6 +1223,36 @@ The two are opposite defects with the same single-verdict signature. **What made
 split diagnostic was that its axis was the compiler's own stages** — prune, diagnostics,
 element scoping — not an arbitrary partition of the output text: each field named a pass,
 so a divergence in one field named the pass to read.
+
+### Widening a set to close an enumeration hazard moves you along a new axis
+
+A hand-written list of "the kinds this applies to" is only right if the domain is closed, so
+the fix is to derive it from the domain itself. That fix has its own failure, and it is not a
+smaller version of the first one. `{const …}` / `{let …}` re-applied template-scope reads from
+a list of two kinds (each items, await bindings) and missed the other three — snippet
+parameters, `let:` bindings and `{@const}` bindings — so a 10-host × 2-syntax grid read
+16 EQ / 4 DIFF. Deriving the list from `state.transform` took it to 20/20.
+
+It also **double-applied** every read the pipeline had already performed: the tag's text goes
+through the instance-script transform first, and only the `$.get(x)` shape has an
+already-wrapped guard downstream, so a prop came out `p()()` and a store `$s()()`. The
+original grid was green on all 20 cells while that happened, because it varied the binding's
+**host** and held the **read shape** fixed at `$.get`/call. A second grid over eight shapes
+— `$$props.p`, `p()`, `$s()`, `$.get(d)`, bare — reported 5 EQ / 3 DIFF on both.
+
+The rule: **the members a widening admits differ from the old members along an axis the
+original grid held constant**, so name that axis and grid it before trusting the widening. And
+prefer a *complement* over a union when one exists — here the answer is `state.transform`
+minus the names the earlier pass already rewrote, which is closed on both sides, where a union
+of five hand-listed kinds is closed on neither.
+
+**The corpus could not have caught it.** A 139,252-unit sweep of the double-applying arm moved
+**2** units, and both are the file the fix repairs — the regression has zero witnesses. Only 33
+of 33,893 components carry a bare `{const}` / `{let}` at all, 17 of those also mention a prop or
+a store, and none of the 17 reads one *inside* the tag. So the sweep, the gate and the ratchet
+would all have scored it green, and the eight-cell probe is the whole detector. When a construct
+is new enough that the corpus holds it in double digits, "the sweep moved nothing" is a
+statement about the population, not about the change.
 
 ### A missing key can spell two things, and the conservative default reads the wrong one
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2865,11 +2865,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 28 entries)
+### Client (`known-failures.client.json`, 27 entries)
 
-Partition of `known-failures.client.json` by verdict: `27 + 1`
+Partition of `known-failures.client.json` by verdict: `26 + 1`
 
-- **27 — the generated JS differs** (`js` / `code-differs`).
+- **26 — the generated JS differs** (`js` / `code-differs`).
 - **1 — the generated CSS differs.**
 
 The error classes this section used to carry are gone: the run behind this
@@ -2993,7 +2993,7 @@ the emitted default was the getter function rather than the store's value. Hashi
 client (entry, target) outputs before and after reports **2** changed units over 1 id,
 `match -> MISMATCH = 0`; the other two ids of that cluster do not move and stay listed.
 
-Every one of the remaining 28 arrived with the wave-2 enrolment (#3130) and is described
+Every one of the remaining 27 arrived with the wave-2 enrolment (#3130) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3100,15 +3100,15 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 42 entries)
+### Client dev (`known-failures.client-dev.json`, 41 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `42`
+Partition of `known-failures.client-dev.json` by verdict: `41`
 
-- **42 — the generated JS differs.**
+- **41 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 42 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 41 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -34,7 +34,6 @@
 	"svelte-spa-router/test/app/src/App.svelte",
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte",
 	"svelte/packages/svelte/tests/snapshot/samples/delegated-locally-declared-shadowed/index.svelte",
-	"sveltekit/packages/kit/src/runtime/components/root.svelte",
 	"svelteui/packages/svelteui-demos/src/demos/core/Modal/ModalForm.svelte",
 	"svelvet/src/lib/components/Edge/Edge.svelte",
 	"syntaxfm-website/src/routes/(site)/guests/+page.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -22,7 +22,6 @@
 	"svelte-maplibre-gl/src/content/examples/geolocate/Geolocate.svelte",
 	"svelte-spa-router/test/app/src/App.svelte",
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte",
-	"sveltekit/packages/kit/src/runtime/components/root.svelte",
 	"svelteui/packages/svelteui-demos/src/demos/core/Modal/ModalForm.svelte",
 	"syntaxfm-website/src/routes/(site)/guests/+page.svelte",
 	"trakt-web/projects/client/src/lib/components/select/SegmentedSelect.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_reads_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_reads_ast.rs
@@ -69,7 +69,7 @@ use oxc_span::SourceType;
 use oxc_syntax::symbol::SymbolId;
 
 use crate::compiler::phases::phase3_transform::shared::js_scan::contains_identifier;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::ast_rewrite;
 use super::scope_analysis::{find_state_var_symbols, is_state_var_reference_or_unresolved};
@@ -162,6 +162,19 @@ pub fn transform_state_reads_ast(
     state_vars: &[String],
     non_reactive_vars: &[String],
 ) -> Option<String> {
+    transform_state_reads_ast_with(source, state_vars, non_reactive_vars, &FxHashMap::default())
+}
+
+/// As [`transform_state_reads_ast`], but `read_map` supplies a name's own read
+/// shape. A template binding is not always read as `$.get(name)` — a snippet
+/// parameter is a getter and reads as `name()` — so the caller passes what the
+/// binding's own transform produces instead of the default.
+pub fn transform_state_reads_ast_with(
+    source: &str,
+    state_vars: &[String],
+    non_reactive_vars: &[String],
+    read_map: &FxHashMap<String, String>,
+) -> Option<String> {
     if state_vars.is_empty() {
         return None;
     }
@@ -213,19 +226,20 @@ pub fn transform_state_reads_ast(
     };
     let span_offset: i32 = if needs_paren_wrap { 1 } else { 0 };
 
-    match run_state_reads_pass(source, &parse_source, span_offset, &effective) {
+    match run_state_reads_pass(source, &parse_source, span_offset, &effective, read_map) {
         ast_rewrite::ParseAttempt::Parsed(out) => out,
         // An expression whose leading token is an object literal — `{ a: m }.a`
         // — is a block statement under the program goal and so never parses.
         // The parser's verdict, not a byte scan, is what tells the two apart.
         ast_rewrite::ParseAttempt::NotParsed if !needs_paren_wrap && trimmed.starts_with('{') => {
-            run_state_reads_pass(source, &paren_wrapped(source), 1, &effective).into_option()
+            run_state_reads_pass(source, &paren_wrapped(source), 1, &effective, read_map)
+                .into_option()
         }
         // The mirror image: a semicolon-free statement block (`standard` style)
         // satisfies the byte scan's object-literal test, and the `(`…`)` it then
         // adds is what makes the parse fail. The same verdict decides here.
         ast_rewrite::ParseAttempt::NotParsed if needs_paren_wrap => {
-            run_state_reads_pass(source, source, 0, &effective).into_option()
+            run_state_reads_pass(source, source, 0, &effective, read_map).into_option()
         }
         ast_rewrite::ParseAttempt::NotParsed => None,
     }
@@ -239,6 +253,7 @@ fn run_state_reads_pass(
     parse_source: &str,
     span_offset: i32,
     effective: &[&str],
+    read_map: &FxHashMap<String, String>,
 ) -> ast_rewrite::ParseAttempt<String> {
     ast_rewrite::with_program_attempt(
         &STATE_READS_ALLOC,
@@ -263,6 +278,8 @@ fn run_state_reads_pass(
                 effective,
                 effective_names: &effective_names,
                 state_var_symbols,
+                read_map,
+                already_transformed_text: !read_map.is_empty(),
                 replacements: Vec::new(),
                 skip_spans: FxHashSet::default(),
             };
@@ -291,6 +308,12 @@ struct StateReadsCollector<'a, 'sem> {
     effective: &'a [&'a str],
     effective_names: &'a [String],
     state_var_symbols: FxHashSet<SymbolId>,
+    read_map: &'a FxHashMap<String, String>,
+    /// True when this pass runs over text an earlier pass already rewrote, so a
+    /// name that pass handled is already `name()` / `$$props.name` and must not
+    /// be read a second time. Only the `$.get(x)` shape leaves the identifier
+    /// bare, and `visit_call_expression` already skips that one.
+    already_transformed_text: bool,
     replacements: Vec<(u32, u32, String)>,
     /// Spans of identifier references claimed by a parent-context
     /// handler (assignment LHS, update target, first arg of $.set
@@ -306,6 +329,13 @@ impl<'a, 'sem> StateReadsCollector<'a, 'sem> {
 
     fn skip(&mut self, ident: &IdentifierReference) {
         self.skip_spans.insert(ident.span.start);
+    }
+
+    fn read_of(&self, name: &str) -> String {
+        self.read_map
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| format!("$.get({})", name))
     }
 }
 
@@ -326,8 +356,9 @@ impl<'a, 'sem, 'ast> Visit<'ast> for StateReadsCollector<'a, 'sem> {
         ) {
             return;
         }
+        let read = self.read_of(name);
         self.replacements
-            .push((ident.span.start, ident.span.end, format!("$.get({})", name)));
+            .push((ident.span.start, ident.span.end, read));
     }
 
     fn visit_assignment_expression(&mut self, expr: &AssignmentExpression<'ast>) {
@@ -374,6 +405,14 @@ impl<'a, 'sem, 'ast> Visit<'ast> for StateReadsCollector<'a, 'sem> {
                 self.skip(id);
             }
         }
+        // `p()` / `$s()` is what the earlier pass emits for a prop or a store,
+        // so its callee is a read that has already happened.
+        if self.already_transformed_text
+            && call.arguments.is_empty()
+            && let Expression::Identifier(callee) = &call.callee
+        {
+            self.skip(callee);
+        }
         walk::walk_call_expression(self, call);
     }
 
@@ -396,10 +435,11 @@ impl<'a, 'sem, 'ast> Visit<'ast> for StateReadsCollector<'a, 'sem> {
             )
         {
             let name = key.name.as_str();
+            let read = self.read_of(name);
             self.replacements.push((
                 prop.span.start,
                 prop.span.end,
-                format!("{}: $.get({})", name, name),
+                format!("{}: {}", name, read),
             ));
             self.skip(value_ident);
             // Still descend into method-body etc.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
@@ -130,29 +130,49 @@ pub fn declaration_tag(node: &DeclarationTag, context: &mut ComponentContext) {
     // registered read transform and are recorded in `await_binding_names` by
     // await_block.rs. The OXC semantic rewrite below preserves shadowing inside
     // callbacks declared by the initializer.
-    let mut template_get_names: Vec<String> = context
-        .state
-        .each_item_names
-        .iter()
-        .filter(|n| context.state.transform.contains_key(n.as_str()))
-        .map(|n| n.to_string())
-        .collect();
-    for name in context.state.await_binding_names.keys() {
-        if context.state.transform.contains_key(name.as_str()) && !template_get_names.contains(name)
-        {
-            template_get_names.push(name.clone());
+    // Upstream visits the declaration with the template visitor, so every
+    // template-scope binding is read through its own transform. This port runs
+    // the instance-script pipeline over the tag's source text instead, which
+    // knows nothing about them — so the reads are re-applied here. The domain
+    // is `state.transform` itself: enumerating a few kinds by hand missed
+    // snippet parameters, `let:` bindings and `{@const}` bindings, all three of
+    // which reached the tag. A name the instance pipeline already rewrote is
+    // `$.get(name)` by now, and the rewrite skips an already-wrapped read.
+    // Upstream visits the declaration with the template visitor, so every
+    // template-scope binding is read through its own transform. This port runs
+    // the instance-script pipeline over the tag's source text instead, which
+    // knows nothing about them, so the reads are re-applied here.
+    //
+    // The domain is `state.transform` itself: enumerating a few template kinds
+    // by hand missed snippet parameters, `let:` bindings and `{@const}`
+    // bindings. Double application is stopped by the rewrite's own
+    // already-read guards, not by a name test — a name test cannot tell a
+    // template binding from the instance binding it shadows.
+    let mut read_map: rustc_hash::FxHashMap<String, String> = rustc_hash::FxHashMap::default();
+    for (name, transform) in context.state.transform.iter() {
+        let Some(read) = transform.read else { continue };
+        let read_text = crate::compiler::phases::phase3_transform::js_ast::codegen::generate_expr(
+            &read(
+                &context.arena,
+                crate::compiler::phases::phase3_transform::js_ast::builders::id(name),
+            ),
+            &context.arena,
+        );
+        if read_text != *name {
+            read_map.insert(name.clone(), read_text);
         }
     }
+    let template_get_names: Vec<String> = read_map.keys().cloned().collect();
     let transformed = if template_get_names.is_empty() {
         transformed
     } else {
-        crate::compiler::phases::phase3_transform::client::expression_utils::wrap_state_vars_in_expr(
+        crate::compiler::phases::phase3_transform::client::state_reads_ast::transform_state_reads_ast_with(
             &transformed,
             &template_get_names,
             &[],
-            &[],
+            &read_map,
         )
-        .into_owned()
+        .unwrap_or(transformed)
     };
 
     let trimmed = transformed.trim();

--- a/crates/rsvelte_core/tests/declaration_tag_template_reads.rs
+++ b/crates/rsvelte_core/tests/declaration_tag_template_reads.rs
@@ -1,0 +1,229 @@
+//! Upstream's `DeclarationTag` visitor calls `context.visit(node.declaration)`,
+//! so every identifier in a `{const …}` / `{let …}` tag is read through its own
+//! entry in `state.transform`. This port runs the tag's SOURCE TEXT through the
+//! instance-script pipeline instead, which knows nothing about template scope,
+//! and then re-applied the template reads from a hand-written list of two kinds
+//! — each items and await bindings.
+//!
+//! A hand-written list is only right if the domain is closed, and this one was
+//! not: a snippet parameter, a `let:` binding and a `{@const}` binding are all
+//! template-scope reads, all three reached the tag, and all three came out as
+//! the bare name. The list is now derived from `state.transform` itself, and a
+//! name's replacement is what its own `read` produces — a snippet parameter is
+//! a getter, so it reads as `v()` and not `$.get(v)`.
+//!
+//! `{@const}` is the control: it goes through `build_expression` and was
+//! correct on every host below before this change.
+//!
+//! Every expected shape was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::compiler::CompileOptions;
+use rsvelte_core::{GenerateMode, compile};
+
+const SCRIPT: &str = "let xs = $state([1]);\nconst pr = Promise.resolve(1);\nlet v = $state(9);";
+
+/// The `c = …` line the client emits for a tag declaring `c`.
+fn declared_c(template: &str) -> String {
+    declared_c_with(SCRIPT, template)
+}
+
+/// As [`declared_c`], with an explicit instance script.
+fn declared_c_with(script: &str, template: &str) -> String {
+    let src = format!("<script>{script}</script>\n{template}\n");
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    js.lines()
+        .map(str::trim)
+        .find(|l| l.contains("c = "))
+        .unwrap_or_else(|| panic!("no `c = ` line for `{template}` in:\n{js}"))
+        .to_string()
+}
+
+#[test]
+fn a_declaration_tag_reads_a_snippet_parameter_through_its_getter() {
+    // A snippet parameter is `v = $.noop`, so its read is a CALL. This is the
+    // one host whose read is not `$.get(v)`, which is why the replacement has
+    // to come from the binding's own transform rather than from one spelling.
+    assert_eq!(
+        declared_c("{#snippet p(v)}{const c = v}{/snippet}{@render p(1)}"),
+        "const c = v();"
+    );
+    assert_eq!(
+        declared_c("{#snippet p({v})}{const c = v}{/snippet}{@render p({ v: 1 })}"),
+        "const c = v();"
+    );
+}
+
+#[test]
+fn a_declaration_tag_reads_a_const_tag_and_a_let_binding_through_get() {
+    assert_eq!(
+        declared_c("{#each xs as q}{@const v = q + 1}{const c = v}{/each}"),
+        "const c = $.get(v);"
+    );
+}
+
+#[test]
+fn the_two_hosts_the_hand_written_list_already_covered_still_work() {
+    // The control against a rewrite that widened the list and lost the shapes
+    // it used to get right.
+    assert_eq!(
+        declared_c("{#each xs as v}{const c = v}{/each}"),
+        "const c = $.get(v);"
+    );
+    assert_eq!(
+        declared_c("{#await pr then v}{const c = v}{/await}"),
+        "const c = $.get(v);"
+    );
+}
+
+#[test]
+fn a_binding_that_needs_no_read_stays_bare() {
+    // The negative half: an each INDEX and a non-reactive item are not signals,
+    // so wrapping either would be the defect this widening could introduce.
+    for template in [
+        "{#each xs as q, v}{const c = v}{/each}",
+        "{#each xs as v (v)}{const c = v}{/each}",
+    ] {
+        assert_eq!(declared_c(template), "const c = v;", "for `{template}`");
+    }
+}
+
+#[test]
+fn an_instance_signal_is_wrapped_once_not_twice() {
+    // The instance-script pipeline has already rewritten its own names by the
+    // time this rewrite runs, so a second pass must not wrap them again. The
+    // `$state` has to be WRITTEN to be discriminating — upstream keeps a
+    // never-written `$state` a plain `let`, and a plain `let` needs no read at
+    // all, so it would pass with the guard removed.
+    let script = "let xs = $state([1]);\nlet v = $state(9);\nfunction bump() { v++; }";
+    let c = |template: &str| declared_c_with(script, template);
+
+    assert_eq!(
+        c("{#if true}{const c = v}{/if}<button onclick={bump}>b</button>"),
+        "const c = $.get(v);"
+    );
+    // …and the snippet parameter beside it still reads as a getter.
+    assert_eq!(
+        c(
+            "{#snippet p(w)}{const c = v + w}{/snippet}{@render p(1)}<button onclick={bump}>b</button>"
+        ),
+        "const c = $.get(v) + w();"
+    );
+}
+
+#[test]
+fn the_at_const_control_is_unchanged_on_every_host() {
+    for (template, expected) in [
+        (
+            "{#snippet p(v)}{@const c = v}{/snippet}{@render p(1)}",
+            "const c = $.derived(v);",
+        ),
+        (
+            "{#each xs as v}{@const c = v}{/each}",
+            "const c = $.derived(() => $.get(v));",
+        ),
+        (
+            "{#each xs as q, v}{@const c = v}{/each}",
+            "const c = $.derived(() => v);",
+        ),
+    ] {
+        assert_eq!(declared_c(template), expected, "for `{template}`");
+    }
+}
+
+#[test]
+fn a_read_the_instance_pipeline_already_applied_is_not_applied_twice() {
+    // The axis that the host grid above holds fixed: the SHAPE of the read.
+    // Every host row reads as `$.get(x)` or as a call, and `$.get(x)` is the
+    // only shape the rewrite skips as already-wrapped — so widening the domain
+    // to the whole transform map emitted `p()()` for a prop and `$s()()` for a
+    // store while all twenty host cells stayed green. These rows are that
+    // second axis; ablate the instance-scope exclusion and only they fail.
+    for (script, template, expected) in [
+        (
+            "let { p = 1 } = $props();",
+            "{#if true}{const c = p + 1}{/if}",
+            "const c = p() + 1;",
+        ),
+        (
+            "let { p = $bindable(1) } = $props();",
+            "{#if true}{const c = p}{/if}",
+            "const c = p();",
+        ),
+        (
+            "import { writable } from 'svelte/store';\nconst s = writable(1);",
+            "{#if true}{const c = $s}{/if}",
+            "const c = $s();",
+        ),
+        (
+            "let { p } = $props();",
+            "{#if true}{const c = p.a}{/if}",
+            "const c = $$props.p.a;",
+        ),
+        (
+            "let { ...rest } = $props();",
+            "{#if true}{const c = rest}{/if}",
+            "const c = rest;",
+        ),
+    ] {
+        assert_eq!(
+            declared_c_with(script, template),
+            expected,
+            "for `{template}`"
+        );
+    }
+}
+
+#[test]
+fn a_template_binding_beside_a_prop_gets_its_own_read() {
+    // Both axes at once: the prop keeps the pipeline's single application and
+    // the each item still gets the template read.
+    assert_eq!(
+        declared_c_with(
+            "let { p } = $props(); let xs = $state([1]);",
+            "{#each xs as v}{const c = p + v}{/each}"
+        ),
+        "const c = $$props.p + $.get(v);"
+    );
+}
+
+#[test]
+fn a_template_binding_that_shadows_an_instance_one_still_gets_the_template_read() {
+    // The third axis, and the one that caught a fix that both grids above
+    // called green: every host row names its binding `v`, so an exclusion
+    // keyed on "is `v` declared in the script" removes the template binding
+    // too. A name cannot tell a binding from the one it shadows — the guard
+    // that stops double application has to be positional, not nominal.
+    let script = "let xs = $state([1]);\nconst pr = Promise.resolve(1);\nlet v = $state(9);";
+    for (template, expected) in [
+        (
+            "{#snippet p(v)}{const c = v}{/snippet}{@render p(1)}",
+            "const c = v();",
+        ),
+        ("{#each xs as v}{const c = v}{/each}", "const c = $.get(v);"),
+        (
+            "{#await pr then v}{const c = v}{/await}",
+            "const c = $.get(v);",
+        ),
+        (
+            "{#each xs as q}{@const v = q + 1}{const c = v}{/each}",
+            "const c = $.get(v);",
+        ),
+    ] {
+        assert_eq!(
+            declared_c_with(script, template),
+            expected,
+            "for `{template}`"
+        );
+    }
+}


### PR DESCRIPTION
Upstream visits a `{const}` / `{let}` tag's declaration with the **template** visitor
(`context.visit(node.declaration)`), so every template-scope binding is read through its own
transform. This port runs the *instance-script* pipeline over the tag's source text instead,
which knows nothing about template bindings, so the reads had to be re-applied afterwards —
and they were re-applied from a **hand-written list of two kinds** (each items, await
bindings). Snippet parameters, `let:` bindings and `{@const}` bindings were read bare, so a
value produced by one of them is frozen at its first-render value.

The domain is `state.transform` itself, so that is what the fix reads.

## The two things a naive widening gets wrong

**It double-applies.** The tag's text goes through the instance-script transform first, and
only the `$.get(x)` shape has an already-wrapped guard downstream, so a prop came out `p()()`
and a store `$s()()`. **The 20-cell host grid was green through this**, because it varies the
binding's *host* and holds the *read shape* fixed at `$.get`/call. A second grid over eight
read shapes reported 5 EQ / 3 DIFF.

**And a name test cannot fix it.** Excluding names declared in the instance or module scope
scores *worse than the unfixed tree*: shadowing grid 14/6 against a base of 16/4, because a
template binding that shadows an instance one has the same name. The guard has to be
**positional** — `p()` / `$s()` is what the earlier pass emits, so a zero-argument call whose
callee is an identifier is a read that has already happened.

## Measurements

```
                          shadowing   non-shadow   read-shape
base (no fix)              16 / 4       —            8 / 0
widened, no guard           —           —            5 / 3
widened, name-excluded     14 / 6       —             —
widened, positional guard  20 / 0      20 / 0        8 / 0
```

Every expected value in `declaration_tag_template_reads.rs` is **generated by probing the
official compiler**, not typed by hand.

Corpus sweep, 139,252 units, this arm against its own merge base:

```
MOVED sveltekit/packages/kit/src/runtime/components/root.svelte	client
MOVED sveltekit/packages/kit/src/runtime/components/root.svelte	client-dev
TOTAL_UNITS=139252 MOVED=2
```

Exactly the two units the fix targets; no collateral. Both are retired here —
`known-failures.client.json` **28 → 27**, `known-failures.client-dev.json` **42 → 41**.

## What the corpus could not have caught

The shape needs a template binding read *inside* a `{const}` / `{let}` tag. 33 of 33,893
components carry the tag at all; 17 of those mention a prop or a store; **none reads one
inside the tag**. The 20-cell grid is what found it, and the 8-cell read-shape grid is what
found the fix's own regression — which is the `Widening a set to close an enumeration hazard
moves you along a new axis` note this PR adds to `AGENTS.md`.
