### PR TITLE
fix(svelte2tsx): ten predicates answered too narrowly — both svelte2tsx ratchets shrink, one empties

### DIFF
--- a/.changeset/svelte2tsx-attribute-host-rules.md
+++ b/.changeset/svelte2tsx-attribute-host-rules.md
@@ -1,0 +1,18 @@
+---
+'@rsvelte/svelte2tsx': patch
+'@rsvelte/compiler': patch
+'@rsvelte/svelte-check': patch
+---
+
+An attribute's host now answers `Attribute.ts`'s two host tests separately, and a
+valueless CSS custom property is `true`.
+
+`element instanceof Element` picks the `data-` workaround
+(`...__sveltets_2_empty({…})`) over the component-only `--` one
+(`__sveltets_2_cssProp`), while the attribute-case fold needs
+`parent.type === 'Element'` as well. A `<slot>` is built as an `Element` whose node
+type is `Slot`, so it takes the first wrapper and not the second — rsvelte had the
+two the wrong way round. A named-slot element is a real element and now folds its
+attribute name's case like any other. And `<C --x />` types the property as `true`,
+not `""`: the `""` fallback in `addProp` is only reached when `addAttribute` is
+called with no value, which the valueless branch never does.

--- a/.changeset/svelte2tsx-invalidate-as-expression.md
+++ b/.changeset/svelte2tsx-invalidate-as-expression.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/compiler": patch
+"@rsvelte/svelte-check": patch
+---
+
+`$: x = y as T` parenthesises its `__sveltets_2_invalidate` arrow body
+
+Upstream wraps that body in parentheses under a three-way condition — an object
+literal, an expression whose text starts with one, or an `as` expression. rsvelte
+answered the whole condition with `rhs.starts_with('{')`, which covers the first
+two and cannot express the third, so a reactive declaration whose right-hand side
+is a TypeScript assertion lost the parentheses.

--- a/.changeset/svelte2tsx-is-attribute-custom-element.md
+++ b/.changeset/svelte2tsx-is-attribute-custom-element.md
@@ -1,0 +1,17 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/compiler": patch
+"@rsvelte/svelte-check": patch
+---
+
+An `is="x-y"` attribute makes an element a custom element, which keeps its attribute-name case
+
+Upstream's `Element.isCustomElement()` has two conditions — a dash in the tag name,
+and an `is=` attribute whose first value chunk is text containing a dash — and only
+a custom element is exempt from the attribute-name lowercasing. rsvelte answered the
+question with `tag.contains('-')` alone, so `<div is="x-y" defaultValue="1">` emitted
+`"defaultvalue"` where official emits `"defaultValue"`, on every element host.
+
+The tag was also being passed as `""` on two of the four hosts, which happened to be
+harmless only because `title` and `svelte:element` contain no dash. Both now pass the
+real tag and the caller answers the whole predicate.

--- a/.changeset/svelte2tsx-mustache-interior.md
+++ b/.changeset/svelte2tsx-mustache-interior.md
@@ -1,0 +1,15 @@
+---
+'@rsvelte/svelte2tsx': patch
+'@rsvelte/compiler': patch
+'@rsvelte/svelte-check': patch
+---
+
+A mustache in an attribute value now contributes the text between its braces, not the
+span of the expression node inside them.
+
+Official copies the interior verbatim into the template literal it builds, so
+`class="x {// why⏎a} z"` keeps the comment and `class="x { a } z"` keeps its two
+spaces; rsvelte emitted `${a}` for both. The interior reaches a template literal
+through two builders — the string one used by `<slot>` and named-slot-element
+attributes, and the segment one used by elements, `style` and component props — and
+both had the expression's span.

--- a/.changeset/svelte2tsx-named-slot-element-bindings.md
+++ b/.changeset/svelte2tsx-named-slot-element-bindings.md
@@ -1,0 +1,17 @@
+---
+'@rsvelte/svelte2tsx': patch
+'@rsvelte/compiler': patch
+'@rsvelte/svelte-check': patch
+---
+
+An element that targets a named slot with a `slot` attribute now lowers its `bind:`
+directives like any other element.
+
+That element is handled by a second port of the element transform, which built its own
+attribute object and its own class/style + transition suffix and never ran the binding
+pass — so `bind:this` stayed a `"bind:this": element` prop instead of becoming
+`const $$_button1 = svelteHTML.createElement(…); … element = $$_button1;`, a two-way
+binding lost its `() => v = __sveltets_2_any(null)` setter, and a void or self-closing
+element closed with a leading space that only an overwritten `</tag>` produces.
+`<svelte:element>` and the special elements share that attribute builder and emit the
+suffix themselves, so they lower the same bindings now too.

--- a/.changeset/svelte2tsx-named-slot-fragment.md
+++ b/.changeset/svelte2tsx-named-slot-fragment.md
@@ -1,0 +1,14 @@
+---
+'@rsvelte/svelte2tsx': patch
+'@rsvelte/compiler': patch
+'@rsvelte/svelte-check': patch
+---
+
+`<svelte:fragment slot="…">` keeps its attribute names and its opener layout.
+
+It is an `Element` whose node type is not `Element`, so the attribute-case fold and
+the number-only rewrite do not reach it — `<svelte:fragment slot="s" someProp="0"
+cols="3" />` keeps `someProp` and types `cols` as a string. And its opener is
+position-preserving like any other element's: the columns the stripped `slot=` and
+`let:` occupy come back as spaces whether or not another attribute survives, where
+rsvelte emitted them only when nothing did.

--- a/.changeset/svelte2tsx-props-typedef-leading-trivia.md
+++ b/.changeset/svelte2tsx-props-typedef-leading-trivia.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/compiler": patch
+"@rsvelte/svelte-check": patch
+---
+
+The `$$ComponentProps` typedef is inserted before the declaration's leading comments
+
+Upstream inserts `;type $$ComponentProps = …;` at `node.parent.pos`, and TypeScript's
+`pos` spans the declaration's leading trivia — so the insertion lands before any
+comment that precedes the `$props()` declaration. rsvelte walked back from the
+`let`/`const` keyword, and two of the three branches that compute this offset stopped
+at whitespace, appending the typedef onto a preceding `// …` line where the line
+comment swallowed it. The output was not TypeScript.

--- a/.changeset/svelte2tsx-special-tag-name-rewrites.md
+++ b/.changeset/svelte2tsx-special-tag-name-rewrites.md
@@ -1,0 +1,15 @@
+---
+'@rsvelte/svelte2tsx': patch
+'@rsvelte/compiler': patch
+'@rsvelte/svelte-check': patch
+---
+
+`<svelte:body>`, `<svelte:window>`, `<svelte:document>`, `<svelte:head>` and
+`<svelte:fragment>` no longer fold an attribute name's case or rewrite a
+number-only value.
+
+Both rewrites need `element instanceof Element && parent.type === 'Element'`, and
+every one of those tags is an `Element` whose node type is not `Element` — only
+`<svelte:element>` carries that type. So `<svelte:window someProp="0" cols="3" />`
+keeps `someProp` and types `cols` as a string, where rsvelte emitted `someprop`
+and `3`. The `data-` wrapper needs only the first condition and is unchanged.

--- a/.changeset/svelte2tsx-store-region-per-script.md
+++ b/.changeset/svelte2tsx-store-region-per-script.md
@@ -1,0 +1,15 @@
+---
+'@rsvelte/svelte2tsx': patch
+'@rsvelte/compiler': patch
+'@rsvelte/svelte-check': patch
+---
+
+A component with a module script now emits two store-subscription ignore regions at the
+render-function start rather than one.
+
+Upstream builds a second `ImplicitStoreValues` for the module script, seeded with the
+instance script's accessed stores but with its own import list, and each instance wraps its
+own names in one `/*Ωignore_startΩ*/ … /*Ωignore_endΩ*/` region. rsvelte collected both
+scripts' imports into one list, which also dropped a name imported by both scripts — upstream
+declares it in each region — and would have emitted the module's region first when the module
+script is written second.

--- a/.changeset/svelte2tsx-valueless-slot-attribute.md
+++ b/.changeset/svelte2tsx-valueless-slot-attribute.md
@@ -1,0 +1,11 @@
+---
+'@rsvelte/svelte2tsx': patch
+'@rsvelte/compiler': patch
+'@rsvelte/svelte-check': patch
+---
+
+A `<slot>` attribute written with no value no longer declares a slot prop.
+
+`handleSlot` skips any attribute whose `value` has no length, and a valueless
+attribute's `value` is `true` — so `<slot a b={b} />` types the slot as `{b: …}` and
+rsvelte typed it as `{a: …, b: …}`, adding a prop consumers never receive.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -6256,6 +6256,14 @@ A third class left this file entirely: rsvelte emitting text no TypeScript parse
 accepts is now its own verdict with its own ratchet — see
 [`svelte2tsx-unparseable-known-failures.json`](#svelte2tsx-unparseable-known-failures).
 
+A third upstream defect has **no entry here at all**, and that absence is a measurement
+rather than a gap: official svelte2tsx throws a raw `TypeError` when a lowercase element's
+`is` attribute has a mustache as its **first** value chunk, and of the 33,904 corpus
+components the 165 carrying `is=` yield **0** such carriers (158 have a mustache-first
+value, every one of them on a component, which upstream's own gate excludes; all 158
+convert cleanly). Not appearing in a ratchet is not the same as not existing — see
+[`upstream_issues/4177-svelte2tsx-is-attribute-mustache-first-chunk-crash.md`](../upstream_issues/4177-svelte2tsx-is-attribute-mustache-first-chunk-crash.md).
+
 Attribution of `svelte2tsx-known-failures.json`:
 
 | n | target | cluster |

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -6790,23 +6790,32 @@ target to match); the opposite direction had no name, so it had no ratchet. The
 `oracle-invalid` test already computed both sides' parseability and discarded one of
 the two answers, so the new verdict costs no extra work.
 
-**Current baseline: `svelte2tsx-unparseable-known-failures.json`, 1 entry.**
+**Current baseline: `svelte2tsx-unparseable-known-failures.json`, 0 entries.**
 
-Partition of `svelte2tsx-unparseable-known-failures.json` by mechanism: `1`
+The ratchet is empty, so any output rsvelte emits that no TS parser accepts — while
+official's parses — fails CI.
 
-The mechanism assignment is the same one-to-one map the other ratchet's table is
-derived from (`compatibility/svelte2tsx-mechanisms.json`), which covers both files.
+Partition of `svelte2tsx-unparseable-known-failures.json` by mechanism: `0`
 
-- **1 — a `//` comment swallows a hoisted type declaration.**
-  `svelte-virtuallists/src/lib/VirtualListNew.svelte` emits
-  `// ====== PROPERTIES ================;type $$ComponentProps =  {` on one line, so
-  the `//` runs to the end of the line and takes the declaration with it
-  (`Unexpected token`). Official emits no `$$ComponentProps` for this source at all,
-  so there are two defects here and only the second one is loud. **Not reduced**: a
-  three-line `<script lang="ts">` with a leading `//` and a typed `$props()`
-  destructure is byte-identical between the two tools, so the hand-written probe says
-  something about the probe rather than about the defect — the reduction has to come
-  from bisecting the real file.
+### Previously: a `//` comment swallowed the props typedef
+
+`svelte-virtuallists/src/lib/VirtualListNew.svelte` emitted
+`// ====== PROPERTIES ================;type $$ComponentProps =  {` on one line, so the
+line comment ran to the end of the line and took the declaration with it. Upstream
+inserts that typedef at `node.parent.pos`, and TypeScript's `pos` spans the
+declaration's LEADING TRIVIA, so official's insertion lands before the comment
+(`};type $$ComponentProps =  {`). rsvelte walked back from the `const` keyword instead,
+and only one of the three branches that compute this offset walked back through
+comments — the other two stopped at whitespace.
+
+Two things about the entry as it was written. It said official emits no
+`$$ComponentProps` for this source at all, and that is wrong: both tools emit it and
+only the offset differed, so there was one defect here rather than two. And its
+"not reduced" note was right about the reduction while wrong about why — a
+hand-written probe reproduces nothing because the axis it was missing is
+`generics=`, which is what makes this offset reachable at all (without it the typedef
+is hoisted out of `$$render` and none of the three branches runs). Delta-debugging
+the real file from 690 lines to 34 is what surfaced it.
 
 The two entries this file did NOT need are the reason it exists. Both were one
 mechanism: an element carrying `slot=` inside a component went through a second

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -6242,11 +6242,11 @@ The svelte2tsx output-parity corpus (`scripts/compat-corpus/svelte2tsx-*`) compa
 rsvelte's svelte2tsx port against **official `svelte2tsx`** byte-for-byte (after
 oxfmt normalization). The ratchet may only shrink.
 
-**Current baseline: `svelte2tsx-known-failures.json`, 6 entries.**
+**Current baseline: `svelte2tsx-known-failures.json`, 5 entries.**
 
-Partition of `svelte2tsx-known-failures.json` by verdict: `4 + 2`
+Partition of `svelte2tsx-known-failures.json` by verdict: `3 + 2`
 
-- **4 — the emitted TSX differs** (`ts-mismatch`).
+- **3 — the emitted TSX differs** (`ts-mismatch`).
 - **2 — one side rejects and the other compiles** (`error-mismatch`). Both are
   `cnblocks`'s `(app)/veil/` components, and the rejecting side is **official**:
   a UTF-8 BOM together with a `<script>` block and markup makes `svelte2tsx`
@@ -6263,7 +6263,7 @@ Attribution of `svelte2tsx-known-failures.json`:
 |---|---|---|
 | 2 | `upstream_issues/svelte2tsx-bom-crashes-on-any-component-with-a-script.md` | official throws on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it |
 
-The remaining 4 carry **no target, and cannot have one**: every one was measured
+The remaining 3 carry **no target, and cannot have one**: every one was measured
 against official on 2026-09-02 and every one is an rsvelte defect, so the only end
 state open to them is elimination. The classification below is the input to that
 work; it is not an attribution, and this gate stays red until the entries are gone.
@@ -6293,10 +6293,33 @@ double count**, so the assignment has to be per entry.
 | 2 | official svelte2tsx throws from magic-string on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it | upstream |
 | 1 | `bind:this` is emitted as a `"bind:this": element` attribute; official binds the created element to a temporary (`const $$_button1 = svelteHTML.createElement(…); … element = $$_button1;`) | source |
 | 1 | an extra `dragItem: dragItem` slot prop is emitted | output only |
-| 1 | two adjacent store-get `/*Ωignore_startΩ*/…/*Ωignore_endΩ*/` regions are emitted as ONE region spanning both, where official closes and reopens | source |
 | 1 | a `//` comment inside a `${…}` hole of a template-literal attribute value is dropped | source |
 
-Partition of `svelte2tsx-known-failures.json` by mechanism: `2 + 1x4`
+Partition of `svelte2tsx-known-failures.json` by mechanism: `2 + 1x3`
+
+### Previously: `ignore-region-merge` (2026-09-02, at 6 entries)
+
+Kept because its description named the symptom — *"two adjacent regions are
+emitted as ONE"* — and the symptom points at a merge that does not exist. There is
+no merging step: upstream builds a **second `ImplicitStoreValues`** for the module
+script (`index.ts:202`), seeded with the instance script's accessed stores but with
+its own `importStatements`, and each instance wraps ITS names in one region and
+appends it at the render-function start. Two regions are two instances. rsvelte
+collected both scripts' import names into one list.
+
+**Six of the 17 grid cells diverged and only two of them discriminate.** The other
+four are satisfied by an implementation that merely splits adjacent regions,
+because with distinct names the union and the two instances print the same
+characters in the same order. What separates the rules:
+
+- a name imported by **both** scripts is declared in **both** regions
+  (`[<a>][<a>]`), because the second instance is seeded with the accessed stores
+  and not with the first one's import list — a union drops the duplicate;
+- the instance region comes first **even when the module script is written
+  second**, so an implementation that emits in file order passes the other five.
+
+Reaching the mechanism is not being able to tell two rules for it apart; count the
+discriminating cells, not the diverging ones.
 
 ### Previously: `unterminated-export-let` (2026-09-02, at 7 entries)
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -6242,11 +6242,10 @@ The svelte2tsx output-parity corpus (`scripts/compat-corpus/svelte2tsx-*`) compa
 rsvelte's svelte2tsx port against **official `svelte2tsx`** byte-for-byte (after
 oxfmt normalization). The ratchet may only shrink.
 
-**Current baseline: `svelte2tsx-known-failures.json`, 3 entries.**
+**Current baseline: `svelte2tsx-known-failures.json`, 2 entries.**
 
-Partition of `svelte2tsx-known-failures.json` by verdict: `1 + 2`
+Partition of `svelte2tsx-known-failures.json` by verdict: `2`
 
-- **1 — the emitted TSX differs** (`ts-mismatch`).
 - **2 — one side rejects and the other compiles** (`error-mismatch`). Both are
   `cnblocks`'s `(app)/veil/` components, and the rejecting side is **official**:
   a UTF-8 BOM together with a `<script>` block and markup makes `svelte2tsx`
@@ -6263,10 +6262,10 @@ Attribution of `svelte2tsx-known-failures.json`:
 |---|---|---|
 | 2 | `upstream_issues/svelte2tsx-bom-crashes-on-any-component-with-a-script.md` | official throws on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it |
 
-The remaining 1 carries **no target, and cannot have one**: it was measured
-against official on 2026-09-02 and is an rsvelte defect, so the only end state open
-to it is elimination. The classification below is the input to that work; it is not
-an attribution, and this gate stays red until the entry is gone.
+Every entry now carries a target, and every one of them is upstream. The
+`ts-mismatch` half of this ratchet is empty: the four entries it held on
+2026-09-02 were each measured against official, each was an rsvelte defect, and
+each is fixed — see the `### Previously:` sections below.
 
 ### Entries by mechanism (2026-09-02)
 
@@ -6291,9 +6290,29 @@ double count**, so the assignment has to be per entry.
 | n | mechanism | pinned |
 |---|---|---|
 | 2 | official svelte2tsx throws from magic-string on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it | upstream |
-| 1 | an extra `dragItem: dragItem` slot prop is emitted | output only |
 
-Partition of `svelte2tsx-known-failures.json` by mechanism: `2 + 1`
+Partition of `svelte2tsx-known-failures.json` by mechanism: `2`
+
+### Previously: `extra-slot-prop` (2026-09-02, at 3 entries)
+
+Kept as `output only` because the divergence was one prop, `dragItem`, and the
+axis is the attribute's **value form**. `<slot … dragItem … />` writes the name
+with no value at all; `handleSlot` (`nodes/slot.ts`) opens its loop with
+`if (!attr.value?.length) continue;` and a valueless attribute's `value` is
+`true`, so official declares no such slot prop and rsvelte declared `dragItem:
+dragItem`.
+
+Named after the prop, the entry reads as a question about `dragItem`. Enumerated
+over the shapes a `<slot>` attribute can take — valueless, shorthand, `=""`,
+a text literal, a mustache, a quoted mustache, text + mustache, a spread, a
+`let:` — **the valueless rows are the only ones that move**, and there are ten
+of them once position (first / last / between two kept entries) and host (a
+named slot, an `{#each}`, a component slot) are crossed in.
+`crates/rsvelte_projection/tests/svelte2tsx_valueless_slot_attribute.rs` is the
+grid; ablating the fix fails exactly those 10 of 19.
+
+The whole-corpus sweep moved 1 unit of 33,901: `MISMATCH -> match` 1,
+`match -> MISMATCH` 0.
 
 ### Previously: `template-hole-comment-dropped` (2026-09-02, at 4 entries)
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -6242,11 +6242,11 @@ The svelte2tsx output-parity corpus (`scripts/compat-corpus/svelte2tsx-*`) compa
 rsvelte's svelte2tsx port against **official `svelte2tsx`** byte-for-byte (after
 oxfmt normalization). The ratchet may only shrink.
 
-**Current baseline: `svelte2tsx-known-failures.json`, 5 entries.**
+**Current baseline: `svelte2tsx-known-failures.json`, 4 entries.**
 
-Partition of `svelte2tsx-known-failures.json` by verdict: `3 + 2`
+Partition of `svelte2tsx-known-failures.json` by verdict: `2 + 2`
 
-- **3 — the emitted TSX differs** (`ts-mismatch`).
+- **2 — the emitted TSX differs** (`ts-mismatch`).
 - **2 — one side rejects and the other compiles** (`error-mismatch`). Both are
   `cnblocks`'s `(app)/veil/` components, and the rejecting side is **official**:
   a UTF-8 BOM together with a `<script>` block and markup makes `svelte2tsx`
@@ -6263,7 +6263,7 @@ Attribution of `svelte2tsx-known-failures.json`:
 |---|---|---|
 | 2 | `upstream_issues/svelte2tsx-bom-crashes-on-any-component-with-a-script.md` | official throws on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it |
 
-The remaining 3 carry **no target, and cannot have one**: every one was measured
+The remaining 2 carry **no target, and cannot have one**: every one was measured
 against official on 2026-09-02 and every one is an rsvelte defect, so the only end
 state open to them is elimination. The classification below is the input to that
 work; it is not an attribution, and this gate stays red until the entries are gone.
@@ -6291,11 +6291,45 @@ double count**, so the assignment has to be per entry.
 | n | mechanism | pinned |
 |---|---|---|
 | 2 | official svelte2tsx throws from magic-string on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it | upstream |
-| 1 | `bind:this` is emitted as a `"bind:this": element` attribute; official binds the created element to a temporary (`const $$_button1 = svelteHTML.createElement(…); … element = $$_button1;`) | source |
 | 1 | an extra `dragItem: dragItem` slot prop is emitted | output only |
 | 1 | a `//` comment inside a `${…}` hole of a template-literal attribute value is dropped | source |
 
-Partition of `svelte2tsx-known-failures.json` by mechanism: `2 + 1x3`
+Partition of `svelte2tsx-known-failures.json` by mechanism: `2 + 1x2`
+
+### Previously: `bind-this-shape` (2026-09-02, at 5 entries)
+
+Kept because the description named ONE directive, and the cause is that an
+element carrying a `slot` **attribute** is lowered by a second port of the element
+transform which never ran the binding pass at all.
+
+`<C><svelte:fragment slot="x"><button bind:this={e}/></svelte:fragment></C>`
+reaches `handle_regular_element`, which declares `const $$_button1 = …` and
+appends `e = $$_button1;`. Move the `slot` onto the element —
+`<C><button slot="x" bind:this={e}/></C>` — and it reaches
+`handle_named_slot_element`, which built its own attribute object and its own
+class/style + transition suffix. `bind:this` was one of three things that port
+lost:
+
+- `bind:this` and the one-way binding attributes stayed props instead of
+  becoming an element variable plus an assignment;
+- a two-way `bind:value` kept its prop but lost the
+  `() => v = __sveltets_2_any(null)` setter the suffix pass appends;
+- a **void or self-closing** element closed with a leading space, which only an
+  overwritten `</tag>` leaves behind — a divergence with no binding in it at all,
+  and one **oxfmt normalizes away**, so the output gate could never report it.
+
+The last one is why the sweep moved **6 units and retired 1**: five of the six
+changed their bytes without changing their verdict. A changed hash is not a fixed
+file, and the two have to be printed separately.
+
+Two hosts share that attribute builder and DO emit the binding suffix
+(`<svelte:element>`, the special elements), so they had the same prop and now
+lower it; `<svelte:fragment>` shares the builder and emits no suffix, and takes
+only `slot` and `let:`, so it keeps the old behaviour behind an explicit flag
+rather than silently dropping a binding.
+
+The positive control fails 10 of the 19 cells; the 9 that pass carry no `slot`
+attribute and went through the other port, where all of this was already right.
 
 ### Previously: `ignore-region-merge` (2026-09-02, at 6 entries)
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -6242,11 +6242,11 @@ The svelte2tsx output-parity corpus (`scripts/compat-corpus/svelte2tsx-*`) compa
 rsvelte's svelte2tsx port against **official `svelte2tsx`** byte-for-byte (after
 oxfmt normalization). The ratchet may only shrink.
 
