### PR TITLE
fix(svelte2tsx): a binding pattern's `$` key is a store everywhere but the first element

### DIFF
--- a/.changeset/svelte2tsx-binding-pattern-store-key.md
+++ b/.changeset/svelte2tsx-binding-pattern-store-key.md
@@ -1,0 +1,18 @@
+---
+'@rsvelte/svelte2tsx': patch
+'@rsvelte/compiler': patch
+'@rsvelte/svelte-check': patch
+---
+
+A `$`-prefixed key of a binding pattern is a store reference everywhere except
+the pattern's first element, and rsvelte emitted no store subscription for any
+of them — `let { a, $permissions: permissions } = o` lost its
+`let $permissions = __sveltets_2_store_get(permissions);` line.
+
+`processInstanceScriptContent` tracks "am I inside a declaration" with a single
+boolean whose on-leave callback clears it unconditionally, so leaving a pattern's
+first element clears a flag the enclosing pattern had set and every element after
+it is walked as an expression. The rule that produces — a key is a name iff it is
+the first element of its own pattern — is reproduced here, including the nested
+cases where entering an inner pattern re-sets the flag. Reported as
+`upstream_issues/svelte2tsx-isdeclaration-is-a-boolean-not-a-stack.md`.

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -5284,7 +5284,7 @@ sample of one tree's output, not an enumeration of the shapes upstream emits.
 
 ## 42. Deliberate-divergence pinning — `scripts/dev/deliberate-divergences-check.mjs`
 
-**Unit.** One `## ` section of `compatibility/deliberate-divergences.md`, 11 of them. The check is
+**Unit.** One `## ` section of `compatibility/deliberate-divergences.md`, 20 of them. The check is
 that each names at least one repository path that (a) exists on disk and (b) is a test — under a
 `tests/` directory, in `compatibility/pattern-corpus/`, or a `scripts/**/test-*.mjs` harness.
 Run by `ci.yml`'s `Corpus verify baseline-flag contract` job and `pnpm run
@@ -8068,6 +8068,51 @@ they are rsvelte-side defects and are not covered here.
 
 Remove this entry when `tsgo --lsp` carries the TypeScript kind — the pinned test fails at that
 point, and both halves become ordinary parity work.
+
+---
+
+### A `@typedef` strip whose offset lands inside the comment (svelte2tsx)
+
+**Pinned by** `crates/rsvelte_projection/tests/svelte2tsx_typedef_tag_offset.rs`, whose other
+test asserts the two rows rsvelte *does* reproduce.
+**Reported upstream** in
+`upstream_issues/svelte2tsx-getlastleadingdoc-mixes-absolute-and-relative-offsets.md`.
+
+`getLastLeadingDoc` (`utils/tsAst.ts:143-160`) removes a declarator's `@typedef` tags before the
+JSDoc is copied onto the prop. The tag span comes from `ts.getAllJSDocTagsOfKind`, whose `pos` /
+`end` are **SourceFile-absolute**, and it is sliced out of `node.getFullText()`, which is
+**node-relative** — so the removal is shifted by `node.pos`, and what that shift hits depends on
+what precedes the comment:
+
+| statement ahead of the comment | shifted slice occurs in it? | official |
+|---|---|---|
+| none (`node.pos == 0`) | — | the tag is removed, as intended |
+| long | no | `replace` no-ops and the tag survives |
+| short | yes | **the wrong text is deleted** |
+
+Measured on one comment with only the preceding statement varied:
+
+```
+row 1  {\n/**\n * \n * @slot {{ a: 1 }}\n */a: a}
+row 2  {\n/**\n * @typedef {import('./X.svelte').T} T\n * @slot {{ a: 1 }}\n */a: a}
+row 3  {\n/**\n * @typedef {i{ a: 1 }}\n */a: a}
+```
+
+rsvelte reproduces rows 1 and 2 — it strips the tags exactly when the comment is the script's
+first token, which is upstream's `node.pos == 0` condition spelled as the condition rather than as
+its symptom. Row 3 it does not: the emitted comment would be truncated in the middle of
+`import('./X.svelte')` and would lose the `@slot` tag that followed, which is a JSDoc block whose
+type expression no longer parses. A byte match cannot pay for that.
+
+This is a divergence the **corpus svelte2tsx gate can observe**, and it does not sit in
+`svelte2tsx-known-failures.json`: 172 of the 33,901 collected components mention `@typedef` and
+**0 of them reach row 3**, so there is no entry to list. That is the reason this section exists —
+the divergence is real, no ratchet holds it, and the only thing standing between it and a future
+"let us match upstream here" is the pinned test.
+
+Remove this entry when upstream subtracts `node.pos`
+(`nodeText.substring(tag.pos - node.pos, tag.end - node.pos)`); rows 2 and 3 both collapse into
+row 1 at that point and the pinned test fails.
 
 <a id="README"></a>
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -6216,11 +6216,11 @@ The svelte2tsx output-parity corpus (`scripts/compat-corpus/svelte2tsx-*`) compa
 rsvelte's svelte2tsx port against **official `svelte2tsx`** byte-for-byte (after
 oxfmt normalization). The ratchet may only shrink.
 
-**Current baseline: `svelte2tsx-known-failures.json`, 8 entries.**
+**Current baseline: `svelte2tsx-known-failures.json`, 7 entries.**
 
