### PR TITLE
fix(client): whether an attribute can go in the template is asked of the RAW name

### DIFF
--- a/.changeset/static-attr-raw-name.md
+++ b/.changeset/static-attr-raw-name.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Ask whether an attribute can be set statically of the raw name, not the normalized one, so a case variant of `autofocus` / `muted` / `defaultValue` / `defaultChecked` stays in the template

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2878,11 +2878,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 15 entries)
+### Client (`known-failures.client.json`, 14 entries)
 
-Partition of `known-failures.client.json` by verdict: `14 + 1`
+Partition of `known-failures.client.json` by verdict: `13 + 1`
 
-- **14 — the generated JS differs** (`js` / `code-differs`).
+- **13 — the generated JS differs** (`js` / `code-differs`).
 - **1 — the generated CSS differs.**
 
 The error classes this section used to carry are gone: the run behind this
@@ -3099,7 +3099,27 @@ let:x>` is the fourth candidate and needs nothing: both compilers reject it.) Th
 one cell per place, plus the cell that separates a scope stack from a flag — inside one named
 slot, an `{#each xs as a}` body reads `$.get(a)` and the very next expression reads a bare `a`.
 
-Every one of the remaining 15 arrived with the wave-2 enrolment (#3130) and is described
+`huly/…/DrawingBoardEditor.svelte` left this target and `client-dev` because whether an
+attribute can go in the template string was asked of the NORMALIZED name. Upstream
+(`RegularElement.js:234-256`) computes `name = get_attribute_name(node, attribute)` and uses it
+only for the branch selectors (`class`, `style`, `autofocus`); both `cannot_be_set_statically`
+and `template.set_prop` take `attribute.name`. rsvelte passed the normalized name to both, so
+`<input autoFocus />` matched the four-name `NON_STATIC_PROPERTIES` list, took the JS branch,
+and emitted `$.autofocus(input, true)` where official writes `<input autofocus=""/>`.
+
+The reported spelling is one cell of ten. A grid over name spelling × namespace × value shape
+reports **22 EQ / 10 DIFF**, and the other four names — `Muted`, `MUTED`, `DefaultValue`,
+`defaultchecked` — lose the attribute **entirely**, with nothing emitted in its place: the
+guard sends them down the JS branch and no arm there handles them. `defaultchecked` is the
+sharpest, because normalization maps it INTO the list from outside it. The svg rows are all EQ
+and stay in the repro as the control that rejects the wrong spelling of the fix:
+`get_attribute_name` is the identity outside `html`, so a fix written as "lowercase the raw
+name" is green on every reported cell and red there. The second, separately-suspected
+divergence in the same lowering — that `template.js`'s `stringify` lowercases a key only in the
+html namespace — was measured over seven cells and **agrees**; it is recorded here so it is not
+re-opened as unmeasured.
+
+Every one of the remaining 14 arrived with the wave-2 enrolment (#3130) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3206,15 +3226,15 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 29 entries)
+### Client dev (`known-failures.client-dev.json`, 28 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `29`
+Partition of `known-failures.client-dev.json` by verdict: `28`
 
-- **29 — the generated JS differs.**
+- **28 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 29 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 28 arrived with the wave-2 enrolment (#3130); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -4,7 +4,6 @@
 	"headscale-ui/src/lib/settings/ServerSettings.svelte",
 	"huly/plugins/contact-resources/src/components/SelectAvatarPopup.svelte",
 	"huly/plugins/process-resources/src/components/settings/ProcessAttributeEditor.svelte",
-	"huly/plugins/text-editor-resources/src/components/DrawingBoardEditor.svelte",
 	"huly/plugins/tracker-resources/src/components/issues/move/SelectReplacement.svelte",
 	"huly/plugins/workbench-resources/src/components/HelpAndSupport.svelte",
 	"immich/web/src/lib/components/asset-viewer/ActivityViewer.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -2,7 +2,6 @@
 	"appwrite-console/src/lib/components/sortButton.svelte",
 	"ha-fusion/src/lib/Modal/VisibilityConfig/Index.svelte",
 	"headscale-ui/src/lib/settings/ServerSettings.svelte",
-	"huly/plugins/text-editor-resources/src/components/DrawingBoardEditor.svelte",
 	"immich/web/src/lib/components/asset-viewer/ActivityViewer.svelte",
 	"mathesar/mathesar_ui/src/components/sort-entry/SortEntry.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -626,8 +626,10 @@ pub fn visit_regular_element(
 
                 // Static text attributes can go in the template
                 let is_true_value = matches!(&attr.value, AttributeValue::True(true));
+                // Upstream asks this of the RAW name and normalizes only for the
+                // branch selectors below, so `autoFocus` takes the static path.
                 if !is_custom_element
-                    && !cannot_be_set_statically(&name)
+                    && !cannot_be_set_statically(&attr.name)
                     && (is_true_value || is_text_attribute(attr))
                 {
                     // `None` is upstream's boolean `true` for a valueless attribute,
@@ -662,7 +664,7 @@ pub fn visit_regular_element(
                         context
                             .state
                             .template
-                            .set_prop(name.clone(), Some(value.unwrap_or_default()));
+                            .set_prop(attr.name.to_string(), Some(value.unwrap_or_default()));
                     }
                 } else if name == "autofocus" {
                     // Special case: autofocus needs $.autofocus() call

--- a/crates/rsvelte_core/tests/static_attribute_raw_name.rs
+++ b/crates/rsvelte_core/tests/static_attribute_raw_name.rs
@@ -1,0 +1,154 @@
+//! Whether an attribute can go in the template string is asked of the RAW name.
+//!
+//! Upstream `RegularElement.js:234-256` computes `name = get_attribute_name(...)`
+//! and then uses it only for the branch selectors (`class`, `style`,
+//! `autofocus`); both `cannot_be_set_statically` and `template.set_prop` take
+//! `attribute.name`. rsvelte passed the normalized name to both, so a case
+//! variant of one of the four non-static properties matched the list and its
+//! attribute was dropped from the template with nothing emitted in its place.
+//!
+//! The grid crosses the name's spelling with the namespace, because
+//! `get_attribute_name` is the identity outside `html` — an svg row cannot tell
+//! the raw name from the normalized one and would report the fix as a no-op.
+//! Every expectation is the official compiler's own output for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn template(src: &str) -> String {
+    let out = compile(
+        src,
+        CompileOptions {
+            filename: Some("P.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    let picked: Vec<&str> = out
+        .lines()
+        .map(str::trim)
+        .filter(|l| l.contains("$.from_") || l.contains("$.autofocus("))
+        .collect();
+    if picked.is_empty() {
+        panic!("no template line in:\n{out}");
+    }
+    picked.join(" | ")
+}
+
+fn check(cells: &[(&str, String, &str)]) {
+    let mut bad = Vec::new();
+    for (label, src, want) in cells {
+        let got = template(src);
+        if !got.contains(want) {
+            bad.push(format!("{label}\n  want: {want}\n  got:  {got}"));
+        }
+    }
+    assert!(bad.is_empty(), "{}", bad.join("\n\n"));
+}
+
+/// A case variant of a non-static property is an ordinary attribute upstream,
+/// and the html serializer lowercases the key it stored.
+#[test]
+fn a_case_variant_of_a_non_static_property_stays_in_the_template() {
+    check(&[
+        (
+            "autoFocus, valueless",
+            "<input autoFocus />\n".to_string(),
+            "$.from_html(`<input autofocus=\"\"/>`)",
+        ),
+        (
+            "autoFocus, static value",
+            "<input autoFocus=\"x\" />\n".to_string(),
+            "$.from_html(`<input autofocus=\"x\"/>`)",
+        ),
+        (
+            "Muted",
+            "<input Muted />\n".to_string(),
+            "$.from_html(`<input muted=\"\"/>`)",
+        ),
+        (
+            "MUTED",
+            "<input MUTED />\n".to_string(),
+            "$.from_html(`<input muted=\"\"/>`)",
+        ),
+        (
+            "DefaultValue — the list spells it `defaultValue`",
+            "<input DefaultValue=\"x\" />\n".to_string(),
+            "$.from_html(`<input defaultvalue=\"x\"/>`)",
+        ),
+        (
+            "defaultchecked — normalization maps it INTO the list, the raw name is not in it",
+            "<input defaultchecked />\n".to_string(),
+            "$.from_html(`<input defaultchecked=\"\"/>`)",
+        ),
+    ]);
+}
+
+/// The controls: the exact spellings the list holds still leave the template,
+/// and `autofocus` still gets its call.
+#[test]
+fn the_listed_spellings_still_leave_the_template() {
+    check(&[
+        (
+            "autofocus keeps its call",
+            "<input autofocus />\n".to_string(),
+            "$.autofocus(input, true)",
+        ),
+        (
+            "autofocus is not in the template",
+            "<input autofocus />\n".to_string(),
+            "$.from_html(`<input/>`)",
+        ),
+        (
+            "muted",
+            "<input muted />\n".to_string(),
+            "$.from_html(`<input/>`)",
+        ),
+        (
+            "defaultValue",
+            "<input defaultValue=\"x\" />\n".to_string(),
+            "$.from_html(`<input/>`)",
+        ),
+        (
+            "defaultChecked",
+            "<input defaultChecked />\n".to_string(),
+            "$.from_html(`<input/>`)",
+        ),
+    ]);
+}
+
+/// Outside `html`, `get_attribute_name` is the identity — so these rows are the
+/// ones that move if the fix is spelled as "lowercase the raw name" instead.
+#[test]
+fn an_svg_attribute_keeps_the_source_spelling() {
+    check(&[
+        (
+            "autoFocus in svg",
+            "<svg><rect autoFocus /></svg>\n".to_string(),
+            "$.from_svg(`<svg><rect autoFocus=\"\"></rect></svg>`)",
+        ),
+        (
+            "Muted in svg",
+            "<svg><rect Muted=\"x\" /></svg>\n".to_string(),
+            "$.from_svg(`<svg><rect Muted=\"x\"></rect></svg>`)",
+        ),
+        (
+            "MUTED in svg",
+            "<svg><rect MUTED /></svg>\n".to_string(),
+            "$.from_svg(`<svg><rect MUTED=\"\"></rect></svg>`)",
+        ),
+        (
+            "autofocus in svg still gets its call",
+            "<svg><rect autofocus /></svg>\n".to_string(),
+            "$.autofocus(rect, true)",
+        ),
+        (
+            "muted in svg leaves the template",
+            "<svg><rect muted /></svg>\n".to_string(),
+            "$.from_svg(`<svg><rect></rect></svg>`)",
+        ),
+    ]);
+}


### PR DESCRIPTION
Whether an attribute can go in the template string is asked of the **raw** name upstream, and
rsvelte asked it of the normalized one. `huly/…/DrawingBoardEditor.svelte` leaves `client` and
`client-dev`.

## The rule

`RegularElement.js:234-256`:

```js
const name = get_attribute_name(node, attribute);

if (
  !is_custom_element &&
  !cannot_be_set_statically(attribute.name) &&   // RAW
  (attribute.value === true || is_text_attribute(attribute)) && …
) {
  …
  context.state.template.set_prop(attribute.name, value === true ? '' : value);  // RAW
} else if (name === 'autofocus') {               // normalized
```

The normalized `name` reaches only the branch selectors. rsvelte passed it to the guard and to
`set_prop` as well, so `<input autoFocus />` matched the four-entry `NON_STATIC_PROPERTIES`
list (`autofocus`, `muted`, `defaultValue`, `defaultChecked`), took the JS branch, and emitted
`$.autofocus(input, true)` where official writes `<input autofocus=""/>`.

## The grid — the reported cell is 1 of 10

Name spelling × namespace (`html` / `svg`) × value shape (valueless / static): **22 EQ, 10 DIFF**
before the fix, 32/32 after.

| name | html | svg |
|---|---|---|
| `autoFocus` | **DIFF** — official `autofocus=""`, rsvelte `$.autofocus(…)` | EQ |
| `Muted` | **DIFF** — official `muted=""`, rsvelte emits **nothing at all** | EQ |
| `MUTED` | **DIFF** — same | EQ |
| `DefaultValue` | **DIFF** — official `defaultvalue=""`, rsvelte nothing | EQ |
| `defaultchecked` | **DIFF** — normalization maps it INTO the list from outside it | EQ |
| `autofocus` / `muted` / `defaultValue` / `defaultChecked` / `readonly` / `dataFoo` / … | EQ | EQ |

Four of the five diverging names lose the attribute **silently**: the guard sends them down the
JS branch and no arm there handles them, so the element is emitted with the attribute simply
gone. Only `autoFocus` has an arm, which is why only it was reported.

The **svg rows are the control**, not padding. `get_attribute_name` is the identity outside
`html`, so a fix spelled "lowercase the raw name" is green on every reported cell and red on
`<svg><rect autoFocus />`, where official keeps the source spelling.

## The second suspected divergence in this lowering was measured and agrees

`template.js`'s `stringify` writes `` ` ${item.is_html ? key.toLowerCase() : key}` `` — the raw
key is lowercased only in the html namespace. Seven cells (`viewBox`, `preserveAspectRatio`, a
camelCase unknown attribute in svg / mathml / html, `readonly` in svg, an alias-mapped name in
html): **7 EQ, 0 DIFF**. Recorded so it is not re-opened as unmeasured — it is measured, and it
is clean.

## Ratchet

| id | target | direction |
|---|---|---|
| `huly/…/text-editor-resources/…/DrawingBoardEditor.svelte` | `client` | `MISMATCH -> match` |
| `huly/…/text-editor-resources/…/DrawingBoardEditor.svelte` | `client-dev` | `MISMATCH -> match` |

`client` 17 → 16, `client-dev` 31 → 30.

## Two-stage sweep

| arm | `named-slot-let` | `static-attr-raw-name` | sha256 |
|---|---|---|---|
| base (`95ba24874`, this branch's own merge base) | ABSENT | ABSENT | `ad7f435344789a2f` |
| head | ABSENT | PRESENT | `b48485a9f5f17f40` |

Stage 1 hashed `js.code + css.code` for every manifest `.svelte` × 4 targets: **135,560 rows,
135,556 distinct keys** — the gap is one id the manifest lists twice, not a key collapse.
**2 units moved.** Stage 2:

```
2 MISMATCH -> match
0 match -> MISMATCH
```

**The baseline was rebuilt to get that number.** The first run compared against a binary from
`4cdc135cb`, one commit older than this branch's merge base, and reported **4** moved units all
in the flattering direction — two of which were #4175's, not this change's. Correcting the base
changed the answer, which is what separates a base check from a formality.

## Repro

`crates/rsvelte_core/tests/static_attribute_raw_name.rs`, 3 tests, every expectation printed
from `submodules/svelte/…/compiler/index.js`:

- the five diverging spellings stay in the template, with the html serializer lowercasing the
  key it stored;
- the four listed spellings still leave it, and `autofocus` still gets its call;
- the svg rows keep the source spelling — the cells that reject a "lowercase it" fix.
