### PR TITLE
fix(client): a destructured `export let` key is a member access, and its rest excludes by key

### DIFF
--- a/.changeset/destructured-export-let-keys.md
+++ b/.changeset/destructured-export-let-keys.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Read a destructured `export let` property through its key, and build a rest element as `$.exclude_from_object`.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2878,11 +2878,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 23 entries)
+### Client (`known-failures.client.json`, 22 entries)
 
-Partition of `known-failures.client.json` by verdict: `22 + 1`
+Partition of `known-failures.client.json` by verdict: `21 + 1`
 
-- **22 — the generated JS differs** (`js` / `code-differs`).
+- **21 — the generated JS differs** (`js` / `code-differs`).
 - **1 — the generated CSS differs.**
 
 The error classes this section used to carry are gone: the run behind this
@@ -2914,6 +2914,18 @@ asking only "is it not the bare name" passes on the bug; the repro therefore var
 binding KIND behind one fixed each block (`plain-import` → `settings`, `local-state` →
 `$.get(settings)`, `exported-prop` → `settings()`, nested each → `$.get(filter),
 $$_import_settings()`). A 139,252-unit four-target sweep moved exactly these 4 units.
+
+One entry left this target and `client-dev` because a destructured `export let` was lowered by
+text rather than through its keys. Upstream's `_extract_paths` builds a rest element as
+`$.exclude_from_object(expression, [keys])` and every property as
+`b.member(expression, prop.key, prop.computed || key.type !== 'Identifier')`; the port
+re-destructured for the rest and spelled every key as a dot access. `huly/…/
+TrainingRequestDueDateEditor.svelte` carries the first. The second is louder and had no
+carrier: **seven of the eight key cells emitted text no JS parser accepts** (`tmp.'a-b'`,
+`tmp.0`, `tmp.[k]`), and only a plain identifier key was right — which is why the repro
+(`crates/rsvelte_core/tests/destructured_export_let_keys.rs`) is one cell per key kind crossed
+with whether the pattern has a rest, rather than the reported shape alone. A 135,560-unit sweep
+moved exactly the 2 units this entry occupies.
 
 One entry left this target and `client-dev` because upstream's `should_proxy` resolves an
 Identifier **through its binding** and rsvelte's class-field lowering did not:
@@ -3030,7 +3042,7 @@ the emitted default was the getter function rather than the store's value. Hashi
 client (entry, target) outputs before and after reports **2** changed units over 1 id,
 `match -> MISMATCH = 0`; the other two ids of that cluster do not move and stay listed.
 