-Partition of `svelte2tsx-known-failures.json` by verdict: `6 + 2`
+Partition of `svelte2tsx-known-failures.json` by verdict: `5 + 2`
 
-- **6 — the emitted TSX differs** (`ts-mismatch`).
+- **5 — the emitted TSX differs** (`ts-mismatch`).
 - **2 — one side rejects and the other compiles** (`error-mismatch`). Both are
   `cnblocks`'s `(app)/veil/` components, and the rejecting side is **official**:
   a UTF-8 BOM together with a `<script>` block and markup makes `svelte2tsx`
@@ -6237,7 +6237,7 @@ Attribution of `svelte2tsx-known-failures.json`:
 |---|---|---|
 | 2 | `upstream_issues/svelte2tsx-bom-crashes-on-any-component-with-a-script.md` | official throws on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it |
 
-The remaining 6 carry **no target, and cannot have one**: every one was measured
+The remaining 5 carry **no target, and cannot have one**: every one was measured
 against official on 2026-09-02 and every one is an rsvelte defect, so the only end
 state open to them is elimination. The classification below is the input to that
 work; it is not an attribution, and this gate stays red until the entries are gone.
@@ -6250,10 +6250,7 @@ version:'5'}`), and the outputs are normalized exactly as the gate normalizes th
 The last column says how far each was pinned — **reduced** (a hand-written input of a
 few lines reproduces it), **source** (the construct is identified in the listed file),
 or **output only** (the outputs differ and the cause is *not* isolated). Read an
-"output only" row as an open question rather than a finding. One of them,
-`appwrite`'s `settings/+page.svelte`, had a plausible cause — `$permissions` as a
-destructuring-rename KEY — and a five-line reduction of that has both tools agreeing,
-so the cause is something else.
+"output only" row as an open question rather than a finding.
 
 **This table is generated from a one-to-one id → mechanism assignment**
 (`compatibility/svelte2tsx-mechanisms.json`, which covers this ratchet and the
@@ -6271,11 +6268,45 @@ double count**, so the assignment has to be per entry.
 | 1 | `bind:this` is emitted as a `"bind:this": element` attribute; official binds the created element to a temporary (`const $$_button1 = svelteHTML.createElement(…); … element = $$_button1;`) | source |
 | 1 | an extra `dragItem: dragItem` slot prop is emitted | output only |
 | 1 | two adjacent store-get `/*Ωignore_startΩ*/…/*Ωignore_endΩ*/` regions are emitted as ONE region spanning both, where official closes and reopens | source |
-| 1 | the `let $permissions = __sveltets_2_store_get(permissions)` line is not emitted at all | output only |
 | 1 | a `//` comment inside a `${…}` hole of a template-literal attribute value is dropped | source |
 | 1 | `export let x: T` with no statement terminator (the file ends at `</script>`) gains `x = __sveltets_2_any(x)`; adding `;` and a newline makes the two agree | reduced |
 
-Partition of `svelte2tsx-known-failures.json` by mechanism: `2 + 1x6`
+Partition of `svelte2tsx-known-failures.json` by mechanism: `2 + 1x5`
+
+### Previously: `store-get-missing` (2026-09-02, at 8 entries)
+
+Kept because the reduction that was supposed to settle it **agreed on both sides**,
+and the table above recorded that agreement as evidence the cause was elsewhere:
+*"had a plausible cause — `$permissions` as a destructuring-rename KEY — and a
+five-line reduction of that has both tools agreeing, so the cause is something
+else."* The cause was the destructuring-rename key. The reduction put it in a
+pattern of **one** element, which is the one position where upstream does not
+resolve it as a store.
+
+`processInstanceScriptContent` (`:284-296`) tracks "am I inside a declaration"
+with a single boolean, and the on-leave callback a binding element pushes clears
+it unconditionally — so leaving a pattern's **first** element clears a flag the
+enclosing pattern had set, and every element after it is walked as an expression.
+A `$`-prefixed property name then reaches the store branch of `handleIdentifier`
+(`:155`). The rule this produces is "a `$`-prefixed key is a name iff it is the
+first element of its own pattern", which is why a one-element reduction is the
+only shape that cannot see it. Filed as
+[`upstream_issues/svelte2tsx-isdeclaration-is-a-boolean-not-a-stack.md`](../upstream_issues/svelte2tsx-isdeclaration-is-a-boolean-not-a-stack.md).
+
+The nested rows are what named the mechanism rather than merely fitting it:
+`{ a, x: { $p: p } }` is quiet because entering the nested pattern **re-sets** the
+flag its sibling had cleared, and `{ x: { a, $p: p } }` is loud for the same
+reason one level down. A rule stated as "not the first key in the statement"
+fits the flat rows and gets both of those backwards.
+
+**Two method notes.** A reduction that reproduces nothing is a fact about the
+reduction, not about the defect — the entry sat at "output only" for that reason
+alone, and the sentence recording it read as a finding. And the positive control
+is what sized the fix: ablating it fails **7 of the 14** grid cells, which is the
+branch condition splitting the grid in half; a fix that reached every cell or one
+cell would have been a different rule. The sweep moved 1 unit of 33,901 —
+`MISMATCH -> match: 1`, `match -> MISMATCH: 0` — and that unit is the entry
+dropped here.
 
 ### Previously: `jsdoc-typedef-injected` (2026-09-02, at 9 entries)
 

