### PR TITLE
fix(svelte2tsx): a prop widener at the script's last byte is discarded upstream

### DIFF
--- a/.changeset/svelte2tsx-script-end-insertion.md
+++ b/.changeset/svelte2tsx-script-end-insertion.md
@@ -1,0 +1,16 @@
+---
+'@rsvelte/svelte2tsx': patch
+'@rsvelte/compiler': patch
+'@rsvelte/svelte-check': patch
+---
+
+A prop widener that would land on the script's last byte is no longer emitted, because
+upstream discards it there.
+
+`preprendStr` overwrites the single character at its insertion point rather than appending,
+so `propTypeAssertToUserDefined`'s `;x = __sveltets_2_any(x);` at `declaration.end` is
+overwritten by the `</script>` removal when the declaration is the last thing in the script.
+Any trailing byte — a space, a tab, a comment, a `;`, a newline — moves the insertion point
+and the widener survives. The same position carries the SvelteKit `./$types.js` annotation
+when the declaration ends at its name, so that is lost with it. Reported as
+`upstream_issues/svelte2tsx-preprendstr-insertion-at-the-script-end-is-overwritten.md`.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -6216,11 +6216,11 @@ The svelte2tsx output-parity corpus (`scripts/compat-corpus/svelte2tsx-*`) compa
 rsvelte's svelte2tsx port against **official `svelte2tsx`** byte-for-byte (after
 oxfmt normalization). The ratchet may only shrink.
 
-**Current baseline: `svelte2tsx-known-failures.json`, 7 entries.**
+**Current baseline: `svelte2tsx-known-failures.json`, 6 entries.**
 
-Partition of `svelte2tsx-known-failures.json` by verdict: `5 + 2`
+Partition of `svelte2tsx-known-failures.json` by verdict: `4 + 2`
 
-- **5 — the emitted TSX differs** (`ts-mismatch`).
+- **4 — the emitted TSX differs** (`ts-mismatch`).
 - **2 — one side rejects and the other compiles** (`error-mismatch`). Both are
   `cnblocks`'s `(app)/veil/` components, and the rejecting side is **official**:
   a UTF-8 BOM together with a `<script>` block and markup makes `svelte2tsx`
@@ -6237,7 +6237,7 @@ Attribution of `svelte2tsx-known-failures.json`:
 |---|---|---|
 | 2 | `upstream_issues/svelte2tsx-bom-crashes-on-any-component-with-a-script.md` | official throws on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it |
 
-The remaining 5 carry **no target, and cannot have one**: every one was measured
+The remaining 4 carry **no target, and cannot have one**: every one was measured
 against official on 2026-09-02 and every one is an rsvelte defect, so the only end
 state open to them is elimination. The classification below is the input to that
 work; it is not an attribution, and this gate stays red until the entries are gone.
@@ -6269,9 +6269,46 @@ double count**, so the assignment has to be per entry.
 | 1 | an extra `dragItem: dragItem` slot prop is emitted | output only |
 | 1 | two adjacent store-get `/*Ωignore_startΩ*/…/*Ωignore_endΩ*/` regions are emitted as ONE region spanning both, where official closes and reopens | source |
 | 1 | a `//` comment inside a `${…}` hole of a template-literal attribute value is dropped | source |
-| 1 | `export let x: T` with no statement terminator (the file ends at `</script>`) gains `x = __sveltets_2_any(x)`; adding `;` and a newline makes the two agree | reduced |
 