-Every one of the remaining 23 arrived with the wave-2 enrolment (#3130) and is described
+Every one of the remaining 22 arrived with the wave-2 enrolment (#3130) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3137,15 +3149,15 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 37 entries)
+### Client dev (`known-failures.client-dev.json`, 36 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `37`
+Partition of `known-failures.client-dev.json` by verdict: `36`
 
-- **37 — the generated JS differs.**
+- **36 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 37 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 36 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -8,7 +8,6 @@
 	"huly/plugins/process-resources/src/components/settings/ProcessAttributeEditor.svelte",
 	"huly/plugins/text-editor-resources/src/components/DrawingBoardEditor.svelte",
 	"huly/plugins/tracker-resources/src/components/issues/move/SelectReplacement.svelte",
-	"huly/plugins/training-resources/src/components/TrainingRequestDueDateEditor.svelte",
 	"huly/plugins/workbench-resources/src/components/HelpAndSupport.svelte",
 	"immich/web/src/lib/components/asset-viewer/ActivityViewer.svelte",
 	"immich/web/src/lib/components/timeline/Timeline.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -5,7 +5,6 @@
 	"ha-fusion/src/lib/Sidebar/Navigate.svelte",
 	"headscale-ui/src/lib/settings/ServerSettings.svelte",
 	"huly/plugins/text-editor-resources/src/components/DrawingBoardEditor.svelte",
-	"huly/plugins/training-resources/src/components/TrainingRequestDueDateEditor.svelte",
 	"immich/web/src/lib/components/asset-viewer/ActivityViewer.svelte",
 	"kite-public/src/lib/components/CategoryNavigation.svelte",
 	"mathesar/mathesar_ui/src/components/sort-entry/SortEntry.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -1564,6 +1564,59 @@ pub(super) fn transform_destructured_export_let(
     Some(format!("let {};", ordered.join(",\n\t")))
 }
 
+/// The member access a destructured property key reads through. Upstream builds
+/// `b.member(expression, prop.key, prop.computed || key.type !== 'Identifier')`,
+/// so only a plain identifier key is a dot access — a computed, string or
+/// numeric key is a bracket access carrying the source's own spelling.
+fn destructured_member_path(base_path: &str, key: &str) -> String {
+    let key = key.trim();
+    if let Some(inner) = key.strip_prefix('[').and_then(|k| k.strip_suffix(']')) {
+        return format!("{}[{}]", base_path, inner.trim());
+    }
+    let is_identifier = !key.is_empty()
+        && key
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphabetic() || c == '_' || c == '$')
+        && key
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '$');
+    if is_identifier {
+        format!("{}.{}", base_path, key)
+    } else {
+        format!("{}[{}]", base_path, key)
+    }
+}
+
+/// The key list `$.exclude_from_object(base, [...])` receives for an object
+/// pattern's rest element: every sibling property's key, spelled the way
+/// upstream's `_extract_paths` spells it — a computed or non-literal key goes
+/// through `String(...)`, everything else is a string literal.
+fn object_rest_excluded_keys(properties: &[&str]) -> Vec<String> {
+    let mut keys = Vec::new();
+    for prop in properties {
+        let prop = prop.trim();
+        if prop.is_empty() || prop.starts_with("...") {
+            continue;
+        }
+        let key = match split_property_key_value(prop) {
+            Some((key, _)) => key.trim(),
+            None => split_binding_name_default(prop).0.trim(),
+        };
+        if let Some(inner) = key.strip_prefix('[').and_then(|k| k.strip_suffix(']')) {
+            keys.push(format!("String({})", inner.trim()));
+        } else if key.len() >= 2
+            && (key.starts_with('\'') && key.ends_with('\'')
+                || key.starts_with('"') && key.ends_with('"'))
+        {
+            keys.push(format!("'{}'", &key[1..key.len() - 1]));
+        } else {
+            keys.push(format!("'{}'", key));
+        }
+    }
+    keys
+}
+
 /// Find the end position of a destructuring pattern in `{ ... } = RHS` or `[ ... ] = RHS`.
 /// Returns the position after the closing `}` or `]`.
 /// Byte offset just past the pattern's closing bracket, relative to `s` as passed.