--- a/compatibility/svelte2tsx-known-failures.json
+++ b/compatibility/svelte2tsx-known-failures.json
@@ -1,6 +1,5 @@
 [
 	"appwrite-console/src/routes/(console)/project-[region]-[project]/overview/platforms/+page.svelte",
-	"appwrite-console/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/settings/+page.svelte",
 	"cnblocks/src/routes/(app)/veil/+layout.svelte",
 	"cnblocks/src/routes/(app)/veil/+page.svelte",
 	"huly/plugins/view-resources/src/components/list/ListCategory.svelte",

--- a/compatibility/svelte2tsx-mechanisms.json
+++ b/compatibility/svelte2tsx-mechanisms.json
@@ -17,10 +17,6 @@
 			"description": "a `//` line comment inside an `export let` type annotation swallows the rest of the emitted line, so the output is not TypeScript",
 			"pinned": "source"
 		},
-		"store-get-missing": {
-			"description": "the `let $permissions = __sveltets_2_store_get(permissions)` line is not emitted at all",
-			"pinned": "output only"
-		},
 		"template-hole-comment-dropped": {
 			"description": "a `//` comment inside a `${…}` hole of a template-literal attribute value is dropped",
 			"pinned": "source"
@@ -36,7 +32,6 @@
 	},
 	"entries": {
 		"appwrite-console/src/routes/(console)/project-[region]-[project]/overview/platforms/+page.svelte": "ignore-region-merge",
-		"appwrite-console/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/settings/+page.svelte": "store-get-missing",
 		"cnblocks/src/routes/(app)/veil/+layout.svelte": "upstream-bom-crash",
 		"cnblocks/src/routes/(app)/veil/+page.svelte": "upstream-bom-crash",
 		"huly/plugins/view-resources/src/components/list/ListCategory.svelte": "extra-slot-prop",

--- a/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
@@ -686,22 +686,6 @@ mod tests {
         );
     }
 
-    /// The one row of `getLastLeadingDoc`'s offset bug rsvelte does NOT
-    /// reproduce: a shift that lands inside the comment makes upstream delete
-    /// the wrong text. Here official emits
-    /// `/**\n * @typedef {import('./X.sv{ a: 1 }}\n */`; rsvelte keeps the
-    /// comment whole. Filed as
-    /// `upstream_issues/svelte2tsx-getlastleadingdoc-mixes-absolute-and-relative-offsets.md`;
-    /// 0 of the corpus's 172 `@typedef`-carrying components reach it.
-    #[test]
-    fn a_shift_that_lands_inside_the_comment_is_a_known_divergence() {
-        let doc = "/**\n * @typedef {import('./X.svelte').T} T\n * @slot {{ a: 1 }}\n */";
-        assert_eq!(
-            props_of(&format!("let z = 1;\n{doc}\nexport let a = z;")),
-            format!("{{\n{doc}a: a}}")
-        );
-    }
-
     // Expected values are `ts.getAllJSDocTagsOfKind`'s own answers, read off the
     // official compiler's props block for each shape.
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/script/script_facts.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/script_facts.rs
@@ -194,6 +194,26 @@ impl<'a> Visit<'a> for ScriptFactsCollector<'_, '_, '_> {
         oxc_ast_visit::walk::walk_call_expression(self, it);
     }
 
