### PR TITLE
fix(client): a class field's `$state` resolves an identifier through its binding

### DIFF
--- a/.changeset/class-field-state-identifier-proxy.md
+++ b/.changeset/class-field-state-identifier-proxy.md
@@ -1,0 +1,6 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A class field's `$state` initializer resolves an identifier through its binding, as upstream's
+`should_proxy` does, instead of wrapping every one in `$.proxy`

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2866,11 +2866,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 26 entries)
+### Client (`known-failures.client.json`, 25 entries)
 
-Partition of `known-failures.client.json` by verdict: `25 + 1`
+Partition of `known-failures.client.json` by verdict: `24 + 1`
 
-- **25 — the generated JS differs** (`js` / `code-differs`).
+- **24 — the generated JS differs** (`js` / `code-differs`).
 - **1 — the generated CSS differs.**
 
 The error classes this section used to carry are gone: the run behind this
@@ -2902,6 +2902,20 @@ asking only "is it not the bare name" passes on the bug; the repro therefore var
 binding KIND behind one fixed each block (`plain-import` → `settings`, `local-state` →
 `$.get(settings)`, `exported-prop` → `settings()`, nested each → `$.get(filter),
 $$_import_settings()`). A 139,252-unit four-target sweep moved exactly these 4 units.
+
+One entry left this target and `client-dev` because upstream's `should_proxy` resolves an
+Identifier **through its binding** and rsvelte's class-field lowering did not:
+`joy-of-code/…/preferences.svelte.ts` initialised a field from a name whose declaration
+is a non-proxied `$state` and rsvelte re-proxied it. There are **four** ports of that
+predicate here and no gate compares any two, so a 24-cell grid — one cell per call site of
+the scope-less port, crossed with four right-hand-side shapes — was written before the fix
+and reported `EQ 19 | DIFF 5`. The scope set is now computed once and threaded into the
+class-field pass and into `private_class_assign_ast`, whose walk starts inside the class
+body and cannot see an outer declaration. A 104,439-unit sweep moved 2 units, one of them
+`MISMATCH -> match`; the module half of that sweep is only live because the harness strips
+TypeScript first — `compile_module` parses plain JS, so all 923 `.svelte.(js|ts)` units had
+been erroring identically in both arms and the first run's `MOVED 0` was arithmetically
+forced.
 
 Two entries left this target and `client-dev` on two `$.mutate` decisions that answer
 differently depending on the HOST the write is written in. `musicat/…/Scrollbar.svelte`
@@ -2994,7 +3008,7 @@ the emitted default was the getter function rather than the store's value. Hashi
 client (entry, target) outputs before and after reports **2** changed units over 1 id,
 `match -> MISMATCH = 0`; the other two ids of that cluster do not move and stay listed.
 