@@ -1605,7 +1658,7 @@ pub(super) fn extract_destructured_export_paths(
         let inner = &pattern[1..pattern.len() - 1];
         let properties = split_destructuring_properties(inner);
 
-        for prop in properties {
+        for prop in &properties {
             let prop = prop.trim();
             if prop.is_empty() {
                 continue;
@@ -1615,14 +1668,14 @@ pub(super) fn extract_destructured_export_paths(
             if let Some(rest_name) = prop.strip_prefix("...") {
                 let rest_name = rest_name.trim();
                 let flags = calculate_prop_flags(rest_name, analysis, true);
-                // Rest elements need special handling
-                let body = format!(
-                    "const {{ {} }} = {}; return {};",
-                    rest_name, base_path, rest_name
-                );
+                let keys = object_rest_excluded_keys(&properties);
                 declarations.push(format!(
-                    "{} = $.prop($$props, '{}', {}, () => {{ {} }})",
-                    rest_name, rest_name, flags, body
+                    "{} = $.prop($$props, '{}', {}, () => $.exclude_from_object({}, [{}]))",
+                    rest_name,
+                    rest_name,
+                    flags,
+                    base_path,
+                    keys.join(", ")
                 ));
                 continue;
             }
@@ -1631,7 +1684,7 @@ pub(super) fn extract_destructured_export_paths(
             // Check for rename: key: value
             if let Some((key, value_pattern)) = split_property_key_value(prop) {
                 // Renamed property: key: value_pattern
-                let new_path = format!("{}.{}", base_path, key);
+                let new_path = destructured_member_path(base_path, key);
 
                 if value_pattern.starts_with('{') || value_pattern.starts_with('[') {
                     // Nested destructuring: b: { c, d: [...] }
@@ -1791,7 +1844,7 @@ pub(super) fn flatten_destructured_let_with_reexported_props(
             }
 
             if let Some((key, value_pattern)) = split_property_key_value(prop) {
-                let new_path = format!("{}.{}", base_path, key);
+                let new_path = destructured_member_path(base_path, key);
 
                 if value_pattern.starts_with('{') || value_pattern.starts_with('[') {
                     // Nested destructuring - recurse
@@ -1899,7 +1952,7 @@ pub(super) fn flatten_destructured_let_as_declarators(
             }
 
             if let Some((key, value_pattern)) = split_property_key_value(prop) {
-                let new_path = format!("{}.{}", base_path, key);
+                let new_path = destructured_member_path(base_path, key);
 
                 if value_pattern.starts_with('{') || value_pattern.starts_with('[') {
                     // Nested destructuring — recurse and collect nested declarators

--- a/crates/rsvelte_core/tests/destructured_export_let_keys.rs
+++ b/crates/rsvelte_core/tests/destructured_export_let_keys.rs
@@ -1,0 +1,139 @@
+//! A destructured `export let` reads each property through its key, and a rest
+//! element reads what the siblings did not take.
+//!
+//! Upstream's `_extract_paths` (`utils/ast.js`) builds the rest as
+//! `$.exclude_from_object(expression, [keys])` and each property as
+//! `b.member(expression, prop.key, prop.computed || key.type !== 'Identifier')`.
+//! rsvelte's text port re-destructured for the rest, and spelled every key as a
+//! dot access — so a string, numeric or computed key emitted `tmp.'a-b'`,
+//! `tmp.0`, `tmp.[k]`: text no JS parser accepts.
+//!
+//! One cell per key kind, crossed with whether the pattern has a rest element,
+//! because the two mechanisms are reached by different branches of the same
+//! loop. Every expectation is the official compiler's output for the same
+//! source (`submodules/svelte`).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn code(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("p.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn component(pattern: &str) -> String {
+    format!("<script>\n  const k = 'kk';\n  export let {pattern} = $$props;\n</script>\n\n{{x}}\n")
+}
+
+/// `x = $.prop($$props, 'x', 24, () => <access>)` for the cell's key.
+fn access_line(pattern: &str) -> String {
+    let out = code(&component(pattern));
+    out.lines()
+        .map(str::trim)
+        .find(|l| l.starts_with("x = $.prop($$props, 'x'"))
+        .unwrap_or_else(|| panic!("no `x` prop declarator in:\n{out}"))
+        .trim_end_matches([',', ';'])
+        .to_string()
+}
+
+#[test]
+fn a_non_identifier_key_reads_through_a_bracket() {
+    let cells: &[(&str, &str)] = &[
+        ("{ ab: x, c }", "x = $.prop($$props, 'x', 24, () => tmp.ab)"),
+        (
+            "{ 'a-b': x, c }",
+            "x = $.prop($$props, 'x', 24, () => tmp['a-b'])",
+        ),
+        (
+            "{ \"a b\": x, c }",
+            "x = $.prop($$props, 'x', 24, () => tmp[\"a b\"])",
+        ),
+        ("{ 0: x, c }", "x = $.prop($$props, 'x', 24, () => tmp[0])"),
+        (
+            "{ [k]: x, c }",
+            "x = $.prop($$props, 'x', 24, () => tmp[k])",
+        ),
+    ];
+    let mut bad = Vec::new();
+    for (pattern, expected) in cells {
+        let got = access_line(pattern);
+        if got != *expected {
+            bad.push(format!(
+                "{pattern}\n  expected {expected}\n  got      {got}"
+            ));
+        }
+    }
+    assert!(bad.is_empty(), "{}", bad.join("\n"));
+}
+
+/// The same five keys with a rest element: the access must not change, and the
+/// key must reach the exclusion list in the spelling upstream gives it — a
+/// literal for an identifier, string or numeric key, `String(...)` for a
+/// computed one.
+#[test]
+fn a_rest_element_excludes_its_siblings_by_key() {
+    let cells: &[(&str, &str)] = &[
+        ("{ ab: x, c, ...rest }", "['ab', 'c']"),
+        ("{ 'a-b': x, c, ...rest }", "['a-b', 'c']"),
+        ("{ \"a b\": x, c, ...rest }", "['a b', 'c']"),
+        ("{ 0: x, c, ...rest }", "['0', 'c']"),
+        ("{ [k]: x, c, ...rest }", "[String(k), 'c']"),
+        ("{ ...rest }", "[]"),
+        ("{ a = 1, b, ...rest }", "['a', 'b']"),
+        ("{ a: { b }, c, ...rest }", "['a', 'c']"),
+    ];
+    let mut bad = Vec::new();
+    for (pattern, keys) in cells {
+        let expected =
+            format!("rest = $.prop($$props, 'rest', 24, () => $.exclude_from_object(tmp, {keys}))");
+        let out = code(&component(pattern));
+        let got = out
+            .lines()
+            .map(str::trim)
+            .find(|l| l.starts_with("rest = $.prop($$props, 'rest'"))
+            .unwrap_or_else(|| panic!("no `rest` prop declarator for {pattern} in:\n{out}"))
+            .trim_end_matches([',', ';'])
+            .to_string();
+        if got != expected {
+            bad.push(format!(
+                "{pattern}\n  expected {expected}\n  got      {got}"
+            ));
+        }
+    }
+    assert!(bad.is_empty(), "{}", bad.join("\n"));
+}
+
+/// The shape the corpus carries (`huly/…/TrainingRequestDueDateEditor.svelte`):
+/// three shorthand siblings and a rest, which is the cell that was reported.
+#[test]
+fn the_reported_shape_matches_official() {
+    let out = code(&component(
+        "{ value, onChange, shouldIgnoreOverdue, ...rest }",
+    ));
+    assert!(
+        out.contains(
+            "rest = $.prop($$props, 'rest', 24, () => $.exclude_from_object(tmp, ['value', 'onChange', 'shouldIgnoreOverdue']))"
+        ),
+        "{out}"
+    );
+}
+
+/// An array pattern's rest is `.slice(n)` and was already right — the arm that
+/// reports the object fix reaching a branch it does not own.
+#[test]
+fn an_array_rest_still_slices() {
+    let out = code(&component("[x, ...rest]"));
+    assert!(
+        out.contains(".slice(1)") && !out.contains("exclude_from_object"),
+        "{out}"
+    );
+}


### PR DESCRIPTION
## What

A destructured `export let` is lowered from the pattern's **text**, and the port spelled
every key as a dot access and rebuilt the rest element by re-destructuring. Upstream's
`_extract_paths` (`phases/3-transform/utils/ast.js:255-330`) does neither:

- a property is `b.member(expression, prop.key, prop.computed || prop.key.type !== 'Identifier')`,
  so only a **plain identifier key** is a dot access;
- a rest element is `$.exclude_from_object(expression, b.array(props))`, whose key list
  spells an Identifier key as `b.literal(name)`, a Literal key as `b.literal(String(value))`,
  and anything else as `b.call('String', key)`.

## The louder half had no corpus carrier

The reported id (`huly/…/TrainingRequestDueDateEditor.svelte`) is the *rest* half, and its
output parses. The key half does not: **seven of the eight key cells emitted text no JS
parser accepts** — `tmp.'a-b'`, `tmp."a b"`, `tmp.0`, `tmp.[k]` — and a plain identifier key
was the one shape that was already right. That is why
`crates/rsvelte_core/tests/destructured_export_let_keys.rs` is one cell per **key kind**
crossed with whether the pattern carries a rest, rather than the reported shape alone: a fix
measured only against the reported cell cannot tell "reaches the reported branch" from
"reaches all of them".

Every expectation in the test is the official compiler's own output for the same source
(`submodules/svelte/packages/svelte/src/compiler/index.js`, the `OFFICIAL_COMPILER_REL` path
the gates use — not the npm build).

## Measurement

Two arms of `librsvelte_napi.dylib`, each staged into `.corpus-cache/rsvelte.node` and
identified by a discriminating probe on its own output before the sweep (the probe carries
**both** halves of the fix: a `[k]` key, which only the member-path change moves, and a rest
element, which only the exclusion change moves).

| mechanism | carrier | population | result |
|---|---|---|---|
| member-path spelling | `js.code` hash | 33,890 ids × 4 targets = 135,560 units | 2 units moved |
| rest exclusion list | `js.code` hash | same | (same 2 units) |
| verdict direction | first differing line vs official | the 2 moved units | `MISMATCH -> match` 2, `match -> MISMATCH` **0** |

The 2 moved units are exactly the `client` and `client-dev` occurrences of the one retired
id. No passing entry changed.

## Ratchet

- `known-failures.client.json` 25 → 24
- `known-failures.client-dev.json` 39 → 38

`compatibility/KNOWN-FAILURES.md` carries the count, the partition line and the mechanism.

## Tests

`cargo test -p rsvelte_core --test destructured_export_let_keys` — 4 passed, 0 failed.