-Partition of `svelte2tsx-known-failures.json` by mechanism: `2 + 1x5`
+Partition of `svelte2tsx-known-failures.json` by mechanism: `2 + 1x4`
+
+### Previously: `unterminated-export-let` (2026-09-02, at 7 entries)
+
+Kept because its own description named the symptom as an rsvelte addition — *"gains
+`x = __sveltets_2_any(x)`"* — where it is an upstream **loss**, and the two spellings
+point at different code.
+
+`preprendStr` (`utils/magic-string.ts:7-17`) does not append. It `overwrite`s the
+single character at the insertion point with `text + that character`, and
+`propTypeAssertToUserDefined` uses it to add `;x = __sveltets_2_any(x);` at
+`declaration.end`. When the declaration is the script's last byte that character is
+the `<` of `</script>`, whose chunk the script-tag removal overwrites afterwards —
+so the widener is discarded with no error. Filed as
+[`upstream_issues/svelte2tsx-preprendstr-insertion-at-the-script-end-is-overwritten.md`](../upstream_issues/svelte2tsx-preprendstr-insertion-at-the-script-end-is-overwritten.md).
+
+The description also recorded that *"adding `;` and a newline makes the two agree"*,
+which is two changes for a one-byte condition: **a space, a tab, a trailing block
+comment, a `;` or a newline each restore it on their own**, because any of them moves
+the insertion point off the `<`. Markup after `</script>` does not, because the
+position that matters is the end of the script **content**.
+
+**Three insertion sites had to be told apart, and two of them are unreachable rather
+than fixed.** Measured one cell per site: the `export { x as y }` re-export path never
+fires when the export precedes the declaration (both tools emit nothing, at the end
+and with a trailing space alike), and a non-exported sibling of that declaration list
+cannot be the script's last token, because the `export { … }` statement has to follow
+it. A guard added to all three on the strength of the mechanism would have been
+untestable at two of them.
+
+That measurement did find a divergence of its own, unrelated to the script end:
+for `export { a as b };let a = 1, c: number` — the export **before** the declaration —
+official widens nothing while rsvelte widens the non-exported sibling `c`, identically
+with and without a trailing space and identically on both arms of this fix. It has no
+corpus witness: the gate is two-sided and green apart from the entries listed above, so
+a divergence that is not one of them is reproduced by no collected unit.
+
+The positive control fails **9 of the 19** cells, and the 10 that pass are the ones a
+position-blind suppression would break.
 
 ### Previously: `store-get-missing` (2026-09-02, at 8 entries)
 

--- a/compatibility/svelte2tsx-known-failures.json
+++ b/compatibility/svelte2tsx-known-failures.json
@@ -4,6 +4,5 @@
 	"cnblocks/src/routes/(app)/veil/+page.svelte",
 	"huly/plugins/view-resources/src/components/list/ListCategory.svelte",
 	"mathesar/mathesar_ui/src/component-library/button/Button.svelte",
-	"sparrow-app/packages/@sparrow-workspaces/src/features/tab-bar/components/tab/Tab.svelte",
-	"sveltekit/packages/package/test/watch/expected/Test.svelte"
+	"sparrow-app/packages/@sparrow-workspaces/src/features/tab-bar/components/tab/Tab.svelte"
 ]

--- a/compatibility/svelte2tsx-mechanisms.json
+++ b/compatibility/svelte2tsx-mechanisms.json
@@ -21,10 +21,6 @@
 			"description": "a `//` comment inside a `${…}` hole of a template-literal attribute value is dropped",
 			"pinned": "source"
 		},