-Every one of the remaining 26 arrived with the wave-2 enrolment (#3130) and is described
+Every one of the remaining 25 arrived with the wave-2 enrolment (#3130) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3101,15 +3115,15 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 40 entries)
+### Client dev (`known-failures.client-dev.json`, 39 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `40`
+Partition of `known-failures.client-dev.json` by verdict: `39`
 
-- **40 — the generated JS differs.**
+- **39 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 40 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 39 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -12,7 +12,6 @@
 	"huly/plugins/workbench-resources/src/components/HelpAndSupport.svelte",
 	"immich/web/src/lib/components/asset-viewer/ActivityViewer.svelte",
 	"immich/web/src/lib/components/timeline/Timeline.svelte",
-	"joy-of-code/src/lib/ui/header/preferences/preferences.svelte.ts",
 	"kite-public/src/lib/components/CategoryNavigation.svelte",
 	"mathesar/mathesar_ui/src/components/sort-entry/SortEntry.svelte",
 	"mathesar/mathesar_ui/src/pages/database/disconnect/DisconnectDatabaseModal.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -7,7 +7,6 @@
 	"huly/plugins/text-editor-resources/src/components/DrawingBoardEditor.svelte",
 	"huly/plugins/training-resources/src/components/TrainingRequestDueDateEditor.svelte",
 	"immich/web/src/lib/components/asset-viewer/ActivityViewer.svelte",
-	"joy-of-code/src/lib/ui/header/preferences/preferences.svelte.ts",
 	"kite-public/src/lib/components/CategoryNavigation.svelte",
 	"mathesar/mathesar_ui/src/components/sort-entry/SortEntry.svelte",
 	"mathesar/mathesar_ui/src/pages/database/disconnect/DisconnectDatabaseModal.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -4,7 +4,7 @@ use memchr::memmem;
 use std::fmt::Write as _;
 
 use super::REGEX_INVALID_IDENTIFIER_CHARS;
-use super::expression_needs_proxy;
+use super::expression_needs_proxy_with_scope;
 use crate::compiler::phases::phase1_parse::parser::is_js_whitespace;
 use crate::compiler::phases::phase1_parse::utils::find_matching_bracket;
 use crate::compiler::phases::phase3_transform::shared::class_body::{
@@ -515,6 +515,7 @@ pub(super) fn emit_class_field(
     field: &ClassStateField,
     all_fields: &[ClassStateField],
     indent: &str,
+    non_proxy_vars: &[String],
 ) -> String {
     let mut output = String::new();
     let body_indent = format!("{}\t", indent);
@@ -563,7 +564,8 @@ pub(super) fn emit_class_field(
         }
     } else if field.rune_type == "$state" {
         let value_trimmed = field.value.trim();
-        let needs_proxy = !value_trimmed.is_empty() && expression_needs_proxy(value_trimmed);
+        let needs_proxy = !value_trimmed.is_empty()
+            && expression_needs_proxy_with_scope(value_trimmed, non_proxy_vars);
         let wrapped_value = if needs_proxy {
             format!("$.proxy({})", field.value)
         } else {
@@ -660,7 +662,7 @@ pub(super) fn emit_class_field(
         // fields (`() => { … this.#x = v … }`), which must lower to
         // `$.set(this.#x, v)`, not the invalid `$.get(this.#x) = v`. It also wraps
         // the remaining reads in `$.get(...)` with correct LHS/update guards.
-        let derived_expr = transform_class_methods(&field.value, all_fields);
+        let derived_expr = transform_class_methods(&field.value, all_fields, non_proxy_vars);
         let _ = writeln!(
             output,
             "{}{} = {}{}$.derived({});",
@@ -947,12 +949,15 @@ pub(super) fn transform_constructor_private_reads(
 }
 
 /// Transform class fields with $state and $derived runes for client-side.
-pub(crate) fn transform_class_fields_client(script: &str) -> String {
-    transform_class_fields_client_with_options(script, true)
+pub(crate) fn transform_class_fields_client(script: &str, non_proxy_vars: &[String]) -> String {
+    transform_class_fields_client_with_options(script, true, non_proxy_vars)
 }
 
-pub(crate) fn transform_module_class_fields_client(script: &str) -> String {
-    transform_class_fields_client_with_options(script, false)
+pub(crate) fn transform_module_class_fields_client(
+    script: &str,
+    non_proxy_vars: &[String],
+) -> String {
+    transform_class_fields_client_with_options(script, false, non_proxy_vars)
 }
 
 /// Lower a class expression nested inside a rune argument or an `extends`
@@ -962,24 +967,37 @@ fn transform_nested_class_expression(
     value: &str,
     indent: &str,
     retain_all_public_jsdoc: bool,
+    non_proxy_vars: &[String],
 ) -> String {
     if memmem::find(value.as_bytes(), b"class").is_none() {
         return value.to_string();
     }
-    transform_class_fields_client_with_options_at(value, retain_all_public_jsdoc, Some(indent))
+    transform_class_fields_client_with_options_at(
+        value,
+        retain_all_public_jsdoc,
+        Some(indent),
+        non_proxy_vars,
+    )
 }
 
 fn transform_class_fields_client_with_options(
     script: &str,
     retain_all_public_jsdoc: bool,
+    non_proxy_vars: &[String],
 ) -> String {
-    transform_class_fields_client_with_options_at(script, retain_all_public_jsdoc, None)
+    transform_class_fields_client_with_options_at(
+        script,
+        retain_all_public_jsdoc,
+        None,
+        non_proxy_vars,
+    )
 }
 
 fn transform_class_fields_client_with_options_at(
     script: &str,
     retain_all_public_jsdoc: bool,
     indent_override: Option<&str>,
+    non_proxy_vars: &[String],
 ) -> String {
     // Check if script contains a class with $state or $derived fields
     if memmem::find(script.as_bytes(), b"class").is_none()
@@ -1028,6 +1046,7 @@ fn transform_class_fields_client_with_options_at(
                     &script[hs..header.body_brace],
                     &class_indent,
                     retain_all_public_jsdoc,
+                    non_proxy_vars,
                 )
             );
             &heritage_header
@@ -1403,7 +1422,11 @@ fn transform_class_fields_client_with_options_at(
             &script[..class_pos],
             class_header,
             &script[class_body_start..class_body_end + 1],
-            transform_class_fields_client_with_options(after_class_body, retain_all_public_jsdoc)
+            transform_class_fields_client_with_options(
+                after_class_body,
+                retain_all_public_jsdoc,
+                non_proxy_vars,
+            )
         );
     }
 
@@ -1415,6 +1438,7 @@ fn transform_class_fields_client_with_options_at(
             &field.value,
             &member_indent,
             retain_all_public_jsdoc,
+            non_proxy_vars,
         );
     }
 
@@ -1470,7 +1494,7 @@ fn transform_class_fields_client_with_options_at(
     let mut prev_shape: Option<MemberShape> = None;
     for field in &fields {
         if field.constructor_declared && !field.is_private {
-            let text = emit_class_field(field, &fields, &member_indent);
+            let text = emit_class_field(field, &fields, &member_indent, non_proxy_vars);
             let (first, last) = field_block_shapes(&text);
             append_member_block(&mut new_class_body, &mut prev_shape, &text, first, last);
         }
@@ -1481,7 +1505,7 @@ fn transform_class_fields_client_with_options_at(
         match member {
             ClassMember::RuneField(field_idx) => {
                 let field = &fields[*field_idx];
-                let text = emit_class_field(field, &fields, &member_indent);
+                let text = emit_class_field(field, &fields, &member_indent, non_proxy_vars);
                 let (first, last) = field_block_shapes(&text);
                 append_member_block(&mut new_class_body, &mut prev_shape, &text, first, last);
             }
@@ -1489,7 +1513,7 @@ fn transform_class_fields_client_with_options_at(
                 if text.trim().is_empty() {
                     continue;
                 }
-                let transformed = transform_class_methods(text, &fields);
+                let transformed = transform_class_methods(text, &fields, non_proxy_vars);
                 let (rejoined, first, last) = rejoin_class_members(&transformed);
                 if let (Some(first), Some(last)) = (first, last) {
                     append_member_block(
@@ -1509,7 +1533,7 @@ fn transform_class_fields_client_with_options_at(
                 for field in &fields {
                     if field.constructor_declared && field.is_private && !field.had_class_body_decl
                     {
-                        let text = emit_class_field(field, &fields, &member_indent);
+                        let text = emit_class_field(field, &fields, &member_indent, non_proxy_vars);
                         let (first, last) = field_block_shapes(&text);
                         append_member_block(
                             &mut new_class_body,
@@ -1571,6 +1595,7 @@ fn transform_class_fields_client_with_options_at(
                                 &fields,
                                 at_ctor_depth,
                                 &member_body_indent,
+                                non_proxy_vars,
                             );
                             let _ =
                                 writeln!(ctor_body, "{}{}", member_body_indent, transformed_line);
@@ -1586,6 +1611,7 @@ fn transform_class_fields_client_with_options_at(
                                 &fields,
                                 pending_at_ctor_depth,
                                 &member_body_indent,
+                                non_proxy_vars,
                             );
                             let _ =
                                 writeln!(ctor_body, "{}{}", member_body_indent, transformed_line);
@@ -1609,6 +1635,7 @@ fn transform_class_fields_client_with_options_at(
                         &fields,
                         pending_at_ctor_depth,
                         &member_body_indent,
+                        non_proxy_vars,
                     );
                     let _ = writeln!(ctor_body, "{}{}", member_body_indent, transformed_line);
                 }
@@ -1662,6 +1689,7 @@ fn transform_class_fields_client_with_options_at(
                                 &state_qualified,
                                 &other_qualified,
                                 &v_read_qualified,
+                                non_proxy_vars,
                             )
                     {
                         ctor_body = rewritten;
@@ -1683,8 +1711,11 @@ fn transform_class_fields_client_with_options_at(
     let after_class_body = &script[class_body_end + 1..]; // Skip closing brace
 
     // Recursively process remaining classes in the script
-    let after_class_transformed =
-        transform_class_fields_client_with_options(after_class_body, retain_all_public_jsdoc);
+    let after_class_transformed = transform_class_fields_client_with_options(
+        after_class_body,
+        retain_all_public_jsdoc,
+        non_proxy_vars,
+    );
 
     // Check if this is a `new class ...` expression that needs wrapping
     // `new class Foo { ... }` -> `new (class Foo { ... })()`
@@ -2005,7 +2036,11 @@ pub(super) fn find_private_field_prefixes(content: &str, field_name: &str) -> Ve
 /// For private state fields (those initialized with $state or $derived),
 /// we need to wrap accesses with $.get() and mutations with $.set().
 /// Handles any variable prefix (this, self, instance, etc.) not just `this`.
-pub(super) fn transform_class_methods(content: &str, fields: &[ClassStateField]) -> String {
+pub(super) fn transform_class_methods(
+    content: &str,
+    fields: &[ClassStateField],
+    non_proxy_vars: &[String],
+) -> String {
     if content.trim().is_empty() || fields.is_empty() {
         return content.to_string();
     }
@@ -2034,6 +2069,7 @@ pub(super) fn transform_class_methods(content: &str, fields: &[ClassStateField])
             &state_qualified,
             &other_qualified,
             &[],
+            non_proxy_vars,
         ) {
             result = rewritten;
         }
@@ -2064,7 +2100,8 @@ pub(super) fn transform_class_methods(content: &str, fields: &[ClassStateField])
                     let rest = &result[value_start..];
                     let value_end = rhs_value_end(rest);
                     let value = rest[..value_end].trim();
-                    let needs_proxy = field.rune_type == "$state" && expression_needs_proxy(value);
+                    let needs_proxy = field.rune_type == "$state"
+                        && expression_needs_proxy_with_scope(value, non_proxy_vars);
                     let replacement = if needs_proxy {
                         format!(
                             "$.set({}, $.get({}) {} {}, true)",
@@ -2097,7 +2134,8 @@ pub(super) fn transform_class_methods(content: &str, fields: &[ClassStateField])
                 let rest = &result[value_start..];
                 let value_end = rhs_value_end(rest);
                 let value = rest[..value_end].trim();
-                let needs_proxy = field.rune_type == "$state" && expression_needs_proxy(value);
+                let needs_proxy = field.rune_type == "$state"
+                    && expression_needs_proxy_with_scope(value, non_proxy_vars);
                 let replacement = if needs_proxy {
                     format!("$.set({}, {}, true)", qualified, value)
                 } else {
@@ -2454,6 +2492,7 @@ pub(super) fn transform_constructor_assignment(
     fields: &[ClassStateField],
     at_ctor_depth: bool,
     continuation_indent: &str,
+    non_proxy_vars: &[String],
 ) -> String {
     let mut result = line.trim().to_string();
 
@@ -2509,8 +2548,8 @@ pub(super) fn transform_constructor_assignment(
                     let private_name = format!("this.#{}", field.private_backing_name);
                     let transformed_rhs = match *rune_type {
                         "$state" => {
-                            let needs_proxy =
-                                !value.trim().is_empty() && expression_needs_proxy(value.trim());
+                            let needs_proxy = !value.trim().is_empty()
+                                && expression_needs_proxy_with_scope(value.trim(), non_proxy_vars);
                             if needs_proxy {
                                 format!("$.state($.proxy({}))", value)
                             } else {
@@ -2593,7 +2632,8 @@ pub(super) fn transform_constructor_assignment(
                         // setter only runs when it actually assigns — and its value
                         // is the bare RHS, which `should_proxy` traces as it does
                         // for `=`.
-                        let proxy = if field.rune_type == "$state" && expression_needs_proxy(value)
+                        let proxy = if field.rune_type == "$state"
+                            && expression_needs_proxy_with_scope(value, non_proxy_vars)
                         {
                             ", true"
                         } else {
@@ -2668,7 +2708,8 @@ pub(super) fn transform_constructor_assignment(
                     // Use private_backing_name for the output
                     // Add proxy flag (true) for $state fields when value could be an object
                     // This matches the official compiler's should_proxy() logic
-                    let needs_proxy = field.rune_type == "$state" && expression_needs_proxy(value);
+                    let needs_proxy = field.rune_type == "$state"
+                        && expression_needs_proxy_with_scope(value, non_proxy_vars);
                     if needs_proxy {
                         return format!(
                             "$.set(this.#{}, {}, true){}",
@@ -2695,7 +2736,7 @@ mod tests {
     #[test]
     fn constructor_wraps_a_member_chain_read_of_a_derived_field() {
         let src = "class A {\n\t#getProps = () => ({});\n\t#props = $derived(this.#getProps());\n\tconstructor() {\n\t\tconst b = this.#props.motion;\n\t}\n}";
-        let out = transform_class_fields_client(src);
+        let out = transform_class_fields_client(src, &[]);
         assert!(
             out.contains("$.get(this.#props).motion"),
             "member-chain read left unwrapped:\n{out}"
@@ -2722,7 +2763,7 @@ mod tests {
     #[test]
     fn class_runes_lower_after_line_comment_separators() {
         let src = "class Box {\n\tvalue = // state\n\t\t$state(1);\n\traw = // raw\n\t\t$state.raw(2);\n\tdoubled = // derived\n\t\t$derived(this.value * 2);\n\tlazy = // derived by\n\t\t$derived.by(() => this.value + 1);\n}";
-        let out = transform_class_fields_client(src);
+        let out = transform_class_fields_client(src, &[]);
 
         for expected in [
             "// state\n\t$.state(1)",
@@ -2742,7 +2783,7 @@ mod tests {
     #[test]
     fn constructor_runes_lower_when_initializer_starts_later() {
         let src = "class Box {\n\t#hidden;\n\tconstructor() {\n\t\tthis.value =\n\t\t\t$state(1);\n\t\tthis.#hidden = // keep\n\t\t\t$state(2);\n\t}\n}";
-        let out = transform_class_fields_client(src);
+        let out = transform_class_fields_client(src, &[]);
 
         assert!(
             out.contains("get value()"),
@@ -2773,7 +2814,7 @@ export class Counter {
         // Regression for C-007: a non-rune class (`Helper`) preceding a rune
         // class (`Counter`) must not suppress lowering of the rune class.
         let script = format!("class Helper {{\n\tvalue = 1;\n}}\n\n{COUNTER}");
-        let out = transform_class_fields_client(&script);
+        let out = transform_class_fields_client(&script, &[]);
 
         // The non-rune class is preserved verbatim.
         assert!(
@@ -2803,7 +2844,7 @@ export class Counter {
 
         // The `Counter` class must be lowered exactly as if it stood alone —
         // the preceding non-rune class must not change its output.
-        let standalone = transform_class_fields_client(COUNTER);
+        let standalone = transform_class_fields_client(COUNTER, &[]);
         assert!(
             out.ends_with(standalone.trim_end()) || out.contains(standalone.trim_end()),
             "Counter lowering should match the standalone case.\nwith Helper:\n{out}\nstandalone:\n{standalone}"
@@ -2813,7 +2854,7 @@ export class Counter {
     #[test]
     fn standalone_rune_class_still_lowers() {
         // Existing behavior: a single rune class lowers as before.
-        let out = transform_class_fields_client(COUNTER);
+        let out = transform_class_fields_client(COUNTER, &[]);
         assert!(out.contains("$.state(0)"), "expected lowering:\n{out}");
         assert!(
             !out.contains("count = $state(0)"),
@@ -2823,7 +2864,7 @@ export class Counter {
 
     #[test]
     fn public_rune_field_moves_a_leading_block_comment_to_its_value() {
-        let out = transform_class_fields_client("class C {\n\t/* c */\n\tn = $state(0);\n}");
+        let out = transform_class_fields_client("class C {\n\t/* c */\n\tn = $state(0);\n}", &[]);
         assert!(
             out.contains("#n = /* c */\n\t$.state(0);"),
             "leading block comment should be attached to the generated backing field value:\n{out}"
@@ -2832,7 +2873,7 @@ export class Counter {
 
     #[test]
     fn public_rune_field_moves_leading_line_comments_to_its_value() {
-        let out = transform_class_fields_client("class C {\n\t// c\n\tn = $state(0);\n}");
+        let out = transform_class_fields_client("class C {\n\t// c\n\tn = $state(0);\n}", &[]);
         assert!(
             out.contains("#n = // c\n\t$.state(0);"),
             "leading line comments should be attached to the generated backing field value:\n{out}"
@@ -2842,7 +2883,7 @@ export class Counter {
     #[test]
     fn script_without_runes_is_unchanged() {
         let script = "class Helper {\n\tvalue = 1;\n}\n";
-        assert_eq!(transform_class_fields_client(script), script);
+        assert_eq!(transform_class_fields_client(script, &[]), script);
     }
 
     #[test]
@@ -2851,7 +2892,7 @@ export class Counter {
             "\t", "  ", "\n", "\u{a0}", "\u{feff}", "\u{b}", "\u{c}", "\u{3000}",
         ] {
             let script = format!("class{separator}K {{\n\tv = $state(1);\n}}\n");
-            let out = transform_class_fields_client(&script);
+            let out = transform_class_fields_client(&script, &[]);
             for expected in ["#v = $.state(1)", "get v()", "set v(value)"] {
                 assert!(
                     out.contains(expected),
@@ -2870,7 +2911,11 @@ export class Counter {
             "// we avoid class here\nconst make = () => {\n\tconst v = $state(1);\n\treturn v;\n};\n",
             "const label = 'class name';\nconst make = () => {\n\tconst v = $state(1);\n\treturn v;\n};\n",
         ] {
-            assert_eq!(transform_class_fields_client(script), script, "{script:?}");
+            assert_eq!(
+                transform_class_fields_client(script, &[]),
+                script,
+                "{script:?}"
+            );
         }
     }
 
@@ -2892,7 +2937,7 @@ export class Counter {
   });
   constructor() {}
 }"#;
-        let out = transform_class_fields_client(script);
+        let out = transform_class_fields_client(script, &[]);
         assert!(
             out.contains("#creating"),
             "creating should be transformed to private backing field:\n{out}"
@@ -2912,7 +2957,7 @@ export class Counter {
         // Issue #2087: everything after the first rune field on a physical line
         // used to be discarded, so `#d` and its accessors never reached the output.
         let script = "export class Foo { n = $state(1); d = $derived(this.n * 2); }";
-        let out = transform_class_fields_client(script);
+        let out = transform_class_fields_client(script, &[]);
         for expected in [
             "#n = $.state(1)",
             "get n()",
@@ -2928,7 +2973,7 @@ export class Counter {
     #[test]
     fn single_line_nested_class_lowers_every_rune_field() {
         let script = "class Outer { a = $state(1); b = $derived(this.a); }\nclass Inner { c = $state(2); d = $derived(this.c); }";
-        let out = transform_class_fields_client(script);
+        let out = transform_class_fields_client(script, &[]);
         for expected in ["#b = $.derived(", "#d = $.derived(", "get b()", "get d()"] {
             assert!(out.contains(expected), "missing {expected}:\n{out}");
         }
@@ -2940,7 +2985,7 @@ export class Counter {
         // scan reads `inner = class Inner { c = $state(2)` as a single field and
         // lowers `inner` to the INNER field's value.
         let script = "class Outer { a = $state(1); inner = class Inner { c = $state(2); e = $derived(this.c * 3); }; }";
-        let out = transform_class_fields_client(script);
+        let out = transform_class_fields_client(script, &[]);
         assert!(out.contains("#a = $.state(1)"), "missing #a:\n{out}");
         assert!(
             !out.contains("#inner = $.state("),
@@ -2953,7 +2998,7 @@ export class Counter {
     #[test]
     fn same_line_members_survive_alongside_methods() {
         let script = "class Foo { n = $state(1); get twice() { return this.n * 2 } d = $derived(this.n + 1); }";
-        let out = transform_class_fields_client(script);
+        let out = transform_class_fields_client(script, &[]);
         assert!(out.contains("#n = $.state(1)"), "missing #n:\n{out}");
         assert!(out.contains("get twice()"), "method dropped:\n{out}");
         assert!(out.contains("#d = $.derived("), "missing #d:\n{out}");

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -300,7 +300,10 @@ pub fn transform_client_module(
     let source = paren_stripped.as_deref().unwrap_or(source);
 
     // Transform the module source (rune replacements, class fields, etc.)
-    let class_transformed = transform_module_class_fields_client(source);
+    let class_transformed = transform_module_class_fields_client(
+        source,
+        &compute_non_proxy_scope(analysis).non_proxy_vars,
+    );
 
     // Transform destructured assignments whose LHS contains state variables into
     // IIFE / sequence form (mirrors upstream `visit_assignment_expression` in
@@ -468,7 +471,10 @@ pub(crate) fn transform_module_source_for_module(
     server: bool,
     preserve_inspect: bool,
 ) -> String {
-    let class_transformed = transform_module_class_fields_client(source);
+    let class_transformed = transform_module_class_fields_client(
+        source,
+        &compute_non_proxy_scope(analysis).non_proxy_vars,
+    );
     transform_module_script_runes_with_target(
         &class_transformed,
         source,
@@ -2322,7 +2328,10 @@ pub(crate) fn transform_client(
     // Transform class fields first (before rune transforms strip the rune names)
     // Then transform remaining rune calls ($state, $derived, etc.) in module-level script
     if let Some((non_imports, retained_comment_stripped)) = module_script_non_imports {
-        let class_transformed = transform_module_class_fields_client(&non_imports);
+        let class_transformed = transform_module_class_fields_client(
+            &non_imports,
+            &compute_non_proxy_scope(analysis).non_proxy_vars,
+        );
         let has_effect_rune =
             class_transformed.contains("$effect") || class_transformed.contains("$inspect");
         let transformed = transform_module_script_runes(
@@ -6866,6 +6875,233 @@ fn split_trailing_comment_run(result: &mut String) -> Option<String> {
     Some(result.split_off(cut))
 }
 
+/// The non-proxy binding set upstream's `should_proxy` resolves an Identifier
+/// through. Extracted so the class-field lowering, which runs before the
+/// statement walk, reads the same list the walk does.
+struct NonProxyScope {
+    instance_scope_for_proxy: usize,
+    reactive_mut_binding_names: rustc_hash::FxHashSet<String>,
+    non_proxy_vars: Vec<String>,
+}
+
+fn compute_non_proxy_scope(analysis: &ComponentAnalysis) -> NonProxyScope {
+    // Pre-compute non-proxyable variables once (invariant across all statements).
+    // This mirrors the official Svelte compiler's should_proxy() which resolves
+    // identifiers to their binding's initial values.
+    let instance_scope_for_proxy = analysis.root.instance_scope_index;
+    // First, collect names of bindings (state/derived/stores) that can be
+    // reassigned via $.set(). If a non-proxy inner-scope binding shadows one of
+    // these, treating it as non-proxy could wrongly strip the proxy flag from
+    // an assignment to the reactive one (since the text-based transform can't
+    // distinguish scopes). Note: Props with the same name as inner locals are
+    // not a concern because Svelte disallows that naming collision.
+    let reactive_mut_binding_names: rustc_hash::FxHashSet<String> = analysis
+        .root
+        .bindings
+        .iter()
+        .filter(|b| {
+            matches!(
+                b.kind,
+                BindingKind::State
+                    | BindingKind::RawState
+                    | BindingKind::Derived
+                    | BindingKind::StoreSub
+            )
+        })
+        .map(|b| b.name.clone())
+        .collect();
+
+    // For inner-scope bindings, we additionally require that no OTHER binding
+    // with the same name exists. This prevents conflicts with function parameters
+    // or other scoped bindings that the text-based transform cannot distinguish.
+    let name_occurrences: rustc_hash::FxHashMap<String, usize> = {
+        let mut map: rustc_hash::FxHashMap<String, usize> = rustc_hash::FxHashMap::default();
+        for b in &analysis.root.bindings {
+            *map.entry(b.name.clone()).or_insert(0) += 1;
+        }
+        map
+    };
+
+    // Names where EVERY binding of that name (across all inner scopes) has a
+    // known non-proxyable initial type. This enables safe non-proxy treatment
+    // even when the same local name is declared in multiple sibling scopes.
+    // (`is_non_proxy_node_type` is now a module-level free fn so the module
+    // transform path can share it.)
+    let names_all_non_proxy: rustc_hash::FxHashSet<String> = {
+        use rustc_hash::FxHashMap;
+        let mut per_name: FxHashMap<String, (bool, usize)> = FxHashMap::default();
+        for b in &analysis.root.bindings {
+            // Only consider inner (non-top-level) non-reactive function-local bindings.
+            let is_top_level = b.scope_index == 0 || b.scope_index == instance_scope_for_proxy;
+            if is_top_level || b.reassigned {
+                per_name.insert(b.name.clone(), (false, 0));
+                continue;
+            }
+            if matches!(
+                b.kind,
+                BindingKind::State
+                    | BindingKind::RawState
+                    | BindingKind::Derived
+                    | BindingKind::Prop
+                    | BindingKind::BindableProp
+                    | BindingKind::StoreSub
+                    | BindingKind::Template
+            ) {
+                per_name.insert(b.name.clone(), (false, 0));
+                continue;
+            }
+            if reactive_mut_binding_names.contains(&b.name) {
+                per_name.insert(b.name.clone(), (false, 0));
+                continue;
+            }
+            let ok = b
+                .initial_node_type
+                .as_deref()
+                .map(is_non_proxy_node_type)
+                .unwrap_or(false);
+            let entry = per_name.entry(b.name.clone()).or_insert((true, 0));
+            if !ok {
+                entry.0 = false;
+            }
+            entry.1 += 1;
+        }
+        per_name
+            .into_iter()
+            .filter_map(|(n, (ok, cnt))| if ok && cnt > 0 { Some(n) } else { None })
+            .collect()
+    };
+
+    let non_proxy_vars: Vec<String> = analysis
+        .root
+        .bindings
+        .iter()
+        .filter(|b| {
+            if b.reassigned {
+                return false;
+            }
+            // Never mark a variable as non-proxy if another binding with the same
+            // name is reactive (state/derived/store) — the text-based transform
+            // can't distinguish between them.
+            if reactive_mut_binding_names.contains(&b.name) {
+                return false;
+            }
+            let is_top_level = b.scope_index == 0 || b.scope_index == instance_scope_for_proxy;
+            // Regular non-reactive bindings with initial literal/primitive value.
+            //
+            // Mirror upstream `should_proxy(Identifier)`: it resolves the
+            // binding's `initial` and recurses — `should_proxy(binding.initial)`.
+            // That returns `false` (→ NON-proxy) ONLY when the initial is one of
+            // the false-list types (literal / template literal / arrow / function
+            // expression / unary / binary, or the `undefined` identifier). For any
+            // other initial — CallExpression (e.g. a `$props()` call), object /
+            // array literal, member access, `new`, etc. — `should_proxy` falls
+            // through to `return true`, so the binding stays proxy-eligible.
+            // (Marking a CallExpression-initialised binding as non-proxy wrongly
+            // dropped the proxy on `let x = $state(propWithDefault)`.)
+            // Gate on `initial_node_type` (the init NODE's presence) rather than
+            // `b.initial` (a literal-string field that stays None for
+            // BinaryExpression / ArrowFunctionExpression / UnaryExpression
+            // initials). Upstream `should_proxy` resolves the binding's initial
+            // *node* and recurses, returning false (→ non-proxy) for the
+            // non-proxy node types regardless of whether the initial is a
+            // literal. `let root = depth === 0` (BinaryExpression) and
+            // `let f = () => {}` (ArrowFunctionExpression) must therefore be
+            // treated as non-proxy even though their literal-string `initial`
+            // is None.
+            if is_top_level
+                && !matches!(
+                    b.kind,
+                    BindingKind::State
+                        | BindingKind::RawState
+                        | BindingKind::Derived
+                        | BindingKind::Prop
+                        | BindingKind::BindableProp
+                        | BindingKind::StoreSub
+                )
+                && b.import_source.is_none()
+                && (b
+                    .initial_node_type
+                    .as_deref()
+                    .map(is_non_proxy_node_type)
+                    .unwrap_or(false)
+                    || (b.initial_node_type.as_deref() == Some("Identifier")
+                        && b.initial_identifier_name.as_deref() == Some("undefined")))
+            {
+                return true;
+            }
+            // Inner-scope non-reactive function-local bindings: include when the
+            // name is unique across all bindings (so the text-based transform can
+            // safely treat references to this name as non-proxy). Example:
+            //   function onTouchStart() {
+            //     const isHoverScrollbar = foo() !== undefined;
+            //     stateVar = isHoverScrollbar; // -> $.set(stateVar, isHoverScrollbar)
+            //   }
+            if !is_top_level
+                && !matches!(
+                    b.kind,
+                    BindingKind::State
+                        | BindingKind::RawState
+                        | BindingKind::Derived
+                        | BindingKind::Prop
+                        | BindingKind::BindableProp
+                        | BindingKind::StoreSub
+                        | BindingKind::Template // @const, each items, etc. handled below
+                )
+                && (name_occurrences.get(&b.name).copied().unwrap_or(0) == 1
+                    || names_all_non_proxy.contains(&b.name))
+                && let Some(ref node_type) = b.initial_node_type
+            {
+                match node_type.as_str() {
+                    "Literal"
+                    | "TemplateLiteral"
+                    | "ArrowFunctionExpression"
+                    | "FunctionExpression"
+                    | "UnaryExpression"
+                    | "BinaryExpression" => return true,
+                    _ => {}
+                }
+            }
+
+            // NOTE: props are intentionally NOT classified non-proxy here. Upstream
+            // `should_proxy` resolves an Identifier to `binding.initial`, and for a
+            // destructured prop (`let { x = 0 } = $props()`) that initial is the
+            // `$props()` CallExpression — never the default value. A CallExpression
+            // recurses to `return true`, so a prop reference is always proxy-eligible
+            // regardless of its default's type. (Classifying props by their default
+            // type wrongly dropped the proxy on `let count = $state(propWithDefault)`.)
+
+            // Template bindings (@const declarations, let directive bindings) whose
+            // initial value is a known non-proxyable primitive expression. Matches the
+            // official compiler's should_proxy() tracing through template bindings.
+            // Only include when the name is unique (or all same-named bindings are
+            // also known non-proxyable) — otherwise the text-based transform can't
+            // distinguish a template @const from a same-named function parameter.
+            if matches!(b.kind, BindingKind::Template)
+                && let Some(ref node_type) = b.initial_node_type
+                && (name_occurrences.get(&b.name).copied().unwrap_or(0) == 1
+                    || names_all_non_proxy.contains(&b.name))
+            {
+                match node_type.as_str() {
+                    "Literal"
+                    | "TemplateLiteral"
+                    | "ArrowFunctionExpression"
+                    | "FunctionExpression"
+                    | "UnaryExpression"
+                    | "BinaryExpression" => return true,
+                    _ => {}
+                }
+            }
+            false
+        })
+        .map(|b| b.name.clone())
+        .collect();
+    NonProxyScope {
+        instance_scope_for_proxy,
+        reactive_mut_binding_names,
+        non_proxy_vars,
+    }
+}
+
 fn transform_instance_script_for_visitors(
     script: &str,
     analysis: &ComponentAnalysis,
@@ -7001,13 +7237,17 @@ fn transform_instance_script_for_visitors(
         String::new()
     };
 
+    // Upstream's `should_proxy` resolves an Identifier through its binding, so the
+    // class-field lowering needs this set even though it runs before the walk.
+    let non_proxy_scope = compute_non_proxy_scope(analysis);
+
     // Transform class fields only if the script contains class definitions with runes
     let script: std::borrow::Cow<str> = if contains_identifier(&script, "class")
         && (memmem::find(script.as_bytes(), b"$state").is_some()
             || memmem::find(script.as_bytes(), b"$derived").is_some())
     {
         super::profile::record_pn(super::profile::PN_INV_CLASS);
-        let out = transform_class_fields_client(&script);
+        let out = transform_class_fields_client(&script, &non_proxy_scope.non_proxy_vars);
         #[cfg(feature = "measure-pa-split")]
         if out != *script {
             super::profile::record_pn(super::profile::PN_CHG_CLASS);
@@ -7613,217 +7853,11 @@ fn transform_instance_script_for_visitors(
     };
 
     let mut result = String::new();
-
-    // Pre-compute non-proxyable variables once (invariant across all statements).
-    // This mirrors the official Svelte compiler's should_proxy() which resolves
-    // identifiers to their binding's initial values.
-    let instance_scope_for_proxy = analysis.root.instance_scope_index;
-    // First, collect names of bindings (state/derived/stores) that can be
-    // reassigned via $.set(). If a non-proxy inner-scope binding shadows one of
-    // these, treating it as non-proxy could wrongly strip the proxy flag from
-    // an assignment to the reactive one (since the text-based transform can't
-    // distinguish scopes). Note: Props with the same name as inner locals are
-    // not a concern because Svelte disallows that naming collision.
-    let reactive_mut_binding_names: rustc_hash::FxHashSet<String> = analysis
-        .root
-        .bindings
-        .iter()
-        .filter(|b| {
-            matches!(
-                b.kind,
-                BindingKind::State
-                    | BindingKind::RawState
-                    | BindingKind::Derived
-                    | BindingKind::StoreSub
-            )
-        })
-        .map(|b| b.name.clone())
-        .collect();
-
-    // For inner-scope bindings, we additionally require that no OTHER binding
-    // with the same name exists. This prevents conflicts with function parameters
-    // or other scoped bindings that the text-based transform cannot distinguish.
-    let name_occurrences: rustc_hash::FxHashMap<String, usize> = {
-        let mut map: rustc_hash::FxHashMap<String, usize> = rustc_hash::FxHashMap::default();
-        for b in &analysis.root.bindings {
-            *map.entry(b.name.clone()).or_insert(0) += 1;
-        }
-        map
-    };
-
-    // Names where EVERY binding of that name (across all inner scopes) has a
-    // known non-proxyable initial type. This enables safe non-proxy treatment
-    // even when the same local name is declared in multiple sibling scopes.
-    // (`is_non_proxy_node_type` is now a module-level free fn so the module
-    // transform path can share it.)
-    let names_all_non_proxy: rustc_hash::FxHashSet<String> = {
-        use rustc_hash::FxHashMap;
-        let mut per_name: FxHashMap<String, (bool, usize)> = FxHashMap::default();
-        for b in &analysis.root.bindings {
-            // Only consider inner (non-top-level) non-reactive function-local bindings.
-            let is_top_level = b.scope_index == 0 || b.scope_index == instance_scope_for_proxy;
-            if is_top_level || b.reassigned {
-                per_name.insert(b.name.clone(), (false, 0));
-                continue;
-            }
-            if matches!(
-                b.kind,
-                BindingKind::State
-                    | BindingKind::RawState
-                    | BindingKind::Derived
-                    | BindingKind::Prop
-                    | BindingKind::BindableProp
-                    | BindingKind::StoreSub
-                    | BindingKind::Template
-            ) {
-                per_name.insert(b.name.clone(), (false, 0));
-                continue;
-            }
-            if reactive_mut_binding_names.contains(&b.name) {
-                per_name.insert(b.name.clone(), (false, 0));
-                continue;
-            }
-            let ok = b
-                .initial_node_type
-                .as_deref()
-                .map(is_non_proxy_node_type)
-                .unwrap_or(false);
-            let entry = per_name.entry(b.name.clone()).or_insert((true, 0));
-            if !ok {
-                entry.0 = false;
-            }
-            entry.1 += 1;
-        }
-        per_name
-            .into_iter()
-            .filter_map(|(n, (ok, cnt))| if ok && cnt > 0 { Some(n) } else { None })
-            .collect()
-    };
-
-    let non_proxy_vars: Vec<String> = analysis
-        .root
-        .bindings
-        .iter()
-        .filter(|b| {
-            if b.reassigned {
-                return false;
-            }
-            // Never mark a variable as non-proxy if another binding with the same
-            // name is reactive (state/derived/store) — the text-based transform
-            // can't distinguish between them.
-            if reactive_mut_binding_names.contains(&b.name) {
-                return false;
-            }
-            let is_top_level = b.scope_index == 0 || b.scope_index == instance_scope_for_proxy;
-            // Regular non-reactive bindings with initial literal/primitive value.
-            //
-            // Mirror upstream `should_proxy(Identifier)`: it resolves the
-            // binding's `initial` and recurses — `should_proxy(binding.initial)`.
-            // That returns `false` (→ NON-proxy) ONLY when the initial is one of
-            // the false-list types (literal / template literal / arrow / function
-            // expression / unary / binary, or the `undefined` identifier). For any
-            // other initial — CallExpression (e.g. a `$props()` call), object /
-            // array literal, member access, `new`, etc. — `should_proxy` falls
-            // through to `return true`, so the binding stays proxy-eligible.
-            // (Marking a CallExpression-initialised binding as non-proxy wrongly
-            // dropped the proxy on `let x = $state(propWithDefault)`.)
-            // Gate on `initial_node_type` (the init NODE's presence) rather than
-            // `b.initial` (a literal-string field that stays None for
-            // BinaryExpression / ArrowFunctionExpression / UnaryExpression
-            // initials). Upstream `should_proxy` resolves the binding's initial
-            // *node* and recurses, returning false (→ non-proxy) for the
-            // non-proxy node types regardless of whether the initial is a
-            // literal. `let root = depth === 0` (BinaryExpression) and
-            // `let f = () => {}` (ArrowFunctionExpression) must therefore be
-            // treated as non-proxy even though their literal-string `initial`
-            // is None.
-            if is_top_level
-                && !matches!(
-                    b.kind,
-                    BindingKind::State
-                        | BindingKind::RawState
-                        | BindingKind::Derived
-                        | BindingKind::Prop
-                        | BindingKind::BindableProp
-                        | BindingKind::StoreSub
-                )
-                && b.import_source.is_none()
-                && (b
-                    .initial_node_type
-                    .as_deref()
-                    .map(is_non_proxy_node_type)
-                    .unwrap_or(false)
-                    || (b.initial_node_type.as_deref() == Some("Identifier")
-                        && b.initial_identifier_name.as_deref() == Some("undefined")))
-            {
-                return true;
-            }
-            // Inner-scope non-reactive function-local bindings: include when the
-            // name is unique across all bindings (so the text-based transform can
-            // safely treat references to this name as non-proxy). Example:
-            //   function onTouchStart() {
-            //     const isHoverScrollbar = foo() !== undefined;
-            //     stateVar = isHoverScrollbar; // -> $.set(stateVar, isHoverScrollbar)
-            //   }
-            if !is_top_level
-                && !matches!(
-                    b.kind,
-                    BindingKind::State
-                        | BindingKind::RawState
-                        | BindingKind::Derived
-                        | BindingKind::Prop
-                        | BindingKind::BindableProp
-                        | BindingKind::StoreSub
-                        | BindingKind::Template // @const, each items, etc. handled below
-                )
-                && (name_occurrences.get(&b.name).copied().unwrap_or(0) == 1
-                    || names_all_non_proxy.contains(&b.name))
-                && let Some(ref node_type) = b.initial_node_type
-            {
-                match node_type.as_str() {
-                    "Literal"
-                    | "TemplateLiteral"
-                    | "ArrowFunctionExpression"
-                    | "FunctionExpression"
-                    | "UnaryExpression"
-                    | "BinaryExpression" => return true,
-                    _ => {}
-                }
-            }
-
-            // NOTE: props are intentionally NOT classified non-proxy here. Upstream
-            // `should_proxy` resolves an Identifier to `binding.initial`, and for a
-            // destructured prop (`let { x = 0 } = $props()`) that initial is the
-            // `$props()` CallExpression — never the default value. A CallExpression
-            // recurses to `return true`, so a prop reference is always proxy-eligible
-            // regardless of its default's type. (Classifying props by their default
-            // type wrongly dropped the proxy on `let count = $state(propWithDefault)`.)
-
-            // Template bindings (@const declarations, let directive bindings) whose
-            // initial value is a known non-proxyable primitive expression. Matches the
-            // official compiler's should_proxy() tracing through template bindings.
-            // Only include when the name is unique (or all same-named bindings are
-            // also known non-proxyable) — otherwise the text-based transform can't
-            // distinguish a template @const from a same-named function parameter.
-            if matches!(b.kind, BindingKind::Template)
-                && let Some(ref node_type) = b.initial_node_type
-                && (name_occurrences.get(&b.name).copied().unwrap_or(0) == 1
-                    || names_all_non_proxy.contains(&b.name))
-            {
-                match node_type.as_str() {
-                    "Literal"
-                    | "TemplateLiteral"
-                    | "ArrowFunctionExpression"
-                    | "FunctionExpression"
-                    | "UnaryExpression"
-                    | "BinaryExpression" => return true,
-                    _ => {}
-                }
-            }
-            false
-        })
-        .map(|b| b.name.clone())
-        .collect();
+    let NonProxyScope {
+        instance_scope_for_proxy,
+        reactive_mut_binding_names,
+        non_proxy_vars,
+    } = non_proxy_scope;
 
     // Reassignment-only non-proxy list = `non_proxy_vars` PLUS props whose default
     // value is a non-proxy primitive. Upstream's `AssignmentExpression` proxy

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_class_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_class_assign_ast.rs
@@ -161,6 +161,17 @@ struct BindingInfoCollector {
     reassigned: HashSet<String>,
 }
 
+impl BindingInfoCollector {
+    /// The class body is a fragment, so a binding declared outside it is
+    /// invisible to the walk above — upstream resolves it through the enclosing
+    /// scope. A local declaration of the same name is nearer and wins.
+    fn seed_outer_non_proxy(&mut self, names: &[String]) {
+        for name in names {
+            self.var_proxy.entry(name.clone()).or_insert(false);
+        }
+    }
+}
+
 impl<'ast> Visit<'ast> for BindingInfoCollector {
     fn visit_variable_declarator(&mut self, decl: &VariableDeclarator<'ast>) {
         walk::walk_variable_declarator(self, decl);
@@ -284,6 +295,7 @@ pub fn transform_private_class_assign_ast(
     state_qualified: &[String],
     other_qualified: &[String],
     v_read_qualified: &[String],
+    outer_non_proxy: &[String],
 ) -> Option<String> {
     let spliced = || {
         transform_private_class_assign_spliced(
@@ -291,6 +303,7 @@ pub fn transform_private_class_assign_ast(
             state_qualified,
             other_qualified,
             v_read_qualified,
+            outer_non_proxy,
         )
     };
     ast_rewrite::dual_run::resolve("private_class_assign_ast:inplace", source, spliced, || {
@@ -299,6 +312,7 @@ pub fn transform_private_class_assign_ast(
             state_qualified,
             other_qualified,
             v_read_qualified,
+            outer_non_proxy,
         )
     })
 }
@@ -308,13 +322,20 @@ fn transform_private_class_assign_spliced(
     state_qualified: &[String],
     other_qualified: &[String],
     v_read_qualified: &[String],
+    outer_non_proxy: &[String],
 ) -> Option<String> {
     if !target_present(source, state_qualified, other_qualified) {
         return None;
     }
 
     ast_rewrite::fixed_point(source, |src| {
-        single_pass(src, state_qualified, other_qualified, v_read_qualified)
+        single_pass(
+            src,
+            state_qualified,
+            other_qualified,
+            v_read_qualified,
+            outer_non_proxy,
+        )
     })
 }
 
@@ -323,6 +344,7 @@ fn single_pass(
     state_qualified: &[String],
     other_qualified: &[String],
     v_read_qualified: &[String],
+    outer_non_proxy: &[String],
 ) -> Option<String> {
     MODULE_PRIVATE_CLASS_ASSIGN_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
@@ -394,6 +416,7 @@ fn single_pass(
 
         let mut binding_info = BindingInfoCollector::default();
         binding_info.visit_program(program_ref);
+        binding_info.seed_outer_non_proxy(outer_non_proxy);
 
         let mut collector = PrivateClassAssignCollector {
             source: parse_str,
@@ -622,7 +645,7 @@ mod tests {
         state_qualified: &[String],
         other_qualified: &[String],
     ) -> Option<String> {
-        transform_private_class_assign_ast(source, state_qualified, other_qualified, &[])
+        transform_private_class_assign_ast(source, state_qualified, other_qualified, &[], &[])
     }
 
     /// A constructor body whose names are all `$state` / `$state.raw`, so every
@@ -637,13 +660,13 @@ mod tests {
             .chain(other_qualified.iter())
             .cloned()
             .collect();
-        transform_private_class_assign_ast(source, state_qualified, other_qualified, &v_read)
+        transform_private_class_assign_ast(source, state_qualified, other_qualified, &v_read, &[])
     }
 
     /// A constructor body holding a `$derived` field: upstream still reads it
     /// through `$.get`, so it is absent from `v_read_qualified`.
     fn ctor_body_derived(source: &str, derived_qualified: &[String]) -> Option<String> {
-        transform_private_class_assign_ast(source, &[], derived_qualified, &[])
+        transform_private_class_assign_ast(source, &[], derived_qualified, &[], &[])
     }
 
     #[test]
@@ -971,6 +994,7 @@ pub(crate) fn transform_private_class_assign_in_place(
     state_qualified: &[String],
     other_qualified: &[String],
     v_read_qualified: &[String],
+    outer_non_proxy: &[String],
 ) -> ast_rewrite::Rewrite {
     if !target_present(source, state_qualified, other_qualified) {
         return ast_rewrite::Rewrite::Unchanged;
@@ -986,6 +1010,7 @@ pub(crate) fn transform_private_class_assign_in_place(
         |allocator, program, parse_str| {
             let mut binding_info = BindingInfoCollector::default();
             binding_info.visit_program(program);
+            binding_info.seed_outer_non_proxy(outer_non_proxy);
 
             let mut rewriter = PrivateClassAssignRewriter {
                 b: crate::compiler::phases::phase3_transform::builders::B::new(allocator),
@@ -1163,7 +1188,7 @@ mod in_place_tests {
         state_qualified: &[String],
         other_qualified: &[String],
     ) -> Option<String> {
-        transform_private_class_assign_ast(source, state_qualified, other_qualified, &[])
+        transform_private_class_assign_ast(source, state_qualified, other_qualified, &[], &[])
     }
 
     fn method_body_in_place(
@@ -1171,7 +1196,7 @@ mod in_place_tests {
         state_qualified: &[String],
         other_qualified: &[String],
     ) -> Option<String> {
-        transform_private_class_assign_in_place(source, state_qualified, other_qualified, &[])
+        transform_private_class_assign_in_place(source, state_qualified, other_qualified, &[], &[])
             .into_option()
     }
 
@@ -1185,8 +1210,14 @@ mod in_place_tests {
             .chain(other_qualified.iter())
             .cloned()
             .collect();
-        transform_private_class_assign_in_place(source, state_qualified, other_qualified, &v_read)
-            .into_option()
+        transform_private_class_assign_in_place(
+            source,
+            state_qualified,
+            other_qualified,
+            &v_read,
+            &[],
+        )
+        .into_option()
     }
 
     #[test]
@@ -1321,8 +1352,9 @@ mod shared_decision_tests {
     #[test]
     fn spliced_path_lowers_every_decision() {
         for (source, state, other, expected) in DECISIONS {
-            let out = transform_private_class_assign_spliced(source, &ssv(state), &ssv(other), &[])
-                .unwrap_or_else(|| panic!("spliced path did not rewrite `{source}`"));
+            let out =
+                transform_private_class_assign_spliced(source, &ssv(state), &ssv(other), &[], &[])
+                    .unwrap_or_else(|| panic!("spliced path did not rewrite `{source}`"));
             assert_eq!(&out, expected, "spliced path, source `{source}`");
         }
     }
@@ -1332,7 +1364,7 @@ mod shared_decision_tests {
     fn in_place_path_lowers_every_decision() {
         for (source, state, other, expected) in DECISIONS {
             let out =
-                transform_private_class_assign_in_place(source, &ssv(state), &ssv(other), &[])
+                transform_private_class_assign_in_place(source, &ssv(state), &ssv(other), &[], &[])
                     .into_option()
                     .unwrap_or_else(|| panic!("in-place path did not rewrite `{source}`"));
             assert_eq!(&out, expected, "in-place path, source `{source}`");

--- a/crates/rsvelte_core/tests/class_field_state_proxy_4168.rs
+++ b/crates/rsvelte_core/tests/class_field_state_proxy_4168.rs
@@ -1,0 +1,199 @@
+//! A class field's `$state` initializer must resolve an identifier through its
+//! binding, not sniff the text.
+//!
+//! Upstream `should_proxy(node, scope)` recurses into `binding.initial` for an
+//! `Identifier`, so `const D = 5; #a = $state(D)` emits `$.state(D)`. rsvelte's
+//! class-field lowering calls the scope-less `expression_needs_proxy`, which
+//! sees an identifier, cannot resolve it, and wraps every one in `$.proxy`.
+//!
+//! `class_transforms.rs` has six `expression_needs_proxy` call sites across
+//! three functions, and a fix that reaches the reported one reads exactly like
+//! a fix that reaches all six — so the grid below carries one cell per site.
+//! `ident-nonproxy` / `ident-proxy` are the discriminating pair (identical as
+//! text, opposite under binding resolution); the two literal rows are controls
+//! that a scope-less sniff already gets right, and `method-compound` is the
+//! control that cannot move at all, because a compound assignment's value is a
+//! BinaryExpression upstream and never proxies.
+//!
+//! Every expectation is the byte-exact output of the official compiler
+//! (`submodules/svelte`, v5.56.10).
+
+use rsvelte_core::{GenerateMode, ModuleCompileOptions, compile_module};
+
+fn emit(source: &str) -> String {
+    compile_module(
+        source,
+        ModuleCompileOptions {
+            filename: Some("p.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn state_lines(code: &str) -> Vec<String> {
+    code.lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| l.contains("$.state(") || l.contains("$.set("))
+        .collect()
+}
+
+type Cell = (&'static str, &'static str, &'static [&'static str]);
+
+const CELLS: &[Cell] = &[
+    (
+        "field-init/ident-nonproxy",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(D);\n\tget a() { return this.#a; }\n}\n",
+        &["#a = $.state(D);"],
+    ),
+    (
+        "field-init/ident-proxy",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(OBJ);\n\tget a() { return this.#a; }\n}\n",
+        &["#a = $.state($.proxy(OBJ));"],
+    ),
+    (
+        "field-init/literal",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(1);\n\tget a() { return this.#a; }\n}\n",
+        &["#a = $.state(1);"],
+    ),
+    (
+        "field-init/object",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state({ z: 1 });\n\tget a() { return this.#a; }\n}\n",
+        &["#a = $.state($.proxy({ z: 1 }));"],
+    ),
+    (
+        "method-compound/ident-nonproxy",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tm() { this.#a += D; }\n}\n",
+        &["#a = $.state(0);", "$.set(this.#a, $.get(this.#a) + D);"],
+    ),
+    (
+        "method-compound/ident-proxy",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tm() { this.#a += OBJ; }\n}\n",
+        &["#a = $.state(0);", "$.set(this.#a, $.get(this.#a) + OBJ);"],
+    ),
+    (
+        "method-compound/literal",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tm() { this.#a += 1; }\n}\n",
+        &["#a = $.state(0);", "$.set(this.#a, $.get(this.#a) + 1);"],
+    ),
+    (
+        "method-compound/object",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tm() { this.#a += { z: 1 }; }\n}\n",
+        &[
+            "#a = $.state(0);",
+            "$.set(this.#a, $.get(this.#a) + { z: 1 });",
+        ],
+    ),
+    (
+        "method-assign/ident-nonproxy",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tm() { this.#a = D; }\n}\n",
+        &["#a = $.state(0);", "$.set(this.#a, D);"],
+    ),
+    (
+        "method-assign/ident-proxy",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tm() { this.#a = OBJ; }\n}\n",
+        &["#a = $.state(0);", "$.set(this.#a, OBJ, true);"],
+    ),
+    (
+        "method-assign/literal",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tm() { this.#a = 1; }\n}\n",
+        &["#a = $.state(0);", "$.set(this.#a, 1);"],
+    ),
+    (
+        "method-assign/object",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tm() { this.#a = { z: 1 }; }\n}\n",
+        &["#a = $.state(0);", "$.set(this.#a, { z: 1 }, true);"],
+    ),
+    (
+        "ctor-rune/ident-nonproxy",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\tconstructor() { this.a = $state(D); }\n}\n",
+        &["$.set(this.#a, value, true);", "this.#a = $.state(D);"],
+    ),
+    (
+        "ctor-rune/ident-proxy",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\tconstructor() { this.a = $state(OBJ); }\n}\n",
+        &[
+            "$.set(this.#a, value, true);",
+            "this.#a = $.state($.proxy(OBJ));",
+        ],
+    ),
+    (
+        "ctor-rune/literal",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\tconstructor() { this.a = $state(1); }\n}\n",
+        &["$.set(this.#a, value, true);", "this.#a = $.state(1);"],
+    ),
+    (
+        "ctor-rune/object",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\tconstructor() { this.a = $state({ z: 1 }); }\n}\n",
+        &[
+            "$.set(this.#a, value, true);",
+            "this.#a = $.state($.proxy({ z: 1 }));",
+        ],
+    ),
+    (
+        "ctor-logical/ident-nonproxy",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tconstructor() { this.#a ||= D; }\n}\n",
+        &["#a = $.state(0);", "this.#a.v || $.set(this.#a, D);"],
+    ),
+    (
+        "ctor-logical/ident-proxy",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tconstructor() { this.#a ||= OBJ; }\n}\n",
+        &[
+            "#a = $.state(0);",
+            "this.#a.v || $.set(this.#a, OBJ, true);",
+        ],
+    ),
+    (
+        "ctor-logical/literal",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tconstructor() { this.#a ||= 1; }\n}\n",
+        &["#a = $.state(0);", "this.#a.v || $.set(this.#a, 1);"],
+    ),
+    (
+        "ctor-logical/object",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tconstructor() { this.#a ||= { z: 1 }; }\n}\n",
+        &[
+            "#a = $.state(0);",
+            "this.#a.v || $.set(this.#a, { z: 1 }, true);",
+        ],
+    ),
+    (
+        "ctor-assign/ident-nonproxy",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tconstructor() { this.#a = D; }\n}\n",
+        &["#a = $.state(0);", "$.set(this.#a, D);"],
+    ),
+    (
+        "ctor-assign/ident-proxy",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tconstructor() { this.#a = OBJ; }\n}\n",
+        &["#a = $.state(0);", "$.set(this.#a, OBJ, true);"],
+    ),
+    (
+        "ctor-assign/literal",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tconstructor() { this.#a = 1; }\n}\n",
+        &["#a = $.state(0);", "$.set(this.#a, 1);"],
+    ),
+    (
+        "ctor-assign/object",
+        "const D = 5;\nconst OBJ = { a: 1 };\nexport class K {\n\t#a = $state(0);\n\tconstructor() { this.#a = { z: 1 }; }\n}\n",
+        &["#a = $.state(0);", "$.set(this.#a, { z: 1 }, true);"],
+    ),
+];
+
+#[test]
+fn every_call_site_resolves_an_identifier_through_its_binding() {
+    let mut diffs = Vec::new();
+    for (name, src, expect) in CELLS {
+        let got = state_lines(&emit(src));
+        let want: Vec<String> = expect.iter().map(|s| s.to_string()).collect();
+        if got == want {
+            println!("EQ   {name}");
+        } else {
+            println!("DIFF {name}\n  want {want:?}\n  got  {got:?}");
+            diffs.push(*name);
+        }
+    }
+    println!("EQ {} | DIFF {}", CELLS.len() - diffs.len(), diffs.len());
+    assert!(diffs.is_empty(), "diverging cells: {diffs:?}");
+}


### PR DESCRIPTION
Upstream's `should_proxy(node, scope)` recurses into `binding.initial` for an
`Identifier`, so `const D = 5; #a = $state(D)` emits `$.state(D)`. The class-field
lowering called the scope-less `expression_needs_proxy`, which sees an identifier,
cannot resolve it, and wraps every one in `$.proxy`.

## The grid found four sites nobody had looked at

#4168 reports the **field initializer**. `class_transforms.rs` has six
`expression_needs_proxy` call sites across three functions, so the repro carries
one cell per site crossed with four RHS shapes — `ident-nonproxy` / `ident-proxy`
are the discriminating pair (identical as text, opposite under binding
resolution) and the two literal rows are controls a scope-less sniff already
gets right.

```
before   EQ 19 | DIFF 5
after    EQ 24 | DIFF 0
```

The five diverging cells are `field-init`, `method-assign`, `ctor-rune`,
`ctor-logical` and `ctor-assign` — **the reported one and four that were not in
the report**. `method-compound` is the control that cannot move: a compound
assignment's value is a `BinaryExpression` upstream and never proxies, so its
four cells are green in both arms.

## A fourth port of `should_proxy`

`private_class_assign_ast.rs` carries `should_proxy_with_bindings`, whose
`var_proxy` map is built by walking the **class-body fragment**. A module-level
`const D = 5` is not in that text, so the binding is unknown and the RHS proxies.
Threading the list into `class_transforms.rs` alone left `method-assign`
diverging; the outer names have to be seeded into that map too (a local
declaration of the same name is nearer and wins).

That makes four ports of one upstream function — `expression_needs_proxy`,
`expression_needs_proxy_with_scope`, `should_proxy_ast`, and
`should_proxy_with_bindings` — and no gate compares any of them to each other.

## Blast radius

Two arms, `sha256` and a discriminating probe on both (the probe's `server` row
agrees in both arms, which is the control — the server has no proxy):

```
sw_before  97a2c309478e2a4a…   probe client 8bcaf17483722ea0
sw_after   8f75174177d4900d…   probe client 14a6a36af20253f5
```

```
components  compatibility/sources  33,890 files x 3 targets = 101,670 units   MOVED 0
modules     923 .svelte.(js|ts)     x 3 targets =   2,769 units   MOVED 2
            MISMATCH -> match  1 file (client, client-dev)
            match -> MISMATCH  0
```

The single moved file is `joy-of-code/.../preferences.svelte.ts`, which is the
`known-failures.client.json` / `known-failures.client-dev.json` entry #4168
names. Its output now carries `#textSize = $.state(DEFAULT_TEXT_SIZE);` where it
carried `$.state($.proxy(DEFAULT_TEXT_SIZE));`, matching official.

**The instrument needed fixing before that number meant anything.** `corpus_hash`
walks `.svelte` only, and `compile_module` parses plain JS — so a first pass
reported `MOVED 0` over 104,439 units with every one of the 923 module files
returning the *same* `js_parse_error` in both arms. The population that carries
the defect was entirely dead. The sweep now mirrors `compile.mjs`'s esbuild TS
strip; 110 of the 923 still fail to compile in both arms (`dollar_binding_invalid`
and friends — real errors both compilers raise), so the module sweep's live
population is 813 files.

Closes #4168
