### PR TITLE
fix(client): the namespace scan stops at an html element, not at any element

### DIFF
--- a/.changeset/namespace-scan-stops-at-html.md
+++ b/.changeset/namespace-scan-stops-at-html.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+The namespace scan now stops at the first **html** element, as upstream does, rather than at the first element of any kind. An `<svg>` in an `{#if}` branch stopped the walk before the sibling branch was reached, so a branch whose content is html was templated with `$.from_svg`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,8 @@ see gate-coverage 19a, where both are recorded as discriminating cases. And the 
 produced every one of these defects — huly, open-webui, carbon-components-svelte, SMUI — **were
 not corpus sources at the time**, so the gate baselined at 0 while the instances lived outside the
 population it inspected; that is why each fix lands a `compatibility/pattern-corpus` repro. All
-four are corpus sources now (#3130 took the corpus to 103 repositories), which closes the
+four are corpus sources now (**#3176** took the corpus to 103 repositories; this file and
+`KNOWN-FAILURES.md` cited #3130 — an unrelated CSS issue — 16 times), which closes the
 population hole for these particular four and for nothing else — the lesson is that the gate's
 population is a choice, not a given.
 
@@ -377,10 +378,12 @@ Every `.svelte` / `.svelte.(js|ts)` source (including markdown code blocks) from
 source repository — sveltejs/svelte, sveltejs/svelte.dev and **101** real-world projects (huly,
 immich, open-webui, carbon-components-svelte, SMUI, threlte, bits-ui, … ), all pinned as
 submodules and listed in `scripts/compat-corpus/corpus-sources.json` — is compiled with both the official compiler and
-rsvelte for CSR, SSR **and** dev-mode CSR (the three targets declared in
-`scripts/compat-corpus/targets.mjs`). Outputs must be byte-identical after comparison-side normalization
+rsvelte for CSR, SSR, dev-mode SSR **and** dev-mode CSR (the **four** targets declared in
+`scripts/compat-corpus/targets.mjs` — this paragraph said three until 2026-09-02, and a sweep
+written from it reported "collateral 0" over three quarters of its population). Outputs must be
+byte-identical after comparison-side normalization
 (oxfmt + blank-line stripping — never compiler post-passes). To grow the corpus, add a submodule
-plus a line to `corpus-sources.json`. CI ratchet: `compatibility/known-failures.{client,server,client-dev}.json`
+plus a line to `corpus-sources.json`. CI ratchet: `compatibility/known-failures.{client,server,server-dev,client-dev}.json`
 may only shrink, and each remaining failure is justified in `compatibility/KNOWN-FAILURES.md#known-failures`. Every
 ratchet is two-sided: a new failure **and** a listed entry that already passes both fail CI, so the PR
 that fixes entries must re-baseline in the same PR instead of leaving a backlog for a later one. The
@@ -1044,7 +1047,37 @@ Rules, in the order they are cheap:
    without any truncation at all: a stage that **pairs** two measurements can pair
    the wrong rows, so use an associative array keyed by id (`awk`) and never
    `join`, whose ordering precondition your data will violate the first time an
-   id contains a non-ASCII byte.
+   id contains a non-ASCII byte. **And the rule is not "use `awk`" — it is: do
+   not build a stage that renders a composite key to text and re-parses it.**
+   `-F'\t'` only makes that stage safe for today's separator; a pipeline that
+   keeps the key as an object (`out[`${id}|${target}`]`, JSON, `Object.keys()`)
+   has no such stage at all. Measured: with the default field separator a corpus
+   id containing a space (`Checkbox Group.svelte`) splits across `$1`/`$2`, so a
+   file's four target rows collapse onto one key and the comparison reads the
+   *target name* where it meant to read the hash — **100 moved units reported
+   for a change that moves 2**. Over-reporting is the direction this instance
+   took; the array keeps the **last** row's value per key, so a real movement in
+   any of the preceding targets is *hidden* whenever that last value matches.
+   One bug, both directions, same input.
+   What exposed it was the **shape** of the printed paths, not the count: a
+   count is a threshold and says only "more than expected", while `Checkbox
+   Group.svelte` printed three times is a signature that cannot occur. Had the
+   corpus held four space-bearing ids instead of 47, the same bug would have
+   reported `MOVED=6` and been written up as "4 collateral units".
+   The cheap control is to print the key count beside the row count — a collapse
+   makes them differ, and `139252 rows, 139252 distinct keys` retires the
+   question for that run. Two cautions from getting this wrong while writing it
+   up: **the size of a collapse cannot be derived from the number of bad inputs**
+   — 47 space-bearing ids over four targets lose 161 keys, not 141, because 20
+   of them are **id-to-id** collisions (`…/examples/01 - foo.svelte` and
+   `…/01 - bar.svelte` both reduce to `$1=…/01`, `$2=-`), which is a count only
+   the ids themselves carry, never their number. **Those 20 are the worse half**:
+   a same-id collapse compares the wrong target of the right file and printed the
+   repeated-path signature that exposed this, while an id-to-id collapse compares
+   a *different file's* output and prints nothing anomalous at all. And the
+   number in this paragraph was published as measured before it had been run; it
+   was wrong, and the conclusion survived only because it did not depend on it —
+   which is knowable *after* the fact and is therefore not a licence to estimate.
 2. **When "pass" is spelled as silence, the run needs a positive control.**
    Introduce the defect the check exists to catch, confirm the check goes red,
    remove it, and confirm the tree is byte-identical again (`git diff` empty).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,7 +419,7 @@ fixture suite was green on #3386 by **compensation**, two different inputs produ
 number, and fixing the compiler turns that row red until the harness mirrors the trim.
 
 The same `verify.mjs` run also gates compiler **warnings** — `(code, line, column)` per entry —
-on ratchets of their own (`warning-known-failures.{client,server,client-dev}.json` and
+on ratchets of their own (`warning-known-failures.{client,server,server-dev,client-dev}.json` and
 `warning-position-known-failures.*`, justified in `compatibility/KNOWN-FAILURES.md#warning-known-failures`).
 Codes and positions ratchet separately: a wrong set of codes is a semantic bug, a wrong position
 is one systemic cause, and folded together the larger position backlog would hide every semantic
@@ -429,7 +429,7 @@ scored the very entry that reproduces it as `MATCH`. When adding a gate, ask wha
 not look at, not only what the input does not contain.
 
 Compiler **errors** ratchet the same way and for the same reason
-(`error-{message,position,end,frame}-known-failures.{client,server,client-dev}.json`, justified
+(`error-{message,position,end,frame}-known-failures.{client,server,server-dev,client-dev}.json`, justified
 in `compatibility/KNOWN-FAILURES.md#error-known-failures`). The output verdict compares an error's `code` and
 nothing else, and that field is **saturated**: 0 divergences over the 2,843 `(id, target)` pairs
 both compilers reject. Every other field was invisible until it was captured — `message` 121

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2865,11 +2865,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 27 entries)
+### Client (`known-failures.client.json`, 26 entries)
 
-Partition of `known-failures.client.json` by verdict: `26 + 1`
+Partition of `known-failures.client.json` by verdict: `25 + 1`
 
-- **26 — the generated JS differs** (`js` / `code-differs`).
+- **25 — the generated JS differs** (`js` / `code-differs`).
 - **1 — the generated CSS differs.**
 
 The error classes this section used to carry are gone: the run behind this
@@ -2993,7 +2993,7 @@ the emitted default was the getter function rather than the store's value. Hashi
 client (entry, target) outputs before and after reports **2** changed units over 1 id,
 `match -> MISMATCH = 0`; the other two ids of that cluster do not move and stay listed.
 
-Every one of the remaining 27 arrived with the wave-2 enrolment (#3130) and is described
+Every one of the remaining 26 arrived with the wave-2 enrolment (#3130) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3100,15 +3100,15 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 41 entries)
+### Client dev (`known-failures.client-dev.json`, 40 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `41`
+Partition of `known-failures.client-dev.json` by verdict: `40`
 
-- **41 — the generated JS differs.**
+- **40 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 41 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 40 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -3,7 +3,6 @@
 	"ha-fusion/src/lib/Main/Views.svelte",
 	"ha-fusion/src/lib/Modal/VisibilityConfig/Index.svelte",
 	"ha-fusion/src/lib/Sidebar/Navigate.svelte",
-	"haptic/apps/homepage/src/lib/components/tooltip.svelte",
 	"headscale-ui/src/lib/settings/ServerSettings.svelte",
 	"huly/plugins/contact-resources/src/components/SelectAvatarPopup.svelte",
 	"huly/plugins/process-resources/src/components/settings/ProcessAttributeEditor.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -3,7 +3,6 @@
 	"ha-fusion/src/lib/Main/Views.svelte",
 	"ha-fusion/src/lib/Modal/VisibilityConfig/Index.svelte",
 	"ha-fusion/src/lib/Sidebar/Navigate.svelte",
-	"haptic/apps/homepage/src/lib/components/tooltip.svelte",
 	"headscale-ui/src/lib/settings/ServerSettings.svelte",
 	"huly/plugins/text-editor-resources/src/components/DrawingBoardEditor.svelte",
 	"huly/plugins/training-resources/src/components/TrainingRequestDueDateEditor.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
@@ -1175,7 +1175,7 @@ pub(crate) enum NsScan {
 
 /// Faithful port of upstream's `check_nodes_for_namespace()`. The walk descends
 /// through block containers (`{#if}` / `{#each}` / `{#await}` / `{#key}` /
-/// fragments) and stops at the first element it reaches; components, render
+/// fragments) and stops at the first html element it reaches; components, render
 /// tags, and nested snippets are *not* descended (they reset the namespace
 /// themselves). When the scan finds no element — only whitespace, text, or
 /// dynamic anchors — the result is `Keep`/`MaybeHtml`, and the caller falls
@@ -1195,15 +1195,18 @@ pub(crate) fn check_nodes_for_namespace<'a, N: AsRef<TemplateNode<'a>>>(nodes: &
 }
 
 /// Apply the element-namespace rule from upstream's `RegularElement` /
-/// `SvelteElement` walk visitors. Returns `true` to stop the walk (upstream's
-/// `stop()`): the first element reached determines the namespace.
+/// `SvelteElement` walk visitors. Upstream calls `stop()` only for an html
+/// element; an svg/mathml one records the namespace and lets the walk carry on,
+/// so a later non-empty `Text` can still downgrade it to `maybe_html`.
 fn apply_element_namespace(svg: bool, mathml: bool, ns: &mut NsScan) -> bool {
     if !svg && !mathml {
         *ns = NsScan::Html;
-    } else if *ns == NsScan::Keep {
+        return true;
+    }
+    if *ns == NsScan::Keep {
         *ns = if svg { NsScan::Svg } else { NsScan::Mathml };
     }
-    true
+    false
 }
 
 /// Recursive walk mirroring upstream `check_nodes_for_namespace()`'s zimmerframe

--- a/crates/rsvelte_core/tests/namespace_scan_stops_at_html.rs
+++ b/crates/rsvelte_core/tests/namespace_scan_stops_at_html.rs
@@ -1,0 +1,136 @@
+//! Upstream's `check_nodes_for_namespace` calls `stop()` for an **html**
+//! element only (`3-transform/utils.js:374-381`); an svg or mathml element
+//! records the namespace and lets the walk carry on, so a later non-empty
+//! `Text` can still downgrade it to `maybe_html` — which the caller reads as
+//! "undecided" and falls back to the inherited namespace.
+//!
+//! This port stopped at the FIRST element of either kind, and its doc comment
+//! asserted that rule in words. Because an `{#if}` scans `consequent ||
+//! alternate` with a short-circuit `||`, an `<svg>` in the consequent returned
+//! "stop" and the alternate was never scanned, so a component-plus-text branch
+//! after an svg branch was templated with `$.from_svg`.
+//!
+//! Six of the eight rows below already agreed before the change: order, host
+//! block and the presence of the text each move a cell on their own, so a fix
+//! that repairs the two and breaks any of the six is distinguishable from one
+//! that does not.
+//!
+//! Every expected shape was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::compiler::CompileOptions;
+use rsvelte_core::{GenerateMode, compile};
+
+/// The `$.from_*` template lines the client emits, in order.
+fn template_roots(template: &str) -> Vec<String> {
+    let src = format!("<script>import C from './C.svelte'; let a=1,b=2;</script>\n{template}\n");
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    js.lines()
+        .map(str::trim)
+        .filter(|l| {
+            l.contains("$.from_html(") || l.contains("$.from_svg(") || l.contains("$.from_mathml(")
+        })
+        .map(str::to_string)
+        .collect()
+}
+
+#[test]
+fn a_branch_after_an_svg_branch_is_still_html() {
+    // The two rows the unconditional stop broke: the `<svg>` consequent
+    // returned "stop", so the alternate was never scanned and its component
+    // plus text was templated as svg.
+    for (template, expected) in [
+        (
+            "{#if a}<svg><g></g></svg>{:else if b}<C /> text{/if}",
+            vec![
+                "var root = $.from_svg(`<svg><g></g></svg>`);",
+                "var root_1 = $.from_html(`<!> text`, 1);",
+            ],
+        ),
+        (
+            "{#if a}<svg><g></g></svg>{:else}<C /> text{/if}",
+            vec![
+                "var root = $.from_svg(`<svg><g></g></svg>`);",
+                "var root_1 = $.from_html(`<!> text`, 1);",
+            ],
+        ),
+    ] {
+        assert_eq!(template_roots(template), expected, "for `{template}`");
+    }
+}
+
+#[test]
+fn an_svg_branch_with_nothing_to_downgrade_it_stays_svg() {
+    // The control for the change itself: without a non-empty `Text` after the
+    // component nothing sets `maybe_html`, and without a component there is no
+    // second template at all. A fix that simply stopped recording svg would
+    // move these.
+    for (template, expected) in [
+        (
+            "{#if a}<svg><g></g></svg>{:else if b}<C />{/if}",
+            vec!["var root = $.from_svg(`<svg><g></g></svg>`);"],
+        ),
+        (
+            "{#if a}<svg><g></g></svg>{:else if b}text{/if}",
+            vec!["var root = $.from_svg(`<svg><g></g></svg>`);"],
+        ),
+    ] {
+        assert_eq!(template_roots(template), expected, "for `{template}`");
+    }
+}
+
+#[test]
+fn order_and_host_block_each_move_a_cell_on_their_own() {
+    // Three controls that were already right: a sibling of the `{#if}`, the
+    // same two branches in the opposite order, and an `{#each}` host. Each
+    // reaches the same scan by a different route.
+    for (template, expected) in [
+        (
+            "{#if a}<svg><g></g></svg>{/if}<C /> text",
+            vec![
+                "var root = $.from_svg(`<svg><g></g></svg>`);",
+                "var root_1 = $.from_html(`<!><!> text`, 1);",
+            ],
+        ),
+        (
+            "{#if a}<C /> text{:else if b}<svg><g></g></svg>{/if}",
+            vec![
+                "var root = $.from_html(`<!> text`, 1);",
+                "var root_1 = $.from_svg(`<svg><g></g></svg>`);",
+            ],
+        ),
+        (
+            "{#if a}<svg><g></g></svg>{/if}{#each [1] as z}<C /> t{/each}",
+            vec![
+                "var root = $.from_svg(`<svg><g></g></svg>`);",
+                "var root_1 = $.from_html(`<!> t`, 1);",
+                "var root_2 = $.from_html(`<!><!>`, 1);",
+            ],
+        ),
+    ] {
+        assert_eq!(template_roots(template), expected, "for `{template}`");
+    }
+}
+
+#[test]
+fn an_html_element_still_stops_the_scan() {
+    // The half of the rule that must NOT change: an html element sets `html`
+    // and stops, which is the only `stop()` upstream performs.
+    assert_eq!(
+        template_roots("{#if a}<i></i>{:else if b}<C /> text{/if}"),
+        vec![
+            "var root = $.from_html(`<i></i>`);",
+            "var root_1 = $.from_html(`<!> text`, 1);",
+        ]
+    );
+}


### PR DESCRIPTION
Upstream's `check_nodes_for_namespace` calls `stop()` for an **html** element only
(`3-transform/utils.js:374-381`); an svg or mathml element records the namespace and lets
the walk carry on, so a later non-empty `Text` can still downgrade it to `maybe_html` —
which the caller reads as "undecided" and falls back to the inherited namespace.

```js
const RegularElement = (node, { stop }) => {
    if (!node.metadata.svg && !node.metadata.mathml) {
        namespace = 'html';
        stop();                       // <- stop() ONLY here
    } else if (namespace === 'keep') {
        namespace = node.metadata.svg ? 'svg' : 'mathml';
    }
};
```

`apply_element_namespace` returned `true` unconditionally, and its doc comment asserted
that rule in words ("the first element reached determines the namespace"). Because an
`{#if}` scans `consequent || alternate` with a short-circuit `||`, an `<svg>` in the
consequent returned "stop" and **the alternate was never scanned at all**, so a
component-plus-text branch after an svg branch was templated with `$.from_svg`.

## Measurements

Eight cells against the official compiler:

| arm | EQ | DIFF |
|---|---|---|
| this branch | **8** | 0 |
| its own merge base | 6 | **2** |

The six agreeing rows are the control set — order, host block and the presence of the
text each move a cell on their own, so a fix that repairs the two and breaks any of the
six is distinguishable from one that does not. Every expected shape is **generated from
the official compiler**, not typed by hand.

Corpus sweep, 139,252 units, this arm against its own merge base:

```
139252 rows, 139252 distinct keys        (no key collision in this comparison)
MOVED	haptic/apps/homepage/src/lib/components/tooltip.svelte	client
MOVED	haptic/apps/homepage/src/lib/components/tooltip.svelte	client-dev
```

That file is byte-equal to official on **all four** targets under this arm
(`client`, `client-dev`, `server`, `server-dev`), so it is retired here:
`known-failures.client.json` **27 → 26**, `known-failures.client-dev.json` **41 → 40**.

## The `AGENTS.md` note

The first comparison of that sweep reported **100** moved units. 47 corpus ids contain a
space, and an `awk` keyed on `$1`/`$2` under the default field separator collapses each
file's four target rows onto one key — so it compared the *target name* where it meant to
compare the hash. The note records the rule (do not build a stage that renders a composite
key to text and re-parses it), the cheap control (print the key count beside the row count),
that the same collapse **hides** a movement as readily as it invents one, and that 20 of
the 161 lost keys are id-to-id collisions that print nothing anomalous at all.

Stacked on #4164, which is stacked on #4161.