-**Current baseline: `svelte2tsx-known-failures.json`, 4 entries.**
+**Current baseline: `svelte2tsx-known-failures.json`, 3 entries.**
 
-Partition of `svelte2tsx-known-failures.json` by verdict: `2 + 2`
+Partition of `svelte2tsx-known-failures.json` by verdict: `1 + 2`
 
-- **2 — the emitted TSX differs** (`ts-mismatch`).
+- **1 — the emitted TSX differs** (`ts-mismatch`).
 - **2 — one side rejects and the other compiles** (`error-mismatch`). Both are
   `cnblocks`'s `(app)/veil/` components, and the rejecting side is **official**:
   a UTF-8 BOM together with a `<script>` block and markup makes `svelte2tsx`
@@ -6263,10 +6263,10 @@ Attribution of `svelte2tsx-known-failures.json`:
 |---|---|---|
 | 2 | `upstream_issues/svelte2tsx-bom-crashes-on-any-component-with-a-script.md` | official throws on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it |
 
-The remaining 2 carry **no target, and cannot have one**: every one was measured
-against official on 2026-09-02 and every one is an rsvelte defect, so the only end
-state open to them is elimination. The classification below is the input to that
-work; it is not an attribution, and this gate stays red until the entries are gone.
+The remaining 1 carries **no target, and cannot have one**: it was measured
+against official on 2026-09-02 and is an rsvelte defect, so the only end state open
+to it is elimination. The classification below is the input to that work; it is not
+an attribution, and this gate stays red until the entry is gone.
 
 ### Entries by mechanism (2026-09-02)
 
@@ -6292,9 +6292,35 @@ double count**, so the assignment has to be per entry.
 |---|---|---|
 | 2 | official svelte2tsx throws from magic-string on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it | upstream |
 | 1 | an extra `dragItem: dragItem` slot prop is emitted | output only |
-| 1 | a `//` comment inside a `${…}` hole of a template-literal attribute value is dropped | source |
 
-Partition of `svelte2tsx-known-failures.json` by mechanism: `2 + 1x2`
+Partition of `svelte2tsx-known-failures.json` by mechanism: `2 + 1`
+
+### Previously: `template-hole-comment-dropped` (2026-09-02, at 4 entries)
+
+Kept because the description named a **comment**, and the axis is the mustache's
+interior against the expression node's span. Official copies the text between the
+braces into its template literal; rsvelte copied the expression's own span, so
+everything the braces hold that the node does not was dropped — a comment, yes,
+but also a newline and plain padding. `class="x { a } z"` lost its two spaces and
+has no comment in it anywhere.
+
+A repro written from the justification would have been all comments, and half of
+the 25 cells the fix moves carry none. **A justification is a hypothesis about
+why an entry diverges; it is not the identification of the axis**, and a repro
+built from it inherits the hypothesis.
+
+The interior reaches a template literal through **two ports** — the string
+builder and the segment builder in `template/attributes/attribute.rs` — and no
+gate compares them to each other. Measured one arm at a time on the same 46-cell
+grid: reverting only the string builder leaves 10 cells failing (`<slot>` and
+named-slot-element attributes), reverting only the segment builder leaves 15
+(element, `style`, component attributes), reverting both leaves 25. This is the
+third of the three svelte2tsx entries retired on 2026-09-02 to be a two-ports
+defect.
+
+`crates/rsvelte_projection/tests/svelte2tsx_mustache_interior.rs` is the grid.
+The whole-corpus sweep moved 4 units of 33,901 and changed one verdict:
+`MISMATCH -> match` 1, `match -> MISMATCH` 0.
 
 ### Previously: `bind-this-shape` (2026-09-02, at 5 entries)
 

--- a/compatibility/svelte2tsx-known-failures.json
+++ b/compatibility/svelte2tsx-known-failures.json
@@ -1,6 +1,5 @@
 [
 	"cnblocks/src/routes/(app)/veil/+layout.svelte",
 	"cnblocks/src/routes/(app)/veil/+page.svelte",
-	"huly/plugins/view-resources/src/components/list/ListCategory.svelte",
-	"sparrow-app/packages/@sparrow-workspaces/src/features/tab-bar/components/tab/Tab.svelte"
+	"huly/plugins/view-resources/src/components/list/ListCategory.svelte"
 ]

--- a/compatibility/svelte2tsx-known-failures.json
+++ b/compatibility/svelte2tsx-known-failures.json
@@ -1,5 +1,4 @@
 [
 	"cnblocks/src/routes/(app)/veil/+layout.svelte",
-	"cnblocks/src/routes/(app)/veil/+page.svelte",
-	"huly/plugins/view-resources/src/components/list/ListCategory.svelte"
+	"cnblocks/src/routes/(app)/veil/+page.svelte"
 ]

--- a/compatibility/svelte2tsx-known-failures.json
+++ b/compatibility/svelte2tsx-known-failures.json
@@ -2,6 +2,5 @@
 	"cnblocks/src/routes/(app)/veil/+layout.svelte",
 	"cnblocks/src/routes/(app)/veil/+page.svelte",
 	"huly/plugins/view-resources/src/components/list/ListCategory.svelte",
-	"mathesar/mathesar_ui/src/component-library/button/Button.svelte",
 	"sparrow-app/packages/@sparrow-workspaces/src/features/tab-bar/components/tab/Tab.svelte"
 ]

