### PR TITLE
fix(compiler): a component's `let:` variable is out of scope in its named slots

### DIFF
--- a/.changeset/named-slot-let-scope.md
+++ b/.changeset/named-slot-let-scope.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Treat a component's `let:` variable as out of scope inside that component's named slots, the way upstream's scope chain does.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2878,11 +2878,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 17 entries)
+### Client (`known-failures.client.json`, 15 entries)
 
-Partition of `known-failures.client.json` by verdict: `16 + 1`
+Partition of `known-failures.client.json` by verdict: `14 + 1`
 
-- **16 — the generated JS differs** (`js` / `code-differs`).
+- **14 — the generated JS differs** (`js` / `code-differs`).
 - **1 — the generated CSS differs.**
 
 The error classes this section used to carry are gone: the run behind this
@@ -3058,7 +3058,48 @@ the same reconstruction defect recorded above for the `style:`-directive cluster
 same day by a different person on a different file: **a reconstruction that drops a rescue
 stage is over-strict, and its non-zero is a candidate list, not a finding.**
 
-Every one of the remaining 17 arrived with the wave-2 enrolment (#3130) and is described
+Two entries left this target and `client-dev` because a component's `let:` variable was
+treated as in scope inside that component's NAMED slots. Upstream's `Component` scope
+visitor gives every `slot=`-carrying child `context.state.scope.child()` — a child of the
+scope OUTSIDE the component — while the `let:` bindings are declared in
+`metadata.scopes.default` (`phases/scope.js`), so the name is a plain global there:
+`is_pure` reports the read as non-reactive and legacy `build_expression` collects no
+reference for it. rsvelte answered both questions by name, and scope 0 is deliberately
+polluted with every child scope's declarations, so the lookup always found the binding —
+`mathesar/…/DisconnectDatabaseModal.svelte` and `…/UpgradeDatabaseModal.svelte` came out
+with the read inside a `$.template_effect` and with a `$.deep_read_state` in front of it.
+The repro crosses the slot the read sits in with the **mode**, because the two halves sit on
+opposite sides of `build_expression`'s `runes || maybe_runes` early return: a component with
+no `<script>` is `maybe_runes`, where no `$.deep_read_state` can be emitted at all, so a grid
+without a legacy row measures only one of the two ports.
+
+A first version answered the reference half in phase 2 instead, by testing the binding's
+declaring scope against the reference's — and a 135,560-unit sweep reported a third id
+moving. `svelte-ux/…/SelectField/+page.svelte` was **not listed**, so that unit was
+`match -> MISMATCH`: upstream's `determine_slot(node) ? context.state : …` declares a
+slotted node's own `let:` in the ENCLOSING scope, so `<M slot="option" let:option
+class={cls(option)}>` still reads it from its own attributes, and the phase-2 rule dropped
+four dependency reads. The nine-cell grid was green through all of it, because every cell it
+held put the `let:` and the reference on **different** nodes — the axis was varied and the
+three-on-one-node arrangement was held fixed. The repro now carries that cell, chosen the
+way a control has to be: an implementation that makes it red exists and was run before the
+cell was written.
+
+The corrected version then moved a fourth id, and the second sweep is the only reason it was
+not shipped: `carbon-components-svelte/…/TreeView.lazyLoad.test.svelte` and Svelte's own
+`runtime-legacy/samples/const-tag-component/main.svelte` went `match -> MISMATCH`. The mask is
+keyed by NAME, and a slotted node's own `let:` of the SAME name is a different binding that
+upstream declares in the enclosing scope — so `<C let:a>` around `<span slot="t" let:a>` had
+the child's binding masked by the parent's. The reduction is two cells: with the `let:` on only
+one of the two nodes, both spellings already agreed. Clearing the mask where a `let:` is
+registered is three edits, not one, because rsvelte registers a `let:` in three places —
+`build_slot_function`, `process_element_let_directives` and `visit_svelte_fragment` — and the
+reported file reaches the second while the corpus file reaches the third. (`<svelte:element
+let:x>` is the fourth candidate and needs nothing: both compilers reject it.) The repro carries
+one cell per place, plus the cell that separates a scope stack from a flag — inside one named
+slot, an `{#each xs as a}` body reads `$.get(a)` and the very next expression reads a bare `a`.
+
+Every one of the remaining 15 arrived with the wave-2 enrolment (#3130) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3165,15 +3206,15 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 31 entries)
+### Client dev (`known-failures.client-dev.json`, 29 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `31`
+Partition of `known-failures.client-dev.json` by verdict: `29`
 
-- **31 — the generated JS differs.**
+- **29 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 31 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 29 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -10,8 +10,6 @@
 	"immich/web/src/lib/components/asset-viewer/ActivityViewer.svelte",
 	"immich/web/src/lib/components/timeline/Timeline.svelte",
 	"mathesar/mathesar_ui/src/components/sort-entry/SortEntry.svelte",
-	"mathesar/mathesar_ui/src/pages/database/disconnect/DisconnectDatabaseModal.svelte",
-	"mathesar/mathesar_ui/src/systems/databases/upgrade-database/UpgradeDatabaseModal.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
 	"musicat/src/lib/views/InternetArchiveView.svelte",
 	"networking-toolbox/src/lib/components/home/SiteMapList.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -5,8 +5,6 @@
 	"huly/plugins/text-editor-resources/src/components/DrawingBoardEditor.svelte",
 	"immich/web/src/lib/components/asset-viewer/ActivityViewer.svelte",
 	"mathesar/mathesar_ui/src/components/sort-entry/SortEntry.svelte",
-	"mathesar/mathesar_ui/src/pages/database/disconnect/DisconnectDatabaseModal.svelte",
-	"mathesar/mathesar_ui/src/systems/databases/upgrade-database/UpgradeDatabaseModal.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
 	"networking-toolbox/src/lib/components/home/SiteMapList.svelte",
 	"photon/src/lib/ui/navbar/Profile.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -1725,6 +1725,12 @@ pub struct ComponentClientTransformState<'a> {
     /// inside a sibling `{#if}`).
     pub transform_deep_read: ImHashMap<String, ()>,
 
+    /// `let:` names a component declared for its DEFAULT slot while a NAMED
+    /// slot of that same component is being visited. Upstream gives a named
+    /// slot a child of the scope OUTSIDE the component, so the name is a
+    /// global there and `is_pure` reports the expression as non-reactive.
+    pub lets_out_of_scope: ImHashMap<String, ()>,
+
     /// Await then/catch bindings whose active read transform is `$.get(name)`.
     /// Await fragments scope these alongside `transform`; text-based template
     /// declaration lowering uses the set to apply the same scoped reads.
@@ -2088,6 +2094,7 @@ impl<'a> ComponentClientTransformState<'a> {
             memoizer: Memoizer::with_scope_declarations(scope, scope_root),
             transform: ImHashMap::new(),
             transform_deep_read: ImHashMap::new(),
+            lets_out_of_scope: ImHashMap::new(),
             await_binding_names: ImHashMap::new(),
             each_shadowing_names: ImHashMap::new(),
             events: indexmap::IndexSet::default(),
@@ -2146,6 +2153,16 @@ impl<'a> ComponentClientTransformState<'a> {
 
     /// Get a binding by name from the current scope or parent scopes.
     pub fn get_binding(&self, name: &str) -> Option<&Binding> {
+        let binding = self.lookup_binding(name)?;
+        // A component's `let:` binding is not in scope inside that component's
+        // named slots, and the lookup below is by name across every scope.
+        if self.lets_out_of_scope.contains_key(name) && binding.kind == BindingKind::Let {
+            return None;
+        }
+        Some(binding)
+    }
+
+    fn lookup_binding(&self, name: &str) -> Option<&Binding> {
         // First check current scope
         if let Some(&index) = self.scope.declarations.get(name) {
             return self.scope_root.bindings.get(index);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -1278,6 +1278,7 @@ impl<'a> ComponentContext<'a> {
         // so we can restore them after visiting children.
         let mut saved_transforms: Vec<(String, Option<IdentifierTransform>)> = Vec::new();
         let saved_deep_read_for_svelte_fragment = self.state.transform_deep_read.clone();
+        let saved_lets_out_of_scope = self.state.lets_out_of_scope.clone();
 
         for attribute in &frag.attributes {
             if let Attribute::LetDirective(let_dir) = attribute {
@@ -1340,6 +1341,10 @@ impl<'a> ComponentContext<'a> {
                     );
                     // Let directive bindings are template-kind.
                     self.state.transform_deep_read.insert(name.clone(), ());
+                    // A slotted node's OWN `let:` is declared in the ENCLOSING
+                    // scope upstream, so it is in scope here even when the
+                    // component's `let:` of the same name is not.
+                    self.state.lets_out_of_scope.remove(&name);
                 } else if let Some((derived_name, binding_names, const_stmt)) =
                     crate::compiler::phases::phase3_transform::client::visitors::shared::component::build_destructured_let_directive(
                         let_dir, self,
@@ -1375,6 +1380,7 @@ impl<'a> ComponentContext<'a> {
                                 store_source: None,
                             },
                         );
+                        self.state.lets_out_of_scope.remove(&name);
                         self.state.transform_deep_read.insert(name, ());
                     }
 
@@ -1408,6 +1414,7 @@ impl<'a> ComponentContext<'a> {
             }
         }
         self.state.transform_deep_read = saved_deep_read_for_svelte_fragment;
+        self.state.lets_out_of_scope = saved_lets_out_of_scope;
 
         TransformResult::None
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -170,6 +170,7 @@ pub fn fragment(
         memoizer: Memoizer::with_parent_conflicts(&context.state.memoizer),
         transform: fragment_transform,
         transform_deep_read: fragment_transform_deep_read,
+        lets_out_of_scope: context.state.lets_out_of_scope.clone(),
         await_binding_names: context.state.await_binding_names.clone(),
         each_shadowing_names: context.state.each_shadowing_names.clone(),
         events: indexmap::IndexSet::default(), // Start empty, merge back later

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -58,6 +58,7 @@ struct LetDirectiveResult {
     )>,
     saved_transform_deep_read: im::HashMap<String, ()>,
     saved_shadowed_prop_names: im::HashSet<String>,
+    saved_lets_out_of_scope: im::HashMap<String, ()>,
 }
 
 fn process_element_let_directives(
@@ -72,6 +73,7 @@ fn process_element_let_directives(
     )> = Vec::new();
     let saved_transform_deep_read = context.state.transform_deep_read.clone();
     let saved_shadowed_prop_names = context.state.shadowed_prop_names.clone();
+    let saved_lets_out_of_scope = context.state.lets_out_of_scope.clone();
 
     for let_dir in let_directives {
         let prop_name = &let_dir.name;
@@ -141,6 +143,10 @@ fn process_element_let_directives(
             // each_block.rs / snippet_block.rs). e.g. `let { data } = $props()`
             // outside + `<tbody slot="…" let:data>` must read `$.get(data)`.
             context.state.shadowed_prop_names.insert(name.clone());
+            // A slotted node's OWN `let:` is declared in the ENCLOSING scope
+            // upstream (`determine_slot(node) ? context.state : …`), so it is in
+            // scope here even when the component's `let:` of the same name is not.
+            context.state.lets_out_of_scope.remove(&name);
         } else if let Some((derived_name, binding_names, const_stmt)) =
             crate::compiler::phases::phase3_transform::client::visitors::shared::component::build_destructured_let_directive(
                 let_dir, context,
@@ -171,6 +177,7 @@ fn process_element_let_directives(
                     },
                 );
                 context.state.transform_deep_read.insert(name.clone(), ());
+                context.state.lets_out_of_scope.remove(&name);
                 context.state.shadowed_prop_names.insert(name);
             }
         }
@@ -180,6 +187,7 @@ fn process_element_let_directives(
         saved_transforms,
         saved_transform_deep_read,
         saved_shadowed_prop_names,
+        saved_lets_out_of_scope,
     }
 }
 
@@ -1806,6 +1814,7 @@ pub fn visit_regular_element(
     }
     context.state.transform_deep_read = let_directive_result.saved_transform_deep_read;
     context.state.shadowed_prop_names = let_directive_result.saved_shadowed_prop_names;
+    context.state.lets_out_of_scope = let_directive_result.saved_lets_out_of_scope;
 
     context.state.template.pop_element();
     TransformResult::None

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -2514,6 +2514,18 @@ fn build_slot_function(
         Option<crate::compiler::phases::phase3_transform::client::types::IdentifierTransform>,
     )> = Vec::new();
     let saved_deep_read = context.state.transform_deep_read.clone();
+    let saved_lets_out_of_scope = context.state.lets_out_of_scope.clone();
+
+    // A named slot is a child of the scope OUTSIDE the component, so the
+    // component's `let:` names are globals there — which is what decides whether
+    // the expression is reactive, not only whether it gets a `$.get`.
+    for (name, _) in let_names {
+        if should_apply_let_transforms {
+            context.state.lets_out_of_scope.remove(name);
+        } else {
+            context.state.lets_out_of_scope.insert(name.clone(), ());
+        }
+    }
 
     // Register let directive transforms if this is the appropriate slot
     if should_apply_let_transforms {
@@ -2562,6 +2574,7 @@ fn build_slot_function(
         }
         context.state.transform_deep_read = saved_deep_read;
     }
+    context.state.lets_out_of_scope = saved_lets_out_of_scope;
 
     // If no statements were generated, return None
     if child_statements.is_empty() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -2650,6 +2650,18 @@ fn collect_reactive_references_from_metadata(
             None => continue,
         };
 
+        // A component's `let:` binding is not in scope inside that component's
+        // named slots, so upstream's scope-keyed `references` never holds it
+        // there and no dependency read is emitted for it.
+        if binding.kind == BindingKind::Let
+            && context
+                .state
+                .lets_out_of_scope
+                .contains_key(binding.name.as_str())
+        {
+            continue;
+        }
+
         // Skip normal bindings unless they are imports
         // (matches: binding.kind === 'normal' && binding.declaration_kind !== 'import' -> continue)
         if binding.kind == BindingKind::Normal

--- a/crates/rsvelte_core/tests/named_slot_let_scope.rs
+++ b/crates/rsvelte_core/tests/named_slot_let_scope.rs
@@ -162,3 +162,36 @@ fn a_named_slot_read_collects_no_legacy_reference() {
         ),
     ]);
 }
+
+/// The slotted node's OWN `let:` of the SAME NAME is a different binding, and
+/// upstream declares it in the ENCLOSING scope — so it IS in scope there while
+/// the component's is not. The mask is keyed by name and cannot tell the two
+/// apart on its own; each of the three places that register a `let:` has to
+/// clear it. The rows are one per place: an element, a `svelte:fragment`, and
+/// the destructured spelling.
+#[test]
+fn a_slotted_nodes_own_let_of_the_same_name_is_in_scope() {
+    check(&[
+        (
+            "same name on the component and on an element slot child",
+            format!(
+                "{LEGACY}<C {{controller}} let:options={{a}}>\n  <span slot=\"title\" let:options={{a}}>{{a.n}}</span>\n</C>\n"
+            ),
+            "$.template_effect(() => $.set_text(text, ($.deep_read_state($.get(a)), $.untrack(() => $.get(a).n))));",
+        ),
+        (
+            "same name on the component and on a `svelte:fragment` slot child",
+            format!(
+                "{LEGACY}<C {{controller}} let:options={{a}}>\n  <svelte:fragment slot=\"title\" let:options={{a}}>{{a.n}}</svelte:fragment>\n</C>\n"
+            ),
+            "$.template_effect(() => $.set_text(text, ($.deep_read_state($.get(a)), $.untrack(() => $.get(a).n))));",
+        ),
+        (
+            "same name, destructured on both",
+            format!(
+                "{LEGACY}<C {{controller}} let:options={{{{ n }}}}>\n  <span slot=\"title\" let:options={{{{ n }}}}>{{n}}</span>\n</C>\n"
+            ),
+            "$.template_effect(() => $.set_text(text, $.get(options_1).n));",
+        ),
+    ]);
+}

--- a/crates/rsvelte_core/tests/named_slot_let_scope.rs
+++ b/crates/rsvelte_core/tests/named_slot_let_scope.rs
@@ -1,0 +1,164 @@
+//! A component's `let:` variable is out of scope inside that component's NAMED
+//! slots.
+//!
+//! Upstream's `Component` scope visitor gives every `slot=`-carrying child
+//! `context.state.scope.child()` — a child of the scope OUTSIDE the component —
+//! while the `let:` bindings are declared in `metadata.scopes.default`
+//! (`phases/scope.js`). So the name is a global there, `is_pure` reports the
+//! expression as non-reactive, and legacy `build_expression` collects no
+//! reference for it.
+//!
+//! rsvelte answered both questions with a name lookup that falls back to
+//! "any scope", so the same read came out inside a `$.template_effect` and with
+//! a `$.deep_read_state` in front of it.
+//!
+//! The grid crosses the slot the read sits in with the mode, because the two
+//! defects live on different sides of `build_expression`'s
+//! `runes || maybe_runes` early return: a component with no `<script>` is
+//! `maybe_runes`, and no `$.deep_read_state` can be emitted there at all.
+//! Every expectation is the official compiler's own output for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn code(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("P.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+/// The lines that carry the read: how the text is written, and whether the
+/// write is inside an effect.
+fn read_lines(src: &str) -> String {
+    let out = code(src);
+    let picked: Vec<&str> = out
+        .lines()
+        .map(str::trim)
+        .filter(|l| {
+            l.contains("nodeValue")
+                || l.contains("textContent")
+                || l.contains("set_text")
+                || l.contains("deep_read_state")
+        })
+        .collect();
+    if picked.is_empty() {
+        panic!("no read line in:\n{out}");
+    }
+    picked.join(" | ")
+}
+
+const LEGACY: &str = "<script>\n  export let controller;\n</script>\n";
+
+fn check(cells: &[(&str, String, &str)]) {
+    let mut bad = Vec::new();
+    for (name, src, expected) in cells {
+        let got = read_lines(src);
+        if got != *expected {
+            bad.push(format!("{name}\n  expected {expected}\n  got      {got}"));
+        }
+    }
+    assert!(bad.is_empty(), "{}", bad.join("\n"));
+}
+
+/// `maybe_runes` (no `<script>`): only the reactivity half is observable.
+#[test]
+fn a_named_slot_read_is_not_reactive() {
+    check(&[
+        (
+            "named slot, svelte:fragment",
+            "<C let:options={a}>\n  <svelte:fragment slot=\"title\">{a.n}</svelte:fragment>\n</C>\n"
+                .to_string(),
+            "text.nodeValue = a.n;",
+        ),
+        (
+            "named slot, element",
+            "<C let:options={a}>\n  <span slot=\"title\">{a.n}</span>\n</C>\n".to_string(),
+            "span.textContent = a.n;",
+        ),
+        (
+            "named slot, one component deeper",
+            "<C let:options={a}>\n  <span slot=\"title\"><E>{a.n}</E></span>\n</C>\n".to_string(),
+            "text.nodeValue = a.n;",
+        ),
+    ]);
+}
+
+/// The controls: a read the `let:` DOES reach must stay reactive, and a name
+/// that also has an outer binding resolves to the outer one.
+#[test]
+fn a_default_slot_read_and_a_shadowed_name_still_are() {
+    check(&[
+        (
+            "default slot",
+            "<C let:options={a}>{a.n}</C>\n".to_string(),
+            "$.template_effect(() => $.set_text(text, $.get(a).n));",
+        ),
+        (
+            "named slot with its own let:",
+            "<C>\n  <svelte:fragment slot=\"title\" let:options={a}>{a.n}</svelte:fragment>\n</C>\n"
+                .to_string(),
+            "$.template_effect(() => $.set_text(text, $.get(a).n));",
+        ),
+        (
+            "named slot, outer prop of the same name",
+            "<script>\n  export let a;\n</script>\n<C let:options={a}>\n  <svelte:fragment slot=\"title\">{a.n}</svelte:fragment>\n</C>\n"
+                .to_string(),
+            "$.template_effect(() => $.set_text(text, ($.deep_read_state(a()), $.untrack(() => a().n))));",
+        ),
+    ]);
+}
+
+/// Legacy mode (`export let` in the script) is the only side where
+/// `build_expression` runs, so the reference half is observable only here.
+#[test]
+fn a_named_slot_read_collects_no_legacy_reference() {
+    check(&[
+        (
+            "legacy, svelte:fragment",
+            format!(
+                "{LEGACY}<C {{controller}} let:options={{a}}>\n  <svelte:fragment slot=\"title\">{{a.n}}</svelte:fragment>\n</C>\n"
+            ),
+            "text.nodeValue = ($.untrack(() => a.n));",
+        ),
+        (
+            "legacy, element",
+            format!(
+                "{LEGACY}<C {{controller}} let:options={{a}}>\n  <span slot=\"title\">{{a.n}}</span>\n</C>\n"
+            ),
+            "span.textContent = ($.untrack(() => a.n));",
+        ),
+        (
+            "legacy, one component deeper",
+            format!(
+                "{LEGACY}<C {{controller}} let:options={{a}}>\n  <span slot=\"title\"><E>{{a.n}}</E></span>\n</C>\n"
+            ),
+            "text.nodeValue = ($.untrack(() => a.n));",
+        ),
+        (
+            "legacy, default slot — the control that must keep both",
+            format!("{LEGACY}<C {{controller}} let:options={{a}}>{{a.n}}</C>\n"),
+            "$.template_effect(() => $.set_text(text, ($.deep_read_state($.get(a)), $.untrack(() => $.get(a).n))));",
+        ),
+        (
+            "legacy, the slotted node carries the `let:` itself — upstream declares it in the\n         ENCLOSING scope, so its own attributes still read every dependency",
+            "<script>\n  export let cls;\n</script>\n<S>\n  <M slot=\"option\" let:option let:index class={cls(index, option)}>x</M>\n</S>\n"
+                .to_string(),
+            "$.deep_read_state(cls()), | $.deep_read_state($.get(index)), | $.deep_read_state($.get(option)),",
+        ),
+        (
+            "legacy, a plain identifier is not a member read",
+            format!(
+                "{LEGACY}<C {{controller}} let:options={{a}}>\n  <svelte:fragment slot=\"title\">{{a}}</svelte:fragment>\n</C>\n"
+            ),
+            "text.nodeValue = a;",
+        ),
+    ]);
+}


### PR DESCRIPTION
A component's `let:` variable is out of scope inside that component's **named** slots, and
rsvelte treated it as in scope. Two `mathesar` entries leave `client` and `client-dev`.

## The rule

Upstream's `Component` scope visitor (`phases/scope.js`) writes
`node.metadata.scopes = { default: context.state.scope.child() }` and then chooses
`determine_slot(node) ? context.state : { scope: node.metadata.scopes.default }` per child — so
a `slot=`-carrying child gets `context.state.scope.child()`, a child of the scope **outside**
the component. The `let:` name is a plain global there: `is_pure` reports the read as
non-reactive and legacy `build_expression` collects no reference for it.

rsvelte answered both questions by NAME, and scope 0 is deliberately polluted with every child
scope's declarations, so the lookup always found the binding.

The direct control is one line of official output. For

```svelte
<script>
  export let box;
</script>
<Component {box} let:box>
  <div slot="box1">{@const p = box.width}<div>{p}</div></div>
</Component>
```

official emits `$.deep_read_state(box())` — the **outer prop** — not `$.get(box)`.

## Ratchet

| id | target | direction |
|---|---|---|
| `mathesar/…/database/disconnect/DisconnectDatabaseModal.svelte` | `client` | `MISMATCH -> match` |
| `mathesar/…/database/disconnect/DisconnectDatabaseModal.svelte` | `client-dev` | `MISMATCH -> match` |
| `mathesar/…/upgrade-database/UpgradeDatabaseModal.svelte` | `client` | `MISMATCH -> match` |
| `mathesar/…/upgrade-database/UpgradeDatabaseModal.svelte` | `client-dev` | `MISMATCH -> match` |

`client` 22 → 20, `client-dev` 36 → 34.

## Two-stage sweep

Arms: `main` (4cdc135cb, this branch's own merge base — verified with `git merge-base`) and this
branch. Each arm identified by a discriminating probe on its output, for what it should contain
**and** what it should lack, plus `sha256`:

| arm | `named-slot-let` | `static-attr-raw-name` | sha256 |
|---|---|---|---|
| base | ABSENT | ABSENT | `2466c45eebd986fe` |
| head | PRESENT | ABSENT | `f292a0d0c44022b9` |

Stage 1 hashed `js.code + css.code` for every manifest `.svelte` × 4 targets: **135,560 rows,
135,556 distinct keys** — the gap is one id the manifest lists twice, not a key collapse.
**4 units moved.** Stage 2 compared only those to the oracle:

```
4 MISMATCH -> match
0 match -> MISMATCH
```

## What it cost to get here, because two wrong versions passed their grids

**A first version answered the reference half in phase 2**, by testing the binding's declaring
scope against the reference's. Its nine-cell grid was 9/9 and both target entries flipped — and
the sweep found `svelte-ux/…/SelectField/+page.svelte`, **not listed**, going
`match -> MISMATCH`. Upstream's `determine_slot(node) ? context.state : …` declares a slotted
node's OWN `let:` in the enclosing scope, so `<M slot="option" let:option class={cls(option)}>`
still reads it from its own attributes; the phase-2 rule dropped four dependency reads. Every
cell of that grid put the `let:` and the reference on **different** nodes — the axis was varied
and the three-on-one-node arrangement was held fixed.

**The corrected, phase-3-only version still moved 4 units the wrong way** (`carbon-components-svelte/…/TreeView.lazyLoad.test.svelte`
and Svelte's own `runtime-legacy/samples/const-tag-component/main.svelte`). The mask is keyed by
NAME, and a slotted node's own `let:` of the SAME name is a different binding — so `<C let:a>`
around `<span slot="t" let:a>` had the child's binding masked by the parent's. Reduced to two
cells: with the `let:` on only one of the two nodes, both spellings already agreed.

**Clearing it is three edits, not one.** Upstream declares a `let:` binding in one place;
rsvelte registers one in `build_slot_function`, `process_element_let_directives` and
`visit_svelte_fragment`. The reported file reaches the second, the corpus file reaches the
third. The fourth candidate, `<svelte:element let:x>`, needs nothing — both compilers reject it,
which is what closes the enumeration rather than a search that stopped finding things.

## Repro

`crates/rsvelte_core/tests/named_slot_let_scope.rs`, 4 tests, every expectation printed from
`submodules/svelte/…/compiler/index.js` rather than inferred:

- the reactivity half, in `maybe_runes` (no `<script>`), three slot spellings;
- the reference half, in legacy — the two halves sit on opposite sides of `build_expression`'s
  `runes || maybe_runes` early return, so a grid without a legacy row measures only one port;
- **the regression cell for version 1** (`<M slot="option" let:option let:index class={cls(index, option)}>`),
  added only after running version 1 against it and seeing it red;
- **the regression cells for version 2**, one per registration site: an element, a
  `svelte:fragment`, and the destructured spelling.

Six more cells were measured and are not in the file because they already agreed on both arms:
a named slot whose subtree re-declares the name via `{#each}`, a snippet parameter, an `{#await}`
binding, `{@const}`, a nested component's default slot, and — the one that separates a scope
**stack** from a flag — an `{#each xs as a}` body reading `$.get(a)` with a bare `a` in the very
next expression of the same slot.