-		"unterminated-export-let": {
-			"description": "`export let x: T` with no statement terminator (the file ends at `</script>`) gains `x = __sveltets_2_any(x)`; adding `;` and a newline makes the two agree",
-			"pinned": "reduced"
-		},
 		"upstream-bom-crash": {
 			"description": "official svelte2tsx throws from magic-string on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it",
 			"pinned": "upstream"
@@ -37,7 +33,6 @@
 		"huly/plugins/view-resources/src/components/list/ListCategory.svelte": "extra-slot-prop",
 		"mathesar/mathesar_ui/src/component-library/button/Button.svelte": "bind-this-shape",
 		"sparrow-app/packages/@sparrow-workspaces/src/features/tab-bar/components/tab/Tab.svelte": "template-hole-comment-dropped",
-		"svelte-virtuallists/src/lib/VirtualListNew.svelte": "line-comment-swallows-type",
-		"sveltekit/packages/package/test/watch/expected/Test.svelte": "unterminated-export-let"
+		"svelte-virtuallists/src/lib/VirtualListNew.svelte": "line-comment-swallows-type"
 	}
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
@@ -255,14 +255,22 @@ pub(super) fn handle_export_named_decl(
 
                         if let Some(name) = binding_pattern_simple_name(&declarator.id) {
                             let use_jsdoc = emit_jsdoc && !is_ts;
-                            let (id_start, id_end) = match &declarator.id {
+                            let (id_start_rel, id_end_rel) = match &declarator.id {
                                 oxc::BindingPattern::BindingIdentifier(id) => {
-                                    (id.span.start + offset, id.span.end + offset)
+                                    (id.span.start, id.span.end)
                                 }
-                                _ => (declarator.span.end + offset, declarator.span.end + offset),
+                                _ => (declarator.span.end, declarator.span.end),
                             };
-                            let widen_pos = declarator.span.end + offset;
+                            let (id_start, id_end) = (id_start_rel + offset, id_end_rel + offset);
+                            let widen_rel = declarator.span.end;
+                            let widen_pos = widen_rel + offset;
+                            // Upstream inserts with `preprendStr`, which OVERWRITES the
+                            // character at the position — and the `</script>` removal
+                            // overwrites that same chunk afterwards, so an insertion
+                            // landing on the script's last byte is silently discarded.
+                            let swallowed = |rel: u32| rel as usize == raw_content.len();
                             if do_widen
+                                && !swallowed(id_end_rel)
                                 && let Some(kit) = kit_type
                                 && !use_jsdoc
                             {
@@ -274,7 +282,7 @@ pub(super) fn handle_export_named_decl(
                                     ),
                                 );
                             } else {
-                                if do_widen {
+                                if do_widen && !swallowed(widen_rel) {
                                     str.append_left_fmt(
                                         widen_pos,
                                         format_args!(
@@ -288,7 +296,7 @@ pub(super) fn handle_export_named_decl(
                                             id_start,
                                             format_args!("/** @type {{{kit}}} */ "),
                                         );
-                                    } else {
+                                    } else if !swallowed(id_end_rel) {
                                         str.append_left_fmt(
                                             id_end,
                                             format_args!(

--- a/crates/rsvelte_projection/tests/svelte2tsx_script_end_insertion.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_script_end_insertion.rs
@@ -1,0 +1,215 @@
+//! An insertion that lands on the script's last byte is discarded by upstream,
+//! so the prop widener disappears when a declaration ends at `</script>`.
+//!
+//! `preprendStr` (`utils/magic-string.ts:7-17`) does not append — it
+//! `overwrite`s the single character at the insertion point with
+//! `text + thatCharacter`. `propTypeAssertToUserDefined` inserts
+//! `;x = __sveltets_2_any(x);` at `declaration.end`, and when the declaration is
+//! the last thing in the script that character is the `<` of `</script>`, which
+//! the script-tag removal overwrites afterwards — taking the insertion with it.
+//! One trailing byte of any kind (space, tab, comment, `;`, newline) moves the
+//! insertion point off that character and the widener survives.
+//!
+//! The same position carries the SvelteKit `import('./$types.js')` annotation
+//! when `nameEnd === end`, so that is lost too; `export const snapshot`, whose
+//! annotation goes on the name rather than on the declaration end, is not.
+//!
+//! Every expectation is the pinned `submodules/language-tools` svelte2tsx's own
+//! output on the same source, with the options
+//! `scripts/compat-corpus/svelte2tsx-compile.mjs` passes.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+/// For each name, `name` if `__sveltets_2_any(name)` is emitted and `!name` if
+/// not, plus `KIT` when a `./$types.js` annotation reached the output.
+fn injected(src: &str, filename: &str, is_ts_file: bool, names: &[&str]) -> String {
+    let code = svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: filename.to_string(),
+            is_ts_file,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+    let mut parts: Vec<String> = names
+        .iter()
+        .map(|name| {
+            if code.contains(&format!("__sveltets_2_any({name})")) {
+                (*name).to_string()
+            } else {
+                format!("!{name}")
+            }
+        })
+        .collect();
+    if code.contains("import('./$types.js')") {
+        parts.push("KIT".to_string());
+    }
+    parts.join(",")
+}
+
+#[test]
+fn a_widener_at_the_script_end_is_discarded() {
+    let mut failures = Vec::new();
+    for (label, filename, is_ts, src, names, expected) in [
+        (
+            "at the script end",
+            "T.svelte",
+            true,
+            "<script lang=\"ts\">export let answer: number</script>",
+            &["answer"][..],
+            "!answer",
+        ),
+        (
+            "one trailing space",
+            "T.svelte",
+            true,
+            "<script lang=\"ts\">export let answer: number </script>",
+            &["answer"][..],
+            "answer",
+        ),
+        (
+            "one trailing tab",
+            "T.svelte",
+            true,
+            "<script lang=\"ts\">export let answer: number\t</script>",
+            &["answer"][..],
+            "answer",
+        ),
+        (
+            "trailing block comment",
+            "T.svelte",
+            true,
+            "<script lang=\"ts\">export let answer: number/*c*/</script>",
+            &["answer"][..],
+            "answer",
+        ),
+        (
+            "semicolon terminated",
+            "T.svelte",
+            true,
+            "<script lang=\"ts\">export let answer: number;</script>",
+            &["answer"][..],
+            "answer",
+        ),
+        (
+            "newline before the tag",
+            "T.svelte",
+            true,
+            "<script lang=\"ts\">export let answer: number\n</script>",
+            &["answer"][..],
+            "answer",
+        ),
+        (
+            "markup follows the script",
+            "T.svelte",
+            true,
+            "<script lang=\"ts\">export let answer: number</script>\n<p>x</p>",
+            &["answer"][..],
+            "!answer",
+        ),
+        (
+            "no type annotation",
+            "T.svelte",
+            true,
+            "<script lang=\"ts\">export let answer</script>",
+            &["answer"][..],
+            "!answer",
+        ),
+        (
+            "boolean initializer",
+            "T.svelte",
+            true,
+            "<script lang=\"ts\">export let answer = true</script>",
+            &["answer"][..],
+            "!answer",
+        ),
+        (
+            "non-boolean initializer",
+            "T.svelte",
+            true,
+            "<script lang=\"ts\">export let answer = 1</script>",
+            &["answer"][..],
+            "!answer",
+        ),
+        (
+            "second statement is last",
+            "T.svelte",
+            true,
+            "<script lang=\"ts\">export let a: number;export let answer: number</script>",
+            &["a", "answer"][..],
+            "a,!answer",
+        ),
+        (
+            "last of a comma list",
+            "T.svelte",
+            true,
+            "<script lang=\"ts\">export let a: number, answer: number</script>",
+            &["a", "answer"][..],
+            "a,!answer",
+        ),
+        (
+            "plain JS script",
+            "T.svelte",
+            false,
+            "<script>export let answer</script>",
+            &["answer"][..],
+            "!answer",
+        ),
+        (
+            "kit data, ts, at the end",
+            "+page.svelte",
+            true,
+            "<script lang=\"ts\">export let data</script>",
+            &["data"][..],
+            "!data",
+        ),
+        (
+            "kit data, ts, one space",
+            "+page.svelte",
+            true,
+            "<script lang=\"ts\">export let data </script>",
+            &["data"][..],
+            "data,KIT",
+        ),
+        (
+            "kit data, js, at the end",
+            "+page.svelte",
+            false,
+            "<script>export let data</script>",
+            &["data"][..],
+            "!data",
+        ),
+        (
+            "kit data, js, one space",
+            "+page.svelte",
+            false,
+            "<script>export let data </script>",
+            &["data"][..],
+            "data,KIT",
+        ),
+        (
+            "kit snapshot const at the end",
+            "+page.svelte",
+            true,
+            "<script lang=\"ts\">export const snapshot = 1</script>",
+            &["snapshot"][..],
+            "!snapshot,KIT",
+        ),
+        (
+            "module script, const at the end",
+            "T.svelte",
+            true,
+            "<script context=\"module\" lang=\"ts\">export const a: number = 1</script>",
+            &["a"][..],
+            "!a",
+        ),
+    ] {
+        let actual = injected(src, filename, is_ts, names);
+        if actual != expected {
+            failures.push(format!("{label}: expected {expected:?}, got {actual:?}"));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}

--- a/upstream_issues/README.md
+++ b/upstream_issues/README.md
@@ -116,20 +116,21 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `svelte2tsx-bom-crashes-on-any-component-with-a-script.md` | sveltejs/language-tools (svelte2tsx) | #4048 | unrecorded |
 | `svelte2tsx-getlastleadingdoc-mixes-absolute-and-relative-offsets.md` | sveltejs/language-tools (svelte2tsx) | — | unrecorded |
 | `svelte2tsx-isdeclaration-is-a-boolean-not-a-stack.md` | sveltejs/language-tools (svelte2tsx) | — | unrecorded |
+| `svelte2tsx-preprendstr-insertion-at-the-script-end-is-overwritten.md` | sveltejs/language-tools (svelte2tsx) | — | unrecorded |
 | `svelte2tsx-shorthand-style-directive-modifier.md` | sveltejs/language-tools (svelte2tsx) | #3567, #3578 | unrecorded |
 | `svelte2tsx-transposes-an-unclosed-start-tag.md` | sveltejs/language-tools (svelte2tsx) | — | unrecorded |
 | `tsgo-lsp-completion-item-omits-the-typescript-kind.md` | microsoft/typescript-go (`tsgo --lsp`) | — | unrecorded |
 
-**24** reports carry no rsvelte issue number. Six came out of the lint-parity campaign (five
+**25** reports carry no rsvelte issue number. Six came out of the lint-parity campaign (five
 against `eslint-plugin-svelte`, one against `svelte-eslint-parser`), two out of the
 `two-ports-inventory.md` row 21 shadow probes, seven out of the SCSS-backend burndown — five
 covering every unit `scss-known-failures.json` lists as `grass-rejects-accepted`, plus the two
 classes in that ratchet whose output is not render-neutral (a hoisted declaration, and a slash list
-divided inside a nested rule) — and two out of the LSP differential campaign. The remaining seven
+divided inside a nested rule) — and two out of the LSP differential campaign. The remaining eight
 are later: two `oxfmt` CSS reports from the formatter-parity corpus, one against `esrap`, one
 against `language-tools`, and one against `prettier-plugin-svelte` from the formatter-parity
 burndown (an inline element in a text run overflows `printWidth`, and re-formatting the output is
-not a fixed point), and two against `svelte2tsx` from the svelte2tsx-ratchet burndown.
+not a fixed point), and three against `svelte2tsx` from the svelte2tsx-ratchet burndown.
 None of them names an issue internally — `—` records that, rather than
 inventing a number, and `check-upstream-issues.mjs` holds the count above to the table so this
 paragraph cannot go stale the way it already had (it read "Fifteen" against 19 rows).

--- a/upstream_issues/svelte2tsx-preprendstr-insertion-at-the-script-end-is-overwritten.md
+++ b/upstream_issues/svelte2tsx-preprendstr-insertion-at-the-script-end-is-overwritten.md
@@ -1,0 +1,79 @@
+# An insertion at the script's last byte is overwritten by the `</script>` removal
+
+**Repository**: `sveltejs/language-tools` (`packages/svelte2tsx`)
+**Measured**: 2026-09-02, `submodules/language-tools` at the pinned revision, driven through
+`packages/svelte2tsx/index.js` with the options `scripts/compat-corpus/svelte2tsx-compile.mjs`
+passes: `{ filename, isTsFile, mode: 'ts', namespace: 'html', version: '5' }`.
+
+## Summary
+
+`preprendStr` (`src/utils/magic-string.ts:7-17`) does not append — it **overwrites** the single
+character at the insertion point with `toAppend + that character`:
+
+```ts
+str.overwrite(index, index + 1, toAppend + str.original.charAt(index), { contentOnly: true });
+```
+
+`propTypeAssertToUserDefined` (`nodes/ExportedNames.ts:420-487`) uses it to add
+`;x = __sveltets_2_any(x);` at `declaration.end`, which widens a prop's type so TS does not
+narrow it to its initializer or report it as possibly undefined. When the declaration is the last
+thing in the script, `declaration.end` is the index of the `<` in `</script>` — and the script-tag
+removal overwrites that chunk afterwards, discarding the insertion. No error is raised; the
+widener is simply absent.
+
+One trailing byte of any kind moves the insertion point off that character and it survives.
+
+## Reduction
+
+```svelte
+<!-- A: the declaration is the script's last byte -->
+<script lang="ts">export let answer: number</script>
+```
+
+```svelte
+<!-- B: one space before the closing tag -->
+<script lang="ts">export let answer: number </script>
+```
+
+```
+A   let answer: number;
+B   let answer: number /*Ωignore_startΩ*/;answer = __sveltets_2_any(answer);/*Ωignore_endΩ*/;
+```
+
+A is `sveltekit/packages/package/test/watch/expected/Test.svelte` verbatim.
+
+## The axis
+
+An `x` marks the widener present in the output.
+
+| source | widener |
+|---|---|
+| `export let answer: number</script>` | — |
+| `export let answer: number </script>` | x |
+| `export let answer: number\t</script>` | x |
+| `export let answer: number/*c*/</script>` | x |
+| `export let answer: number;</script>` | x |
+| `export let answer: number\n</script>` | x |
+| `export let a: number;export let answer: number</script>` | on `a` only |
+| `export let a: number, answer: number</script>` | on `a` only |
+
+Markup after `</script>` does not change the answer — the position that matters is the end of the
+**script content**, not of the file.
+
+The same insertion carries the SvelteKit `import('./$types.js')` annotation when
+`nameEnd === end` (`:465-472`), so `export let data` in a `+page.svelte` that ends at `</script>`
+loses its `PageData` type as well as the widener. `export const snapshot`, whose annotation goes
+on the name rather than on the declaration end, is unaffected.
+
+## Fix
+
+Insert rather than overwrite at a position the script-tag transformation also owns — or clamp the
+insertion to `min(declaration.end, scriptContentEnd - 1)`. The cheapest correct change is for
+`preprendStr` to use `appendLeft`, which attaches to the chunk **before** the position and so
+survives a later overwrite of the chunk after it; that is what rsvelte's port does.
+
+## What rsvelte does
+
+Byte equality is the goal, so rsvelte suppresses the insertion when it would land on the script's
+last byte, pinned by
+`crates/rsvelte_projection/tests/svelte2tsx_script_end_insertion.rs`.


### PR DESCRIPTION
Stacked on #4169 (base is `fix/svelte2tsx-store-key-position`, so the diff is this change
alone). **After #4169 is squash-merged this branch must be rebased onto `main`, not merged
as-is.**

## Ratchet ids this PR drops

`compatibility/svelte2tsx-known-failures.json`, **7 → 6**, one id:

- `sveltekit/packages/package/test/watch/expected/Test.svelte`

No other ratchet moves.

## The defect

`preprendStr` (`utils/magic-string.ts:7-17`) does not append. It **overwrites** the single
character at the insertion point with `toAppend + that character`:

```ts
str.overwrite(index, index + 1, toAppend + str.original.charAt(index), { contentOnly: true });
```

`propTypeAssertToUserDefined` uses it to add `;x = __sveltets_2_any(x);` at
`declaration.end`. When the declaration is the last thing in the script, that character is
the `<` of `</script>` — and the script-tag removal overwrites the same chunk afterwards,
discarding the insertion. No error is raised; the widener is simply absent.

The listed entry is the whole file:

```svelte
<script lang="ts">export let answer: number</script>
```

## The axis

One trailing byte of any kind moves the insertion point off that character.

| source | official |
|---|---|
| `export let answer: number</script>` | — |
| `export let answer: number </script>` | widened |
| `export let answer: number\t</script>` | widened |
| `export let answer: number/*c*/</script>` | widened |
| `export let answer: number;</script>` | widened |
| `export let answer: number\n</script>` | widened |
| `…</script>\n<p>x</p>` | — |
| `export let a: number;export let answer: number</script>` | `a` only |
| `export let a: number, answer: number</script>` | `a` only |

Markup after `</script>` does not change the answer: the position that matters is the end of
the script **content**, not of the file. The same position carries the SvelteKit
`import('./$types.js')` annotation when `nameEnd === end`, so `export let data` in a
`+page.svelte` ending at `</script>` loses its `PageData` type too; `export const snapshot`,
whose annotation goes on the name, does not.

## Three sites, one reachable

rsvelte inserts at a declaration end in three places. Rather than guard all three on the
strength of the mechanism, each was measured:

| site | at the script end | verdict |
|---|---|---|
| `export let` (`propTypeAssertToUserDefined`) | reachable | **fixed here** |
| `export { x as y }` re-export of a local `let` | reachable | both tools emit nothing, with and without a trailing byte — the path does not fire when the export precedes the declaration |
| non-exported sibling of that declaration list | **unreachable** — the `export { … }` statement has to follow the list, so a sibling cannot be the script's last token | not guarded |

That measurement found a divergence of its own, unrelated to the script end: for
`export { a as b };let a = 1, c: number` official widens nothing while rsvelte widens the
non-exported sibling `c` — identically with and without a trailing space, and identically on
both arms of this fix. It has no corpus witness (the gate is two-sided and green apart from
the listed entries), and is recorded in `KNOWN-FAILURES.md` rather than fixed here.

## Measurement

Arms identified two-sided: the before arm carries the previous PR's store-key fix and not
this guard, the after arm carries both.

```
units: 33901  moved: 1
MISMATCH -> match:    1
match -> MISMATCH:    0
MISMATCH -> MISMATCH: 0
match -> match:       0
```

Positive control: ablating the guard fails **9 of the 19** cells; the 10 that pass are the
ones a position-blind suppression would break.

## Checks run locally

| check | result |
|---|---|
| `cargo test -p rsvelte_projection --lib --tests` | `TEST_EXIT=0` — 85 suites, 703 passed, 0 failed |
| `cargo clippy -p rsvelte_projection --all-targets --all-features -- -D warnings` | `CLIPPY_EXIT=0` |
| `cargo fmt --all` | no diff |
| `known-failures-md-check.mjs` | 50 ratchets across 36 docs, 32 partitions add up |
| `check-upstream-issues.mjs` | 82 reports, all indexed |
| `check-core-consumer-changesets.mjs` | all three consumer packages named |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ayf2LfKqP7yEEtWjunZ7DF