--- a/compatibility/svelte2tsx-known-failures.json
+++ b/compatibility/svelte2tsx-known-failures.json
@@ -1,5 +1,4 @@
 [
-	"appwrite-console/src/routes/(console)/project-[region]-[project]/overview/platforms/+page.svelte",
 	"cnblocks/src/routes/(app)/veil/+layout.svelte",
 	"cnblocks/src/routes/(app)/veil/+page.svelte",
 	"huly/plugins/view-resources/src/components/list/ListCategory.svelte",

--- a/compatibility/svelte2tsx-mechanisms.json
+++ b/compatibility/svelte2tsx-mechanisms.json
@@ -1,10 +1,6 @@
 {
 	"$schema-note": "id -> mechanism slug for every entry of svelte2tsx-known-failures.json and svelte2tsx-unparseable-known-failures.json. The `Entries by mechanism` table in KNOWN-FAILURES.md is derived from this file: one row per `mechanisms` key, `n` = how many `entries` name it. The assignment is one-to-one, so a double count is unwritable.",
 	"mechanisms": {
-		"bind-this-shape": {
-			"description": "`bind:this` is emitted as a `\"bind:this\": element` attribute; official binds the created element to a temporary (`const $$_button1 = svelteHTML.createElement(…); … element = $$_button1;`)",
-			"pinned": "source"
-		},
 		"extra-slot-prop": {
 			"description": "an extra `dragItem: dragItem` slot prop is emitted",
 			"pinned": "output only"
@@ -26,7 +22,6 @@
 		"cnblocks/src/routes/(app)/veil/+layout.svelte": "upstream-bom-crash",
 		"cnblocks/src/routes/(app)/veil/+page.svelte": "upstream-bom-crash",
 		"huly/plugins/view-resources/src/components/list/ListCategory.svelte": "extra-slot-prop",
-		"mathesar/mathesar_ui/src/component-library/button/Button.svelte": "bind-this-shape",
 		"sparrow-app/packages/@sparrow-workspaces/src/features/tab-bar/components/tab/Tab.svelte": "template-hole-comment-dropped",
 		"svelte-virtuallists/src/lib/VirtualListNew.svelte": "line-comment-swallows-type"
 	}

--- a/compatibility/svelte2tsx-mechanisms.json
+++ b/compatibility/svelte2tsx-mechanisms.json
@@ -9,10 +9,6 @@
 			"description": "a `//` line comment inside an `export let` type annotation swallows the rest of the emitted line, so the output is not TypeScript",
 			"pinned": "source"
 		},
-		"template-hole-comment-dropped": {
-			"description": "a `//` comment inside a `${…}` hole of a template-literal attribute value is dropped",
-			"pinned": "source"
-		},
 		"upstream-bom-crash": {
 			"description": "official svelte2tsx throws from magic-string on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it",
 			"pinned": "upstream"
@@ -22,7 +18,6 @@
 		"cnblocks/src/routes/(app)/veil/+layout.svelte": "upstream-bom-crash",
 		"cnblocks/src/routes/(app)/veil/+page.svelte": "upstream-bom-crash",
 		"huly/plugins/view-resources/src/components/list/ListCategory.svelte": "extra-slot-prop",
-		"sparrow-app/packages/@sparrow-workspaces/src/features/tab-bar/components/tab/Tab.svelte": "template-hole-comment-dropped",
 		"svelte-virtuallists/src/lib/VirtualListNew.svelte": "line-comment-swallows-type"
 	}
 }

--- a/compatibility/svelte2tsx-mechanisms.json
+++ b/compatibility/svelte2tsx-mechanisms.json
@@ -1,10 +1,6 @@
 {
 	"$schema-note": "id -> mechanism slug for every entry of svelte2tsx-known-failures.json and svelte2tsx-unparseable-known-failures.json. The `Entries by mechanism` table in KNOWN-FAILURES.md is derived from this file: one row per `mechanisms` key, `n` = how many `entries` name it. The assignment is one-to-one, so a double count is unwritable.",
 	"mechanisms": {
-		"extra-slot-prop": {
-			"description": "an extra `dragItem: dragItem` slot prop is emitted",
-			"pinned": "output only"
-		},
 		"line-comment-swallows-type": {
 			"description": "a `//` line comment inside an `export let` type annotation swallows the rest of the emitted line, so the output is not TypeScript",
 			"pinned": "source"
@@ -17,7 +13,6 @@
 	"entries": {
 		"cnblocks/src/routes/(app)/veil/+layout.svelte": "upstream-bom-crash",
 		"cnblocks/src/routes/(app)/veil/+page.svelte": "upstream-bom-crash",
-		"huly/plugins/view-resources/src/components/list/ListCategory.svelte": "extra-slot-prop",
 		"svelte-virtuallists/src/lib/VirtualListNew.svelte": "line-comment-swallows-type"
 	}
 }

--- a/compatibility/svelte2tsx-mechanisms.json
+++ b/compatibility/svelte2tsx-mechanisms.json
@@ -9,10 +9,6 @@
 			"description": "an extra `dragItem: dragItem` slot prop is emitted",
 			"pinned": "output only"
 		},
-		"ignore-region-merge": {
-			"description": "two adjacent store-get `/*Ωignore_startΩ*/…/*Ωignore_endΩ*/` regions are emitted as ONE region spanning both, where official closes and reopens",
-			"pinned": "source"
-		},
 		"line-comment-swallows-type": {
 			"description": "a `//` line comment inside an `export let` type annotation swallows the rest of the emitted line, so the output is not TypeScript",
 			"pinned": "source"
@@ -27,7 +23,6 @@
 		}
 	},
 	"entries": {
-		"appwrite-console/src/routes/(console)/project-[region]-[project]/overview/platforms/+page.svelte": "ignore-region-merge",
 		"cnblocks/src/routes/(app)/veil/+layout.svelte": "upstream-bom-crash",
 		"cnblocks/src/routes/(app)/veil/+page.svelte": "upstream-bom-crash",
 		"huly/plugins/view-resources/src/components/list/ListCategory.svelte": "extra-slot-prop",

--- a/compatibility/svelte2tsx-mechanisms.json
+++ b/compatibility/svelte2tsx-mechanisms.json
@@ -1,10 +1,6 @@
 {
 	"$schema-note": "id -> mechanism slug for every entry of svelte2tsx-known-failures.json and svelte2tsx-unparseable-known-failures.json. The `Entries by mechanism` table in KNOWN-FAILURES.md is derived from this file: one row per `mechanisms` key, `n` = how many `entries` name it. The assignment is one-to-one, so a double count is unwritable.",
 	"mechanisms": {
-		"line-comment-swallows-type": {
-			"description": "a `//` line comment inside an `export let` type annotation swallows the rest of the emitted line, so the output is not TypeScript",
-			"pinned": "source"
-		},
 		"upstream-bom-crash": {
 			"description": "official svelte2tsx throws from magic-string on a BOM-prefixed component that has both a `<script>` and markup; rsvelte converts it",
 			"pinned": "upstream"
@@ -12,7 +8,6 @@
 	},
 	"entries": {
 		"cnblocks/src/routes/(app)/veil/+layout.svelte": "upstream-bom-crash",
-		"cnblocks/src/routes/(app)/veil/+page.svelte": "upstream-bom-crash",
-		"svelte-virtuallists/src/lib/VirtualListNew.svelte": "line-comment-swallows-type"
+		"cnblocks/src/routes/(app)/veil/+page.svelte": "upstream-bom-crash"
 	}
 }

--- a/compatibility/svelte2tsx-unparseable-known-failures.json
+++ b/compatibility/svelte2tsx-unparseable-known-failures.json
@@ -1,3 +1,1 @@
-[
-	"svelte-virtuallists/src/lib/VirtualListNew.svelte"
-]
+[]

--- a/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
@@ -694,6 +694,22 @@ mod tests {
         );
     }
 
+    /// The one row of `getLastLeadingDoc`'s offset bug rsvelte does NOT
+    /// reproduce: a shift that lands inside the comment makes upstream delete
+    /// the wrong text. Here official emits
+    /// `/**\n * @typedef {import('./X.sv{ a: 1 }}\n */`; rsvelte keeps the
+    /// comment whole. Filed as
+    /// `upstream_issues/svelte2tsx-getlastleadingdoc-mixes-absolute-and-relative-offsets.md`;
+    /// 0 of the corpus's 172 `@typedef`-carrying components reach it.
+    #[test]
+    fn a_shift_that_lands_inside_the_comment_is_a_known_divergence() {
+        let doc = "/**\n * @typedef {import('./X.svelte').T} T\n * @slot {{ a: 1 }}\n */";
+        assert_eq!(
+            props_of(&format!("let z = 1;\n{doc}\nexport let a = z;")),
+            format!("{{\n{doc}a: a}}")
+        );
+    }
+
     // Expected values are `ts.getAllJSDocTagsOfKind`'s own answers, read off the
     // official compiler's props block for each shape.
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
@@ -220,16 +220,7 @@ pub(super) fn apply_props_typedef(
         // `move(generic_arg.pos, generic_arg.end, node.parent.pos)` — TypeScript's
         // `pos` lands right after the previous statement's trailing trivia.
         let raw_bytes = raw_content.as_bytes();
-        let mut p = info.let_pos as usize;
-        while p > 0 {
-            let prev = raw_bytes[p - 1];
-            if prev == b' ' || prev == b'\t' || prev == b'\n' || prev == b'\r' {
-                p -= 1;
-            } else {
-                break;
-            }
-            // Rest element ({ ...rest }) is intentionally not added as a prop
-        }
+        let p = walk_back_through_trivia(raw_bytes, info.let_pos as usize);
         exported_names.props_let_abs_pos = Some(source_offset(p) + offset);
     } else if info.flags.contains(PropsRuneFlags::TYPE_ANNOTATION)
         && !info
@@ -258,15 +249,7 @@ pub(super) fn apply_props_typedef(
         // `;type $$ComponentProps = <type_text>;` before `function $$render`.
         // Leave type_already_inserted = false so it goes BEFORE render.
         let raw_bytes = raw_content.as_bytes();
-        let mut p = info.let_pos as usize;
-        while p > 0 {
-            let prev = raw_bytes[p - 1];
-            if prev == b' ' || prev == b'\t' || prev == b'\n' || prev == b'\r' {
-                p -= 1;
-            } else {
-                break;
-            }
-        }
+        let p = walk_back_through_trivia(raw_bytes, info.let_pos as usize);
         exported_names.props_let_abs_pos = Some(source_offset(p) + offset);
     } else if info
         .flags

--- a/crates/rsvelte_projection/src/svelte2tsx/script/reactive.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/reactive.rs
@@ -106,8 +106,7 @@ pub(super) fn handle_reactive_statement(
                     let rhs_end = assign.right.span().end;
                     let rhs_text = &raw_content[rhs_start as usize..rhs_end as usize];
 
-                    // Check if RHS starts with `{` (object literal needs wrapping in parens)
-                    let wrapped_rhs = invalidate_rhs(rhs_text);
+                    let wrapped_rhs = invalidate_rhs(rhs_text, &assign.right);
 
                     // Overwrite the RHS
                     let rhs_abs_start = rhs_start + offset;
@@ -211,8 +210,11 @@ fn is_store_assignment(target: &oxc::AssignmentTarget) -> bool {
     matches!(target, oxc::AssignmentTarget::AssignmentTargetIdentifier(id) if id.name.starts_with('$'))
 }
 
-fn invalidate_rhs(rhs: &str) -> String {
-    if rhs.starts_with('{') {
+/// Upstream parenthesises the arrow body for an object literal, for an
+/// expression whose text starts with one, and — a third arm rsvelte's text scan
+/// cannot see — for an `as` expression (`ImplicitTopLevelNames.ts:45-52`).
+fn invalidate_rhs(rhs: &str, expr: &oxc::Expression<'_>) -> String {
+    if rhs.starts_with('{') || matches!(expr, oxc::Expression::TSAsExpression(_)) {
         format!("__sveltets_2_invalidate(() => ({rhs}))")
     } else {
         format!("__sveltets_2_invalidate(() => {rhs})")

--- a/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
@@ -1041,16 +1041,30 @@ pub(super) fn inject_store_subscriptions_with_program(
         }
     }
 
-    collect_module_script_import_stores(module_program, context);
-
     // Official `attachStoreValueDeclarationOfImportsToRenderFn` iterates
     // `importStatements` in IMPORT-DECLARATION order (not first-`$store`-use
-    // order), which is exactly the collection order here (instance imports in
-    // program order, then module imports). Just dedup preserving that order.
+    // order), which is exactly the collection order here. Just dedup preserving
+    // that order.
     context.dedup_imports_preserving_order();
-    if !context.import_store_names.is_empty() {
-        let store_decls = create_store_declarations(&context.import_store_names);
-        str.append_right(offset, &store_decls);
+    let instance_decls = create_store_declarations(&context.import_store_names);
+
+    // The module script gets its OWN `ImplicitStoreValues` (`index.ts:202`), so
+    // its imports are a SECOND ignore region rather than more names in the
+    // first — and a name imported by both scripts is declared in both, because
+    // that instance is seeded with the accessed stores and not with the
+    // instance's import list.
+    context.begin_import_collection();
+    collect_module_script_import_stores(module_program, context);
+    context.dedup_imports_preserving_order();
+    let module_decls = create_store_declarations(&context.import_store_names);
+
+    // The instance script's `modifyCode` runs before the module script is
+    // processed, so its region is appended first.
+    if !instance_decls.is_empty() {
+        str.append_right(offset, &instance_decls);
+    }
+    if !module_decls.is_empty() {
+        str.append_right(offset, &module_decls);
     }
 }
 

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
@@ -4,7 +4,7 @@
 use std::borrow::Cow;
 
 use super::svg::is_svg_attribute;
-use crate::ast::template::{AttributeNode, AttributeValue, AttributeValuePart};
+use crate::ast::template::{Attribute, AttributeNode, AttributeValue, AttributeValuePart};
 use crate::svelte2tsx::svelte2tsx::slice_src;
 use crate::svelte2tsx::template::ctx::ElementOpenerCommentIndex;
 use crate::svelte2tsx::template::segs::{Seg, segs_push_fmt, segs_push_lit, segs_push_src};
@@ -38,6 +38,9 @@ pub enum AttrHost<'a> {
     Element {
         tag: &'a str,
         preserve_case: bool,
+        /// Upstream's `Element.isCustomElement()`, which the caller answers
+        /// because its second half reads a sibling `is=` attribute.
+        is_custom_element: bool,
     },
     /// An `Element` whose node type is not `Element`: `<slot>`,
     /// `<svelte:body|window|document|head|fragment>`.
@@ -69,9 +72,11 @@ impl<'a> AttrHost<'a> {
 pub fn format_attribute_node(node: &AttributeNode, source: &str, host: AttrHost) -> String {
     let is_element = matches!(host, AttrHost::Element { .. });
     let name = &match host {
-        AttrHost::Element { tag, preserve_case } => {
-            transform_attribute_case(&node.name, tag, true, preserve_case)
-        }
+        AttrHost::Element {
+            preserve_case,
+            is_custom_element,
+            ..
+        } => transform_attribute_case(&node.name, is_custom_element, true, preserve_case),
         AttrHost::SpecialTag { .. } | AttrHost::Component => Cow::Borrowed(node.name.as_str()),
     };
 
@@ -304,11 +309,10 @@ pub fn is_js_numeric(data: &str) -> bool {
 /// `preserve_case` (the `foreign` namespace) suppresses the fold entirely.
 pub fn transform_attribute_case<'a>(
     name: &'a str,
-    tag: &str,
+    is_custom_element: bool,
     is_element: bool,
     preserve_case: bool,
 ) -> Cow<'a, str> {
-    let is_custom_element = tag.contains('-');
     if !preserve_case
         && is_element
         && !is_svg_attribute(name)
@@ -327,6 +331,23 @@ pub fn transform_attribute_case<'a>(
     } else {
         Cow::Borrowed(name)
     }
+}
+
+/// Upstream's `Element.isCustomElement()`: a dash in the tag name, or an `is=`
+/// attribute whose FIRST value chunk is text containing a dash.
+pub fn element_is_custom(tag: &str, attributes: &[Attribute]) -> bool {
+    if tag.contains('-') {
+        return true;
+    }
+    attributes.iter().any(|attr| match attr {
+        Attribute::Attribute(node) if node.name == "is" => match &node.value {
+            AttributeValue::Sequence(parts) => {
+                matches!(parts.first(), Some(AttributeValuePart::Text(t)) if t.raw.contains('-'))
+            }
+            _ => false,
+        },
+        _ => false,
+    })
 }
 
 /// Build the leading-comment prefix segs for an attribute starting at
@@ -551,9 +572,11 @@ pub fn append_attribute_node_segments(
     // Element attribute names are lowercased to match intrinsic typings
     // (`defaultValue` → `defaultvalue`); component/slot names are preserved.
     let name_owned = match host {
-        AttrHost::Element { tag, preserve_case } => {
-            transform_attribute_case(&node.name, tag, true, preserve_case)
-        }
+        AttrHost::Element {
+            preserve_case,
+            is_custom_element,
+            ..
+        } => transform_attribute_case(&node.name, is_custom_element, true, preserve_case),
         AttrHost::SpecialTag { .. } | AttrHost::Component => Cow::Borrowed(node.name.as_str()),
     };
     let name = name_owned.as_ref();
@@ -995,22 +1018,22 @@ mod tests {
 
     #[test]
     fn transform_attribute_case_borrows_unchanged_names() {
-        let lowercase = transform_attribute_case("class", "div", true, false);
+        let lowercase = transform_attribute_case("class", false, true, false);
         assert!(matches!(lowercase, Cow::Borrowed("class")));
         assert!(matches!(
-            transform_attribute_case("viewBox", "svg", true, false),
+            transform_attribute_case("viewBox", false, true, false),
             Cow::Borrowed("viewBox")
         ));
         assert!(matches!(
-            transform_attribute_case("defaultValue", "my-input", true, false),
+            transform_attribute_case("defaultValue", true, true, false),
             Cow::Borrowed("defaultValue")
         ));
         assert!(matches!(
-            transform_attribute_case("onClick", "button", true, false),
+            transform_attribute_case("onClick", false, true, false),
             Cow::Borrowed("onClick")
         ));
         assert!(matches!(
-            transform_attribute_case("defaultValue", "Component", false, false),
+            transform_attribute_case("defaultValue", false, false, false),
             Cow::Borrowed("defaultValue")
         ));
     }
@@ -1018,11 +1041,11 @@ mod tests {
     #[test]
     fn transform_attribute_case_allocates_only_for_changed_names() {
         assert_eq!(
-            transform_attribute_case("defaultValue", "input", true, false),
+            transform_attribute_case("defaultValue", false, true, false),
             Cow::Owned::<str>("defaultvalue".to_string())
         );
         assert_eq!(
-            transform_attribute_case("İD", "div", true, false),
+            transform_attribute_case("İD", false, true, false),
             Cow::Owned::<str>("i\u{307}d".to_string())
         );
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
@@ -32,9 +32,28 @@ fn valueless_value(source_name: &str) -> &'static str {
 /// node is a `Slot`, so it is the one host where the two answers differ.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum AttrHost<'a> {
-    Element { tag: &'a str, preserve_case: bool },
-    Slot,
+    /// `element instanceof Element && parent.type === 'Element'` — a real tag
+    /// and `<svelte:element>`, the only hosts that fold the name's case and
+    /// rewrite a number-only attribute.
+    Element {
+        tag: &'a str,
+        preserve_case: bool,
+    },
+    /// An `Element` whose node type is not `Element`: `<slot>`,
+    /// `<svelte:body|window|document|head|fragment>`.
+    SpecialTag {
+        tag: &'a str,
+    },
     Component,
+}
+
+impl<'a> AttrHost<'a> {
+    pub fn tag(self) -> &'a str {
+        match self {
+            Self::Element { tag, .. } | Self::SpecialTag { tag } => tag,
+            Self::Component => "",
+        }
+    }
 }
 
 /// Format a regular attribute: `name="value"` → `"name":value,`.
@@ -53,7 +72,7 @@ pub fn format_attribute_node(node: &AttributeNode, source: &str, host: AttrHost)
         AttrHost::Element { tag, preserve_case } => {
             transform_attribute_case(&node.name, tag, true, preserve_case)
         }
-        _ => Cow::Borrowed(node.name.as_str()),
+        AttrHost::SpecialTag { .. } | AttrHost::Component => Cow::Borrowed(node.name.as_str()),
     };
 
     // Determine wrapping: data-* on elements, --* on components.
@@ -511,7 +530,7 @@ fn push_attribute_name(out: &mut Vec<Seg>, node: &AttributeNode, source: &str, n
 /// retain per-character source-map fidelity.
 ///
 /// Applies the same wrapping rules as `format_attribute_node`:
-/// - `is_element` && `data-*` (not `data-sveltekit-*`) → `__sveltets_2_empty({…})`
+/// - element or slot && `data-*` (not `data-sveltekit-*`) → `__sveltets_2_empty({…})`
 /// - component && `--*` → `__sveltets_2_cssProp({…})`
 ///
 /// (Mirrors `htmlxtojsx_v2/nodes/Attribute.ts` `addAttribute`.)
@@ -520,18 +539,23 @@ pub fn append_attribute_node_segments(
     node: &AttributeNode,
     source: &str,
     comments: &ElementOpenerCommentIndex,
-    is_element: bool,
-    tag: &str,
+    host: AttrHost,
     leading_comment: &str,
-    preserve_case: bool,
 ) {
     let leading = leading_attr_comment_segs(node.start, source, comments);
-    let is_data_attr =
-        is_element && node.name.starts_with("data-") && !node.name.starts_with("data-sveltekit-");
-    let is_css_prop = !is_element && node.name.starts_with("--");
+    let is_element = matches!(host, AttrHost::Element { .. });
+    let is_data_attr = !matches!(host, AttrHost::Component)
+        && node.name.starts_with("data-")
+        && !node.name.starts_with("data-sveltekit-");
+    let is_css_prop = matches!(host, AttrHost::Component) && node.name.starts_with("--");
     // Element attribute names are lowercased to match intrinsic typings
     // (`defaultValue` → `defaultvalue`); component/slot names are preserved.
-    let name_owned = transform_attribute_case(&node.name, tag, is_element, preserve_case);
+    let name_owned = match host {
+        AttrHost::Element { tag, preserve_case } => {
+            transform_attribute_case(&node.name, tag, true, preserve_case)
+        }
+        AttrHost::SpecialTag { .. } | AttrHost::Component => Cow::Borrowed(node.name.as_str()),
+    };
     let name = name_owned.as_ref();
 
     match &node.value {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
@@ -24,23 +24,43 @@ fn valueless_value(source_name: &str) -> &'static str {
     }
 }
 
+/// Which of `Attribute.ts`'s two host tests an attribute is being formatted under.
+///
+/// Upstream asks them separately: `element instanceof Element` picks the
+/// `data-` / `--` wrapper, while the case and number rewrites additionally need
+/// `parent.type === 'Element'`. A `<slot>` is built as an `Element` whose parent
+/// node is a `Slot`, so it is the one host where the two answers differ.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum AttrHost<'a> {
+    Element { tag: &'a str, preserve_case: bool },
+    Slot,
+    Component,
+}
+
 /// Format a regular attribute: `name="value"` → `"name":value,`.
 ///
 /// Shorthand attributes like `{propB}` (where name equals expression text)
 /// produce `propB,` instead of `"propB":propB,`.
 ///
 /// Wrapping rules (mirrors `htmlxtojsx_v2/nodes/Attribute.ts` `addAttribute`):
-/// - `is_element` && name starts with `data-` (but NOT `data-sveltekit-`):
+/// - element or slot && name starts with `data-` (but NOT `data-sveltekit-`):
 ///   `...__sveltets_2_empty({ "data-foo": value })` — boolean/no-value → `__sveltets_2_any()`.
-/// - `!is_element` && name starts with `--`:
-///   `...__sveltets_2_cssProp({ "--x": value })` — boolean/no-value → `""`.
-pub fn format_attribute_node(node: &AttributeNode, source: &str, is_element: bool) -> String {
-    let name = &node.name;
+/// - component && name starts with `--`:
+///   `...__sveltets_2_cssProp({ "--x": value })`.
+pub fn format_attribute_node(node: &AttributeNode, source: &str, host: AttrHost) -> String {
+    let is_element = matches!(host, AttrHost::Element { .. });
+    let name = &match host {
+        AttrHost::Element { tag, preserve_case } => {
+            transform_attribute_case(&node.name, tag, true, preserve_case)
+        }
+        _ => Cow::Borrowed(node.name.as_str()),
+    };
 
     // Determine wrapping: data-* on elements, --* on components.
-    let is_data_attr =
-        is_element && name.starts_with("data-") && !name.starts_with("data-sveltekit-");
-    let is_css_prop = !is_element && name.starts_with("--");
+    let is_data_attr = !matches!(host, AttrHost::Component)
+        && name.starts_with("data-")
+        && !name.starts_with("data-sveltekit-");
+    let is_css_prop = matches!(host, AttrHost::Component) && name.starts_with("--");
 
     /// Wrap the inner `"name":value` (without trailing comma) in the
     /// appropriate helper and re-attach the comma.
@@ -62,11 +82,16 @@ pub fn format_attribute_node(node: &AttributeNode, source: &str, is_element: boo
             // `__sveltets_2_any()` fallback in upstream `Attribute.ts` only applies
             // when the attribute has no value at all, which never happens for a
             // boolean attribute.)
-            // For --* on components: boolean means no value → ""
+            // A `--x` with no value is `true` too: the `""` fallback in
+            // `addProp` only fires when `addAttribute` is called with no value
+            // argument, which the `attr.value === true` branch never does.
             if is_data_attr {
                 format!("...__sveltets_2_empty({{\"{name}\":true}}),")
             } else if is_css_prop {
-                format!("...__sveltets_2_cssProp({{\"{name}\":\"\"}}),")
+                format!(
+                    "...__sveltets_2_cssProp({{\"{name}\":{}}}),",
+                    valueless_value(&node.name)
+                )
             } else {
                 format!("\"{name}\":{},", valueless_value(&node.name))
             }
@@ -487,7 +512,7 @@ fn push_attribute_name(out: &mut Vec<Seg>, node: &AttributeNode, source: &str, n
 ///
 /// Applies the same wrapping rules as `format_attribute_node`:
 /// - `is_element` && `data-*` (not `data-sveltekit-*`) → `__sveltets_2_empty({…})`
-/// - `!is_element` && `--*` → `__sveltets_2_cssProp({…})`
+/// - component && `--*` → `__sveltets_2_cssProp({…})`
 ///
 /// (Mirrors `htmlxtojsx_v2/nodes/Attribute.ts` `addAttribute`.)
 pub fn append_attribute_node_segments(
@@ -529,7 +554,7 @@ pub fn append_attribute_node_segments(
             } else if is_css_prop {
                 segs_push_lit(out, "...__sveltets_2_cssProp({");
                 push_attribute_name(out, node, source, name);
-                segs_push_lit(out, ":\"\"}),");
+                segs_push_fmt(out, format_args!(":{}}}),", valueless_value(&node.name)));
             } else {
                 push_attribute_name(out, node, source, name);
                 segs_push_fmt(out, format_args!(":{},", valueless_value(&node.name)));

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
@@ -145,14 +145,31 @@ pub fn format_attribute_node(node: &AttributeNode, source: &str, is_element: boo
                         value_parts.push(escaped);
                     }
                     AttributeValuePart::ExpressionTag(expr) => {
-                        let expr_text = get_expression_text(&expr.expression, source);
-                        value_parts.push(format!("${{{expr_text}}}"));
+                        // Official copies the mustache's INTERIOR verbatim, so a
+                        // comment or the author's whitespace inside `{ … }`
+                        // survives; the expression node's own span starts after
+                        // both.
+                        value_parts.push(format!("${{{}}}", mustache_interior(expr, source)));
                     }
                 }
             }
             let inner = format!("\"{}\":`{}`", name, value_parts.join(""));
             wrap(&inner, is_data_attr, is_css_prop)
         }
+    }
+}
+
+/// The text between a mustache's braces. Official's `Attribute.ts` copies that
+/// range into the template literal rather than the expression node's own span,
+/// so a comment or whitespace inside `{ … }` reaches the output.
+fn mustache_interior<'s>(
+    expr: &crate::ast::template::ExpressionTag<'_>,
+    source: &'s str,
+) -> &'s str {
+    if expr.end > expr.start + 1 {
+        slice_src(source, expr.start as usize + 1, expr.end as usize - 1)
+    } else {
+        get_expression_text(&expr.expression, source)
     }
 }
 
@@ -704,9 +721,12 @@ pub fn append_attribute_node_segments(
                             segs_push_lit(out, &escaped);
                         }
                         AttributeValuePart::ExpressionTag(expr) => {
-                            let range = get_expression_range(&expr.expression);
                             segs_push_lit(out, "${");
-                            if let Some((s, e)) = range {
+                            // See `mustache_interior`: the slice is the braces'
+                            // contents, not the expression node's span.
+                            if expr.end > expr.start + 1 {
+                                segs_push_src(out, expr.start + 1, expr.end - 1);
+                            } else if let Some((s, e)) = get_expression_range(&expr.expression) {
                                 segs_push_src(out, s, e);
                             } else {
                                 segs_push_lit(out, get_expression_text(&expr.expression, source));

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
@@ -28,7 +28,7 @@ use crate::svelte2tsx::template::utils::expr::{
 
 use action::format_use_directive;
 use attribute::{
-    append_attribute_node_segments, format_attribute_node, trailing_attr_comment_segs,
+    AttrHost, append_attribute_node_segments, format_attribute_node, trailing_attr_comment_segs,
     trailing_attr_comment_text,
 };
 use binding::{bind_is_filtered_from_props, format_bind_directive_segments};
@@ -331,9 +331,9 @@ pub(super) fn build_component_props_string(
                 if node.name == "slot" && drop_slot {
                     continue;
                 }
-                // is_element=false: --* attrs are wrapped with __sveltets_2_cssProp
+                // A component's `--*` attrs are wrapped with __sveltets_2_cssProp
                 // inside format_attribute_node (mirrors Attribute.ts `addProp`).
-                parts.push(format_attribute_node(node, source, false));
+                parts.push(format_attribute_node(node, source, AttrHost::Component));
             }
             Attribute::SpreadAttribute(spread) => {
                 parts.push(format_spread_attribute(spread, source));

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
@@ -118,37 +118,16 @@ pub(super) fn build_attributes_string(
     source: &str,
     comments: &ElementOpenerCommentIndex,
     in_slot_context: bool,
-    preserve_case: bool,
-    preserve_bind: bool,
-) -> String {
-    build_attributes_string_with_tag(
-        attributes,
-        source,
-        comments,
-        "",
-        in_slot_context,
-        preserve_case,
-        preserve_bind,
-    )
-}
-
-pub(super) fn build_attributes_string_with_tag(
-    attributes: &[Attribute],
-    source: &str,
-    comments: &ElementOpenerCommentIndex,
-    parent_tag: &str,
-    in_slot_context: bool,
-    preserve_case: bool,
+    host: AttrHost,
     preserve_bind: bool,
 ) -> String {
     let segs = build_attribute_segments(
         attributes,
         source,
         comments,
-        parent_tag,
         in_slot_context,
         None,
-        preserve_case,
+        host,
         preserve_bind,
     );
     segs_to_string(&segs, source)
@@ -167,10 +146,9 @@ pub(super) fn build_attribute_segments(
     attributes: &[Attribute],
     source: &str,
     comments: &ElementOpenerCommentIndex,
-    parent_tag: &str,
     in_slot_context: bool,
     opener_content_start: Option<u32>,
-    preserve_case: bool,
+    host: AttrHost,
     preserve_bind: bool,
 ) -> Vec<Seg> {
     let mut segs: Vec<Seg> = Vec::with_capacity(attributes.len().saturating_mul(2));
@@ -209,16 +187,7 @@ pub(super) fn build_attribute_segments(
                     }
                     _ => "",
                 };
-                append_attribute_node_segments(
-                    &mut segs,
-                    node,
-                    source,
-                    comments,
-                    true,
-                    parent_tag,
-                    leading,
-                    preserve_case,
-                );
+                append_attribute_node_segments(&mut segs, node, source, comments, host, leading);
                 any_pushed = true;
                 prev_end = Some(node.end);
             }
@@ -235,7 +204,7 @@ pub(super) fn build_attribute_segments(
                 // an element-var assignment. The get/set exception only keeps
                 // one-way binding *attributes* (clientWidth, …) as props.
                 if (is_get_set && bind.name != "this")
-                    || !bind_is_filtered_from_props(&bind.name, parent_tag)
+                    || !bind_is_filtered_from_props(&bind.name, host.tag())
                 {
                     let part = format_bind_directive_segments(bind, source, preserve_bind);
                     push_with_separator(&mut segs, part);
@@ -441,7 +410,12 @@ pub(super) fn build_component_props_segments(
                 // inside append_attribute_node_segments (mirrors Attribute.ts).
                 // Components preserve attribute-name case, so the tag is unused.
                 append_attribute_node_segments(
-                    &mut inner, node, source, comments, false, "", "", false,
+                    &mut inner,
+                    node,
+                    source,
+                    comments,
+                    AttrHost::Component,
+                    "",
                 );
             }
             Attribute::SpreadAttribute(spread) => {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/collect/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/collect/mod.rs
@@ -608,9 +608,9 @@ fn collect_slot_prop_entries(
                 continue; // Skip the name attribute
             }
             match &node.value {
-                AttributeValue::True(_) => {
-                    props.push(format!("{}:{}", node.name, resolve(&node.name)));
-                }
+                // `handleSlot` skips any attribute with no value at all
+                // (`!attr.value?.length`), so `<slot a />` contributes nothing.
+                AttributeValue::True(_) => {}
                 AttributeValue::Expression(expr) => {
                     let expr_text = get_expression_text(&expr.expression, source);
                     props.push(format!("{}:{}", node.name, resolve(expr_text)));

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -618,11 +618,8 @@ pub fn handle_named_slot_svelte_fragment(
     let slot_name = slot_attr_static_name(&el.attributes).unwrap_or_default();
     let let_destructure = build_let_destructure_string(&el.attributes, source);
 
-    // Leading ` ` matches the JS reference, which produces
-    // `\t {const ... ;{ svelteHTML.createElement(...)` after the tab indent
-    // is preserved.
     let block_open = format!(
-        " {{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{let_destructure}}} = {inst_var}.$$slot_def[\"{slot_name}\"];$$_$$;"
+        "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{let_destructure}}} = {inst_var}.$$slot_def[\"{slot_name}\"];$$_$$;"
     );
 
     let opening_tag_end =
@@ -645,32 +642,29 @@ pub fn handle_named_slot_svelte_fragment(
         false,
         options.namespace.preserves_attribute_case(),
     );
-    let inner = if attrs_str.is_empty() {
-        let stripped_count = el
-            .attributes
-            .iter()
-            .filter(|a| {
-                matches!(
-                    a,
-                    Attribute::Attribute(node)
-                        if node.name == "slot"
-                ) || matches!(a, Attribute::LetDirective(_))
-            })
-            .count();
-        // A self-closing tag's ` /` is one more source column the emission
-        // preserves, and it lands inside the braces rather than after them.
-        let width = if has_closing_tag {
-            stripped_count.max(1)
-        } else {
-            stripped_count + 1
-        };
-        " ".repeat(width)
-    } else {
-        attrs_str
-    };
+    // The opener is position-preserving, exactly as on a named-slot element:
+    // the columns the stripped `slot=` / `let:` take up reappear as spaces.
+    let spacing = opener_spacing(
+        source,
+        el.start,
+        &el.name,
+        opening_tag_end,
+        Some((el.start + 1, el.start + 1 + source_offset(el.name.len()))),
+        &el.attributes,
+        &counter.element_opener_comments,
+        OpenerCtx {
+            is_element: true,
+            in_component_slot: true,
+            tag_name: &el.name,
+            is_slot_tag: false,
+            preserve_bind: options.preserves_bind_prefix(),
+        },
+    );
     let opener = format!(
-        "{block_open}{{ {}.createElement(\"svelte:fragment\", {{{inner}}});",
-        options.typings_namespace
+        "{}{block_open}{{ {}.createElement(\"svelte:fragment\", {{{}{attrs_str}}});",
+        " ".repeat(spacing.before_block),
+        options.typings_namespace,
+        " ".repeat(spacing.in_attr_object),
     );
 
     if !has_closing_tag {
@@ -890,11 +884,14 @@ pub fn build_named_slot_element_attrs(
                 }
                 // Named-slot elements become `svelteHTML.createElement(…)` calls,
                 // so they are real DOM elements — apply data-* wrapping.
-                parts.push(format_attribute_node(
-                    node,
-                    source,
-                    AttrHost::Element { tag, preserve_case },
-                ));
+                // `<svelte:fragment>` is an `Element` whose node type is not
+                // `Element`, so neither name rewrite reaches it.
+                let host = if tag == "svelte:fragment" {
+                    AttrHost::SpecialTag { tag }
+                } else {
+                    AttrHost::Element { tag, preserve_case }
+                };
+                parts.push(format_attribute_node(node, source, host));
             }
             Attribute::SpreadAttribute(spread) => {
                 parts.push(format_spread_attribute(spread, source));

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -12,7 +12,7 @@ fn source_offset(value: usize) -> u32 {
     u32::try_from(value).expect("template source offsets are represented as u32")
 }
 
-use crate::svelte2tsx::template::attributes::attribute::format_attribute_node;
+use crate::svelte2tsx::template::attributes::attribute::{AttrHost, format_attribute_node};
 use crate::svelte2tsx::template::attributes::binding::{
     any_bind_needs_element_var, bind_is_filtered_from_props, format_bind_directive,
     sanitize_tag_for_var,
@@ -488,6 +488,7 @@ pub fn handle_named_slot_element(
         &options.typings_namespace,
         &el.name,
         true,
+        options.namespace.preserves_attribute_case(),
     );
 
     let opening_tag_end =
@@ -642,6 +643,7 @@ pub fn handle_named_slot_svelte_fragment(
         // `<svelte:fragment>` emits no binding suffix — and takes only `slot`
         // and `let:`, so there is nothing to lower.
         false,
+        options.namespace.preserves_attribute_case(),
     );
     let inner = if attrs_str.is_empty() {
         let stripped_count = el
@@ -876,6 +878,7 @@ pub fn build_named_slot_element_attrs(
     ns: &str,
     tag: &str,
     lower_bindings: bool,
+    preserve_case: bool,
 ) -> String {
     let mut parts: Vec<String> = Vec::new();
 
@@ -887,7 +890,11 @@ pub fn build_named_slot_element_attrs(
                 }
                 // Named-slot elements become `svelteHTML.createElement(…)` calls,
                 // so they are real DOM elements — apply data-* wrapping.
-                parts.push(format_attribute_node(node, source, true));
+                parts.push(format_attribute_node(
+                    node,
+                    source,
+                    AttrHost::Element { tag, preserve_case },
+                ));
             }
             Attribute::SpreadAttribute(spread) => {
                 parts.push(format_spread_attribute(spread, source));

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -12,7 +12,9 @@ fn source_offset(value: usize) -> u32 {
     u32::try_from(value).expect("template source offsets are represented as u32")
 }
 
-use crate::svelte2tsx::template::attributes::attribute::{AttrHost, format_attribute_node};
+use crate::svelte2tsx::template::attributes::attribute::{
+    AttrHost, element_is_custom, format_attribute_node,
+};
 use crate::svelte2tsx::template::attributes::binding::{
     any_bind_needs_element_var, bind_is_filtered_from_props, format_bind_directive,
     sanitize_tag_for_var,
@@ -889,7 +891,11 @@ pub fn build_named_slot_element_attrs(
                 let host = if tag == "svelte:fragment" {
                     AttrHost::SpecialTag { tag }
                 } else {
-                    AttrHost::Element { tag, preserve_case }
+                    AttrHost::Element {
+                        tag,
+                        preserve_case,
+                        is_custom_element: element_is_custom(tag, attributes),
+                    }
                 };
                 parts.push(format_attribute_node(node, source, host));
             }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -13,10 +13,12 @@ fn source_offset(value: usize) -> u32 {
 }
 
 use crate::svelte2tsx::template::attributes::attribute::format_attribute_node;
-use crate::svelte2tsx::template::attributes::binding::format_bind_directive;
-use crate::svelte2tsx::template::attributes::class_style::build_class_style_directive_suffix_segments;
+use crate::svelte2tsx::template::attributes::binding::{
+    any_bind_needs_element_var, bind_is_filtered_from_props, format_bind_directive,
+    sanitize_tag_for_var,
+};
 use crate::svelte2tsx::template::attributes::directive_suffix::{
-    action_arguments, build_directive_prefix_suffix,
+    action_arguments, build_directive_prefix_suffix, build_element_directive_suffix_segments,
 };
 use crate::svelte2tsx::template::attributes::event_handler::format_on_directive;
 use crate::svelte2tsx::template::attributes::let_::{
@@ -25,7 +27,7 @@ use crate::svelte2tsx::template::attributes::let_::{
 use crate::svelte2tsx::template::attributes::spread::format_spread_attribute;
 use crate::svelte2tsx::template::ctx::{Counter, TemplateNodeExt};
 use crate::svelte2tsx::template::segs::segs_to_string;
-use crate::svelte2tsx::template::utils::expr::get_expression_range;
+use crate::svelte2tsx::template::utils::expr::{get_expression_range, get_set_binding_ranges};
 use crate::svelte2tsx::template::utils::opener_spacing::{OpenerCtx, opener_spacing};
 use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_opening_tag_end};
 use crate::svelte2tsx::template::walk::{process_fragment_inplace, process_node_inplace};
@@ -480,26 +482,46 @@ pub fn handle_named_slot_element(
     );
 
     // Build attributes string excluding `slot` and `let:` directives
-    let attrs_str =
-        build_named_slot_element_attrs(&el.attributes, source, &options.typings_namespace);
+    let attrs_str = build_named_slot_element_attrs(
+        &el.attributes,
+        source,
+        &options.typings_namespace,
+        &el.name,
+        true,
+    );
 
     let opening_tag_end =
         find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
 
-    // class:/style: directives lower to statements after createElement
-    // (`class:bar` → ` bar;`), same as a regular element. The `let:` binding
-    // itself is consumed by the `$$slot_def[…]` destructure above (and any use
-    // in the body emits its own reference), so it is NOT re-emitted here.
-    let class_style_suffix = segs_to_string(
-        &build_class_style_directive_suffix_segments(&el.attributes, source),
-        source,
-    );
-
-    // Actions precede the element and transitions follow it, same as a regular
-    // element — see `handle_regular_element`.
-    let (directive_prefix, directive_suffix, action_count) =
+    // Actions precede the element, same as a regular element — see
+    // `handle_regular_element`. Its `directive_suffix` is unused for the same
+    // reason it is there: the segment builder below covers transitions too.
+    let (directive_prefix, _directive_suffix, action_count) =
         build_directive_prefix_suffix(&el.attributes, source, &el.name, &options.typings_namespace);
     let actions_arg = action_arguments(action_count);
+
+    // A `bind:this` / one-way binding needs the created element in a variable to
+    // assign from. The index is the element's nesting DEPTH, as on a regular
+    // element.
+    let element_var = any_bind_needs_element_var(&el.attributes, source)
+        .then(|| format!("$$_{}{depth}", sanitize_tag_for_var(&el.name)));
+
+    // class:/style:/transition:/bind: lower to statements after createElement in
+    // ONE source-order pass, exactly as on a regular element. The `let:` binding
+    // itself is consumed by the `$$slot_def[…]` destructure above (and any use
+    // in the body emits its own reference), so it is NOT re-emitted here.
+    let directive_suffix = segs_to_string(
+        &build_element_directive_suffix_segments(
+            &el.attributes,
+            source,
+            element_var.as_deref(),
+            &el.name,
+            options.is_ts_file || !options.emit_jsdoc,
+            &el.name,
+            &options.typings_namespace,
+        ),
+        source,
+    );
 
     let spacing = opener_spacing(
         source,
@@ -521,8 +543,11 @@ pub fn handle_named_slot_element(
     // destructure (`{ …, foo: bar } = …$$slot_def["…"]`); official emits NO
     // separate `bar;` reflection statement (that would duplicate the `{bar}`
     // content expression).
+    let element_var_decl = element_var
+        .as_ref()
+        .map_or_else(String::new, |var| format!("const {var} = "));
     let opener = format!(
-        "{}{}{}{{ {}.createElement(\"{}\"{}, {{{}{}}});{}{}",
+        "{}{}{}{{ {}{}.createElement(\"{}\"{}, {{{}{}}});{}",
         " ".repeat(spacing.before_block),
         block_open,
         // An action prefix gets its own block so `$$action_N` is scoped to the
@@ -532,21 +557,22 @@ pub fn handle_named_slot_element(
         } else {
             format!("{{{directive_prefix}")
         },
+        element_var_decl,
         options.typings_namespace,
         el.name,
         actions_arg,
         " ".repeat(spacing.in_attr_object),
         attrs_str,
-        class_style_suffix,
         directive_suffix
     );
     str.overwrite(el.start, opening_tag_end, &opener);
     // An action prefix opens one more block, which the closer below has to match.
-    let close = if directive_prefix.is_empty() {
-        " }}"
-    } else {
-        " }}}"
-    };
+    // The leading space is the one the overwritten `</tag>` leaves behind, so an
+    // element that has no closing tag to overwrite does not get it — same rule
+    // as `close_regular_element`.
+    let extra_close = if directive_prefix.is_empty() { "" } else { "}" };
+    let close = format!(" }}}}{extra_close}");
+    let close_no_tag = format!("}}}}{extra_close}");
 
     // This named-slot element is a RegularElement — its children are at depth+1.
     hoist_snippet_blocks(&el.fragment, source, str);
@@ -562,13 +588,13 @@ pub fn handle_named_slot_element(
         .ends_with("/>");
     let is_void = crate::compiler::utils::is_void_element(&el.name);
     if is_void || is_self_closing_source {
-        str.append_left(el.end, close);
+        str.append_left(el.end, &close_no_tag);
     } else {
         let closing_tag_start = find_closing_tag_start(source, el.end);
         if closing_tag_start < el.end {
-            str.overwrite(closing_tag_start, el.end, close);
+            str.overwrite(closing_tag_start, el.end, &close);
         } else {
-            str.append_left(el.end, close);
+            str.append_left(el.end, &close_no_tag);
         }
     }
 }
@@ -608,8 +634,15 @@ pub fn handle_named_slot_svelte_fragment(
     // position-preserving emission leaves one space per stripped attribute
     // visible inside the empty `{}` (so `slot="x" let:y` → 2 spaces,
     // `slot="x" let:y let:z` → 3 spaces, etc.).
-    let attrs_str =
-        build_named_slot_element_attrs(&el.attributes, source, &options.typings_namespace);
+    let attrs_str = build_named_slot_element_attrs(
+        &el.attributes,
+        source,
+        &options.typings_namespace,
+        &el.name,
+        // `<svelte:fragment>` emits no binding suffix — and takes only `slot`
+        // and `let:`, so there is nothing to lower.
+        false,
+    );
     let inner = if attrs_str.is_empty() {
         let stripped_count = el
             .attributes
@@ -834,7 +867,16 @@ pub fn handle_named_slot_svelte_self(
 }
 
 /// Build attribute string for a named slot element, excluding `slot` and `let:` directives.
-pub fn build_named_slot_element_attrs(attributes: &[Attribute], source: &str, ns: &str) -> String {
+/// `lower_bindings` says the caller also emits the post-`createElement` binding
+/// suffix, so `bind:this` and the one-way binding attributes must leave the
+/// props object — the hosts that do not emit that suffix would drop them.
+pub fn build_named_slot_element_attrs(
+    attributes: &[Attribute],
+    source: &str,
+    ns: &str,
+    tag: &str,
+    lower_bindings: bool,
+) -> String {
     let mut parts: Vec<String> = Vec::new();
 
     for attr in attributes {
@@ -851,11 +893,20 @@ pub fn build_named_slot_element_attrs(attributes: &[Attribute], source: &str, ns
                 parts.push(format_spread_attribute(spread, source));
             }
             Attribute::BindDirective(bind) => {
-                parts.push(format_bind_directive(
-                    bind,
-                    source,
-                    ns == crate::svelte2tsx::interfaces::DEFAULT_TYPINGS_NAMESPACE,
-                ));
+                // Same rule as a regular element's props object: `bind:this` and
+                // the one-way binding attributes are lowered to statements after
+                // `createElement`, not carried as props.
+                let is_get_set = get_set_binding_ranges(&bind.expression, source).is_some();
+                if !lower_bindings
+                    || (is_get_set && bind.name != "this")
+                    || !bind_is_filtered_from_props(&bind.name, tag)
+                {
+                    parts.push(format_bind_directive(
+                        bind,
+                        source,
+                        ns == crate::svelte2tsx::interfaces::DEFAULT_TYPINGS_NAMESPACE,
+                    ));
+                }
             }
             Attribute::OnDirective(on) => {
                 parts.push(format_on_directive(on, source));

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
@@ -7,6 +7,7 @@ use crate::ast::template::{Attribute, SvelteDynamicElement};
 use crate::svelte2tsx::magic_string::MagicString;
 use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, slice_src};
 
+use crate::svelte2tsx::template::attributes::attribute::AttrHost;
 use crate::svelte2tsx::template::attributes::binding::{
     any_bind_needs_element_var, build_bind_directive_suffix, element_var_base_name,
 };
@@ -88,7 +89,10 @@ pub fn handle_svelte_dynamic_element(
             source,
             &counter.element_opener_comments,
             saved_slot.is_some(),
-            options.namespace.preserves_attribute_case(),
+            AttrHost::Element {
+                tag: "",
+                preserve_case: options.namespace.preserves_attribute_case(),
+            },
             options.preserves_bind_prefix(),
         )
     };

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
@@ -7,7 +7,7 @@ use crate::ast::template::{Attribute, SvelteDynamicElement};
 use crate::svelte2tsx::magic_string::MagicString;
 use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, slice_src};
 
-use crate::svelte2tsx::template::attributes::attribute::AttrHost;
+use crate::svelte2tsx::template::attributes::attribute::{AttrHost, element_is_custom};
 use crate::svelte2tsx::template::attributes::binding::{
     any_bind_needs_element_var, build_bind_directive_suffix, element_var_base_name,
 };
@@ -90,8 +90,9 @@ pub fn handle_svelte_dynamic_element(
             &counter.element_opener_comments,
             saved_slot.is_some(),
             AttrHost::Element {
-                tag: "",
+                tag: &el.name,
                 preserve_case: options.namespace.preserves_attribute_case(),
+                is_custom_element: element_is_custom(&el.name, &el.attributes),
             },
             options.preserves_bind_prefix(),
         )

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
@@ -74,7 +74,13 @@ pub fn handle_svelte_dynamic_element(
     // In a named-slot context the `slot` attribute is consumed by the wrapper
     // block, so build the attributes without it.
     let attrs_str = if named_slot.is_some() {
-        build_named_slot_element_attrs(&el.attributes, source, &options.typings_namespace)
+        build_named_slot_element_attrs(
+            &el.attributes,
+            source,
+            &options.typings_namespace,
+            &el.name,
+            true,
+        )
     } else {
         build_attributes_string(
             &el.attributes,

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
@@ -80,6 +80,7 @@ pub fn handle_svelte_dynamic_element(
             &options.typings_namespace,
             &el.name,
             true,
+            options.namespace.preserves_attribute_case(),
         )
     } else {
         build_attributes_string(

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
@@ -4,6 +4,7 @@ use crate::ast::template::{RegularElement, SlotElement, TitleElement};
 use crate::svelte2tsx::magic_string::MagicString;
 use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, slice_src};
 
+use crate::svelte2tsx::template::attributes::attribute::AttrHost;
 use crate::svelte2tsx::template::attributes::binding::{
     any_bind_needs_element_var, sanitize_tag_for_var,
 };
@@ -191,10 +192,12 @@ fn regular_opener_attributes(
         &el.attributes,
         source,
         &counter.element_opener_comments,
-        &el.name,
         in_component_slot,
         Some(content_start),
-        options.namespace.preserves_attribute_case(),
+        AttrHost::Element {
+            tag: &el.name,
+            preserve_case: options.namespace.preserves_attribute_case(),
+        },
         options.preserves_bind_prefix(),
     );
     let spacing = opener_spacing(
@@ -336,7 +339,10 @@ pub fn handle_title_element(
         source,
         &counter.element_opener_comments,
         saved_slot.is_some(),
-        options.namespace.preserves_attribute_case(),
+        AttrHost::Element {
+            tag: "",
+            preserve_case: options.namespace.preserves_attribute_case(),
+        },
         options.preserves_bind_prefix(),
     );
 

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
@@ -4,7 +4,7 @@ use crate::ast::template::{RegularElement, SlotElement, TitleElement};
 use crate::svelte2tsx::magic_string::MagicString;
 use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, slice_src};
 
-use crate::svelte2tsx::template::attributes::attribute::AttrHost;
+use crate::svelte2tsx::template::attributes::attribute::{AttrHost, element_is_custom};
 use crate::svelte2tsx::template::attributes::binding::{
     any_bind_needs_element_var, sanitize_tag_for_var,
 };
@@ -197,6 +197,7 @@ fn regular_opener_attributes(
         AttrHost::Element {
             tag: &el.name,
             preserve_case: options.namespace.preserves_attribute_case(),
+            is_custom_element: element_is_custom(&el.name, &el.attributes),
         },
         options.preserves_bind_prefix(),
     );
@@ -340,8 +341,9 @@ pub fn handle_title_element(
         &counter.element_opener_comments,
         saved_slot.is_some(),
         AttrHost::Element {
-            tag: "",
+            tag: &el.name,
             preserve_case: options.namespace.preserves_attribute_case(),
+            is_custom_element: element_is_custom(&el.name, &el.attributes),
         },
         options.preserves_bind_prefix(),
     );

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -13,7 +13,7 @@ use crate::ast::template::{
 use crate::svelte2tsx::magic_string::MagicString;
 use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, SvelteVersion, slice_src};
 
-use crate::svelte2tsx::template::attributes::attribute::format_attribute_node;
+use crate::svelte2tsx::template::attributes::attribute::{AttrHost, format_attribute_node};
 use crate::svelte2tsx::template::attributes::binding::format_component_bind_directive;
 use crate::svelte2tsx::template::attributes::class_style::build_class_style_directive_suffix_segments;
 use crate::svelte2tsx::template::attributes::directive_suffix::build_component_directive_suffix;
@@ -929,7 +929,7 @@ pub fn handle_svelte_self(
                     }
                     // `<svelte:self>` is component-like (`__sveltets_2_createComponentAny`),
                     // so apply --* CSS-prop wrapping, not data-* element wrapping.
-                    prop_parts.push(format_attribute_node(node, source, false));
+                    prop_parts.push(format_attribute_node(node, source, AttrHost::Component));
                 }
                 Attribute::SpreadAttribute(spread) => {
                     prop_parts.push(format_spread_attribute(spread, source));

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
@@ -294,7 +294,11 @@ pub fn build_slot_props_string(
                 }
                 // A `<slot>` is built as an `Element` upstream, so the `data-`
                 // wrapper applies to it and the component-only `--` one does not.
-                parts.push(format_attribute_node(node, source, AttrHost::Slot));
+                parts.push(format_attribute_node(
+                    node,
+                    source,
+                    AttrHost::SpecialTag { tag: "slot" },
+                ));
             }
             Attribute::SpreadAttribute(spread) => {
                 parts.push(format_spread_attribute(spread, source));

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
@@ -4,7 +4,7 @@ use crate::ast::template::{Attribute, AttributeValue, AttributeValuePart, SlotEl
 use crate::svelte2tsx::magic_string::MagicString;
 use crate::svelte2tsx::svelte2tsx::Svelte2TsxOptions;
 
-use crate::svelte2tsx::template::attributes::attribute::format_attribute_node;
+use crate::svelte2tsx::template::attributes::attribute::{AttrHost, format_attribute_node};
 use crate::svelte2tsx::template::attributes::binding::format_bind_directive;
 use crate::svelte2tsx::template::attributes::spread::format_spread_attribute;
 use crate::svelte2tsx::template::ctx::Counter;
@@ -292,9 +292,9 @@ pub fn build_slot_props_string(
                 if node.name == "name" || (node.name == "slot" && drop_slot_attr) {
                     continue;
                 }
-                // Slot props are neither DOM-element props nor component props;
-                // use is_element=false (no data-* wrapping; --* wrapping if present).
-                parts.push(format_attribute_node(node, source, false));
+                // A `<slot>` is built as an `Element` upstream, so the `data-`
+                // wrapper applies to it and the component-only `--` one does not.
+                parts.push(format_attribute_node(node, source, AttrHost::Slot));
             }
             Attribute::SpreadAttribute(spread) => {
                 parts.push(format_spread_attribute(spread, source));

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
@@ -194,6 +194,7 @@ pub fn handle_svelte_special_element(
             &options.typings_namespace,
             &el.name,
             true,
+            options.namespace.preserves_attribute_case(),
         )
     } else {
         build_attributes_string(

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
@@ -7,6 +7,7 @@ use crate::ast::template::{SvelteElement, TemplateNode};
 use crate::svelte2tsx::magic_string::MagicString;
 use crate::svelte2tsx::svelte2tsx::Svelte2TsxOptions;
 
+use crate::svelte2tsx::template::attributes::attribute::AttrHost;
 use crate::svelte2tsx::template::attributes::binding::{
     any_bind_needs_element_var, build_bind_directive_suffix, element_var_base_name,
 };
@@ -202,7 +203,9 @@ pub fn handle_svelte_special_element(
             source,
             &counter.element_opener_comments,
             saved_slot.is_some(),
-            options.namespace.preserves_attribute_case(),
+            // `<svelte:body|window|document|head|fragment>` is an `Element` whose
+            // node type is not `Element`, so neither name rewrite applies.
+            AttrHost::SpecialTag { tag: &el.name },
             options.preserves_bind_prefix(),
         )
     };

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
@@ -188,7 +188,13 @@ pub fn handle_svelte_special_element(
     // In a named-slot context the `slot` attribute is consumed by the wrapper
     // block, so build the attributes without it.
     let attrs_str = if named_slot.is_some() {
-        build_named_slot_element_attrs(&el.attributes, source, &options.typings_namespace)
+        build_named_slot_element_attrs(
+            &el.attributes,
+            source,
+            &options.typings_namespace,
+            &el.name,
+            true,
+        )
     } else {
         build_attributes_string(
             &el.attributes,

--- a/crates/rsvelte_projection/tests/svelte2tsx_attribute_name_rewrites.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_attribute_name_rewrites.rs
@@ -1,0 +1,389 @@
+//! `Attribute.ts` folds an attribute name's case and rewrites a number-only
+//! value under `element instanceof Element && parent.type === 'Element'` — two
+//! conditions, where the `data-` / `--` wrapper needs only the first.
+//!
+//! Every `<svelte:…>` tag is built as an `Element`, but only `<svelte:element>`
+//! carries the node type `Element`. So `<svelte:body|window|document|head|fragment>`
+//! take the `data-` wrapper and neither name rewrite, and rsvelte applied both
+//! rewrites to all of them.
+//!
+//! The grid is host × the attribute shapes that separate the rules: a mixed-case
+//! name and a number-only value are what the second condition gates, an SVG-cased
+//! name / an `on`-prefixed name / a custom-element tag are the three exemptions
+//! inside the case fold itself, and the `data-` and `--` rows pin the first
+//! condition so a fix to the second cannot quietly move it.
+//!
+//! Each expectation is the template body of the pinned
+//! `submodules/language-tools` svelte2tsx's own output for that source.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn template_body(src: &str) -> String {
+    let code = svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "T.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+    const OPEN: &str = "async () => {\n";
+    let start = code.find(OPEN).expect("render body") + OPEN.len();
+    let end = code[start..]
+        .find("\nreturn { props:")
+        .expect("render body end")
+        + start;
+    code[start..end].to_string()
+}
+
+#[test]
+fn only_an_element_typed_node_folds_an_attribute_name() {
+    let mut failures = Vec::new();
+    for (label, src, expected) in [
+        (
+            "div, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div someProp=\"0\" />",
+            " { svelteHTML.createElement(\"div\", {  \"someprop\":`0`,});}};",
+        ),
+        (
+            "div, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div cols=\"3\" />",
+            " { svelteHTML.createElement(\"div\", {  \"cols\":3,});}};",
+        ),
+        (
+            "div, svg-cased name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div viewBox=\"0\" />",
+            " { svelteHTML.createElement(\"div\", {  \"viewBox\":`0`,});}};",
+        ),
+        (
+            "div, on-prefixed name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div onFoo=\"0\" />",
+            " { svelteHTML.createElement(\"div\", {  \"onFoo\":`0`,});}};",
+        ),
+        (
+            "div, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div data-x={b} />",
+            " { svelteHTML.createElement(\"div\", {  ...__sveltets_2_empty({\"data-x\":b}),});}};",
+        ),
+        (
+            "div, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div --x=\"1\" />",
+            " { svelteHTML.createElement(\"div\", {  \"--x\":`1`,});}};",
+        ),
+        (
+            "custom element, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<my-el someProp=\"0\" />",
+            " { svelteHTML.createElement(\"my-el\", {  \"someProp\":`0`,});}};",
+        ),
+        (
+            "custom element, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<my-el cols=\"3\" />",
+            " { svelteHTML.createElement(\"my-el\", {  \"cols\":3,});}};",
+        ),
+        (
+            "custom element, svg-cased name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<my-el viewBox=\"0\" />",
+            " { svelteHTML.createElement(\"my-el\", {  \"viewBox\":`0`,});}};",
+        ),
+        (
+            "custom element, on-prefixed name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<my-el onFoo=\"0\" />",
+            " { svelteHTML.createElement(\"my-el\", {  \"onFoo\":`0`,});}};",
+        ),
+        (
+            "custom element, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<my-el data-x={b} />",
+            " { svelteHTML.createElement(\"my-el\", {  ...__sveltets_2_empty({\"data-x\":b}),});}};",
+        ),
+        (
+            "custom element, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<my-el --x=\"1\" />",
+            " { svelteHTML.createElement(\"my-el\", {  \"--x\":`1`,});}};",
+        ),
+        (
+            "svg, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svg someProp=\"0\" />",
+            " { svelteHTML.createElement(\"svg\", {  \"someprop\":`0`,});}};",
+        ),
+        (
+            "svg, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svg cols=\"3\" />",
+            " { svelteHTML.createElement(\"svg\", {  \"cols\":3,});}};",
+        ),
+        (
+            "svg, svg-cased name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svg viewBox=\"0\" />",
+            " { svelteHTML.createElement(\"svg\", {  \"viewBox\":`0`,});}};",
+        ),
+        (
+            "svg, on-prefixed name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svg onFoo=\"0\" />",
+            " { svelteHTML.createElement(\"svg\", {  \"onFoo\":`0`,});}};",
+        ),
+        (
+            "svg, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svg data-x={b} />",
+            " { svelteHTML.createElement(\"svg\", {  ...__sveltets_2_empty({\"data-x\":b}),});}};",
+        ),
+        (
+            "svg, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svg --x=\"1\" />",
+            " { svelteHTML.createElement(\"svg\", {  \"--x\":`1`,});}};",
+        ),
+        (
+            "svelte:element, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:element this={\"div\"} someProp=\"0\" />",
+            " { svelteHTML.createElement(\"div\", {    \"someprop\":`0`,});}};",
+        ),
+        (
+            "svelte:element, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:element this={\"div\"} cols=\"3\" />",
+            " { svelteHTML.createElement(\"div\", {    \"cols\":3,});}};",
+        ),
+        (
+            "svelte:element, svg-cased name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:element this={\"div\"} viewBox=\"0\" />",
+            " { svelteHTML.createElement(\"div\", {    \"viewBox\":`0`,});}};",
+        ),
+        (
+            "svelte:element, on-prefixed name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:element this={\"div\"} onFoo=\"0\" />",
+            " { svelteHTML.createElement(\"div\", {    \"onFoo\":`0`,});}};",
+        ),
+        (
+            "svelte:element, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:element this={\"div\"} data-x={b} />",
+            " { svelteHTML.createElement(\"div\", {    ...__sveltets_2_empty({\"data-x\":b}),});}};",
+        ),
+        (
+            "svelte:element, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:element this={\"div\"} --x=\"1\" />",
+            " { svelteHTML.createElement(\"div\", {    \"--x\":`1`,});}};",
+        ),
+        (
+            "svelte:body, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:body someProp=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:body\", {  \"someProp\":`0`,});}};",
+        ),
+        (
+            "svelte:body, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:body cols=\"3\" />",
+            " { svelteHTML.createElement(\"svelte:body\", {  \"cols\":`3`,});}};",
+        ),
+        (
+            "svelte:body, svg-cased name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:body viewBox=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:body\", {  \"viewBox\":`0`,});}};",
+        ),
+        (
+            "svelte:body, on-prefixed name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:body onFoo=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:body\", {  \"onFoo\":`0`,});}};",
+        ),
+        (
+            "svelte:body, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:body data-x={b} />",
+            " { svelteHTML.createElement(\"svelte:body\", {  ...__sveltets_2_empty({\"data-x\":b}),});}};",
+        ),
+        (
+            "svelte:body, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:body --x=\"1\" />",
+            " { svelteHTML.createElement(\"svelte:body\", {  \"--x\":`1`,});}};",
+        ),
+        (
+            "svelte:window, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:window someProp=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:window\", {  \"someProp\":`0`,});}};",
+        ),
+        (
+            "svelte:window, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:window cols=\"3\" />",
+            " { svelteHTML.createElement(\"svelte:window\", {  \"cols\":`3`,});}};",
+        ),
+        (
+            "svelte:window, svg-cased name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:window viewBox=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:window\", {  \"viewBox\":`0`,});}};",
+        ),
+        (
+            "svelte:window, on-prefixed name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:window onFoo=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:window\", {  \"onFoo\":`0`,});}};",
+        ),
+        (
+            "svelte:window, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:window data-x={b} />",
+            " { svelteHTML.createElement(\"svelte:window\", {  ...__sveltets_2_empty({\"data-x\":b}),});}};",
+        ),
+        (
+            "svelte:window, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:window --x=\"1\" />",
+            " { svelteHTML.createElement(\"svelte:window\", {  \"--x\":`1`,});}};",
+        ),
+        (
+            "svelte:document, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:document someProp=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:document\", {  \"someProp\":`0`,});}};",
+        ),
+        (
+            "svelte:document, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:document cols=\"3\" />",
+            " { svelteHTML.createElement(\"svelte:document\", {  \"cols\":`3`,});}};",
+        ),
+        (
+            "svelte:document, svg-cased name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:document viewBox=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:document\", {  \"viewBox\":`0`,});}};",
+        ),
+        (
+            "svelte:document, on-prefixed name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:document onFoo=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:document\", {  \"onFoo\":`0`,});}};",
+        ),
+        (
+            "svelte:document, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:document data-x={b} />",
+            " { svelteHTML.createElement(\"svelte:document\", {  ...__sveltets_2_empty({\"data-x\":b}),});}};",
+        ),
+        (
+            "svelte:document, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:document --x=\"1\" />",
+            " { svelteHTML.createElement(\"svelte:document\", {  \"--x\":`1`,});}};",
+        ),
+        (
+            "svelte:head, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:head someProp=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:head\", {  \"someProp\":`0`,});}};",
+        ),
+        (
+            "svelte:head, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:head cols=\"3\" />",
+            " { svelteHTML.createElement(\"svelte:head\", {  \"cols\":`3`,});}};",
+        ),
+        (
+            "svelte:head, svg-cased name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:head viewBox=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:head\", {  \"viewBox\":`0`,});}};",
+        ),
+        (
+            "svelte:head, on-prefixed name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:head onFoo=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:head\", {  \"onFoo\":`0`,});}};",
+        ),
+        (
+            "svelte:head, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:head data-x={b} />",
+            " { svelteHTML.createElement(\"svelte:head\", {  ...__sveltets_2_empty({\"data-x\":b}),});}};",
+        ),
+        (
+            "svelte:head, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:head --x=\"1\" />",
+            " { svelteHTML.createElement(\"svelte:head\", {  \"--x\":`1`,});}};",
+        ),
+        (
+            "svelte:fragment, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:fragment someProp=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:fragment\", {  \"someProp\":`0`,});}};",
+        ),
+        (
+            "svelte:fragment, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:fragment cols=\"3\" />",
+            " { svelteHTML.createElement(\"svelte:fragment\", {  \"cols\":`3`,});}};",
+        ),
+        (
+            "svelte:fragment, svg-cased name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:fragment viewBox=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:fragment\", {  \"viewBox\":`0`,});}};",
+        ),
+        (
+            "svelte:fragment, on-prefixed name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:fragment onFoo=\"0\" />",
+            " { svelteHTML.createElement(\"svelte:fragment\", {  \"onFoo\":`0`,});}};",
+        ),
+        (
+            "svelte:fragment, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:fragment data-x={b} />",
+            " { svelteHTML.createElement(\"svelte:fragment\", {  ...__sveltets_2_empty({\"data-x\":b}),});}};",
+        ),
+        (
+            "svelte:fragment, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:fragment --x=\"1\" />",
+            " { svelteHTML.createElement(\"svelte:fragment\", {  \"--x\":`1`,});}};",
+        ),
+        (
+            "slot, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot someProp=\"0\" />",
+            " { __sveltets_createSlot(\"default\", {  \"someProp\":`0`,});}};",
+        ),
+        (
+            "slot, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot cols=\"3\" />",
+            " { __sveltets_createSlot(\"default\", {  \"cols\":`3`,});}};",
+        ),
+        (
+            "slot, svg-cased name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot viewBox=\"0\" />",
+            " { __sveltets_createSlot(\"default\", {  \"viewBox\":`0`,});}};",
+        ),
+        (
+            "slot, on-prefixed name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot onFoo=\"0\" />",
+            " { __sveltets_createSlot(\"default\", {  \"onFoo\":`0`,});}};",
+        ),
+        (
+            "slot, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot data-x={b} />",
+            " { __sveltets_createSlot(\"default\", {  ...__sveltets_2_empty({\"data-x\":b}),});}};",
+        ),
+        (
+            "slot, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot --x=\"1\" />",
+            " { __sveltets_createSlot(\"default\", {  \"--x\":`1`,});}};",
+        ),
+        (
+            "component, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C someProp=\"0\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"someProp\":`0`,}});}};",
+        ),
+        (
+            "component, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C cols=\"3\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"cols\":`3`,}});}};",
+        ),
+        (
+            "component, svg-cased name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C viewBox=\"0\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"viewBox\":`0`,}});}};",
+        ),
+        (
+            "component, on-prefixed name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C onFoo=\"0\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"onFoo\":`0`,}});}};",
+        ),
+        (
+            "component, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C data-x={b} />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"data-x\":b,}});}};",
+        ),
+        (
+            "component, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C --x=\"1\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  ...__sveltets_2_cssProp({\"--x\":`1`}),}});}};",
+        ),
+    ] {
+        let actual = template_body(src);
+        if actual != expected {
+            failures.push(format!(
+                "{label}\n  expected {expected:?}\n  actual   {actual:?}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of 66 cells diverge from official:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_invalidate_paren.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_invalidate_paren.rs
@@ -1,0 +1,147 @@
+//! Upstream parenthesises the `__sveltets_2_invalidate` arrow body under a
+//! three-way condition (`ImplicitTopLevelNames.ts:45-52`): an object literal, an
+//! expression whose text starts with one, or an `as` expression. rsvelte answered
+//! it with `rhs.starts_with('{')`, which covers the first two and cannot see the
+//! third. Expectations are generated from official svelte2tsx.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn invalidate_call(src: &str) -> String {
+    let code = svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "C.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+    const OPEN: &str = "__sveltets_2_invalidate(() => ";
+    let start = code.find(OPEN).expect("no invalidate call");
+    let end = code[start..].find(");").expect("no invalidate end") + start + 2;
+    code[start..end].to_string()
+}
+
+const CASES: &[(&str, &str, &str)] = &[
+    (
+        "object literal",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = { a: 1 };\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => ({ a: 1 }));",
+    ),
+    (
+        "object member",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = { a: 1 }.a;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => ({ a: 1 }.a));",
+    ),
+    (
+        "object element access",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = { a: 1 }['a'];\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => ({ a: 1 }['a']));",
+    ),
+    (
+        "object binary",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = { a: 1 }.a + 1;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => ({ a: 1 }.a + 1));",
+    ),
+    (
+        "object conditional",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = { a: 1 }.a ? 1 : 2;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => ({ a: 1 }.a ? 1 : 2));",
+    ),
+    (
+        "as expression",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = q as Record<string, any>;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => (q as Record<string, any>));",
+    ),
+    (
+        "as any",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = q as any;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => (q as any));",
+    ),
+    (
+        "object as any",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = { a: 1 } as any;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => ({ a: 1 } as any));",
+    ),
+    (
+        "as chained",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = q as any as string;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => (q as any as string));",
+    ),
+    (
+        "satisfies",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = q satisfies any;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => q satisfies any);",
+    ),
+    (
+        "non-null",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = q!;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => q!);",
+    ),
+    (
+        "identifier",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = q;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => q);",
+    ),
+    (
+        "call",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = f(q);\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => f(q));",
+    ),
+    (
+        "binary",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = q + 1;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => q + 1);",
+    ),
+    (
+        "template",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = `${q}`;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => `${q}`);",
+    ),
+    (
+        "array",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = [q];\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => [q]);",
+    ),
+    (
+        "arrow",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = () => q;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => () => q);",
+    ),
+    (
+        "conditional",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = q ? 1 : 2;\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => q ? 1 : 2);",
+    ),
+    (
+        "parenthesized object",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = ({ a: 1 });\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => ({ a: 1 }));",
+    ),
+    (
+        "iife",
+        "<script lang=\"ts\">\n  let q: any;\n  function f(x: any) { return x; }\n  $: w = (() => { return 1 })();\n</script>\n{w}",
+        "__sveltets_2_invalidate(() => (() => { return 1 })());",
+    ),
+];
+
+#[test]
+fn an_as_expression_is_parenthesised_inside_the_invalidate_arrow() {
+    let mut failures = Vec::new();
+    for (label, source, expected) in CASES {
+        let actual = invalidate_call(source);
+        if actual != *expected {
+            failures.push(format!(
+                "{label}\n  expected {expected:?}\n  actual   {actual:?}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} cells diverge from official:\n{}",
+        failures.len(),
+        CASES.len(),
+        failures.join("\n")
+    );
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_is_attribute_custom_element.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_is_attribute_custom_element.rs
@@ -1,0 +1,228 @@
+//! Upstream's `Element.isCustomElement()` has two conditions — a dash in the
+//! tag name, and an `is=` attribute whose first value chunk is text containing a
+//! dash — and only a custom element keeps a mixed-case attribute name. rsvelte
+//! implemented the first condition only, so `is="x-y"` lowercased the name on
+//! every host. Expectations are generated from official svelte2tsx.
+//!
+//! `is={expr}` is absent on purpose: official throws from `isCustomElement`
+//! (`value[0].data` is undefined on a mustache), so it has no expected output.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn template_body(src: &str) -> String {
+    let code = svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "C.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+    const OPEN: &str = "async () => {\n";
+    let start = code.find(OPEN).expect("render body") + OPEN.len();
+    let end = code[start..]
+        .find("\nreturn { props:")
+        .expect("render body end")
+        + start;
+    code[start..end].to_string()
+}
+
+const CASES: &[(&str, &str, &str)] = &[
+    (
+        "div, is with dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<div is=\"x-y\" defaultValue=\"1\"></div>",
+        " { svelteHTML.createElement(\"div\", {   \"is\":`x-y`,\"defaultValue\":`1`,}); }};",
+    ),
+    (
+        "div, is without dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<div is=\"plain\" defaultValue=\"1\"></div>",
+        " { svelteHTML.createElement(\"div\", {   \"is\":`plain`,\"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "div, is empty",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<div is=\"\" defaultValue=\"1\"></div>",
+        " { svelteHTML.createElement(\"div\", { \"is\":\"\",\"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "div, is valueless",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<div is defaultValue=\"1\"></div>",
+        " { svelteHTML.createElement(\"div\", { \"is\":true,\"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "div, no is",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<div  defaultValue=\"1\"></div>",
+        " { svelteHTML.createElement(\"div\", { \"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "button, is with dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<button is=\"x-y\" defaultValue=\"1\"></button>",
+        " { svelteHTML.createElement(\"button\", {   \"is\":`x-y`,\"defaultValue\":`1`,}); }};",
+    ),
+    (
+        "button, is without dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<button is=\"plain\" defaultValue=\"1\"></button>",
+        " { svelteHTML.createElement(\"button\", {   \"is\":`plain`,\"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "button, is empty",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<button is=\"\" defaultValue=\"1\"></button>",
+        " { svelteHTML.createElement(\"button\", { \"is\":\"\",\"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "button, is valueless",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<button is defaultValue=\"1\"></button>",
+        " { svelteHTML.createElement(\"button\", { \"is\":true,\"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "button, no is",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<button  defaultValue=\"1\"></button>",
+        " { svelteHTML.createElement(\"button\", { \"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "title, is with dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<title is=\"x-y\" defaultValue=\"1\"></title>",
+        " { svelteHTML.createElement(\"title\", {   \"is\":`x-y`,\"defaultValue\":`1`,}); }};",
+    ),
+    (
+        "title, is without dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<title is=\"plain\" defaultValue=\"1\"></title>",
+        " { svelteHTML.createElement(\"title\", {   \"is\":`plain`,\"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "title, is empty",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<title is=\"\" defaultValue=\"1\"></title>",
+        " { svelteHTML.createElement(\"title\", { \"is\":\"\",\"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "title, is valueless",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<title is defaultValue=\"1\"></title>",
+        " { svelteHTML.createElement(\"title\", { \"is\":true,\"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "title, no is",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<title  defaultValue=\"1\"></title>",
+        " { svelteHTML.createElement(\"title\", { \"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "svelte:element, is with dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<svelte:element this={tt} is=\"x-y\" defaultValue=\"1\"></svelte:element>",
+        " { svelteHTML.createElement(tt, {     \"is\":`x-y`,\"defaultValue\":`1`,}); }};",
+    ),
+    (
+        "svelte:element, is without dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<svelte:element this={tt} is=\"plain\" defaultValue=\"1\"></svelte:element>",
+        " { svelteHTML.createElement(tt, {     \"is\":`plain`,\"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "svelte:element, is empty",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<svelte:element this={tt} is=\"\" defaultValue=\"1\"></svelte:element>",
+        " { svelteHTML.createElement(tt, {   \"is\":\"\",\"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "svelte:element, is valueless",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<svelte:element this={tt} is defaultValue=\"1\"></svelte:element>",
+        " { svelteHTML.createElement(tt, {   \"is\":true,\"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "svelte:element, no is",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<svelte:element this={tt}  defaultValue=\"1\"></svelte:element>",
+        " { svelteHTML.createElement(tt, {   \"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "named-slot elem, is with dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<C><div slot=\"s\" is=\"x-y\" defaultValue=\"1\"></div></C>",
+        " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {     \"is\":`x-y`,\"defaultValue\":`1`,}); }} C}};",
+    ),
+    (
+        "named-slot elem, is without dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<C><div slot=\"s\" is=\"plain\" defaultValue=\"1\"></div></C>",
+        " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {     \"is\":`plain`,\"defaultvalue\":`1`,}); }} C}};",
+    ),
+    (
+        "named-slot elem, is empty",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<C><div slot=\"s\" is=\"\" defaultValue=\"1\"></div></C>",
+        " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {   \"is\":\"\",\"defaultvalue\":`1`,}); }} C}};",
+    ),
+    (
+        "named-slot elem, is valueless",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<C><div slot=\"s\" is defaultValue=\"1\"></div></C>",
+        " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {   \"is\":true,\"defaultvalue\":`1`,}); }} C}};",
+    ),
+    (
+        "named-slot elem, no is",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<C><div slot=\"s\"  defaultValue=\"1\"></div></C>",
+        " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {   \"defaultvalue\":`1`,}); }} C}};",
+    ),
+    (
+        "dash tag, is with dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<my-el is=\"x-y\" defaultValue=\"1\"></my-el>",
+        " { svelteHTML.createElement(\"my-el\", {   \"is\":`x-y`,\"defaultValue\":`1`,}); }};",
+    ),
+    (
+        "dash tag, is without dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<my-el is=\"plain\" defaultValue=\"1\"></my-el>",
+        " { svelteHTML.createElement(\"my-el\", {   \"is\":`plain`,\"defaultValue\":`1`,}); }};",
+    ),
+    (
+        "dash tag, is empty",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<my-el is=\"\" defaultValue=\"1\"></my-el>",
+        " { svelteHTML.createElement(\"my-el\", { \"is\":\"\",\"defaultValue\":`1`,}); }};",
+    ),
+    (
+        "dash tag, is valueless",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<my-el is defaultValue=\"1\"></my-el>",
+        " { svelteHTML.createElement(\"my-el\", { \"is\":true,\"defaultValue\":`1`,}); }};",
+    ),
+    (
+        "dash tag, no is",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<my-el  defaultValue=\"1\"></my-el>",
+        " { svelteHTML.createElement(\"my-el\", { \"defaultValue\":`1`,}); }};",
+    ),
+    (
+        "div, is dash then mustache",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<div is=\"x-y{v}\" defaultValue=\"1\"></div>",
+        " { svelteHTML.createElement(\"div\", {   \"is\":`x-y${v}`,\"defaultValue\":`1`,}); }};",
+    ),
+    (
+        "div, is mustache then dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<div is=\"a{v}-b\" defaultValue=\"1\"></div>",
+        " { svelteHTML.createElement(\"div\", {   \"is\":`a${v}-b`,\"defaultvalue\":`1`,}); }};",
+    ),
+    (
+        "dash tag, is without dash",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<my-el is=\"plain\" fooBar=\"1\"></my-el>",
+        " { svelteHTML.createElement(\"my-el\", {   \"is\":`plain`,\"fooBar\":`1`,}); }};",
+    ),
+    (
+        "div, svg attribute",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<div is=\"x-y\" viewBox=\"1\"></div>",
+        " { svelteHTML.createElement(\"div\", {   \"is\":`x-y`,\"viewBox\":`1`,}); }};",
+    ),
+    (
+        "div, on-prefixed",
+        "<script lang=\"ts\">import C from './C.svelte'; let tt: any; let v: any;</script>\n<div is=\"x-y\" onFoo=\"1\"></div>",
+        " { svelteHTML.createElement(\"div\", {   \"is\":`x-y`,\"onFoo\":`1`,}); }};",
+    ),
+];
+
+#[test]
+fn an_is_attribute_makes_an_element_custom_and_keeps_its_attribute_case() {
+    let mut failures = Vec::new();
+    for (label, source, expected) in CASES {
+        let actual = template_body(source);
+        if actual != *expected {
+            failures.push(format!(
+                "{label}\n  expected {expected:?}\n  actual   {actual:?}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} cells diverge from official:\n{}",
+        failures.len(),
+        CASES.len(),
+        failures.join("\n")
+    );
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_mustache_interior.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_mustache_interior.rs
@@ -1,0 +1,292 @@
+//! Official copies the text BETWEEN a mustache's braces into its output; rsvelte
+//! copied the expression node's own span. Anything the braces hold that the node
+//! does not — a comment, a newline, plain padding — was therefore dropped, so
+//! `class="x {// c\na} z"` lost the comment and `class="x { a } z"` lost the two
+//! spaces.
+//!
+//! The axis is the mustache interior against the expression span, NOT "a comment
+//! is dropped": the ratchet entry named a comment, and of the 25 cells the fix
+//! moves, 10 carry none.
+//!
+//! The hosts are crossed in because the interior reaches a template literal
+//! through two ports. Reverting only the string builder leaves the 10
+//! `<slot>` / named-slot-element cells failing; reverting only the segment
+//! builder leaves the 15 element / `style` / component cells failing; reverting
+//! both leaves 25. The remaining hosts — a lone-mustache value, a text
+//! mustache, an `on:` handler — never enter a template literal and are the
+//! controls.
+//!
+//! Each expectation is the template body of the pinned
+//! `submodules/language-tools` svelte2tsx's own output for that source.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn template_body(src: &str) -> String {
+    let code = svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "T.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+    const OPEN: &str = "async () => {\n";
+    let start = code.find(OPEN).expect("render body") + OPEN.len();
+    let end = code[start..]
+        .find("\nreturn { props:")
+        .expect("render body end")
+        + start;
+    code[start..end].to_string()
+}
+
+#[test]
+fn a_mustache_carries_its_interior_not_its_expression_span() {
+    let mut failures = Vec::new();
+    for (label, src, expected) in [
+        (
+            "quoted concat, bare",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class=\"x {a} z\">c</button>",
+            " { svelteHTML.createElement(\"button\", { \"class\":`x ${a} z`,});  }};",
+        ),
+        (
+            "quoted concat, spaces",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class=\"x { a } z\">c</button>",
+            " { svelteHTML.createElement(\"button\", { \"class\":`x ${ a } z`,});  }};",
+        ),
+        (
+            "quoted concat, newlines",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class=\"x {\na\n} z\">c</button>",
+            " { svelteHTML.createElement(\"button\", { \"class\":`x ${\na\n} z`,});  }};",
+        ),
+        (
+            "quoted concat, line comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class=\"x {// why\na} z\">c</button>",
+            " { svelteHTML.createElement(\"button\", { \"class\":`x ${// why\na} z`,});  }};",
+        ),
+        (
+            "quoted concat, block comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class=\"x {/* why */ a} z\">c</button>",
+            " { svelteHTML.createElement(\"button\", { \"class\":`x ${/* why */ a} z`,});  }};",
+        ),
+        (
+            "quoted concat, block comment after",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class=\"x {a /* why */} z\">c</button>",
+            " { svelteHTML.createElement(\"button\", { \"class\":`x ${a /* why */} z`,});  }};",
+        ),
+        (
+            "bare attr, bare",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class={a}>c</button>",
+            " { svelteHTML.createElement(\"button\", { \"class\":a,});  }};",
+        ),
+        (
+            "bare attr, spaces",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class={ a }>c</button>",
+            "  { svelteHTML.createElement(\"button\", { \"class\":a,});  }};",
+        ),
+        (
+            "bare attr, newlines",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class={\na\n}>c</button>",
+            "  { svelteHTML.createElement(\"button\", { \"class\":a,});  }};",
+        ),
+        (
+            "bare attr, line comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class={// why\na}>c</button>",
+            " { svelteHTML.createElement(\"button\", { \"class\":a,});  }};",
+        ),
+        (
+            "bare attr, block comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class={/* why */ a}>c</button>",
+            " { svelteHTML.createElement(\"button\", { \"class\":a,});  }};",
+        ),
+        (
+            "bare attr, block comment after",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class={a /* why */}>c</button>",
+            " { svelteHTML.createElement(\"button\", {  \"class\":a,});  }};",
+        ),
+        (
+            "quoted only, bare",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class=\"{a}\">c</button>",
+            "  { svelteHTML.createElement(\"button\", { \"class\":a,});  }};",
+        ),
+        (
+            "quoted only, spaces",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class=\"{ a }\">c</button>",
+            " { svelteHTML.createElement(\"button\", {  \"class\":a,});  }};",
+        ),
+        (
+            "quoted only, newlines",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class=\"{\na\n}\">c</button>",
+            " { svelteHTML.createElement(\"button\", {  \"class\":a,});  }};",
+        ),
+        (
+            "quoted only, line comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class=\"{// why\na}\">c</button>",
+            "  { svelteHTML.createElement(\"button\", { \"class\":a,});  }};",
+        ),
+        (
+            "quoted only, block comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class=\"{/* why */ a}\">c</button>",
+            "  { svelteHTML.createElement(\"button\", { \"class\":a,});  }};",
+        ),
+        (
+            "quoted only, block comment after",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button class=\"{a /* why */}\">c</button>",
+            " { svelteHTML.createElement(\"button\", {  \"class\":a,});  }};",
+        ),
+        (
+            "style attr, bare",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button style=\"top: {a}px\">c</button>",
+            " { svelteHTML.createElement(\"button\", { \"style\":`top: ${a}px`,});  }};",
+        ),
+        (
+            "style attr, spaces",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button style=\"top: { a }px\">c</button>",
+            " { svelteHTML.createElement(\"button\", { \"style\":`top: ${ a }px`,});  }};",
+        ),
+        (
+            "style attr, newlines",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button style=\"top: {\na\n}px\">c</button>",
+            " { svelteHTML.createElement(\"button\", { \"style\":`top: ${\na\n}px`,});  }};",
+        ),
+        (
+            "style attr, line comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button style=\"top: {// why\na}px\">c</button>",
+            " { svelteHTML.createElement(\"button\", { \"style\":`top: ${// why\na}px`,});  }};",
+        ),
+        (
+            "style attr, block comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button style=\"top: {/* why */ a}px\">c</button>",
+            " { svelteHTML.createElement(\"button\", { \"style\":`top: ${/* why */ a}px`,});  }};",
+        ),
+        (
+            "style attr, block comment after",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button style=\"top: {a /* why */}px\">c</button>",
+            " { svelteHTML.createElement(\"button\", { \"style\":`top: ${a /* why */}px`,});  }};",
+        ),
+        (
+            "component attr, bare",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<C name=\"x {a} z\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"name\":`x ${a} z`,}});}};",
+        ),
+        (
+            "component attr, spaces",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<C name=\"x { a } z\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"name\":`x ${ a } z`,}});}};",
+        ),
+        (
+            "component attr, newlines",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<C name=\"x {\na\n} z\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"name\":`x ${\na\n} z`,}});}};",
+        ),
+        (
+            "component attr, line comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<C name=\"x {// why\na} z\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"name\":`x ${// why\na} z`,}});}};",
+        ),
+        (
+            "component attr, block comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<C name=\"x {/* why */ a} z\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"name\":`x ${/* why */ a} z`,}});}};",
+        ),
+        (
+            "component attr, block comment after",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<C name=\"x {a /* why */} z\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"name\":`x ${a /* why */} z`,}});}};",
+        ),
+        (
+            "slot element attr, bare",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<slot foo=\"x {a} z\" />",
+            " { __sveltets_createSlot(\"default\", {  \"foo\":`x ${a} z`,});}};",
+        ),
+        (
+            "slot element attr, spaces",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<slot foo=\"x { a } z\" />",
+            " { __sveltets_createSlot(\"default\", {  \"foo\":`x ${ a } z`,});}};",
+        ),
+        (
+            "slot element attr, newlines",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<slot foo=\"x {\na\n} z\" />",
+            " { __sveltets_createSlot(\"default\", {  \"foo\":`x ${\na\n} z`,});}};",
+        ),
+        (
+            "slot element attr, line comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<slot foo=\"x {// why\na} z\" />",
+            " { __sveltets_createSlot(\"default\", {  \"foo\":`x ${// why\na} z`,});}};",
+        ),
+        (
+            "slot element attr, block comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<slot foo=\"x {/* why */ a} z\" />",
+            " { __sveltets_createSlot(\"default\", {  \"foo\":`x ${/* why */ a} z`,});}};",
+        ),
+        (
+            "slot element attr, block comment after",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<slot foo=\"x {a /* why */} z\" />",
+            " { __sveltets_createSlot(\"default\", {  \"foo\":`x ${a /* why */} z`,});}};",
+        ),
+        (
+            "named-slot element attr, bare",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<C><button slot=\"s\" class=\"x {a} z\">c</button></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"button\", {   \"class\":`x ${a} z`,});  }} C}};",
+        ),
+        (
+            "named-slot element attr, spaces",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<C><button slot=\"s\" class=\"x { a } z\">c</button></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"button\", {   \"class\":`x ${ a } z`,});  }} C}};",
+        ),
+        (
+            "named-slot element attr, newlines",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<C><button slot=\"s\" class=\"x {\na\n} z\">c</button></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"button\", {   \"class\":`x ${\na\n} z`,});  }} C}};",
+        ),
+        (
+            "named-slot element attr, line comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<C><button slot=\"s\" class=\"x {// why\na} z\">c</button></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"button\", {   \"class\":`x ${// why\na} z`,});  }} C}};",
+        ),
+        (
+            "named-slot element attr, block comment before",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<C><button slot=\"s\" class=\"x {/* why */ a} z\">c</button></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"button\", {   \"class\":`x ${/* why */ a} z`,});  }} C}};",
+        ),
+        (
+            "named-slot element attr, block comment after",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<C><button slot=\"s\" class=\"x {a /* why */} z\">c</button></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"button\", {   \"class\":`x ${a /* why */} z`,});  }} C}};",
+        ),
+        (
+            "text mustache, line comment",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<p>{// why\na}</p>",
+            " { svelteHTML.createElement(\"p\", {});// why\na; }};",
+        ),
+        (
+            "text mustache, spaces",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<p>{ a }</p>",
+            " { svelteHTML.createElement(\"p\", {}); a ; }};",
+        ),
+        (
+            "on:click, line comment",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button on:click={// why\na}>c</button>",
+            " { svelteHTML.createElement(\"button\", {  \"on:click\":a,});  }};",
+        ),
+        (
+            "on:click, spaces",
+            "<script lang=\"ts\">import C from './C.svelte';let a: any = 1;</script>\n<button on:click={ a }>c</button>",
+            "  { svelteHTML.createElement(\"button\", {  \"on:click\":a,});  }};",
+        ),
+    ] {
+        let actual = template_body(src);
+        if actual != expected {
+            failures.push(format!(
+                "{label}\n  expected {expected:?}\n  actual   {actual:?}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of 46 cells diverge from official:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_named_slot_element_bindings.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_named_slot_element_bindings.rs
@@ -1,0 +1,151 @@
+//! An element that targets a named slot with a `slot` ATTRIBUTE is lowered by a
+//! second port of the element transform, and that port never ran the `bind:`
+//! machinery.
+//!
+//! `<C><svelte:fragment slot="x"><button bind:this={e}/></svelte:fragment></C>`
+//! reaches `handle_regular_element`, which declares `const $$_button1 = …` and
+//! appends `e = $$_button1;`. `<C><button slot="x" bind:this={e}/></C>` reaches
+//! `handle_named_slot_element` instead, which built its own attribute object and
+//! its own class/style + transition suffix — so `bind:this` stayed a
+//! `"bind:this": e` prop, a two-way binding lost its
+//! `() => v = __sveltets_2_any(null)` setter, and a void or self-closing element
+//! closed with a leading space that only an overwritten `</tag>` leaves behind.
+//!
+//! The axis is the binding kind crossed with the host that carries the `slot`
+//! attribute, plus the directives that share the same suffix pass. The rows
+//! without a `slot` attribute are the controls: they went through the other port
+//! and were already right.
+//!
+//! Each expectation is the `createElement`-bearing lines of the pinned
+//! `submodules/language-tools` svelte2tsx's own output, trimmed and joined with
+//! ` | `.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn element_lines(src: &str) -> String {
+    let code = svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "T.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+    code.lines()
+        .filter(|line| line.contains("createElement"))
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+#[test]
+fn a_named_slot_element_lowers_its_bindings_like_any_other() {
+    let mut failures = Vec::new();
+    for (label, src, expected) in [
+        (
+            "plain element",
+            "<script lang=\"ts\">let element: HTMLButtonElement;</script>\n<button bind:this={element}>x</button>",
+            "{ const $$_button0 = svelteHTML.createElement(\"button\", { });element = $$_button0;  }};",
+        ),
+        (
+            "inside an each",
+            "<script lang=\"ts\">let element: HTMLButtonElement;</script>\n{#each [1] as n}<button bind:this={element}>{n}</button>{/each}",
+            "for(let n of __sveltets_2_ensureArray([1])){ { const $$_button0 = svelteHTML.createElement(\"button\", { });element = $$_button0;n; }}};",
+        ),
+        (
+            "inside a component slot",
+            "<script lang=\"ts\">import C from './C.svelte';let element: HTMLButtonElement;</script>\n<C><button bind:this={element}>x</button></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {children:() => { return __sveltets_2_any(0); },}}); { const $$_button1 = svelteHTML.createElement(\"button\", { });element = $$_button1;  } C}};",
+        ),
+        (
+            "inside a named slot fragment",
+            "<script lang=\"ts\">import C from './C.svelte';let element: HTMLButtonElement;</script>\n<C><svelte:fragment slot=\"trigger\"><button bind:this={element}>x</button></svelte:fragment></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"trigger\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", { }); { const $$_button2 = svelteHTML.createElement(\"button\", { });element = $$_button2;  } }} C}};",
+        ),
+        (
+            "slot attr + bind:this",
+            "<script lang=\"ts\">import C from './C.svelte';let element: HTMLButtonElement;</script>\n<C><button slot=\"trigger\" bind:this={element}>x</button></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"trigger\"];$$_$$;{ const $$_button1 = svelteHTML.createElement(\"button\", {  });element = $$_button1;  }} C}};",
+        ),
+        (
+            "slot attr, bind:this first",
+            "<script lang=\"ts\">import C from './C.svelte';let element: HTMLButtonElement;</script>\n<C><button bind:this={element} slot=\"trigger\">x</button></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"trigger\"];$$_$$;{ const $$_button1 = svelteHTML.createElement(\"button\", {  });element = $$_button1;  }} C}};",
+        ),
+        (
+            "slot attr + bind:value on input",
+            "<script lang=\"ts\">import C from './C.svelte';let v = '';</script>\n<C><input slot=\"trigger\" bind:value={v} /></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"trigger\"];$$_$$;{ svelteHTML.createElement(\"input\", {    \"bind:value\":v,});/*Ωignore_startΩ*/() => v = __sveltets_2_any(null);/*Ωignore_endΩ*/}} C}};",
+        ),
+        (
+            "slot attr + bind:clientWidth self-closing",
+            "<script lang=\"ts\">import C from './C.svelte';let v = 1;</script>\n<C><div slot=\"t\" bind:clientWidth={v} /></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"t\"];$$_$$;{ const $$_div1 = svelteHTML.createElement(\"div\", {   });v= $$_div1.clientWidth;}} C}};",
+        ),
+        (
+            "slot attr + bind:clientWidth with close tag",
+            "<script lang=\"ts\">import C from './C.svelte';let v = 1;</script>\n<C><div slot=\"t\" bind:clientWidth={v}></div></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"t\"];$$_$$;{ const $$_div1 = svelteHTML.createElement(\"div\", {  });v= $$_div1.clientWidth; }} C}};",
+        ),
+        (
+            "slot attr void, no binding",
+            "<script lang=\"ts\">import C from './C.svelte';</script>\n<C><input slot=\"t\" /></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"t\"];$$_$$;{ svelteHTML.createElement(\"input\", {  });}} C}};",
+        ),
+        (
+            "slot attr self-closing div, no binding",
+            "<script lang=\"ts\">import C from './C.svelte';</script>\n<C><div slot=\"t\" /></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"t\"];$$_$$;{ svelteHTML.createElement(\"div\", {  });}} C}};",
+        ),
+        (
+            "slot attr + on: directive",
+            "<script lang=\"ts\">import C from './C.svelte';let f = () => {};</script>\n<C><button slot=\"trigger\" on:click={f}>x</button></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"trigger\"];$$_$$;{ svelteHTML.createElement(\"button\", {   \"on:click\":f,});  }} C}};",
+        ),
+        (
+            "slot attr + class: directive",
+            "<script lang=\"ts\">import C from './C.svelte';let on = true;</script>\n<C><button slot=\"t\" class:a={on}>x</button></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"t\"];$$_$$;{ svelteHTML.createElement(\"button\", {  });on;  }} C}};",
+        ),
+        (
+            "slot attr + use: action",
+            "<script lang=\"ts\">import C from './C.svelte';import { a } from './a';</script>\n<C><button slot=\"t\" use:a>x</button></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"t\"];$$_$$;{const $$action_0 = __sveltets_2_ensureAction(a(svelteHTML.mapElementTag('button')));{ svelteHTML.createElement(\"button\", __sveltets_2_union($$action_0), {  });  }}} C}};",
+        ),
+        (
+            "slot attr + transition:",
+            "<script lang=\"ts\">import C from './C.svelte';import { fade } from 'svelte/transition';</script>\n<C><button slot=\"t\" transition:fade>x</button></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"t\"];$$_$$;{ svelteHTML.createElement(\"button\", {  });__sveltets_2_ensureTransition(fade(svelteHTML.mapElementTag('button')));  }} C}};",
+        ),
+        (
+            "slot attr + use: and bind:this",
+            "<script lang=\"ts\">import C from './C.svelte';import { a } from './a';let element: HTMLButtonElement;</script>\n<C><button slot=\"t\" use:a bind:this={element}>x</button></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"t\"];$$_$$;{const $$action_0 = __sveltets_2_ensureAction(a(svelteHTML.mapElementTag('button')));{ const $$_button1 = svelteHTML.createElement(\"button\", __sveltets_2_union($$action_0), {   });element = $$_button1;  }}} C}};",
+        ),
+        (
+            "slot attr + bind:group on input",
+            "<script lang=\"ts\">import C from './C.svelte';let g: string[] = [];</script>\n<C><input slot=\"t\" type=\"checkbox\" bind:group={g} /></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"t\"];$$_$$;{ svelteHTML.createElement(\"input\", {     \"type\":`checkbox`,});g = __sveltets_2_any(null);}} C}};",
+        ),
+        (
+            "svelte:element in a named slot",
+            "<script lang=\"ts\">import C from './C.svelte';let element: HTMLElement;</script>\n<C><svelte:element this={'div'} slot=\"t\" bind:this={element} /></C>",
+            "{ const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"t\"];$$_$$;{ const $$_svelteelement1 = svelteHTML.createElement('div', {    });element = $$_svelteelement1;}} C}};",
+        ),
+        (
+            "slot attr at top level (no component)",
+            "<script lang=\"ts\">let element: HTMLButtonElement;</script>\n<button slot=\"trigger\" bind:this={element}>x</button>",
+            "{ const $$_button0 = svelteHTML.createElement(\"button\", {  \"slot\":`trigger`,});element = $$_button0;  }};",
+        ),
+    ] {
+        let actual = element_lines(src);
+        if actual != expected {
+            failures.push(format!(
+                "{label}:\n  expected {expected:?}\n  actual   {actual:?}"
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_named_slot_host_rules.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_named_slot_host_rules.rs
@@ -1,0 +1,322 @@
+//! A `slot="…"` attribute routes its element through a second port, and that
+//! port answered two questions its own way.
+//!
+//! `<svelte:fragment slot="s">` is an `Element` whose node type is not
+//! `Element`, so neither the attribute-case fold nor the number-only rewrite
+//! reaches it — the same rule the root-level `<svelte:…>` tags follow. And its
+//! opener is position-preserving like any other element's, so the columns the
+//! stripped `slot=` / `let:` occupy come back as spaces; rsvelte emitted those
+//! spaces only when nothing else survived the strip, and none at all otherwise.
+//!
+//! The grid is the host carrying `slot="…"` × the attribute shapes that separate
+//! the rules, plus the layout rows that vary what the spacing is a function of:
+//! the stripped attribute's own length and count are held against the kept
+//! attributes' count, a self-closing tag against one with a closing tag, and the
+//! source's own whitespace. Only the last group can tell "one space per stripped
+//! attribute" from the position-preserving rule, and the two agree on every row
+//! that has nothing left to keep.
+//!
+//! Each expectation is the template body of the pinned
+//! `submodules/language-tools` svelte2tsx's own output for that source.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn template_body(src: &str) -> String {
+    let code = svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "T.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+    const OPEN: &str = "async () => {\n";
+    let start = code.find(OPEN).expect("render body") + OPEN.len();
+    let end = code[start..]
+        .find("\nreturn { props:")
+        .expect("render body end")
+        + start;
+    code[start..end].to_string()
+}
+
+#[test]
+fn a_named_slot_host_keeps_its_own_name_and_layout_rules() {
+    let mut failures = Vec::new();
+    for (label, src, expected) in [
+        (
+            "div, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><div slot=\"s\" someProp=\"0\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {    \"someprop\":`0`,});}} C}};",
+        ),
+        (
+            "div, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><div slot=\"s\" cols=\"3\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {    \"cols\":3,});}} C}};",
+        ),
+        (
+            "div, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><div slot=\"s\" data-x={b} /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {    ...__sveltets_2_empty({\"data-x\":b}),});}} C}};",
+        ),
+        (
+            "div, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><div slot=\"s\" --x=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {    \"--x\":`1`,});}} C}};",
+        ),
+        (
+            "div, valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><div slot=\"s\" x /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}});  {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {  \"x\":true,});}} C}};",
+        ),
+        (
+            "custom element, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><my-el slot=\"s\" someProp=\"0\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"my-el\", {    \"someProp\":`0`,});}} C}};",
+        ),
+        (
+            "custom element, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><my-el slot=\"s\" cols=\"3\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"my-el\", {    \"cols\":3,});}} C}};",
+        ),
+        (
+            "custom element, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><my-el slot=\"s\" data-x={b} /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"my-el\", {    ...__sveltets_2_empty({\"data-x\":b}),});}} C}};",
+        ),
+        (
+            "custom element, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><my-el slot=\"s\" --x=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"my-el\", {    \"--x\":`1`,});}} C}};",
+        ),
+        (
+            "custom element, valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><my-el slot=\"s\" x /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}});  {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"my-el\", {  \"x\":true,});}} C}};",
+        ),
+        (
+            "svg, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svg slot=\"s\" someProp=\"0\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svg\", {    \"someprop\":`0`,});}} C}};",
+        ),
+        (
+            "svg, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svg slot=\"s\" cols=\"3\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svg\", {    \"cols\":3,});}} C}};",
+        ),
+        (
+            "svg, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svg slot=\"s\" data-x={b} /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svg\", {    ...__sveltets_2_empty({\"data-x\":b}),});}} C}};",
+        ),
+        (
+            "svg, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svg slot=\"s\" --x=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svg\", {    \"--x\":`1`,});}} C}};",
+        ),
+        (
+            "svg, valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svg slot=\"s\" x /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}});  {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svg\", {  \"x\":true,});}} C}};",
+        ),
+        (
+            "svelte:element, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:element this={\"div\"} slot=\"s\" someProp=\"0\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {     \"someprop\":`0`,});}} C}};",
+        ),
+        (
+            "svelte:element, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:element this={\"div\"} slot=\"s\" cols=\"3\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {     \"cols\":3,});}} C}};",
+        ),
+        (
+            "svelte:element, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:element this={\"div\"} slot=\"s\" data-x={b} /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {     ...__sveltets_2_empty({\"data-x\":b}),});}} C}};",
+        ),
+        (
+            "svelte:element, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:element this={\"div\"} slot=\"s\" --x=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {     \"--x\":`1`,});}} C}};",
+        ),
+        (
+            "svelte:element, valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:element this={\"div\"} slot=\"s\" x /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}});  {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {   \"x\":true,});}} C}};",
+        ),
+        (
+            "svelte:self, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:self slot=\"s\" someProp=\"0\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ __sveltets_2_createComponentAny({    \"someProp\":`0`,});}} C}};",
+        ),
+        (
+            "svelte:self, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:self slot=\"s\" cols=\"3\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ __sveltets_2_createComponentAny({    \"cols\":`3`,});}} C}};",
+        ),
+        (
+            "svelte:self, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:self slot=\"s\" data-x={b} /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ __sveltets_2_createComponentAny({    \"data-x\":b,});}} C}};",
+        ),
+        (
+            "svelte:self, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:self slot=\"s\" --x=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ __sveltets_2_createComponentAny({    ...__sveltets_2_cssProp({\"--x\":`1`}),});}} C}};",
+        ),
+        (
+            "svelte:self, valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:self slot=\"s\" x /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}});  {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ __sveltets_2_createComponentAny({  \"x\":true,});}} C}};",
+        ),
+        (
+            "svelte:component, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:component this={D} slot=\"s\" someProp=\"0\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ const $$_tnenopmoc_etlevs1C = __sveltets_2_ensureComponent(D); new $$_tnenopmoc_etlevs1C({ target: __sveltets_2_any(), props: {     \"someProp\":`0`,}});}} C}};",
+        ),
+        (
+            "svelte:component, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:component this={D} slot=\"s\" cols=\"3\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ const $$_tnenopmoc_etlevs1C = __sveltets_2_ensureComponent(D); new $$_tnenopmoc_etlevs1C({ target: __sveltets_2_any(), props: {     \"cols\":`3`,}});}} C}};",
+        ),
+        (
+            "svelte:component, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:component this={D} slot=\"s\" data-x={b} /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ const $$_tnenopmoc_etlevs1C = __sveltets_2_ensureComponent(D); new $$_tnenopmoc_etlevs1C({ target: __sveltets_2_any(), props: {     \"data-x\":b,}});}} C}};",
+        ),
+        (
+            "svelte:component, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:component this={D} slot=\"s\" --x=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ const $$_tnenopmoc_etlevs1C = __sveltets_2_ensureComponent(D); new $$_tnenopmoc_etlevs1C({ target: __sveltets_2_any(), props: {     ...__sveltets_2_cssProp({\"--x\":`1`}),}});}} C}};",
+        ),
+        (
+            "svelte:component, valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:component this={D} slot=\"s\" x /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}});  {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ const $$_tnenopmoc_etlevs1C = __sveltets_2_ensureComponent(D); new $$_tnenopmoc_etlevs1C({ target: __sveltets_2_any(), props: {   \"x\":true,}});}} C}};",
+        ),
+        (
+            "svelte:fragment, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\" someProp=\"0\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {    \"someProp\":`0`,});}} C}};",
+        ),
+        (
+            "svelte:fragment, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\" cols=\"3\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {    \"cols\":`3`,});}} C}};",
+        ),
+        (
+            "svelte:fragment, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\" data-x={b} /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {    ...__sveltets_2_empty({\"data-x\":b}),});}} C}};",
+        ),
+        (
+            "svelte:fragment, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\" --x=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {    \"--x\":`1`,});}} C}};",
+        ),
+        (
+            "svelte:fragment, valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\" x /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}});  {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {  \"x\":true,});}} C}};",
+        ),
+        (
+            "component, mixed-case name",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><D slot=\"s\" someProp=\"0\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ const $$_D1C = __sveltets_2_ensureComponent(D); new $$_D1C({ target: __sveltets_2_any(), props: {    \"someProp\":`0`,}});}} C}};",
+        ),
+        (
+            "component, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><D slot=\"s\" cols=\"3\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ const $$_D1C = __sveltets_2_ensureComponent(D); new $$_D1C({ target: __sveltets_2_any(), props: {    \"cols\":`3`,}});}} C}};",
+        ),
+        (
+            "component, data- attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><D slot=\"s\" data-x={b} /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ const $$_D1C = __sveltets_2_ensureComponent(D); new $$_D1C({ target: __sveltets_2_any(), props: {    \"data-x\":b,}});}} C}};",
+        ),
+        (
+            "component, css custom property",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><D slot=\"s\" --x=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ const $$_D1C = __sveltets_2_ensureComponent(D); new $$_D1C({ target: __sveltets_2_any(), props: {    ...__sveltets_2_cssProp({\"--x\":`1`}),}});}} C}};",
+        ),
+        (
+            "component, valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><D slot=\"s\" x /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}});  {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ const $$_D1C = __sveltets_2_ensureComponent(D); new $$_D1C({ target: __sveltets_2_any(), props: {  \"x\":true,}});}} C}};",
+        ),
+        (
+            "fragment, one attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\" x=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {    \"x\":`1`,});}} C}};",
+        ),
+        (
+            "fragment, longer name",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\" xx=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {    \"xx\":`1`,});}} C}};",
+        ),
+        (
+            "fragment, longer slot name",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"ss\" x=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"ss\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {    \"x\":`1`,});}} C}};",
+        ),
+        (
+            "fragment, let: plus attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\" let:y x=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,y,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {    \"x\":`1`,});}} C}};",
+        ),
+        (
+            "fragment, two attributes",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\" x=\"1\" y=\"2\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {      \"x\":`1`,\"y\":`2`,});}} C}};",
+        ),
+        (
+            "fragment, slot last",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment x=\"1\" slot=\"s\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {   \"x\":`1`,});}} C}};",
+        ),
+        (
+            "fragment, with closing tag",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\" x=\"1\"></svelte:fragment></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {   \"x\":`1`,}); }} C}};",
+        ),
+        (
+            "fragment, extra whitespace",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment    slot=\"s\"   x=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {    \"x\":`1`,});}} C}};",
+        ),
+        (
+            "fragment, no other attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {  });}} C}};",
+        ),
+        (
+            "fragment, one let:",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\" let:y /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}});  {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,y,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {  });}} C}};",
+        ),
+        (
+            "fragment, two let:",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\" let:y let:z /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}});  {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,y,z,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {   });}} C}};",
+        ),
+        (
+            "fragment, empty with closing tag",
+            "<script lang=\"ts\">import C from './C.svelte'; import D from './D.svelte'; export let b: any;</script>\n<C><svelte:fragment slot=\"s\"></svelte:fragment></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", { }); }} C}};",
+        ),
+    ] {
+        let actual = template_body(src);
+        if actual != expected {
+            failures.push(format!(
+                "{label}\n  expected {expected:?}\n  actual   {actual:?}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of 52 cells diverge from official:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_props_typedef_position.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_props_typedef_position.rs
@@ -1,0 +1,233 @@
+//! Where the synthesised `;type $$ComponentProps = …;` is inserted. Upstream
+//! uses `node.parent.pos`, and TypeScript's `pos` spans the declaration's LEADING
+//! TRIVIA — so the insertion lands before any comment that precedes the `$props()`
+//! declaration. rsvelte walks back from the `let`/`const` keyword, and only one of
+//! the three branches that compute this offset walked back through comments; the
+//! other two stopped at whitespace and appended the typedef onto a `//` line, where
+//! the line comment swallowed it.
+//!
+//! `generics=` is on its own axis because it is what makes the offset reachable:
+//! without it the typedef is hoisted out of `$$render` and no branch here runs.
+//! Expectations are generated from official svelte2tsx.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn typedef_line(src: &str) -> String {
+    let code = svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "C.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+    let i = code.find("$$ComponentProps").expect("no props typedef");
+    let start = code[..i].rfind('\n').map_or(0, |n| n + 1);
+    let end = code[i..].find('\n').map_or(code.len(), |n| n + i);
+    code[start..end].to_string()
+}
+
+const CASES: &[(&str, &str, &str)] = &[
+    (
+        "with generics / inline object / no trivia",
+        "<script lang=\"ts\" generics=\"T\">\n  const { a }: { a: T[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: T[] };",
+    ),
+    (
+        "with generics / inline object / line comment",
+        "<script lang=\"ts\" generics=\"T\">\n  // C\n  const { a }: { a: T[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: T[] };",
+    ),
+    (
+        "with generics / inline object / two line comments",
+        "<script lang=\"ts\" generics=\"T\">\n  // one\n  // two\n  const { a }: { a: T[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: T[] };",
+    ),
+    (
+        "with generics / inline object / block comment",
+        "<script lang=\"ts\" generics=\"T\">\n  /* C */\n  const { a }: { a: T[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: T[] };",
+    ),
+    (
+        "with generics / inline object / jsdoc comment",
+        "<script lang=\"ts\" generics=\"T\">\n  /** C */\n  const { a }: { a: T[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: T[] };",
+    ),
+    (
+        "with generics / inline object / comment then blank",
+        "<script lang=\"ts\" generics=\"T\">\n  // C\n\n  const { a }: { a: T[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: T[] };",
+    ),
+    (
+        "with generics / intersection / no trivia",
+        "<script lang=\"ts\" generics=\"T\">\n  interface Cfg { b?: number }\n  const { a }: { a: T[] } & Cfg = $props();\n</script>\n{a}",
+        "  interface Cfg { b?: number };type $$ComponentProps =  { a: T[] } & Cfg;",
+    ),
+    (
+        "with generics / intersection / line comment",
+        "<script lang=\"ts\" generics=\"T\">\n  interface Cfg { b?: number }\n  // C\n  const { a }: { a: T[] } & Cfg = $props();\n</script>\n{a}",
+        "  interface Cfg { b?: number };type $$ComponentProps =  { a: T[] } & Cfg;",
+    ),
+    (
+        "with generics / intersection / two line comments",
+        "<script lang=\"ts\" generics=\"T\">\n  interface Cfg { b?: number }\n  // one\n  // two\n  const { a }: { a: T[] } & Cfg = $props();\n</script>\n{a}",
+        "  interface Cfg { b?: number };type $$ComponentProps =  { a: T[] } & Cfg;",
+    ),
+    (
+        "with generics / intersection / block comment",
+        "<script lang=\"ts\" generics=\"T\">\n  interface Cfg { b?: number }\n  /* C */\n  const { a }: { a: T[] } & Cfg = $props();\n</script>\n{a}",
+        "  interface Cfg { b?: number };type $$ComponentProps =  { a: T[] } & Cfg;",
+    ),
+    (
+        "with generics / intersection / jsdoc comment",
+        "<script lang=\"ts\" generics=\"T\">\n  interface Cfg { b?: number }\n  /** C */\n  const { a }: { a: T[] } & Cfg = $props();\n</script>\n{a}",
+        "  interface Cfg { b?: number };type $$ComponentProps =  { a: T[] } & Cfg;",
+    ),
+    (
+        "with generics / intersection / comment then blank",
+        "<script lang=\"ts\" generics=\"T\">\n  interface Cfg { b?: number }\n  // C\n\n  const { a }: { a: T[] } & Cfg = $props();\n</script>\n{a}",
+        "  interface Cfg { b?: number };type $$ComponentProps =  { a: T[] } & Cfg;",
+    ),
+    (
+        "with generics / union / no trivia",
+        "<script lang=\"ts\" generics=\"T\">\n  const { a }: { a: T[] } | { a: T[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: T[] } | { a: T[] };",
+    ),
+    (
+        "with generics / union / line comment",
+        "<script lang=\"ts\" generics=\"T\">\n  // C\n  const { a }: { a: T[] } | { a: T[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: T[] } | { a: T[] };",
+    ),
+    (
+        "with generics / union / two line comments",
+        "<script lang=\"ts\" generics=\"T\">\n  // one\n  // two\n  const { a }: { a: T[] } | { a: T[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: T[] } | { a: T[] };",
+    ),
+    (
+        "with generics / union / block comment",
+        "<script lang=\"ts\" generics=\"T\">\n  /* C */\n  const { a }: { a: T[] } | { a: T[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: T[] } | { a: T[] };",
+    ),
+    (
+        "with generics / union / jsdoc comment",
+        "<script lang=\"ts\" generics=\"T\">\n  /** C */\n  const { a }: { a: T[] } | { a: T[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: T[] } | { a: T[] };",
+    ),
+    (
+        "with generics / union / comment then blank",
+        "<script lang=\"ts\" generics=\"T\">\n  // C\n\n  const { a }: { a: T[] } | { a: T[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: T[] } | { a: T[] };",
+    ),
+    (
+        "without generics / inline object / no trivia",
+        "<script lang=\"ts\">\n  const { a }: { a: number[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] };function $$render() {",
+    ),
+    (
+        "without generics / inline object / line comment",
+        "<script lang=\"ts\">\n  // C\n  const { a }: { a: number[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] };function $$render() {",
+    ),
+    (
+        "without generics / inline object / two line comments",
+        "<script lang=\"ts\">\n  // one\n  // two\n  const { a }: { a: number[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] };function $$render() {",
+    ),
+    (
+        "without generics / inline object / block comment",
+        "<script lang=\"ts\">\n  /* C */\n  const { a }: { a: number[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] };function $$render() {",
+    ),
+    (
+        "without generics / inline object / jsdoc comment",
+        "<script lang=\"ts\">\n  /** C */\n  const { a }: { a: number[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] };function $$render() {",
+    ),
+    (
+        "without generics / inline object / comment then blank",
+        "<script lang=\"ts\">\n  // C\n\n  const { a }: { a: number[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] };function $$render() {",
+    ),
+    (
+        "without generics / intersection / no trivia",
+        "<script lang=\"ts\">\n  interface Cfg { b?: number }\n  const { a }: { a: number[] } & Cfg = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] } & Cfg;function $$render() {",
+    ),
+    (
+        "without generics / intersection / line comment",
+        "<script lang=\"ts\">\n  interface Cfg { b?: number }\n  // C\n  const { a }: { a: number[] } & Cfg = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] } & Cfg;function $$render() {",
+    ),
+    (
+        "without generics / intersection / two line comments",
+        "<script lang=\"ts\">\n  interface Cfg { b?: number }\n  // one\n  // two\n  const { a }: { a: number[] } & Cfg = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] } & Cfg;function $$render() {",
+    ),
+    (
+        "without generics / intersection / block comment",
+        "<script lang=\"ts\">\n  interface Cfg { b?: number }\n  /* C */\n  const { a }: { a: number[] } & Cfg = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] } & Cfg;function $$render() {",
+    ),
+    (
+        "without generics / intersection / jsdoc comment",
+        "<script lang=\"ts\">\n  interface Cfg { b?: number }\n  /** C */\n  const { a }: { a: number[] } & Cfg = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] } & Cfg;function $$render() {",
+    ),
+    (
+        "without generics / intersection / comment then blank",
+        "<script lang=\"ts\">\n  interface Cfg { b?: number }\n  // C\n\n  const { a }: { a: number[] } & Cfg = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] } & Cfg;function $$render() {",
+    ),
+    (
+        "without generics / union / no trivia",
+        "<script lang=\"ts\">\n  const { a }: { a: number[] } | { a: number[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] } | { a: number[] };function $$render() {",
+    ),
+    (
+        "without generics / union / line comment",
+        "<script lang=\"ts\">\n  // C\n  const { a }: { a: number[] } | { a: number[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] } | { a: number[] };function $$render() {",
+    ),
+    (
+        "without generics / union / two line comments",
+        "<script lang=\"ts\">\n  // one\n  // two\n  const { a }: { a: number[] } | { a: number[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] } | { a: number[] };function $$render() {",
+    ),
+    (
+        "without generics / union / block comment",
+        "<script lang=\"ts\">\n  /* C */\n  const { a }: { a: number[] } | { a: number[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] } | { a: number[] };function $$render() {",
+    ),
+    (
+        "without generics / union / jsdoc comment",
+        "<script lang=\"ts\">\n  /** C */\n  const { a }: { a: number[] } | { a: number[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] } | { a: number[] };function $$render() {",
+    ),
+    (
+        "without generics / union / comment then blank",
+        "<script lang=\"ts\">\n  // C\n\n  const { a }: { a: number[] } | { a: number[] } = $props();\n</script>\n{a}",
+        ";type $$ComponentProps =  { a: number[] } | { a: number[] };function $$render() {",
+    ),
+];
+
+#[test]
+fn the_props_typedef_is_inserted_before_the_declarations_leading_comments() {
+    let mut failures = Vec::new();
+    for (label, source, expected) in CASES {
+        let actual = typedef_line(source);
+        if actual != *expected {
+            failures.push(format!(
+                "{label}\n  expected {expected:?}\n  actual   {actual:?}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} cells diverge from official:\n{}",
+        failures.len(),
+        CASES.len(),
+        failures.join("\n")
+    );
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_slot_attribute_prefix_rules.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_slot_attribute_prefix_rules.rs
@@ -1,0 +1,359 @@
+//! `Attribute.ts` asks two different questions about an attribute's host, and
+//! rsvelte answered both with one flag. `element instanceof Element` picks the
+//! `data-` workaround (`...__sveltets_2_empty({…})`) over the component-only
+//! `--` one (`__sveltets_2_cssProp`); the case and number rewrites need
+//! `parent.type === 'Element'` as well.
+//!
+//! A `<slot>` is the one host where the two answers differ: `index.ts` builds it
+//! as an `Element` whose node type is `Slot`. So it takes the `data-` wrapper and
+//! not the `--` one, and neither rewrite — and rsvelte had the two wrappers
+//! exactly the wrong way round while agreeing on the rewrites.
+//!
+//! The grid is host × attribute-name prefix so the two questions are separable:
+//! an element and a component pin the rows where the answers agree, and a
+//! collapse of either question back onto one flag moves a cell.
+//!
+//! Each expectation is the template body of the pinned
+//! `submodules/language-tools` svelte2tsx's own output for that source.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn template_body(src: &str) -> String {
+    let code = svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "T.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+    const OPEN: &str = "async () => {\n";
+    let start = code.find(OPEN).expect("render body") + OPEN.len();
+    let end = code[start..]
+        .find("\nreturn { props:")
+        .expect("render body end")
+        + start;
+    code[start..end].to_string()
+}
+
+#[test]
+fn a_slot_takes_the_element_prefix_rule_and_not_the_component_one() {
+    let mut failures = Vec::new();
+    for (label, src, expected) in [
+        (
+            "slot, data- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot data-x={b} />",
+            " { __sveltets_createSlot(\"default\", {  ...__sveltets_2_empty({\"data-x\":b}),});}};",
+        ),
+        (
+            "slot, data- literal",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot data-x=\"y\" />",
+            " { __sveltets_createSlot(\"default\", {  ...__sveltets_2_empty({\"data-x\":`y`}),});}};",
+        ),
+        (
+            "slot, data- valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot data-x />",
+            "  { __sveltets_createSlot(\"default\", {...__sveltets_2_empty({\"data-x\":true}),});}};",
+        ),
+        (
+            "slot, data-sveltekit- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot data-sveltekit-preload-data={b} />",
+            " { __sveltets_createSlot(\"default\", {  \"data-sveltekit-preload-data\":b,});}};",
+        ),
+        (
+            "slot, -- literal",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot --x=\"1\" />",
+            " { __sveltets_createSlot(\"default\", {  \"--x\":`1`,});}};",
+        ),
+        (
+            "slot, -- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot --x={b} />",
+            " { __sveltets_createSlot(\"default\", {  \"--x\":b,});}};",
+        ),
+        (
+            "slot, -- valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot --x />",
+            "  { __sveltets_createSlot(\"default\", {\"--x\":true,});}};",
+        ),
+        (
+            "slot, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot cols=\"3\" />",
+            " { __sveltets_createSlot(\"default\", {  \"cols\":`3`,});}};",
+        ),
+        (
+            "slot, mixed-case attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot someProp=\"0\" />",
+            " { __sveltets_createSlot(\"default\", {  \"someProp\":`0`,});}};",
+        ),
+        (
+            "slot, plain expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<slot x={b} />",
+            " { __sveltets_createSlot(\"default\", {  \"x\":b,});}};",
+        ),
+        (
+            "element, data- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div data-x={b} />",
+            " { svelteHTML.createElement(\"div\", {  ...__sveltets_2_empty({\"data-x\":b}),});}};",
+        ),
+        (
+            "element, data- literal",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div data-x=\"y\" />",
+            " { svelteHTML.createElement(\"div\", {  ...__sveltets_2_empty({\"data-x\":`y`}),});}};",
+        ),
+        (
+            "element, data- valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div data-x />",
+            "  { svelteHTML.createElement(\"div\", {...__sveltets_2_empty({\"data-x\":true}),});}};",
+        ),
+        (
+            "element, data-sveltekit- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div data-sveltekit-preload-data={b} />",
+            " { svelteHTML.createElement(\"div\", {  \"data-sveltekit-preload-data\":b,});}};",
+        ),
+        (
+            "element, -- literal",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div --x=\"1\" />",
+            " { svelteHTML.createElement(\"div\", {  \"--x\":`1`,});}};",
+        ),
+        (
+            "element, -- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div --x={b} />",
+            " { svelteHTML.createElement(\"div\", {  \"--x\":b,});}};",
+        ),
+        (
+            "element, -- valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div --x />",
+            "  { svelteHTML.createElement(\"div\", {\"--x\":true,});}};",
+        ),
+        (
+            "element, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div cols=\"3\" />",
+            " { svelteHTML.createElement(\"div\", {  \"cols\":3,});}};",
+        ),
+        (
+            "element, mixed-case attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div someProp=\"0\" />",
+            " { svelteHTML.createElement(\"div\", {  \"someprop\":`0`,});}};",
+        ),
+        (
+            "element, plain expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<div x={b} />",
+            " { svelteHTML.createElement(\"div\", {  \"x\":b,});}};",
+        ),
+        (
+            "component, data- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C data-x={b} />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"data-x\":b,}});}};",
+        ),
+        (
+            "component, data- literal",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C data-x=\"y\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"data-x\":`y`,}});}};",
+        ),
+        (
+            "component, data- valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C data-x />",
+            "  { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {\"data-x\":true,}});}};",
+        ),
+        (
+            "component, data-sveltekit- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C data-sveltekit-preload-data={b} />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"data-sveltekit-preload-data\":b,}});}};",
+        ),
+        (
+            "component, -- literal",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C --x=\"1\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  ...__sveltets_2_cssProp({\"--x\":`1`}),}});}};",
+        ),
+        (
+            "component, -- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C --x={b} />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  ...__sveltets_2_cssProp({\"--x\":b}),}});}};",
+        ),
+        (
+            "component, -- valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C --x />",
+            "  { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {...__sveltets_2_cssProp({\"--x\":true}),}});}};",
+        ),
+        (
+            "component, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C cols=\"3\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"cols\":`3`,}});}};",
+        ),
+        (
+            "component, mixed-case attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C someProp=\"0\" />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"someProp\":`0`,}});}};",
+        ),
+        (
+            "component, plain expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C x={b} />",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); new $$_C0C({ target: __sveltets_2_any(), props: {  \"x\":b,}});}};",
+        ),
+        (
+            "svelte:component, data- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:component this={C} data-x={b} />",
+            " { const $$_tnenopmoc_etlevs0C = __sveltets_2_ensureComponent(C); new $$_tnenopmoc_etlevs0C({ target: __sveltets_2_any(), props: {    \"data-x\":b,}});}};",
+        ),
+        (
+            "svelte:component, data- literal",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:component this={C} data-x=\"y\" />",
+            " { const $$_tnenopmoc_etlevs0C = __sveltets_2_ensureComponent(C); new $$_tnenopmoc_etlevs0C({ target: __sveltets_2_any(), props: {    \"data-x\":`y`,}});}};",
+        ),
+        (
+            "svelte:component, data- valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:component this={C} data-x />",
+            "  { const $$_tnenopmoc_etlevs0C = __sveltets_2_ensureComponent(C); new $$_tnenopmoc_etlevs0C({ target: __sveltets_2_any(), props: {  \"data-x\":true,}});}};",
+        ),
+        (
+            "svelte:component, data-sveltekit- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:component this={C} data-sveltekit-preload-data={b} />",
+            " { const $$_tnenopmoc_etlevs0C = __sveltets_2_ensureComponent(C); new $$_tnenopmoc_etlevs0C({ target: __sveltets_2_any(), props: {    \"data-sveltekit-preload-data\":b,}});}};",
+        ),
+        (
+            "svelte:component, -- literal",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:component this={C} --x=\"1\" />",
+            " { const $$_tnenopmoc_etlevs0C = __sveltets_2_ensureComponent(C); new $$_tnenopmoc_etlevs0C({ target: __sveltets_2_any(), props: {    ...__sveltets_2_cssProp({\"--x\":`1`}),}});}};",
+        ),
+        (
+            "svelte:component, -- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:component this={C} --x={b} />",
+            " { const $$_tnenopmoc_etlevs0C = __sveltets_2_ensureComponent(C); new $$_tnenopmoc_etlevs0C({ target: __sveltets_2_any(), props: {    ...__sveltets_2_cssProp({\"--x\":b}),}});}};",
+        ),
+        (
+            "svelte:component, -- valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:component this={C} --x />",
+            "  { const $$_tnenopmoc_etlevs0C = __sveltets_2_ensureComponent(C); new $$_tnenopmoc_etlevs0C({ target: __sveltets_2_any(), props: {  ...__sveltets_2_cssProp({\"--x\":true}),}});}};",
+        ),
+        (
+            "svelte:component, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:component this={C} cols=\"3\" />",
+            " { const $$_tnenopmoc_etlevs0C = __sveltets_2_ensureComponent(C); new $$_tnenopmoc_etlevs0C({ target: __sveltets_2_any(), props: {    \"cols\":`3`,}});}};",
+        ),
+        (
+            "svelte:component, mixed-case attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:component this={C} someProp=\"0\" />",
+            " { const $$_tnenopmoc_etlevs0C = __sveltets_2_ensureComponent(C); new $$_tnenopmoc_etlevs0C({ target: __sveltets_2_any(), props: {    \"someProp\":`0`,}});}};",
+        ),
+        (
+            "svelte:component, plain expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:component this={C} x={b} />",
+            " { const $$_tnenopmoc_etlevs0C = __sveltets_2_ensureComponent(C); new $$_tnenopmoc_etlevs0C({ target: __sveltets_2_any(), props: {    \"x\":b,}});}};",
+        ),
+        (
+            "svelte:self, data- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:self data-x={b} />",
+            " { __sveltets_2_createComponentAny({  \"data-x\":b,});}};",
+        ),
+        (
+            "svelte:self, data- literal",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:self data-x=\"y\" />",
+            " { __sveltets_2_createComponentAny({  \"data-x\":`y`,});}};",
+        ),
+        (
+            "svelte:self, data- valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:self data-x />",
+            "  { __sveltets_2_createComponentAny({\"data-x\":true,});}};",
+        ),
+        (
+            "svelte:self, data-sveltekit- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:self data-sveltekit-preload-data={b} />",
+            " { __sveltets_2_createComponentAny({  \"data-sveltekit-preload-data\":b,});}};",
+        ),
+        (
+            "svelte:self, -- literal",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:self --x=\"1\" />",
+            " { __sveltets_2_createComponentAny({  ...__sveltets_2_cssProp({\"--x\":`1`}),});}};",
+        ),
+        (
+            "svelte:self, -- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:self --x={b} />",
+            " { __sveltets_2_createComponentAny({  ...__sveltets_2_cssProp({\"--x\":b}),});}};",
+        ),
+        (
+            "svelte:self, -- valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:self --x />",
+            "  { __sveltets_2_createComponentAny({...__sveltets_2_cssProp({\"--x\":true}),});}};",
+        ),
+        (
+            "svelte:self, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:self cols=\"3\" />",
+            " { __sveltets_2_createComponentAny({  \"cols\":`3`,});}};",
+        ),
+        (
+            "svelte:self, mixed-case attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:self someProp=\"0\" />",
+            " { __sveltets_2_createComponentAny({  \"someProp\":`0`,});}};",
+        ),
+        (
+            "svelte:self, plain expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<svelte:self x={b} />",
+            " { __sveltets_2_createComponentAny({  \"x\":b,});}};",
+        ),
+        (
+            "named-slot element, data- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C><div slot=\"s\" data-x={b} /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {    ...__sveltets_2_empty({\"data-x\":b}),});}} C}};",
+        ),
+        (
+            "named-slot element, data- literal",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C><div slot=\"s\" data-x=\"y\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {    ...__sveltets_2_empty({\"data-x\":`y`}),});}} C}};",
+        ),
+        (
+            "named-slot element, data- valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C><div slot=\"s\" data-x /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}});  {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {  ...__sveltets_2_empty({\"data-x\":true}),});}} C}};",
+        ),
+        (
+            "named-slot element, data-sveltekit- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C><div slot=\"s\" data-sveltekit-preload-data={b} /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {    \"data-sveltekit-preload-data\":b,});}} C}};",
+        ),
+        (
+            "named-slot element, -- literal",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C><div slot=\"s\" --x=\"1\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {    \"--x\":`1`,});}} C}};",
+        ),
+        (
+            "named-slot element, -- expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C><div slot=\"s\" --x={b} /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {    \"--x\":b,});}} C}};",
+        ),
+        (
+            "named-slot element, -- valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C><div slot=\"s\" --x /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}});  {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {  \"--x\":true,});}} C}};",
+        ),
+        (
+            "named-slot element, number-only attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C><div slot=\"s\" cols=\"3\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {    \"cols\":3,});}} C}};",
+        ),
+        (
+            "named-slot element, mixed-case attribute",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C><div slot=\"s\" someProp=\"0\" /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {    \"someprop\":`0`,});}} C}};",
+        ),
+        (
+            "named-slot element, plain expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let b: any;</script>\n<C><div slot=\"s\" x={b} /></C>",
+            " { const $$_C0C = __sveltets_2_ensureComponent(C); const $$_C0 = new $$_C0C({ target: __sveltets_2_any(), props: {}}); {const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,} = $$_C0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"div\", {    \"x\":b,});}} C}};",
+        ),
+    ] {
+        let actual = template_body(src);
+        if actual != expected {
+            failures.push(format!(
+                "{label}\n  expected {expected:?}\n  actual   {actual:?}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of 60 cells diverge from official:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_store_region_per_script.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_store_region_per_script.rs
@@ -1,0 +1,166 @@
+//! A store-subscription ignore region is per `ImplicitStoreValues` INSTANCE,
+//! and a component with a module script has two of them.
+//!
+//! `index.ts:202` builds a second `ImplicitStoreValues` for the module script,
+//! seeded with the instance script's accessed stores but with its own
+//! `importStatements`. Each one runs `attachStoreValueDeclarationOfImportsToRenderFn`,
+//! which wraps ITS names in one `/*\u{03A9}ignore_start\u{03A9}*/ … /*\u{03A9}ignore_end\u{03A9}*/`
+//! region and appends it at the render-function start — so the two scripts'
+//! imports are two adjacent regions, the instance's first, because the instance
+//! script is processed before the module script.
+//!
+//! rsvelte collected both scripts' import names into one list and emitted one
+//! region. Two rows separate a faithful port from one that merely splits
+//! adjacent regions: a name imported by BOTH scripts is declared in both
+//! regions (the second instance is seeded with the accessed stores, not with
+//! the first one's import list), and the instance region comes first even when
+//! the module script is written second.
+//!
+//! The shape below abbreviates the emitted lines: `[` and `]` are the ignore
+//! delimiters, `<n>` is `;let $n = __sveltets_2_store_get(n);`, and ` | ` joins
+//! separate lines. Every expectation is the pinned `submodules/language-tools`
+//! svelte2tsx's own output on the same source.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+/// The emitted store-subscription lines, with the ignore delimiters and the
+/// declarations abbreviated.
+fn store_shape(src: &str) -> String {
+    let code = svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "T.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+    let lines: Vec<&str> = code
+        .lines()
+        .filter(|line| line.contains("__sveltets_2_store_get"))
+        .collect();
+    if lines.is_empty() {
+        return "(none)".to_string();
+    }
+    let mut out = lines.join(" | ");
+    out = out
+        .replace("/*\u{03A9}ignore_start\u{03A9}*/", "[")
+        .replace("/*\u{03A9}ignore_end\u{03A9}*/", "]");
+    // `;let $n = __sveltets_2_store_get(n);` -> `<n>`
+    let mut abbreviated = String::new();
+    let mut rest = out.as_str();
+    while let Some(at) = rest.find(";let $") {
+        abbreviated.push_str(&rest[..at]);
+        let after = &rest[at + ";let $".len()..];
+        let name_end = after
+            .find(' ')
+            .expect("a store declaration has a space after its name");
+        abbreviated.push('<');
+        abbreviated.push_str(&after[..name_end]);
+        abbreviated.push('>');
+        let tail = &after[name_end..];
+        let end = tail.find(");").expect("a store declaration ends with `);`");
+        rest = &tail[end + 2..];
+    }
+    abbreviated.push_str(rest);
+    abbreviated.trim().to_string()
+}
+
+#[test]
+fn each_script_gets_its_own_store_subscription_region() {
+    let mut failures = Vec::new();
+    for (label, src, expected) in [
+        (
+            "two imports, two modules",
+            "<script lang=\"ts\">\n\timport { columns } from './a';\n\timport { canWrite } from './b';\n</script>\n<p>{$columns}{$canWrite}</p>",
+            "[<columns><canWrite>]",
+        ),
+        (
+            "two imports, one module",
+            "<script lang=\"ts\">\n\timport { a, b } from './a';\n</script>\n<p>{$a}{$b}</p>",
+            "[<a><b>]",
+        ),
+        (
+            "one import",
+            "<script lang=\"ts\">\n\timport { a } from './a';\n</script>\n<p>{$a}</p>",
+            "[<a>]",
+        ),
+        (
+            "two local lets",
+            "<script lang=\"ts\">\n\tlet a = 1;\n\tlet b = 2;\n</script>\n<p>{$a}{$b}</p>",
+            "let a = 1[<a>]; | \tlet b = 2[<b>];",
+        ),
+        (
+            "one let, two declarators",
+            "<script lang=\"ts\">\n\tlet a = 1, b = 2;\n</script>\n<p>{$a}{$b}</p>",
+            "let a = 1, b = 2[<a>][<b>];",
+        ),
+        (
+            "module + instance import",
+            "<script lang=\"ts\" module>\n\timport { columns } from './a';\n</script>\n<script lang=\"ts\">\n\timport { canWrite } from './b';\n</script>\n<p>{$columns}{$canWrite}</p>",
+            "[<canWrite>][<columns>]",
+        ),
+        (
+            "module only",
+            "<script lang=\"ts\" module>\n\timport { columns } from './a';\n</script>\n<p>{$columns}</p>",
+            "async () => {[<columns>]",
+        ),
+        (
+            "instance only",
+            "<script lang=\"ts\">\n\timport { canWrite } from './b';\n</script>\n<p>{$canWrite}</p>",
+            "[<canWrite>]",
+        ),
+        (
+            "module 2 + instance 1",
+            "<script lang=\"ts\" module>\n\timport { m1 } from './a';\n\timport { m2 } from './b';\n</script>\n<script lang=\"ts\">\n\timport { i1 } from './c';\n</script>\n<p>{$m1}{$m2}{$i1}</p>",
+            "[<i1>][<m1><m2>]",
+        ),
+        (
+            "context=module spelling",
+            "<script lang=\"ts\" context=\"module\">\n\timport { columns } from './a';\n</script>\n<script lang=\"ts\">\n\timport { canWrite } from './b';\n</script>\n<p>{$columns}{$canWrite}</p>",
+            "[<canWrite>][<columns>]",
+        ),
+        (
+            "module import + instance let",
+            "<script lang=\"ts\" module>\n\timport { columns } from './a';\n</script>\n<script lang=\"ts\">\n\tlet canWrite = 1;\n</script>\n<p>{$columns}{$canWrite}</p>",
+            "[<columns>] | \tlet canWrite = 1[<canWrite>];",
+        ),
+        (
+            "same name imported in both",
+            "<script lang=\"ts\" module>\n\timport { a } from './a';\n</script>\n<script lang=\"ts\">\n\timport { a } from './a';\n</script>\n<p>{$a}</p>",
+            "[<a>][<a>]",
+        ),
+        (
+            "module import unused in template",
+            "<script lang=\"ts\" module>\n\timport { m } from './a';\n</script>\n<script lang=\"ts\">\n\timport { i } from './b';\n</script>\n<p>{$i}</p>",
+            "[<i>]",
+        ),
+        (
+            "instance import unused",
+            "<script lang=\"ts\" module>\n\timport { m } from './a';\n</script>\n<script lang=\"ts\">\n\timport { i } from './b';\n</script>\n<p>{$m}</p>",
+            "[<m>]",
+        ),
+        (
+            "module store used only in module",
+            "<script lang=\"ts\" module>\n\timport { m } from './a';\n\tconst x = $m;\n</script>\n<script lang=\"ts\">\n\timport { i } from './b';\n</script>\n<p>{$i}</p>",
+            "[<i>]",
+        ),
+        (
+            "two instance, two module",
+            "<script lang=\"ts\" module>\n\timport { m1 } from './a';\n\timport { m2 } from './b';\n</script>\n<script lang=\"ts\">\n\timport { i1 } from './c';\n\timport { i2 } from './d';\n</script>\n<p>{$m1}{$m2}{$i1}{$i2}</p>",
+            "[<i1><i2>][<m1><m2>]",
+        ),
+        (
+            "module first in file order",
+            "<script lang=\"ts\">\n\timport { i1 } from './c';\n</script>\n<script lang=\"ts\" module>\n\timport { m1 } from './a';\n</script>\n<p>{$m1}{$i1}</p>",
+            "[<i1>][<m1>]",
+        ),
+    ] {
+        let actual = store_shape(src);
+        if actual != expected {
+            failures.push(format!("{label}: expected {expected:?}, got {actual:?}"));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_valueless_slot_attribute.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_valueless_slot_attribute.rs
@@ -1,0 +1,150 @@
+//! A `<slot>` attribute with no value at all contributes nothing to the
+//! component's `slots: { … }` type. `handleSlot` (`nodes/slot.ts`) opens its loop
+//! with `if (!attr.value?.length) continue;` and a valueless attribute's `value`
+//! is `true`, so `<slot a />` declares no `a`; rsvelte declared `a:a`.
+//!
+//! The axis is the attribute's VALUE FORM, not the one prop the ratchet entry
+//! named: the rows below carry every shape a `<slot>` attribute can take, and the
+//! valueless ones are the only shape that moves. Position and host are crossed in
+//! because the divergence is an extra entry in a list — first, last and between
+//! two kept entries are three different ways for a list to be wrong — and because
+//! an `{#each}` and a component slot resolve their entries through a different
+//! scope.
+//!
+//! Each expectation is the `slots: { … }` clause of the pinned
+//! `submodules/language-tools` svelte2tsx's own output. That clause is the whole
+//! subject: `<slot data-x />` also diverges in the `__sveltets_createSlot` call
+//! and is left to the grid that covers it.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn slots_clause(src: &str) -> String {
+    let code = svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "T.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+    let start = code.find("slots: {").expect("slots clause");
+    let end = code[start..].find("}}").expect("slots clause end") + start + 2;
+    code[start..end].to_string()
+}
+
+#[test]
+fn a_valueless_slot_attribute_declares_no_slot_prop() {
+    let mut failures = Vec::new();
+    for (label, src, expected) in [
+        (
+            "valueless alone",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot a />",
+            "slots: {'default': {}}",
+        ),
+        (
+            "valueless first",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot a b={b} />",
+            "slots: {'default': {b:b}}",
+        ),
+        (
+            "valueless last",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot b={b} a />",
+            "slots: {'default': {b:b}}",
+        ),
+        (
+            "valueless between",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot b={b} a c=\"x\" />",
+            "slots: {'default': {b:b, c:\"x\"}}",
+        ),
+        (
+            "two valueless",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot a b />",
+            "slots: {'default': {}}",
+        ),
+        (
+            "valueless with spread",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot {...o} a />",
+            "slots: {'default': {...o}}",
+        ),
+        (
+            "valueless on a named slot",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot name=\"s\" a />",
+            "slots: {'s': {}}",
+        ),
+        (
+            "valueless, uppercase name",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot A />",
+            "slots: {'default': {}}",
+        ),
+        (
+            "valueless inside an each",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n{#each [1] as it}<slot a x={it} />{/each}",
+            "slots: {'default': {x:__sveltets_2_unwrapArr([1])}}",
+        ),
+        (
+            "valueless inside a component slot",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<C><svelte:fragment slot=\"s\"><slot a /></svelte:fragment></C>",
+            "slots: {'default': {}}",
+        ),
+        (
+            "shorthand",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot {a} />",
+            "slots: {'default': {a:a}}",
+        ),
+        (
+            "empty string",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot a=\"\" />",
+            "slots: {'default': {a:\"\"}}",
+        ),
+        (
+            "text literal",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot a=\"x\" />",
+            "slots: {'default': {a:\"x\"}}",
+        ),
+        (
+            "expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot a={b} />",
+            "slots: {'default': {a:b}}",
+        ),
+        (
+            "quoted expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot a=\"{b}\" />",
+            "slots: {'default': {a:b}}",
+        ),
+        (
+            "text plus expression",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot a=\"x{b}\" />",
+            "slots: {'default': {a:\"__svelte_ts_string\"}}",
+        ),
+        (
+            "spread alone",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot {...o} />",
+            "slots: {'default': {...o}}",
+        ),
+        (
+            "let: directive",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot let:a />",
+            "slots: {'default': {}}",
+        ),
+        (
+            "no attributes",
+            "<script lang=\"ts\">import C from './C.svelte'; export let a: any; export let b: any; const o = {a:1};</script>\n<slot />",
+            "slots: {'default': {}}",
+        ),
+    ] {
+        let actual = slots_clause(src);
+        if actual != expected {
+            failures.push(format!(
+                "{label}\n  expected {expected:?}\n  actual   {actual:?}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of 19 cells diverge from official:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}

--- a/upstream_issues/4177-svelte2tsx-is-attribute-mustache-first-chunk-crash.md
+++ b/upstream_issues/4177-svelte2tsx-is-attribute-mustache-first-chunk-crash.md
@@ -1,0 +1,77 @@
+# svelte2tsx throws when an `is` attribute's first value chunk is a mustache
+
+`svelte2tsx` (language-tools, `packages/svelte2tsx`) kills the conversion with a raw
+`TypeError` — no diagnostic, no position — when a lowercase element carries an `is`
+attribute whose **first** value chunk is a mustache tag:
+
+```svelte
+<script lang="ts">
+	import C from './C.svelte';
+	let x: any;
+</script>
+
+<div is={x}>a</div>
+```
+
+```
+TypeError: Cannot read properties of undefined (reading 'includes')
+    at Element.isCustomElement   (svelte2tsx/index.js:2310:218)
+    at transformAttributeCase    (svelte2tsx/index.js:2735:53)
+    at handleAttribute           (svelte2tsx/index.js:2760:15)
+```
+
+`src/htmlxtojsx_v2/nodes/Element.ts:267-271` reads the attribute's first chunk through an
+optional chain that stops one level short:
+
+```js
+if (
+    this.node.attributes
+        ?.find((a: BaseNode) => a.name === 'is')
+        ?.value[0]?.data.includes('-')
+) {
+```
+
+It guards "no `attributes`", "no `is`" and "no `value[0]`", but not the case where `value[0]`
+**exists and carries no `data`** — a `MustacheTag`.
+
+The axis is neither the presence of `is` nor the presence of a mustache, but that the
+**first** chunk of the value is one. Three controls separate it, and all three convert:
+
+| input | official | rsvelte |
+|---|---|---|
+| `<div is={x}>a</div>` | **throws** | `createElement("div", { "is":x,})` |
+| `<div is="{x}y-z">a</div>` | **throws** | ``createElement("div", { "is":`${x}y-z`,})`` |
+| `<C is={x}>a</C>` | ok | ok |
+| `<div is="x-y">a</div>` | ok | ok |
+| `<div is="x-y{x}">a</div>` | ok | ok |
+
+The third row is the gate — `Attribute.ts:143-145` calls the predicate only when
+`element instanceof Element && parent.type === 'Element'`, so a component never reaches it.
+The fifth is the discriminating one: a mustache anywhere but the first position is fine,
+because `value[0]` is then a `Text`.
+
+`<div is={x}>` is a valid Svelte document: the official *compiler* accepts it on every
+target, and so does rsvelte. Only `svelte2tsx` fails, so `svelte-check` and the language
+server report nothing for the whole file.
+
+**Population.** Over the 33,904 `.svelte` files of the compatibility corpus, 165 carry an
+`is=` attribute, 158 of those have a value whose first chunk is a mustache, and **0** of
+those 158 sit on a lowercase tag — every one is a component, which the gate above excludes.
+All 158 were run through the official converter: 0 crashes, 0 other throws, 158 ok. The two
+witnesses above are therefore constructed, not collected.
+
+rsvelte's svelte2tsx port converts both witnesses, which is what a divergence here would look
+like: the corpus parity gate scores such a pair as `error-mismatch` (official errors, rsvelte
+converts). **No entry of `compatibility/svelte2tsx-known-failures.json` names this shape,
+because the corpus holds 0 carriers of it** — a defect that does not appear in a ratchet is
+not a defect that does not exist, and the 158-file measurement above is exactly that
+distinction. The shape is held out of `compatibility/pattern-corpus` until upstream decides
+the behaviour, the same choice as
+[`3132-svelte2tsx-let-object-rest-crash.md`](3132-svelte2tsx-let-object-rest-crash.md).
+
+Measured against `submodules/language-tools` pinned at
+`092af3826bada5cd591b0efccc39eed970169465`, both sides with
+`{filename:'C.svelte', isTsFile:true, mode:'ts', namespace:'html', version:'5'}`.
+
+Desired upstream behaviour: `?.data?.includes('-')`, so a non-`Text` first chunk means "not a
+custom element" instead of a crash.

--- a/upstream_issues/README.md
+++ b/upstream_issues/README.md
@@ -81,6 +81,7 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `4046-svelte-a-reordered-reactive-statement-reprints-earlier-comments.md` | sveltejs/svelte | #4046 | unrecorded |
 | `4111-svelte-await-catch-binding-transform-leaks-out-of-the-block.md` | sveltejs/svelte | #4111 | unrecorded |
 | `4117-svelte-class-shorthand-reaches-attributes-untransformed.md` | sveltejs/svelte | #4117 | unrecorded |
+| `4177-svelte2tsx-is-attribute-mustache-first-chunk-crash.md` | sveltejs/language-tools (svelte2tsx) | #4177 | unrecorded |
 | `grass-css-color-4-relative-syntax.md` | connorskees/grass | — | unrecorded |
 | `grass-explicit-extension-specifier.md` | connorskees/grass | — | unrecorded |
 | `grass-hoists-a-declaration-written-after-a-nested-rule.md` | connorskees/grass | — | unrecorded |


### PR DESCRIPTION
Ten svelte2tsx defects found by enumerating upstream's own predicates rather than by
reading divergences. Both svelte2tsx ratchets shrink; one of them empties.

## Ratchet changes, with direction

Measured on `383cc4433` (this PR's merge base), one verdict per id through the gate's
own normalization, before arm = `origin/main`, after arm = this branch.

**`svelte2tsx-known-failures.json` — 6 → 2, four dropped:**

| id | direction |
|---|---|
| `appwrite-console/…/overview/platforms/+page.svelte` | `MISMATCH -> match` |
| `huly/plugins/view-resources/…/list/ListCategory.svelte` | `MISMATCH -> match` |
| `mathesar/…/component-library/button/Button.svelte` | `MISMATCH -> match` |
| `sparrow-app/…/tab-bar/components/tab/Tab.svelte` | `MISMATCH -> match` |

Kept: `cnblocks/…/veil/+layout.svelte` and `+page.svelte`, both `error-mismatch` where
the rejecting side is official (a BOM crash in `magic-string`).

**`svelte2tsx-unparseable-known-failures.json` — 1 → 0, one dropped:**

| id | direction |
|---|---|
| `svelte-virtuallists/src/lib/VirtualListNew.svelte` | `MISMATCH -> match` |

Both files' contents are byte-identical to what the branch already carried, and
`git status` was empty after the re-derivation. That is worth stating precisely: the
values did not move, the **justification** did — from "carried over by a rebase from an
older base" to "measured on `383cc4433`, this PR's merge base". Only the second is a
reason to accept them.

**Nothing moved the other way.** Whole-corpus two-stage sweep over all 33,901 manifest
components: 180 units moved, and of those `MISMATCH -> match: 5`, **`match -> MISMATCH: 0`**,
`MISMATCH -> MISMATCH: 3`, `match -> match: 172`. The three that stay MISMATCH are
unchanged by this branch (two `mathesar` cell-fabric files and a `migrate` sample) and
are reported by a reconstruction that lacks the gate's `ast_equiv` rescue stage, so they
are candidates rather than findings.

## What the ten fixes are

Each one is an upstream predicate rsvelte answered with a narrower one:

- an attribute's host answers **two** upstream questions (`element instanceof Element`
  and `parent.type === 'Element'`), not one
- only an `Element`-typed node folds an attribute's name — `<slot>` and the
  `<svelte:*>` tags are `Element` instances with other node types
- `<svelte:fragment slot>` keeps its names, and its opener is position-preserving
- `isCustomElement()` is two conditions; the second reads a sibling `is=` attribute
- the `__sveltets_2_invalidate` arrow body is parenthesised under a three-way OR whose
  third arm is an `as` expression
- the props typedef is inserted at `node.parent.pos`, which spans leading trivia
- a mustache contributes its **interior**, not its expression's span
- a valueless `<slot>` attribute declares no slot prop
- a named-slot element lowers its bindings through the ordinary emitter
- each script gets its own store-subscription ignore region

Every fix lands a grid generated from official, and every grid was ablated: the ablation
is reported by the **names** of the cells that go red, not by their count.

## One note for reviewers

`compatibility/svelte2tsx-mechanisms.json` is **hand-derived and has zero readers** —
no script in the repository reads it (`grep -rln 'svelte2tsx-mechanisms'` returns 0).
What *is* checked is the summary: `scripts/compat-corpus/known-failures-md-check.mjs`
validates the `Partition … by mechanism: N` line in `KNOWN-FAILURES.md` against the
ratchet's length. So the check is on the summary and not on the primary source: a wrong
`description` or `pinned` in that JSON fails nothing. It also requires the partition line
**even at zero entries**, which is how it is written here.

`node scripts/compat-corpus/known-failures-md-check.mjs` → EXIT 0,
`50 declared ratchets across 36 docs match their JSON; 32 cluster partitions add up.`

## Upstream report for #4177 (last commit)

`upstream_issues/4177-svelte2tsx-is-attribute-mustache-first-chunk-crash.md` — official
svelte2tsx throws a raw `TypeError` when a lowercase element's `is` attribute has a
mustache as its **first** value chunk (`Element.ts:267-271`; the optional chain guards a
missing `value[0]` but not a `value[0]` with no `data`). Five rows, two throwing and three
controls, isolate the axis as *first chunk*, not *`is=`* and not *a mustache anywhere*.

This shape has **no entry in any ratchet here**, and that is measured rather than assumed:
of the 33,904 corpus components, 165 carry `is=`, 158 of those have a mustache-first value,
and **0** of those 158 sit on a lowercase tag — all 158 convert cleanly through official.
`KNOWN-FAILURES.md` says so in the `svelte2tsx-known-failures` section, because not
appearing in a ratchet and not existing are different things.

`node scripts/ci/check-upstream-issues.mjs` → EXIT 0, `83 reports, all indexed with an
explicit filing state`; with the index row removed it returns EXIT 1 naming the file, so the
guard moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ayf2LfKqP7yEEtWjunZ7DF