+    fn visit_object_pattern(&mut self, it: &oxc::ObjectPattern<'a>) {
+        if self.collect_store_facts {
+            // Upstream clears `isDeclaration` when the pattern's FIRST element is
+            // left, so every `$`-prefixed key after it is walked as an expression
+            // and resolves as a store (`processInstanceScriptContent.ts:293`).
+            for property in it.properties.iter().skip(1) {
+                if property.shorthand {
+                    continue;
+                }
+                if let oxc::PropertyKey::StaticIdentifier(key) = &property.key
+                    && key.name.starts_with('$')
+                {
+                    self.store_scan
+                        .add_binding_pattern_key_position(key.span.start + self.offset);
+                }
+            }
+        }
+        oxc_ast_visit::walk::walk_object_pattern(self, it);
+    }
+
     fn visit_reg_exp_literal(&mut self, it: &oxc::RegExpLiteral<'a>) {
         if self.collect_store_facts {
             self.store_scan

--- a/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
@@ -28,21 +28,33 @@ struct StoreCandidate {
 
 impl StoreCandidate {
     const SELF_NAMED_RUNE_FLAG: u32 = 1;
+    const PROPERTY_KEY_FLAG: u32 = 2;
 
-    fn new(name_start: usize, name_end: usize, may_be_self_named_rune: bool) -> Self {
+    fn new(
+        name_start: usize,
+        name_end: usize,
+        may_be_self_named_rune: bool,
+        is_property_key: bool,
+    ) -> Self {
         let name_len = u32::try_from(name_end - name_start).expect("store name exceeds u32");
         let name_len_and_flags = name_len
-            .checked_mul(2)
+            .checked_mul(4)
             .expect("store name exceeds packed length");
         Self {
             name_start: source_offset(name_start),
-            name_len_and_flags: name_len_and_flags + u32::from(may_be_self_named_rune),
+            name_len_and_flags: name_len_and_flags
+                + u32::from(may_be_self_named_rune)
+                + if is_property_key {
+                    Self::PROPERTY_KEY_FLAG
+                } else {
+                    0
+                },
         }
     }
 
     fn name<'s>(&self, source: &'s str) -> &'s str {
         let start = self.name_start as usize;
-        let end = start + (self.name_len_and_flags >> 1) as usize;
+        let end = start + (self.name_len_and_flags >> 2) as usize;
         &source[start..end]
     }
 
@@ -52,6 +64,10 @@ impl StoreCandidate {
 
     const fn may_be_self_named_rune(&self) -> bool {
         self.name_len_and_flags & Self::SELF_NAMED_RUNE_FLAG != 0
+    }
+
+    const fn is_property_key(&self) -> bool {
+        self.name_len_and_flags & Self::PROPERTY_KEY_FLAG != 0
     }
 }
 
@@ -70,6 +86,11 @@ pub struct StoreScanContext<'s> {
     /// reference in: a string literal, a template literal's text chunks, and
     /// the imported (property) name of an aliased import specifier.
     pub(super) opaque_dollar_spans: Vec<(u32, u32)>,
+    /// `$`-prefixed KEYS of a binding pattern that upstream nevertheless
+    /// resolves as stores, because its `isDeclaration` flag is a boolean whose
+    /// reset fires when the pattern's first element is left — so every element
+    /// after the first is walked as if it were an expression.
+    pub(super) binding_pattern_key_positions: Vec<u32>,
     /// The template half of the same question, which no parsed program answers
     /// here. Computed on first use: a source with no `$` never needs it.
     template_opaque: Option<Vec<(u32, u32)>>,
@@ -96,6 +117,7 @@ impl<'s> StoreScanContext<'s> {
             self_named_rune_calls: Vec::new(),
             regex_literal_spans: Vec::new(),
             opaque_dollar_spans: Vec::new(),
+            binding_pattern_key_positions: Vec::new(),
             template_opaque: None,
             import_store_names: Vec::new(),
             seen_import_store_names: HashSet::new(),
@@ -107,6 +129,7 @@ impl<'s> StoreScanContext<'s> {
         self.self_named_rune_calls.clear();
         self.regex_literal_spans.clear();
         self.opaque_dollar_spans.clear();
+        self.binding_pattern_key_positions.clear();
     }
 
     pub(super) fn has_dollar(&mut self) -> bool {
@@ -141,6 +164,10 @@ impl<'s> StoreScanContext<'s> {
         self.opaque_dollar_spans.push(span);
     }
 
+    pub(super) fn add_binding_pattern_key_position(&mut self, pos: u32) {
+        self.binding_pattern_key_positions.push(pos);
+    }
+
     pub(super) fn finish_script_facts(&mut self) {
         self.self_named_rune_calls.sort_unstable();
         self.self_named_rune_calls.dedup();
@@ -148,6 +175,8 @@ impl<'s> StoreScanContext<'s> {
         self.regex_literal_spans.dedup();
         self.opaque_dollar_spans.sort_unstable();
         self.opaque_dollar_spans.dedup();
+        self.binding_pattern_key_positions.sort_unstable();
+        self.binding_pattern_key_positions.dedup();
     }
 
     pub(super) fn collect_loose_dollar_names(
@@ -203,6 +232,7 @@ impl<'s> StoreScanContext<'s> {
                     &self.regex_literal_spans,
                     &self.opaque_dollar_spans,
                     template_opaque,
+                    &self.binding_pattern_key_positions,
                 ) {
                     self.accessed_stores.insert(name);
                 }
@@ -218,6 +248,7 @@ impl<'s> StoreScanContext<'s> {
         let rune_calls = &self.self_named_rune_calls;
         let regex_spans = &self.regex_literal_spans;
         let opaque_spans = &self.opaque_dollar_spans;
+        let pattern_keys = &self.binding_pattern_key_positions;
         let stores = &mut self.accessed_stores;
         collect_store_candidates(source, self.script_spans, |candidate| {
             if let Some(name) = resolve_store_candidate(
@@ -228,6 +259,7 @@ impl<'s> StoreScanContext<'s> {
                 regex_spans,
                 opaque_spans,
                 template_opaque,
+                pattern_keys,
             ) {
                 stores.insert(name);
             }
@@ -713,10 +745,10 @@ fn collect_store_candidates(
         // whitespace) by `:` AND preceded (skipping whitespace) by `{` or `,`
         // (which excludes a ternary `cond ? $name : x`, where the preceding
         // token is `?`).
-        if is_object_property_key(bytes, pos, end) {
-            i = end;
-            continue;
-        }
+        // A binding-pattern key is NOT always skipped upstream — see
+        // `is_property_key` on the candidate — so it is emitted and filtered in
+        // `resolve_store_candidate`, which has the AST's answer.
+        let is_property_key = is_object_property_key(bytes, pos, end);
         if RESERVED_STORE_NAMES.contains(&full) {
             i = end;
             continue;
@@ -734,6 +766,7 @@ fn collect_store_candidates(
             next,
             end,
             matches!(full, "$state" | "$props" | "$derived"),
+            is_property_key,
         ));
         i = end;
     }
@@ -747,8 +780,12 @@ fn resolve_store_candidate<'s>(
     regex_literal_spans: &[(u32, u32)],
     opaque_dollar_spans: &[(u32, u32)],
     template_opaque_ranges: &[(u32, u32)],
+    binding_pattern_key_positions: &[u32],
 ) -> Option<&'s str> {
     let pos = candidate.pos();
+    if candidate.is_property_key() && binding_pattern_key_positions.binary_search(&pos).is_err() {
+        return None;
+    }
     if position_in_spans(regex_literal_spans, pos)
         || position_in_spans(opaque_dollar_spans, pos)
         || position_in_spans(template_opaque_ranges, pos)

--- a/crates/rsvelte_projection/tests/svelte2tsx_binding_pattern_store_key.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_binding_pattern_store_key.rs
@@ -1,0 +1,126 @@
+//! A `$`-prefixed KEY of a binding pattern is a store reference for upstream
+//! everywhere except the pattern's first element.
+//!
+//! `processInstanceScriptContent.ts:284-296` tracks "am I inside a declaration"
+//! with a single boolean whose reset is pushed when the FIRST element of a
+//! pattern is left, so every element after it is walked as an expression and
+//! its key resolves as a store. rsvelte skipped every object-property key, so
+//! `let { a, $permissions: permissions } = o` emitted no
+//! `__sveltets_2_store_get(permissions)` line at all.
+//!
+//! The rows below are the axis that separates the two readings — an element's
+//! index within its own pattern, crossed with the pattern's host — and every
+//! expectation is the official tool's own output on the same source with
+//! `{isTsFile: true, mode: 'ts', namespace: 'html', version: '5'}`, the options
+//! `svelte2tsx-compile.mjs` uses. Upstream's behaviour is reported in
+//! `upstream_issues/svelte2tsx-isdeclaration-is-a-boolean-not-a-stack.md`;
+//! byte equality is the goal, so rsvelte reproduces it.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+/// The store names `__sveltets_2_store_get(...)` is called with, sorted.
+fn store_gets(src: &str) -> Vec<String> {
+    let code = svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "T.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+    let mut found: Vec<String> = code
+        .match_indices("__sveltets_2_store_get(")
+        .map(|(at, needle)| {
+            let rest = &code[at + needle.len()..];
+            let end = rest.find(')').unwrap_or(rest.len());
+            rest[..end].to_string()
+        })
+        .collect();
+    found.sort();
+    found
+}
+
+#[test]
+fn a_binding_pattern_key_is_a_store_everywhere_but_the_first_element() {
+    let mut failures = Vec::new();
+    for (name, src, expected) in [
+        (
+            "only element",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tlet { $permissions: permissions } = o;\n</script>\n<p>{permissions}</p>",
+            &[][..],
+        ),
+        (
+            "second element",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tlet { a, $permissions: permissions } = o;\n</script>\n<p>{permissions}</p>",
+            &["permissions"][..],
+        ),
+        (
+            "third element",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tlet { a, b, $permissions: permissions } = o;\n</script>\n<p>{permissions}</p>",
+            &["permissions"][..],
+        ),
+        (
+            "only element of a nested pattern",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tlet { x: { $permissions: permissions } } = o;\n</script>\n<p>{permissions}</p>",
+            &[][..],
+        ),
+        (
+            "nested pattern is the second element",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tlet { a, x: { $permissions: permissions } } = o;\n</script>\n<p>{permissions}</p>",
+            &[][..],
+        ),
+        (
+            "second element of a nested pattern",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tlet { x: { a, $permissions: permissions } } = o;\n</script>\n<p>{permissions}</p>",
+            &["permissions"][..],
+        ),
+        (
+            "inside an array pattern",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tlet [a, { $permissions: permissions }] = [o, o];\n</script>\n<p>{permissions}</p>",
+            &[][..],
+        ),
+        (
+            "only element, second statement",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tlet z = 1;\n\tlet { $permissions: permissions } = o;\n</script>\n<p>{permissions}</p>",
+            &[][..],
+        ),
+        (
+            "second element of a parameter pattern",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tfunction f({ a, $permissions: permissions }: any) { return permissions; }\n\tlet permissions = f(o);\n</script>\n<p>{permissions}</p>",
+            &["permissions"][..],
+        ),
+        (
+            "after an element with a default",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tlet { a = 1, $permissions: permissions } = o;\n</script>\n<p>{permissions}</p>",
+            &["permissions"][..],
+        ),
+        (
+            "two keys after a plain first",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tlet { a, $p: p, $q: q } = o;\n</script>\n<p>{p}{q}</p>",
+            &["p", "q"][..],
+        ),
+        (
+            "two keys, the first is a key",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tlet { $p: p, $q: q } = o;\n</script>\n<p>{p}{q}</p>",
+            &["q"][..],
+        ),
+        (
+            "assignment destructuring, second element",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tlet p: any, a: any;\n\t({ a, $p: p } = o);\n</script>\n<p>{p}</p>",
+            &[][..],
+        ),
+        (
+            "assignment destructuring, only element",
+            "<script lang=\"ts\">\n\tlet o: any = {};\n\tlet p: any;\n\t({ $p: p } = o);\n</script>\n<p>{p}</p>",
+            &[][..],
+        ),
+    ] {
+        let actual = store_gets(src);
+        if actual != expected {
+            failures.push(format!("{name}: expected {expected:?}, got {actual:?}"));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_typedef_tag_offset.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_typedef_tag_offset.rs
@@ -1,0 +1,55 @@
+//! `getLastLeadingDoc` strips a declarator's `@typedef` tags with a
+//! SourceFile-absolute span indexed into a node-relative slice, so the removal
+//! is shifted by `node.pos` — three outcomes, of which rsvelte reproduces two.
+//!
+//! | statement ahead of the comment | shifted slice occurs in it? | official |
+//! |---|---|---|
+//! | none (`node.pos == 0`) | — | the tag is removed |
+//! | long | no | `replace` no-ops, the tag survives |
+//! | short | yes | **the wrong text is deleted** |
+//!
+//! Rows 1 and 2 are parity assertions. Row 3 is the recorded deliberate
+//! divergence (`compatibility/GATES.md#deliberate-divergences`): reproducing it
+//! would mean emitting a JSDoc comment truncated in the middle of a type name.
+//! Reported in
+//! `upstream_issues/svelte2tsx-getlastleadingdoc-mixes-absolute-and-relative-offsets.md`.
+//!
+//! Every `official` value below is the pinned `submodules/language-tools`
+//! svelte2tsx's own output on the same source.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+const DOC: &str = "/**\n * @typedef {import('./X.svelte').T} T\n * @slot {{ a: 1 }}\n */";
+const PAD: &str = "const pad = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';";
+
+fn props_of(script: &str) -> String {
+    let source = format!("<script>\n{script}\n</script>\n<p>x</p>\n");
+    let code = svelte2tsx(&source, Svelte2TsxOptions::default())
+        .expect("svelte2tsx")
+        .code;
+    let start = code.find("return { props: ").expect("props object") + "return { props: ".len();
+    let rest = &code[start..];
+    rest[..rest.find(", exports:").expect("exports")].to_string()
+}
+
+#[test]
+fn the_tag_is_removed_only_where_upstreams_offset_is_zero() {
+    assert_eq!(
+        props_of(&format!("{DOC}\nexport let a = 1;")),
+        "{\n/**\n * \n * @slot {{ a: 1 }}\n */a: a}"
+    );
+    assert_eq!(
+        props_of(&format!("{PAD}\n{DOC}\nexport let a = 1;")),
+        format!("{{\n{DOC}a: a}}")
+    );
+}
+
+#[test]
+fn a_shift_that_lands_inside_the_comment_is_a_known_divergence() {
+    // Official emits `{\n/**\n * @typedef {i{ a: 1 }}\n */a: a}` here — the
+    // slice it deletes starts inside the comment and runs past the `@slot` tag.
+    assert_eq!(
+        props_of(&format!("let z = 1;\n{DOC}\nexport let a = z;")),
+        format!("{{\n{DOC}a: a}}")
+    );
+}

--- a/upstream_issues/README.md
+++ b/upstream_issues/README.md
@@ -115,20 +115,21 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `svelte-snippet-name-colliding-with-an-import.md` | sveltejs/svelte | #3567 | unrecorded |
 | `svelte2tsx-bom-crashes-on-any-component-with-a-script.md` | sveltejs/language-tools (svelte2tsx) | #4048 | unrecorded |
 | `svelte2tsx-getlastleadingdoc-mixes-absolute-and-relative-offsets.md` | sveltejs/language-tools (svelte2tsx) | — | unrecorded |
+| `svelte2tsx-isdeclaration-is-a-boolean-not-a-stack.md` | sveltejs/language-tools (svelte2tsx) | — | unrecorded |
 | `svelte2tsx-shorthand-style-directive-modifier.md` | sveltejs/language-tools (svelte2tsx) | #3567, #3578 | unrecorded |
 | `svelte2tsx-transposes-an-unclosed-start-tag.md` | sveltejs/language-tools (svelte2tsx) | — | unrecorded |
 | `tsgo-lsp-completion-item-omits-the-typescript-kind.md` | microsoft/typescript-go (`tsgo --lsp`) | — | unrecorded |
 
-**23** reports carry no rsvelte issue number. Six came out of the lint-parity campaign (five
+**24** reports carry no rsvelte issue number. Six came out of the lint-parity campaign (five
 against `eslint-plugin-svelte`, one against `svelte-eslint-parser`), two out of the
 `two-ports-inventory.md` row 21 shadow probes, seven out of the SCSS-backend burndown — five
 covering every unit `scss-known-failures.json` lists as `grass-rejects-accepted`, plus the two
 classes in that ratchet whose output is not render-neutral (a hoisted declaration, and a slash list
-divided inside a nested rule) — and two out of the LSP differential campaign. The remaining six
+divided inside a nested rule) — and two out of the LSP differential campaign. The remaining seven
 are later: two `oxfmt` CSS reports from the formatter-parity corpus, one against `esrap`, one
 against `language-tools`, and one against `prettier-plugin-svelte` from the formatter-parity
 burndown (an inline element in a text run overflows `printWidth`, and re-formatting the output is
-not a fixed point), and one against `svelte2tsx` from the svelte2tsx-ratchet burndown.
+not a fixed point), and two against `svelte2tsx` from the svelte2tsx-ratchet burndown.
 None of them names an issue internally — `—` records that, rather than
 inventing a number, and `check-upstream-issues.mjs` holds the count above to the table so this
 paragraph cannot go stale the way it already had (it read "Fifteen" against 19 rows).

--- a/upstream_issues/svelte2tsx-isdeclaration-is-a-boolean-not-a-stack.md
+++ b/upstream_issues/svelte2tsx-isdeclaration-is-a-boolean-not-a-stack.md
@@ -1,0 +1,110 @@
+# `isDeclaration` is a boolean, so a binding pattern's second element is walked as an expression
+
+**Repository**: `sveltejs/language-tools` (`packages/svelte2tsx`)
+**Measured**: 2026-09-02, `submodules/language-tools` at the pinned revision, driven through
+`packages/svelte2tsx/index.js` with the options `scripts/compat-corpus/svelte2tsx-compile.mjs`
+passes: `{ filename, isTsFile, mode: 'ts', namespace: 'html', version: '5' }`.
+
+## Summary
+
+`processInstanceScriptContent` decides whether a `$`-prefixed identifier is a **store reference**
+or a **declared name** from one boolean, `isDeclaration` (`:94`). Entering a binding element's
+name sets it and pushes an on-leave callback that clears it (`:293-296`):
+
+```ts
+if (ts.isBindingElement(parent) && parent.name == node) {
+    isDeclaration = true;
+    onLeaveCallbacks.push(() => (isDeclaration = false));
+}
+```
+
+The reset is unconditional, so leaving the **first** element of a pattern clears a flag the
+enclosing pattern had set — and every element after it is walked with `isDeclaration === false`.
+`handleIdentifier` (`:155`) then takes the `else` branch for that element's *property name*, where
+a `$`-prefixed identifier is registered as a store auto-subscription.
+
+The rule this produces is "a `$`-prefixed key is a name iff it is the first element of its own
+pattern", which is not a rule anyone would write. A stack (or restoring the previous value
+instead of assigning `false`) is what the nesting requires.
+
+## Reduction
+
+Both inputs destructure the same key; only the element that precedes it differs.
+
+```svelte
+<!-- A: the only element -->
+<script lang="ts">
+	let o: any = {};
+	let { $permissions: permissions } = o;
+</script>
+<p>{permissions}</p>
+```
+
+```svelte
+<!-- B: one plain element precedes it -->
+<script lang="ts">
+	let o: any = {};
+	let { a, $permissions: permissions } = o;
+</script>
+<p>{permissions}</p>
+```
+
+Emitted:
+
+```
+A  let { $permissions: permissions } = o;
+
+B  let { a, $permissions: permissions } = o/*Ωignore_startΩ*/;let $permissions = __sveltets_2_store_get(permissions);/*Ωignore_endΩ*/;
+```
+
+B subscribes to `permissions` — a local destructured value, not a store — and declares a
+`$permissions` that shadows the key it was read from.
+
+## The full axis
+
+An element's index within **its own** pattern, crossed with the pattern's host. `-` is no
+`__sveltets_2_store_get` call.
+
+| source | official |
+|---|---|
+| `let { $permissions: permissions } = o` | `-` |
+| `let { a, $permissions: permissions } = o` | `permissions` |
+| `let { a, b, $permissions: permissions } = o` | `permissions` |
+| `let { a = 1, $permissions: permissions } = o` | `permissions` |
+| `let { x: { $permissions: permissions } } = o` | `-` |
+| `let { a, x: { $permissions: permissions } } = o` | `-` |
+| `let { x: { a, $permissions: permissions } } = o` | `permissions` |
+| `let [a, { $permissions: permissions }] = [o, o]` | `-` |
+| `function f({ a, $permissions: permissions }: any)` | `permissions` |
+| `let { $p: p, $q: q } = o` | `q` |
+| `let { a, $p: p, $q: q } = o` | `p`, `q` |
+| `({ a, $p: p } = o)` | `-` |
+
+The nested rows are the ones that name the mechanism: `{ a, x: { $p: p } }` is quiet because
+entering the nested pattern **re-sets** the flag its sibling had cleared, while
+`{ x: { a, $p: p } }` is loud for the same reason one level down. Assignment destructuring is
+quiet because it is an `ObjectLiteralExpression`, which `handleIdentifier` excludes by
+`!ts.isPropertyAssignment(parent) || parent.initializer == ident`.
+
+## Real-world instance
+
+`appwrite-console/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/settings/+page.svelte`.
+
+## Fix
+
+Restore the previous value rather than clearing:
+
+```ts
+if (ts.isBindingElement(parent) && parent.name == node) {
+    const previous = isDeclaration;
+    isDeclaration = true;
+    onLeaveCallbacks.push(() => (isDeclaration = previous));
+}
+```
+
+The same shape applies to the `isVariableDeclaration` and `isImportClause` resets at `:284-301`.
+
+## What rsvelte does
+
+Byte equality is the goal, so rsvelte reproduces the rule as measured, pinned by
+`crates/rsvelte_projection/tests/svelte2tsx_binding_pattern_store_key.rs`.


### PR DESCRIPTION
Stacked on #4162 (base is `fix/svelte2tsx-unparseable-and-events`, so the diff is this
change alone). **After #4162 is squash-merged this branch must be rebased onto `main`, not
merged as-is** — the base commit disappears into the squash.

## Ratchet ids this PR drops

`compatibility/svelte2tsx-known-failures.json`, **8 → 7**, one id:

- `appwrite-console/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/settings/+page.svelte`

No other ratchet moves.

## The defect

`processInstanceScriptContent` decides whether a `$`-prefixed identifier is a **store
reference** or a **declared name** from one boolean, `isDeclaration`. Entering a binding
element's name sets it and pushes an on-leave callback that clears it
(`processInstanceScriptContent.ts:293-296`):

```ts
if (ts.isBindingElement(parent) && parent.name == node) {
    isDeclaration = true;
    onLeaveCallbacks.push(() => (isDeclaration = false));
}
```

The reset is unconditional, so leaving the **first** element of a pattern clears a flag the
enclosing pattern had set, and every element after it is walked with `isDeclaration === false`.
`handleIdentifier` (`:155`) then takes the store branch for that element's *property name*.

rsvelte skipped every object-property key, so
`let { a, $permissions: permissions } = o` emitted no
`let $permissions = __sveltets_2_store_get(permissions);` line at all.

## The axis

An element's index within **its own** pattern, crossed with the pattern's host.
`-` is no `__sveltets_2_store_get` call. Every value is official's own output.

| source | official |
|---|---|
| `let { $permissions: permissions } = o` | `-` |
| `let { a, $permissions: permissions } = o` | `permissions` |
| `let { a, b, $permissions: permissions } = o` | `permissions` |
| `let { a = 1, $permissions: permissions } = o` | `permissions` |
| `let { x: { $permissions: permissions } } = o` | `-` |
| `let { a, x: { $permissions: permissions } } = o` | `-` |
| `let { x: { a, $permissions: permissions } } = o` | `permissions` |
| `let [a, { $permissions: permissions }] = [o, o]` | `-` |
| `function f({ a, $permissions: permissions }: any)` | `permissions` |
| `let { $p: p, $q: q } = o` | `q` |
| `let { a, $p: p, $q: q } = o` | `p`, `q` |
| `({ a, $p: p } = o)` | `-` |

The nested rows are what name the mechanism rather than merely fitting it: `{ a, x: { $p: p } }`
is quiet because entering the nested pattern **re-sets** the flag its sibling had cleared, and
`{ x: { a, $p: p } }` is loud for the same reason one level down. A rule stated as "not the first
key in the statement" fits the flat rows and gets both of those backwards.

## Measurement

Two-stage sweep, distinct binaries per arm, arms identified two-sided (base answers `-` where
after answers `permissions`, and an unrelated `@typedef` fingerprint is 0 differing lines on
both). Stage 1 hashes every corpus component; stage 2 re-verdicts only what moved, through the
gate's own normalization.

```
units: 33901  moved: 1
MISMATCH -> match:    1
match -> MISMATCH:    0
MISMATCH -> MISMATCH: 0
match -> match:       0
```

33,901 is the number of `.svelte` entries in `compatibility/manifest.json` (34,828 total; the
other 927 are `.svelte.(js|ts)` modules svelte2tsx does not convert). svelte2tsx has no compile
targets, so it is not target-multiplied.

Positive control: ablating the fix fails **7 of the 14** grid cells — the branch condition
splitting the grid in half, which a fix reaching every cell or one cell would not do. Restoring
leaves `git diff` empty and the test green.

## Why the entry sat at "output only"

The mechanism table's justification read: *"had a plausible cause — `$permissions` as a
destructuring-rename KEY — and a five-line reduction of that has both tools agreeing, so the
cause is something else."* The cause **was** the destructuring-rename key. The reduction put it
in a pattern of one element, which is the one position where upstream does not resolve it as a
store — so a reduction that reproduces nothing was recorded as a finding about the defect when it
was a fact about the reduction. That is written up in the `Previously:` section.

## Also here

Both are about a pin the previous commit left unheld.

- The `@typedef` offset divergence is now registered in
  `compatibility/GATES.md#deliberate-divergences`. Its pin had to **move out of** `export_decl.rs`:
  the gate's pin predicate accepts only a path under `tests/`, in `compatibility/pattern-corpus/`,
  or a `test-*.mjs` / `*.test.mjs` harness, so a `#[test]` inside `src/` is citable and is not a
  pin. It is now `crates/rsvelte_projection/tests/svelte2tsx_typedef_tag_offset.rs`, with the two
  rows rsvelte *does* reproduce beside it as controls. Gate 42's own prose said "11 of them"
  against a checker that counts 20; corrected.
- That test's doc comment quoted official's corrupted output from a **different input**. The
  deleted slice is offset by `node.pos`, so the quoted bytes change with whatever precedes the
  comment. The value is now the one measured on the test's own source
  (`{\n/**\n * @typedef {i{ a: 1 }}\n */a: a}`).

## Checks run locally

| check | result |
|---|---|
| `cargo test -p rsvelte_projection --lib --tests` | `TEST_EXIT=0` — 84 suites, 702 passed, 0 failed |
| `cargo clippy -p rsvelte_projection --all-targets --all-features -- -D warnings` | `CLIPPY_EXIT=0` |
| `cargo fmt --all` | no diff |
| `known-failures-md-check.mjs` | 50 ratchets across 36 docs, 32 partitions add up (positive control: `5 + 2` → `6 + 2` fails with two independent messages) |
| `deliberate-divergences-check.mjs` | 20 recorded, each pinned (positive control: replacing this section's `**Pinned by**` with prose names it at `GATES.md:8074`) |
| `check-upstream-issues.mjs` | 81 reports, all indexed |
| `check-core-consumer-changesets.mjs` | all three consumer packages named |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ayf2LfKqP7yEEtWjunZ7DF
