### PR TITLE
docs: three count spellings that rotted alone, and a self-test that held its own counts as literals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1342,6 +1342,38 @@ release test targets were all green. What attributed it was a completed *previou
 same corpus sweep: without a baseline rate, a sweep that stops printing is indistinguishable from
 a sweep competing with a build for CPU.
 
+### If the mechanism already has a name in the code, measure the name
+
+Asked whether two CSS residuals were one mechanism or two, the instruction given was "flip one
+arm and see whether the fix moves both" — which needs two builds and answers only *after* a fix
+exists. The cheaper answer was already in the tree: the empty-rule elision sits inside
+`!ctx.dev`, so varying `dev` reports **which path a case takes** directly. One build, and the
+two rows separate (`DIFF/DIFF` for the one that is not the empty check, `DIFF/EQ` for the one
+that is). A two-arm probe measures *what a change does*; an existing flag measures *where the
+input goes*, and the second question is usually the one being asked. This is the sibling of
+"a mechanism with a name is settled by `git log -S`" — that one is about provenance, this one
+about path.
+
+The same episode carries the shape of a well-run zero. The carrier count over 32,650 collected
+components was **0**, and it is only readable because the detector was positive-controlled
+first: 11 constructed cells, **two of which must answer `none`**, so the instrument is shown to
+produce both a hit and a miss; and the target selector was checked by running a known-diverging
+file through the identical wiring and watching it swing per target, which is what rules out a
+silently ignored argument. State the denominator's own deviation too — 32,650 is not the
+pipeline's 33,893 (no markdown blocks, one submodule unexpanded) — and say the difference could
+contain a carrier rather than asserting it cannot.
+
+### Say which of the summary and the distribution is primary
+
+"Keep the distribution beside the summary so a wrong summary can be recomputed" is the rule this
+repository nearly adopted after a `6.00` that should have been `5.96` — recoverable exactly
+because the distribution (3,551 files at 6, 81 at 4) was written next to it. It is not the rule.
+The `parse-ast` paragraph has the opposite failure on record: a summary of `459` above a cluster
+split that *also* summed to 459, while the JSON held **321** — the two went stale together and
+neither checks the other. The recoverable form is **naming the primary source**: the map's
+numbers are recomputable because the JSON is primary and the prose is derived. A distribution
+transcribed into prose is just a second summary.
+
 ### A guard and the computation behind it are two claims about one shape
 
 `try_hug_mixed` admitted a line prefix with `indent.ends_with('>')` — written for a parent's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1342,6 +1342,33 @@ release test targets were all green. What attributed it was a completed *previou
 same corpus sweep: without a baseline rate, a sweep that stops printing is indistinguishable from
 a sweep competing with a build for CPU.
 
+### A guard and the computation behind it are two claims about one shape
+
+`try_hug_mixed` admitted a line prefix with `indent.ends_with('>')` — written for a parent's
+hugged `>` alone on the line — and then computed the hug's indentation as *the prefix sliced up
+to its last space*, which is only that same string on that same shape. A comment ends in `>`
+too, so a leading `<!-- … -->` passed the guard and was re-emitted as indentation on top of its
+own `-->`: text `compile()` rejects, 1 file in 33,644 (#4151). **Tightening the guard is the
+cheap direction and it is usually wrong.** It removed the corruption, and it also removed the
+hug — the same 5-case grid then read 3 MATCH / 2 DIFF where the oracle wants 5, and the version
+that widened the guard later cost 4 corpus entries. Fixing the *computation* (the line's own
+leading whitespace, which agrees with the slice on the shape the slice was written for) took the
+grid to 5/5 and the ratchet from 549 to 547 with 0 new failures. Ask which of the two encodes
+the shape: the guard names it, the computation assumes it, and only one of them is load-bearing.
+
+The other half is that the premise under the guard was itself wrong. "Comments are always line
+boundaries" is a sentence in the code; the oracle glues `><!-- … -->` to a wrapped open tag
+exactly as it glues text, which one probe settles. **A refusal justified by a comment is a place
+to probe the oracle, not a place to work around.**
+
+And the closing measurement needed a **set difference, not a count**. Compiling both sides'
+formatted output over the whole population returns 1,014 rejections on each side — the sources
+that do not compile at all (`lang="ts"` and friends) — so the raw count answers nothing. The
+quantity is *rejected by rsvelte and accepted by the oracle*: 1 before, 0 after. The mirror
+direction is not decoration either; it returned 2, both already carried by
+`fmt-oracle-excluded.json`, which is what says the 0 is a property of the fix and not of a
+population that lost its rejections for some other reason.
+
 ### Split the verdict before you split the cause
 
 A cell that reports one pass/fail per input tells you the input diverges; a cell that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,7 +372,12 @@ entries** each, which is a FALSE-SHRINK failure. Their 86 queued jobs were there
 red before any of them ran; rebasing did not cost the queue, it *freed* it (`running 16 → 8`,
 `queued 153 → 104`). The trap is that **the branch's own tree is self-consistent**, so nothing
 measurable locally explains the red — "the ratchet is right on my branch, so the rebase can wait"
-is a true statement and an irrelevant one.
+is a true statement and an irrelevant one. **And the same fact is a tool, not only a
+hazard**: a PR run's artifact records its own `projectRevision` as the merge ref, so it says which
+upstream commits were *in* the tree it measured. Reading that first shrinks or dissolves the
+question "does `main` moving invalidate this measurement" — in one instance four commits' worth of
+reachability was traced by hand and the artifact then showed three of them had been in the
+measured tree all along.
 
 **And a cancelled run also shows up RED, where it is indistinguishable from a real regression.**
 `Tests` is a rollup job that reads its shards' `result`s and exits 1 unless every one is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1211,6 +1211,15 @@ this session" is an assumption, and the two disagree silently. The prefix does n
 reset — it only makes each call independent of the previous call's cwd. What it cannot fake is
 the build's own `Compiling <crate> (<path>)` line, so read that before trusting any arm.
 
+**And the same hazard has a read-only form that no `Compiling` line can catch.** A ratchet census
+run in the primary checkout reported `known-failures.client.json` at **17**; `origin/main` reads
+**14**, because that checkout was parked on a documentation branch cut before three merges. There
+was no build, no arm and no binary — just `readFileSync` over `compatibility/`, which is the
+cheapest possible measurement and was of the wrong tree. A census is a measurement of a tree in
+exactly the way a baseline is, so name the tree in the output (`git rev-parse HEAD` beside the
+counts) rather than in your intention; a number with no revision beside it cannot be checked by
+anyone, including the person who produced it.
+
 A second, independent signal is the **diff between the two arms' trees** (`git diff <base> HEAD
 -- crates/`): a one-line answer to "do these arms differ by the change I think they do". Neither
 signal is sufficient alone — the `Compiling` line says which tree was read but not what is in it,
@@ -1676,6 +1685,30 @@ the same line would print if the arrangement were reversed. Nothing is missing f
 so re-reading it more carefully cannot help; only a different operation can — **read the names
 of the tests that ran, not the count**, and where a suite prints its own denominators
 (`770/770 official segments`, `0/1634 out of range`) run it with `--nocapture` so those appear.
+
+**A verdict over a set must state the set's size, because an empty set satisfies every rule
+written as "nothing failed".** A check-run monitor asked "is any run incomplete, is any run a
+failure" and printed `COMPLETE seen=0 total_count=0 fail=0` for two different PRs — a green
+sentence about a commit that has no checks at all. One of the two is not a transient: a
+Changesets release PR is opened with `GITHUB_TOKEN`, which does not trigger `pull_request`
+workflows, so **that PR structurally has zero check-runs and no gate has ever seen it**. The fix
+is not an `if seen == 0` arm; it is that the reader must print the denominator and refuse to
+conclude at zero, and must additionally assert `seen == total_count` — the check-runs API pages
+at 30, so `total_count` and the length of what you received are two different numbers and only
+the second is yours. Both halves have now produced a false green on this repository within one
+day of each other.
+
+**A gate can be written, unit-tested, self-tested and wired to nothing.**
+`scripts/ci/attribution-check.mjs` owns the question "is every ratchet entry attributed", ships 8
+passing controls under `pnpm run test:attribution-check`, and
+`grep -rn 'attribution-check\|check:attribution' .github/workflows/` returns **0**. On the day
+this was found, *both* people who had published a census of that question had built it by hand
+from the `Attribution of` prose in `KNOWN-FAILURES.md` rather than by running the checker — one of
+them in the same report that named that prose as ungated and rotting. The two hand-built censuses
+agreed to within a difference that fully explains (16 = client 22→14 plus client-dev 36→28), and
+**that agreement is not evidence the method is sound**: two readings of one document are one
+measurement. Ask which artifact in the tree *owns* a question before answering it; "it is not in
+CI" is a reason to run it locally, never a reason it is not the authority.
 
 **An instrument can be dead on exactly the population that carries the defect, and it reports
 that as agreement.** Row 4 above is not a missing column so much as a column filled in with a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,9 +499,9 @@ is why that suite reads 100% while the class exists. **A gate's first baseline m
 the surface was ungated, not how much someone let rot.**
 
 **Those three numbers are the FIRST baseline (2721 entries) and none of them is a current work
-item.** The ratchet stands at 304 over ten clusters — `span` 78, `node-type` 62,
+item.** The ratchet stands at 301 over ten clusters — `span` 78, `node-type` 62,
 `comment-attachment` 50, `estree-fields` 38, `unclustered` 36, `child-count` 14, `css-shape` 14,
-`loc-presence` 9, `ast-mode` 2, `accepts-what-official-rejects` 1 — and there is no
+`loc-presence` 6, `ast-mode` 2, `accepts-what-official-rejects` 1 — and there is no
 `character` cluster at all. Grepping the keys for `character` returns 0 and **means nothing**,
 because `verify.mjs` folds `start`/`end`/`loc` into one key per node type, so a
 `loc.start.character` divergence sits inside `span`. Measured directly on one input, both
@@ -509,12 +509,19 @@ compilers emit zero `character`-bearing `loc`s and `phases/1-parse` does not imp
 `locate-character` at all (only `preprocess/index.js`, `state.js` and
 `utils/compile_diagnostic.js` do) — which suggests the paragraph above describes the
 *diagnostic* path rather than `parse()` output, but one input is not a population. Count the
-JSON, not this paragraph — and this paragraph has already been wrong once: it read 459 over a
-cluster split that summed to 459 while the file held 321, so **the count and the split go stale
-together and neither checks the other**. And read `304` as `165 bases × axis`: 139 of those bases
-carry a key on both axes and 26 on one, so the defect ceiling is 165, not 304. The collapse is not
-uniform across clusters (2.00x for `estree-fields` and `comment-attachment`, 1.56x for
-`css-shape`), so a per-cluster estimate cannot be had by scaling the total.
+JSON, not this paragraph — this paragraph has already been wrong twice, and the second time
+named the mechanism. It once read 459 over a cluster split that summed to 459 while the file
+held 321. Then it read 304 / `loc-presence` 9 while the file held 301 / 6 — and the history says
+those were **correct one commit earlier**: `051e359dc` moved the JSON and the doc's partition
+line together and left this file untouched, because `known-failures-md-check.mjs` gates the
+partition line and gates no prose. That is the same mechanism `fmt`'s attribution paragraph
+carried for 241 entries. So it is not that a count and a split go stale together — **one half is
+gated and the other rots alone**, and the gated half is where to read the number. And read `301`
+as `163 bases × axis`: 138 of those bases carry a key on both axes and 25 on one
+(`138×2 + 25 = 301`), so the defect ceiling is 163, not 301. The collapse is not uniform across
+clusters — measured, 1.00x to 2.00x against a whole-file 1.847x, so scaling the total gives
+`css-shape` 7.6 where it actually has 9 — which is why a per-cluster estimate cannot be had by
+scaling the total.
 
 **And the clusters partition KEY SHAPES, not causes, so a mechanism can span three rows while
 each row reads as its own backlog.** `lang="ts"` does not merely enable extra syntax — it selects
@@ -1218,6 +1225,16 @@ reach at all. **Ask what mechanism could carry the change to each moved file
 before attributing any of them**; a direction that matches your hypothesis is
 the cheapest thing for an artefact to imitate.
 
+It recurred, and the second instance is cheaper to detect than the first because the
+discrepancy is a git fact rather than a mechanism argument. A baseline arm was built at
+`4cdc135cb` while the head branch's own merge base had moved to `95ba24874` one merge earlier,
+so the two arms differed by the change under test **and** by the PR that had landed in between.
+The sweep reported **4** moved units, all `MISMATCH -> match` — the flattering direction, at a
+plausible size. Rebuilding the baseline at the branch's actual merge base gave **2**, and the
+other two were the intervening PR's. `git merge-base <branch> origin/main` against the commit
+the baseline binary was built from is one command and settles it; run it before the sweep, not
+after a result you like.
+
 **The last row is a different failure and the probe cannot see it.** Rows 1-6 are
 an arm whose *identity* is wrong, and a discriminating probe settles every one of
 them. Row 7 is two arms that are the *same* arm — and probing both returns the
@@ -1505,6 +1522,38 @@ and which a direction-free key had reported as uniform.
 edge, so a change under `crates/rsvelte_projection/src/svelte2tsx/` reaches it and a
 changeset naming only `@rsvelte/svelte2tsx` fails `check-core-consumer-changesets.mjs`.
 Name every consumer the checker lists, not the one whose directory you edited.
+
+### A fix that reaches the reported file has reached one of the places that register the rule
+
+Upstream declares a `let:` binding once, in `phases/scope.js`. rsvelte registers one in
+**three** places — `build_slot_function` (the component's own), `process_element_let_directives`
+(a slotted element's own) and `visit_svelte_fragment` (a `svelte:fragment`'s own) — so a rule
+about `let:` scope is three edits, and the count is not visible from any one of them. The
+reported file reached the second and a corpus file reached the third, which is why the first
+corrected version still moved 4 units the wrong way: `<C let:a>` around `<span slot="t" let:a>`
+had the child's binding masked by the parent's, because the mask is keyed by NAME and upstream's
+`determine_slot(node) ? context.state : …` declares a slotted node's own `let:` in the ENCLOSING
+scope. The fourth candidate, `<svelte:element let:x>`, needs nothing — both compilers reject it,
+which is what closes the enumeration rather than a search that stopped finding things.
+
+Two cheap controls came out of it. **A cell that separates a scope STACK from a flag**: inside
+one named slot, an `{#each xs as a}` body reads `$.get(a)` and the very next expression reads a
+bare `a` — a mask that is set once and never restored gets exactly one of the two. And **the
+control cell whose value on `main` is already correct is not an identity probe**: `main` has no
+mask at all, so the same-name arrangement passes there by construction; it discriminates the
+broken fix from the corrected one and says nothing about which arm you are holding.
+
+### Two fixes in one file make the arm probe a liar even when the probe is right
+
+An arm is identified by a discriminating probe on its output, and the probe answers only the
+hypothesis it was handed. Two independent fixes landed in `regular_element.rs` on the same
+afternoon — a `let:`-scope mask and the raw-vs-normalized attribute name — and a `git checkout`
+with an uncommitted working tree carried the second onto the first's branch. The probe asked
+"is the `let:` fix in?" (yes) and "is the destructured-rest fix in?" (no, correct), and reported
+a clean arm identity for a binary containing **both** changes; a 30%-complete 135,560-unit sweep
+had to be discarded. The rule the truncation table already states for verdicts applies to arms:
+probe for what the arm should contain **and** for what it should lack, and add a cell per
+in-flight change in the files you touched, not per change you believe you are measuring.
 
 ### A reconstruction of a gate misses in a direction, and the direction is the stage it dropped
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1064,6 +1064,7 @@ followed on the next:
 | `pgrep -c … \|\| echo 0` | `0` | the `\|\|` arm fabricated a datum that reads exactly like a measurement |
 | `cargo test … \| grep -E '^test \|test result' \| head -20` | `TEST_EXIT=101` from `$pipestatus[1]`, and twenty *passing* lines | the **verdict** was read correctly and the lines explaining it were outside the window |
 | `join before.tsv after.tsv` over paths sorted by Rust's byte order | two non-ASCII paths reported as **changed** that were byte-identical | `join` requires its inputs in the locale's collating order and silently **mispairs** rows when they are not |
+| `timeout 120 node probe.mjs 2>&1 \| head -20` | nothing at all, twice | `head` closed the pipe and `timeout` killed the process, so node's block-buffered stdout was **never flushed** — the verdict was not outside the window, it was never produced |
 
 Rules, in the order they are cheap:
 
@@ -1150,6 +1151,19 @@ Rules, in the order they are cheap:
    contradicted it outright and the contradiction was not treated as evidence
    about the instrument. **When someone else's measurement disagrees with yours,
    the first hypothesis is your instrument, not their arithmetic.**
+5. **A window can kill the verdict's PRODUCTION, not only its display.** Rows 1-5
+   of the table lose a verdict that exists; row 6 loses one that never got
+   written. `console.log` to a pipe is block-buffered, `head` closes the pipe and
+   `timeout` sends SIGTERM, so whatever is still in the buffer is gone — and the
+   same command redirected to a file prints all five lines. The distinction
+   matters because **the usual fix does not apply**: widening to `head -200`
+   changes nothing, because the width was never the problem, and someone who
+   knows the table will re-run at the same width and get the same nothing. It
+   also mis-attributes in a specific direction — an empty probe reads as "the
+   thing I am probing is broken", so two plausible mechanisms (a wrong `cwd`, a
+   wrong `--stdio` spelling) were built and one of them was even independently
+   real, which is what made the diagnosis stick for two rounds. Write to a file,
+   then read the file; nothing else recovers an unflushed buffer.
 
 ### Nothing about a measurement arm is evidence of what it measured
 
@@ -1163,8 +1177,10 @@ has been wrong on this repository within one day of the others:
 | the artifact's path | with `CARGO_TARGET_DIR` set, the path no longer depends on cwd — so it stops proving which tree was compiled |
 | the branch you think you are on | an agent's shell cwd silently resets to the main checkout, and `cargo` then compiles someone else's working tree with no error |
 | "the same branch as last time" | the branch was rebased between the two builds, so the arms differ by whatever landed on `main` in between |
+| the source the build read | it was edited *while* the build ran, so the artifact answers to no tree at all — and nothing in the name, the path, or the `Compiling` line records it |
+| two labels, one artifact | a `sed` rename chain applied in an order that made both arms resolve to the same file — the arms were never distinct |
 
-Two rules cover all five. **Identify an arm by a discriminating probe on its
+Two rules cover the first six. **Identify an arm by a discriminating probe on its
 output** — one input whose answer differs between the two arms, run through the
 binary you are about to measure with. A probe only separates the hypothesis you
 handed it: an arm was probed with one fix's fingerprint, came back clean, and was
@@ -1201,6 +1217,23 @@ and the four files were `.svelte.js`, which the changed template visitor cannot
 reach at all. **Ask what mechanism could carry the change to each moved file
 before attributing any of them**; a direction that matches your hypothesis is
 the cheapest thing for an artefact to imitate.
+
+**The last row is a different failure and the probe cannot see it.** Rows 1-6 are
+an arm whose *identity* is wrong, and a discriminating probe settles every one of
+them. Row 7 is two arms that are the *same* arm — and probing both returns the
+same answer, which reads as "the two runs agree, my instrument is sound". What
+denies it is `sha256` of the two artifacts, and hashing alone is not enough
+either: two different files can legitimately hold the same behaviour, so equal
+outputs from distinct hashes is a real zero. The hash rules out sameness and the
+probe rules out mislabelling; **neither substitutes for the other, and both are
+needed on a measurement whose answer is 0**. Note the scope: this class can only
+surface on a run that reports nothing moved, so it is invisible to every
+`moved > 0` sweep, and the instance that produced it was the *third* consecutive
+`moved 0` on the same instrument — **the number you predicted is the one you will
+not re-derive**. The mechanism was a single `sed -e 's#a#b#; …; s#c#a#'` whose
+first substitution pushed the new arm aside and whose third re-created its name:
+collapsing a rename chain into one command hides the intermediate state that
+would have shown `a` being defined twice.
 
 ### Three things answer to "the official compiler", and they disagree
 
@@ -1508,6 +1541,7 @@ of that row going unwritten:
 | the ratchet — the ids that fail today | did anything that passes today break | **population** (the set is the complement of the question's) |
 | `js.code + css.code` over 135,592 pairs | a `loc` change reaching phase 3 comments **and** the source map | **carrier** (nothing in that hash carries a map) |
 | the corpus manifest, 33,898 components | 58 samples under `packages/svelte/tests/sourcemaps` | **population** (same mechanism, disjoint inputs) |
+| `corpus_hash` over 104,439 units, `MOVED 0` | does the class-field `$state` fix move anything | **population** (`corpus_hash` walks `.svelte` only, and `compile_module` parses plain JS — all 923 `.svelte.(js\|ts)` returned the *same* `js_parse_error` in both arms, which is the host the defect lives in) |
 
 None of the three is visible as "measured / not measured", and all three produce a `0` that
 reads as an answer. Writing the population out loud is what makes the first one self-evident —
@@ -1522,6 +1556,17 @@ the same line would print if the arrangement were reversed. Nothing is missing f
 so re-reading it more carefully cannot help; only a different operation can — **read the names
 of the tests that ran, not the count**, and where a suite prints its own denominators
 (`770/770 official segments`, `0/1634 out of range`) run it with `--nocapture` so those appear.
+
+**An instrument can be dead on exactly the population that carries the defect, and it reports
+that as agreement.** Row 4 above is not a missing column so much as a column filled in with a
+number the instrument could not have produced any other value for: every unit of the carrying
+host errored identically in both arms, so `MOVED 0` was arithmetically forced. The check is one
+line and it is the same one as everywhere else here — **count the live units, not the compared
+units**. Re-run through the gate's own preparation (here `compile.mjs`'s esbuild TS strip) and
+the answer becomes `MOVED 2`, both of them the file the issue names. It is worth stating the
+residue too: 110 of the 923 still fail to compile in both arms for reasons both compilers agree
+on, so the module sweep's live population is 813 — a number that belongs in the report, because
+"923 files swept" and "813 files could have moved" are different claims.
 
 ### Working with Subagents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1135,6 +1135,21 @@ Rules, in the order they are cheap:
    (`started_at > created_at`) reported **0**, so the platform-side signature was
    absent and the question stayed open. Run the check on a population where the
    predicate MUST fire before you read a run where it must not.
+   **And the instrument check is only as good as the population it runs on.**
+   Half an hour later the same investigation reported `in_progress: 4` against a
+   20-job ceiling and concluded the scheduler was stalled. It was saturated at
+   exactly 20. `actions/runs?per_page=100` returns the hundred most recent runs
+   **of any status**, and filtering those client-side drops every still-running
+   run older than the window — here a 16-shard job created an hour earlier.
+   Server-side (`?status=in_progress`, `?status=queued`) with paging gives 20 and
+   208. This is the paging-window hazard, and what makes this instance worse than
+   the usual one is that **it faked a plausible number rather than a zero**: `4`
+   was explicable, agreed with the hypothesis under test, and was internally
+   consistent (the "predicate could fire" control read 4 too, because it drew
+   from the same truncated population). A peer's report of 16 running shards
+   contradicted it outright and the contradiction was not treated as evidence
+   about the instrument. **When someone else's measurement disagrees with yours,
+   the first hypothesis is your instrument, not their arithmetic.**
 
 ### Nothing about a measurement arm is evidence of what it measured
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,17 @@ same string for every push to `main`, so at a high merge rate each merge cancell
 predecessor and `main` carried no verdict at all. **A cancelled run and a green run are
 indistinguishable in the branch header.**
 
+**And the same is true one step earlier: a ratchet's correctness is relative to the tree it is
+measured on, and a PR's tree is the MERGE REF.** `pull_request` CI checks out
+`refs/pull/N/merge` — the branch merged with `main` — so when `main` moves, a branch that has not
+changed by a byte can go red. Measured the day #4161 landed: it took `known-failures.client.json`
+from 34 to 28, and three open PRs still carrying the 34-entry file had **6 listed-but-passing
+entries** each, which is a FALSE-SHRINK failure. Their 86 queued jobs were therefore guaranteed
+red before any of them ran; rebasing did not cost the queue, it *freed* it (`running 16 → 8`,
+`queued 153 → 104`). The trap is that **the branch's own tree is self-consistent**, so nothing
+measurable locally explains the red — "the ratchet is right on my branch, so the rebase can wait"
+is a true statement and an irrelevant one.
+
 **And a cancelled run also shows up RED, where it is indistinguishable from a real regression.**
 `Tests` is a rollup job that reads its shards' `result`s and exits 1 unless every one is
 `success` — so a cancellation makes the rollup `FAILURE` while every shard under it is
@@ -696,6 +707,18 @@ Normalization is deliberately identical to `verify.mjs`, so a divergence this ga
 the corpus gate would also report. `--update-baseline` refuses to run under `--no-fmt` or a
 `--families` subset (both would FALSE-SHRINK the ratchet).
 
+**A ratchet entry's justification is a hypothesis about the AXIS, and a repro built from it
+inherits that hypothesis.** A svelte2tsx entry was recorded as "a `//` comment is dropped from a
+mustache in a mixed attribute value". The rule is not about comments: upstream copies the
+mustache interior **verbatim**, and rsvelte sliced by the expression node's span, so everything
+between `{` and the start of the expression was lost. Four cells —
+`class="x {// c⏎a} z"`, `{/*c*/a}`, `{ a }`, `{a /* t */}` — and **two of them contain no
+comment at all**, so a fix built from the entry's own wording (extend the range to cover a
+leading comment) passes half the grid and reads as done. The lesson is one level earlier than
+"reason is not attribution": the prose does not merely fail to say *where* a divergence is
+answered, it can name the wrong *axis* to reproduce it on, and the grid that would catch that is
+the one whose cells are not all instances of the stated cause.
+
 ### Transform idempotency (`scripts/compat-corpus/idempotency-verify.mjs`)
 
 **The one gate here that compares rsvelte to nothing.** With
@@ -999,7 +1022,7 @@ VS Code Dev Containers ("Reopen in Container") also works.
 
 ### grep can return nothing and mean nothing
 
-Four ways `grep` has silently reported "no matches" for strings that were
+Five ways `grep` has silently reported "no matches" for strings that were
 present. All of them produce a confident empty result, so a negative grep is
 never on its own evidence that something is absent — confirm with a positive
 control on a string you know is there.
@@ -1010,6 +1033,15 @@ control on a string you know is there.
 | `Binary file … matches`, no lines printed | one NUL byte anywhere in the file (not non-ASCII — UTF-8 is fine) | `command grep -a`, or `git grep` |
 | `git show rev:file \| grep X` finds nothing | the wrapper's `-I` discards binary-looking **stdin** | `git grep X rev -- file` |
 | later matches missing | `\| head -N` (or `\| tail -N`) truncates with no error | state the denominator, or drop the cap — see the section below, this is the narrow case of a general hazard |
+| every count comes back `0` | zsh expanded an **unquoted** `--include=*.svelte` as a glob, found no match in cwd, and never ran the command | quote every glob-shaped argument: `--include='*.svelte'` |
+
+The fifth row is the one that is not a `grep` bug at all: the other four reach
+`grep` and then lie, while this one means `grep` never ran. Two people hit it in
+one session, an hour apart, and both times the fabricated answer — `0` for every
+repository — **agreed with the hypothesis being tested** ("this population carries
+no carrier"). Quoted and re-run, the first column read `1867`. Neither `echo $?`
+nor `$pipestatus` helps, because zsh's non-zero status is not a failure of the
+command you wrote; the only control that fires is a count you know is non-zero.
 
 ### A truncating or discarding stage turns a failure into a green
 
@@ -1087,6 +1119,17 @@ Rules, in the order they are cheap:
 3. **State the denominator.** "No warnings" is a claim about a population; say
    which one (`-p <crate> --lib --tests`), because the reader cannot tell from
    the output whether your file was in it.
+4. **Check the instrument before the result, not after.** A predicate written to
+   answer "is the CI scheduler stalled" — `status === 'queued' && started_at` —
+   matched **210 of 213** jobs, which agreed with the hypothesis and was
+   internally tidy (the other 3 were exactly the `in_progress` count). It is
+   non-discriminating: the Jobs API stamps a queued job's `started_at` with its
+   `created_at`. What exposed it was the *shape* — six different jobs carrying
+   the identical timestamp to the second — not the count, which is the same
+   signal that named the `awk` key collapse above. The corrected predicate
+   (`started_at > created_at`) reported **0**, so the platform-side signature was
+   absent and the question stayed open. Run the check on a population where the
+   predicate MUST fire before you read a run where it must not.
 
 ### Nothing about a measurement arm is evidence of what it measured
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1354,6 +1354,18 @@ input goes*, and the second question is usually the one being asked. This is the
 "a mechanism with a name is settled by `git log -S`" — that one is about provenance, this one
 about path.
 
+The same family answers *"is this predicate wrong, or is it never reached"* — two hypotheses that
+one sentence ("`is_rule_empty` does not seem to be reached") hides and that repair in different
+functions. A `#[track_caller]` counter settles it in one build: 0 lines on the failing input,
+**4 lines on a neighbouring input that takes the other branch**, so the zero is the wiring and
+not the instrument. It named `transform_rule` → `transform_global_block` →
+`transform_rule_preserving`, where upstream has one `Rule` visitor evaluating
+`is_empty(node, is_in_global_block(path))` at every depth. That is the two-ports shape with a
+piece missing rather than a piece disagreeing: **the second port does not carry the decision at
+all.** Reading the predicate instead would have been a careful study of the correct function.
+And "A was not called" does not entail "B was": where output exists, something wrote it, so the
+probe has to name the writer and not only clear the suspect.
+
 The same episode carries the shape of a well-run zero. The carrier count over 32,650 collected
 components was **0**, and it is only readable because the detector was positive-controlled
 first: 11 constructed cells, **two of which must answer `none`**, so the instrument is shown to

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -228,7 +228,7 @@ samples) — see `AGENTS.md` § "Generated shape matrix" and issue #2281.
 | 24 | `await_waterfall` runtime parity | the `await_waterfall` warnings a **mounted** rsvelte-compiled component logs vs. official's, 3 cases | one warning code, one component shape; nothing else about the running component is observed | [D] |
 | 25 | Differential output-preservation corpus hash | per `.svelte` source × client/server/client-dev/server-dev hash from base-core vs merge-ref-core | changes outside `crates/rsvelte_core`; every PR without the maintainer-applied `output-preserving` label | [S] |
 | 26 | esrap generated-output corpus | parsed JS output × official/rsvelte tree × 4 targets; AST equivalence, comment kind/body sequence, code/map equality, map bounds/order | production synthetic AST spans and whether a mapping points at the corresponding source token | [S] |
-| 27 | LSP differential parity | normalized JSON response field per request against the pinned official server and selected upstream snapshots | **every server notification**; incremental edit and resolve sequences; **inside a corpus `(file, method)`, everything but the divergent-request count**; the oracle-calibration floor is skipped on the corpus job, which enrols 66.7% of the entries, and that job never installs the repositories it measures | [S] [D] |
+| 27 | LSP differential parity | normalized JSON response field per request against the pinned official server and selected upstream snapshots | **every server notification**; incremental edit and resolve sequences; **the whole corpus half — its key carries no divergence and 3,632 of 3,637 files are already listed, so it cannot report a NEW (27o)**; the oracle-calibration floor is skipped on the corpus job, which enrols 66.7% of the entries, and that job never installs the repositories it measures | [S] [D] |
 | 39 | svelte2tsx option axis | full TSX text per (option variant x source) against the official tool, options carried in the fixture | option values outside its grid (`rewriteExternalImports`, `runes`, most `namespace` x `mode` products); `emitDts`; the map, `exportedNames` and `events` | [S] [D] |
 | 38 | NAPI `cssHash` | the scope class the callback produces, and the callback's own argument list, against **official** | one component shape and one option set; only `css.code` / the class in `js.code`; nothing about the wasm or facade ports of the same option | [S] |
 | 39 | Print fixture suite (`tests/print.rs`) | per-sample printed Svelte text vs upstream's `output.svelte` | it compares the text, not **which code produced it** — a source-text shortcut around the whole AST printer was invisible for 43 of 43 samples | [D] |
@@ -446,8 +446,11 @@ differ in the digest alone and 3 in the field count, while `divergentRequestCoun
 of its 3,632 keys) against **0 of 3,632** for `textDocument/definition` and 3 for
 `textDocument/hover`, so what varies is which completion items the two live servers return for the
 same position, not the harness. A shrink-only ratchet cannot hold a key that a re-run rewrites, so
-the field count and the digest are gone and the key is the request count alone; both sweeps then
-reproduce the committed baseline with 0 new and 0 stale.
+the field count and the digest are gone; both sweeps then reproduce the committed baseline with 0
+new and 0 stale. **The request count went the same way afterwards** (`ratchet.mjs:47-55`: two runs
+ten non-Rust commits apart moved one file's hover count 91 → 90 and 88 → 90, "sensitivity without
+direction"), so the key today is `fileId|method|phase` and nothing else — see 27o, which is what
+that leaves.
 
 What that removes is real and is not recoverable from any other row: for a `(file, method)` already
 listed, a newly wrong field in an already-divergent response, a divergence moving to a different
@@ -848,6 +851,39 @@ published code that compiles — 0 of 6,788 real-world sources reach that diverg
 about the **projection's error recovery**, whose population is a document being typed, where a
 half-written expression is the normal case rather than an adversarial one. The two rules point
 opposite ways on the same-looking input, and only the population separates them.
+
+### Blind spot 27o — the corpus half cannot report a NEW, because it is saturated and its key carries no divergence [D]
+
+Two facts compose into one. The aggregate key is `aggregate:${fileId}|${method}${stage}`
+(`ratchet.mjs:55`) — after 27g removed the digest, the field count and finally the request count,
+it carries **nothing about the divergence**. And the corpus population is saturated: of 3,637
+`.svelte` files across the four pinned repositories, **3,632 diverge**, and the five that do not
+are **0 bytes**.
+
+| repository | files | diverging | share |
+|---|---|---|---|
+| bits-ui | 617 | 616 | 99.8% |
+| flowbite-svelte | 1,296 | 1,293 | 99.8% |
+| melt-ui | 43 | 43 | 100.0% |
+| shadcn-svelte | 1,681 | 1,680 | 99.9% |
+| **total** | **3,637** | **3,632** | **99.9%** |
+
+Read off the committed ratchet rather than from a sweep: its 21,630 `aggregate:` keys cover
+exactly **3,632 distinct file ids**, 3,551 of them carrying 6 entries (three methods × two
+phases) and 81 carrying 4. So **every non-empty corpus component already holds an entry for every
+`(method, phase)` the harness sends**, and any new divergence anywhere in that population — of any
+field, of any severity, in any response — is suppressed by a key that is already listed. The only
+direction the corpus half can move is a `(file, method)` becoming *entirely* clean.
+
+This is not an argument that the aggregate key is worthless: a per-identifier key was rejected
+because it produces a six-figure file, this is the granularity that replaced it, and it is what
+makes the shrink direction work at all. It is an argument about what a green run **means**. On
+this half, green is not earned, it is guaranteed. The 2,116 `differential:` / `expected:` keys —
+**8.9% of the ratchet** — are the only ones that carry a divergence pointer, and therefore the
+only ones with live discriminating power.
+
+**Evidence [D]:** the file counts and the key distribution above are measured; the suppression
+follows from the key's own definition at `ratchet.mjs:55`.
 
 ---
 

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -5348,6 +5348,27 @@ has no view of the reverse direction, a divergence that is real and **not** reco
 that population is bounded only by the ratchets whose `.md` attributes entries to this document,
 and today only 6 of 31 ratchet docs make any such attribution.
 
+**A fourth, and it is not reachable from the gate's own code.** The three above fall out of
+reading `test-deliberate-divergences.mjs`; this one only appears when a section's claim is put
+beside the product. A recorded divergence asserts *we choose not to close this difference* — it
+does not assert *we do not have this*. `settings.rs` reads `completions.emmet` and defaults it to
+`true`, and **no code outside `settings.rs` reads that field**, so filing the emmet cluster as
+deliberate and pinning it would freeze a contradiction: the product declares a feature on and
+nothing implements it. The honest terminal states are the feature itself or an explicit decision
+to make the setting truthful; until one of them, the entries stay listed and are described as
+unimplemented. A blind-spot row whose evidence is only ever *structural argument from code* may
+be reporting that its author never looked outside the gate — the reading that produced this one
+was a positive-controlled count of readers, not an argument about the checker.
+
+Measured on `origin/main` (`fd72d98f1`), 6 of the 15 non-empty ratchets carry no `Attribution
+of …` table at all: `lsp-known-failures.json` 23,746, `fmt-known-failures.json` 549,
+`parse-ast-known-failures.json` 301, `known-failures.client-dev.json` 40,
+`known-failures.client.json` 26, `svelte2tsx-unparseable-known-failures.json` 1 — **24,663
+unattributed against 423 attributed**. The ~20 ratchets absent from both columns are empty.
+Read those `n` in the ratchet's own key units and not as defects: `lsp-known-failures.json`
+alone carries two conversions, `aggregate:` at 5.96 entries per diverging file and
+`differential:`/`expected:` at 1.87 per (unit, method, phase).
+
 ## Adding a gate, or a row here
 
 When you add a gate, add its row **before** the ratchet is first baselined, and answer the

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -5386,6 +5386,15 @@ entry that reproduces it as `MATCH`.
 If you cannot answer with a discriminating case or a file:line citation, write `[U]` and say
 what would resolve it.
 
+**A fourth evidence form, and it fails differently from the other three.** A *positive-controlled
+exhaustive search that came back empty* is not a **structural argument from code**: nothing was
+derived, a range was swept and found bare. `completions.emmet` has no reader outside
+`settings.rs`, shown against `settings.html.enable` (read from `server.rs`) as the control that
+the search can find a reader when one exists. The two are refuted by different things — a
+structural argument falls to an error in the reasoning, an empty search falls to an error in the
+search's *range* — so labelling one as the other tells the next reader to re-check the wrong
+half. Write it as its own form and name the range that was swept.
+
 <a id="two-ports-inventory"></a>
 
 ## One upstream decision, N rsvelte implementations

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -701,7 +701,7 @@ of two unrelated errors say nothing, and the code divergence is an
 `error-position-known-failures.<target>.json` hold 0 entries, all four of
 `error-end-known-failures.<target>.json` hold 0 entries, and all four of
 `error-frame-known-failures.<target>.json` hold 0 entries. The wave-2 enrolment
-(#3130) added 1 message, 16 position and 24 end entries — and **no frame entries
+(#3176) added 1 message, 16 position and 24 end entries — and **no frame entries
 at all**, which keeps that comparison's population saturated at 0 across a corpus
 that more than doubled. The counts above are the re-measurement against the tree
 this branch was rebased onto (message 18/17 → 13/12, position 99 → 81, end
@@ -952,7 +952,7 @@ which no rule above matches (not a prefix, not whitespace- or quote-equal). It i
 the one entry that fix moves, out of 34,686 real components whose output was
 diffed across the change.
 
-### Wave-2 enrolment (#3130) — Clusters 20-27
+### Wave-2 enrolment (#3176) — Clusters 20-27
 
 The corpus went from 37 to 104 corpus sources, and the formatter-parity set
 with it. The current run has **33,483 included components, 32,667 matched, 787
@@ -3183,7 +3183,7 @@ comments and compare" said the opposite, because official's line reduces to a ba
 the stripper invents a structural difference; that is the stricter-reconstruction hazard two
 paragraphs above, reached from the other side.
 
-Every one of the remaining 12 arrived with the wave-2 enrolment (#3130) and is described
+Every one of the remaining 12 arrived with the wave-2 enrolment (#3176) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3295,7 +3295,7 @@ Partition of `known-failures.client-dev.json` by verdict: `26`
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 26 arrived with the wave-2 enrolment (#3130); this target was at 0 before
+All remaining 26 arrived with the wave-2 enrolment (#3176); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 
@@ -3486,7 +3486,7 @@ and #2023 were all filed as "not emitted" and all turned out to be emitted in
 the right number and the wrong place.
 
 
-### Wave-2 enrolment (#3130) — where all 1,413 entries come from
+### Wave-2 enrolment (#3176) — where all 1,413 entries come from
 
 The corpus went from 37 corpus sources to 104 (103 pinned repositories plus
 the in-repo `pattern-corpus`) and from 14,780 entries to 34,601. Every entry in all four ratchets above comes from one of the 67 new
@@ -4958,7 +4958,7 @@ what the normalizer absorbs, so these verdicts are only comparable across runs o
 version — which is why the gate prints the version it used. Re-deriving this baseline from
 0.61.0 to 0.62.0 moved the gated bucket from 213 to 525; see "Sensitivity to the normalizer".
 The bucket was burned down from 525 to **30**, and `unparseable` from 2 to **0**, on the
-14,229-seed corpus. The wave-2 enrolment (#3130) took the seed set to 33,406 and the ratchet to
+14,229-seed corpus. The wave-2 enrolment (#3176) took the seed set to 33,406 and the ratchet to
 **168** — `code-mismatch` 160 and `unparseable` **8**. Subsequent fixes reduced that ratchet to
 **165** — `code-mismatch` 159 and `unparseable` **6**. The enrolled entries were not regressions:
 every one is a pre-existing defect in a repository the corpus did not previously hold,
@@ -5518,7 +5518,7 @@ JavaScript, so this ratchet has no tolerance to spend beyond what is listed here
 Everything below the next two paragraphs was written while this ratchet was empty, and it
 said so in as many words: *"the 30 defects above are in repositories that are not corpus
 sources … an empty baseline here is therefore the expected result, not a measurement that
-was skipped."* The wave-2 enrolment (#3130) made huly, open-webui,
+was skipped."* The wave-2 enrolment (#3176) made huly, open-webui,
 carbon-components-svelte and SMUI corpus sources, along with 63 more repositories, and the
 ratchet went to **12 entries across two targets on the first run**. The current tree holds
 **0 entries** after retiring the repaired classes listed below. That is the
@@ -5572,7 +5572,7 @@ against a mutated `verify.mjs`; both flipped.
 **So why was the ratchet empty?** Because the 30 defects above were in repositories that were
 not corpus sources. `corpus-sources.json` listed sveltejs/svelte, svelte.dev and 33 shipped
 libraries; huly, open-webui, carbon and SMUI were none of them. An empty baseline was
-therefore the expected result, not a measurement that was skipped — and #3130 enrolled all
+therefore the expected result, not a measurement that was skipped — and #3176 enrolled all
 four, which is what the table at the top of this file is.
 
 What that meant honestly, then: **this gate was a regression gate, not a burn-down.** It
@@ -5679,7 +5679,7 @@ The first run measured 118 units: **64 match**, **30 diverge**, and **24 are com
 "both backends reject"**. Read the denominator as 94, not 118 — a both-reject pair is parity, but
 it is parity on a comparison that never reached the CSS.
 
-**After the wave-2 enrolment (#3130) the population is 3,033 units**: 1,762 match, 216 diverge on
+**After the wave-2 enrolment (#3176) the population is 3,033 units**: 1,762 match, 216 diverge on
 the CSS, 99 are inputs `grass` rejects and dart-sass accepts, and 956 are both-reject. The
 denominator is therefore 2,077, and `grass` agrees with dart-sass on **84.8%** of it. Treat that
 as the current size of the "near-substitute, not drop-in" claim — it was measured on 94 units
@@ -6747,7 +6747,7 @@ moves when the denominator does. The symptom-keyed table put 13 of those entries
 in a "one entry each" tail, which is where a mechanism goes to look unimportant;
 all such a count says is that nobody has reduced them yet.
 
-### Wave-2 enrolment (#3130)
+### Wave-2 enrolment (#3176)
 
 The list was **0** before the enrolment and all 139 entries come from one of the
 67 new repositories. The 37 pre-existing *real-world* sources still contribute
@@ -7006,7 +7006,7 @@ may only shrink.
 
 **Current baseline: `svelte2tsx-map-known-failures.json`, 0 entries.**
 
-The two `map-missing` entries enrolled by wave 2 (#3130), `chatgpt-web`'s
+The two `map-missing` entries enrolled by wave 2 (#3176), `chatgpt-web`'s
 `Home.svelte` and immich's `VideoNativeViewer.svelte`, now pass after the parser
 fix and were removed together with their stale TSX baseline entries.
 `map-invalid` remains **0** — no map rsvelte emits violates an invariant.
@@ -7380,7 +7380,7 @@ that they agree on every source the corpus holds.
 
 Partition of `warning-known-failures.<target>.json` by direction: `0`
 
-**73 of the 83 pre-existing entries arrived with the wave-2 enrolment (#3130)**,
+**73 of the 83 pre-existing entries arrived with the wave-2 enrolment (#3176)**,
 which took the corpus from 37 corpus sources to 104. The remaining per-code
 incidences total 81 across 80 entries (one entry differs on two codes):
 `css_unused_selector` 48, `state_referenced_locally` 20,
@@ -7759,7 +7759,7 @@ element name as `table` where upstream preserves the namespace form `f:table` in
 the self-closing-tag warning. This is a message-only compiler parity defect, so it
 belongs in this ratchet rather than in the code or position ones.
 
-The second arrived with the wave-2 enrolment (#3130):
+The second arrived with the wave-2 enrolment (#3176):
 `open-webui/src/lib/components/common/Tags.svelte`. Upstream's
 `a11y_role_has_required_aria_props` lists **every** missing attribute for the role
 (`"aria-controls" and "aria-expanded"`); rsvelte lists only the first. The code and

--- a/scripts/compat-corpus/known-failures-md-check.mjs
+++ b/scripts/compat-corpus/known-failures-md-check.mjs
@@ -522,13 +522,13 @@ const idsFor = (key) => {
 	const p = path.join(CORPUS, jsons[0] ?? '');
 	return jsons.length && fs.existsSync(p) ? JSON.parse(fs.readFileSync(p, 'utf8')) : null;
 };
-const declaredPartitions = new Set(PARTITIONS.map((p) => `${p.doc} ${p.key} ${p.prefix ?? ''} ${p.label}`));
+const declaredPartitions = new Set(PARTITIONS.map((p) => `${p.doc}\0${p.key}\0${p.prefix ?? ''}\0${p.label}`));
 
 for (const doc of new Set(RATCHETS.map((r) => r.doc))) {
 	const docBody = docText(doc);
 	if (docBody === null) continue; // already reported above
 	for (const found of partitionLines(docBody)) {
-		const id = `${doc} ${found.key} ${found.prefix ?? ''} ${found.label}`;
+		const id = `${doc}\0${found.key}\0${found.prefix ?? ''}\0${found.label}`;
 		if (!declaredPartitions.has(id)) {
 			fail(
 				`${doc}: partition by "${found.label}" of \`${found.key}\`${found.prefix ? ` under \`${found.prefix}\`` : ''} is not declared in PARTITIONS — add it, so deleting the line fails too`,
@@ -632,11 +632,50 @@ for (const doc of new Set(PARTITIONS.map((p) => p.doc))) {
 		// means the residue after an attributed cluster, which is a different number.
 		const end = lines.findIndex((l, at) => at > i && /^### /.test(l));
 		const section = lines.slice(i + 1, end === -1 ? lines.length : end).join('\n');
+		const next = lines.findIndex((l, at) => at > i && partitionLines(l.trim())[0]);
+		const stop = [end, next].filter((x) => x !== -1);
+		const scoped = lines.slice(i + 1, stop.length ? Math.min(...stop) : lines.length).join('\n');
 		for (const m of section.matchAll(/(?:All|Every one of the) remaining \*{0,2}([\d,]+)/g)) {
 			const stated = Number(m[1].replace(/,/g, ''));
 			if (stated !== partition.sum) {
 				fail(
 					`${doc}:${i + 1}: the section says "remaining ${m[1]}" but its partition sums to ${partition.sum}.`,
+				);
+			}
+		}
+
+		// (c) The same claim in two more spellings. `All N …` at the start of a
+		// sentence states the whole population; `The other N …` states the residue
+		// after the section's attribution table. Both were unchecked, and both had
+		// gone stale by an order of magnitude while (a) and (b) were green — which
+		// reads, to the next author, as "counts in this file are checked".
+		//
+		// Scoped to a non-empty partition, and to the region before the NEXT
+		// partition line rather than the next heading. Without the first, six
+		// `All N generated comparisons now match` lines in `matrix-known-failures.md`
+		// are read as entry counts against a partition of 0; without the second, one
+		// such line is reported once per partition sharing its heading — the measured
+		// shape was 3 distinct sentences reported 22 times.
+		if (partition.sum === 0) continue;
+		const attributed = [...scoped.matchAll(/^\|\s*([\d,]+)\s*\|/gm)].reduce(
+			(a, m) => a + Number(m[1].replace(/,/g, '')),
+			0,
+		);
+		for (const m of scoped.matchAll(/^All \*{0,2}([\d,]+)\*{0,2} /gm)) {
+			const stated = Number(m[1].replace(/,/g, ''));
+			if (stated !== partition.sum) {
+				fail(
+					`${doc}:${i + 1}: the section says "All ${m[1]}" but its partition sums to ${partition.sum}.`,
+				);
+			}
+		}
+		for (const m of scoped.matchAll(/^The other \*{0,2}([\d,]+)\*{0,2} /gm)) {
+			const stated = Number(m[1].replace(/,/g, ''));
+			const want = partition.sum - attributed;
+			if (stated !== want) {
+				fail(
+					`${doc}:${i + 1}: the section says "The other ${m[1]}" but its partition sums to ` +
+						`${partition.sum} with ${attributed} attributed, leaving ${want}.`,
 				);
 			}
 		}

--- a/scripts/dev/test-known-failures-md-check.mjs
+++ b/scripts/dev/test-known-failures-md-check.mjs
@@ -225,6 +225,19 @@ const bump = (dir, file, re, wrong, replace) => {
 	return { real, wrong };
 };
 
+// Put a line-anchored sentence into a doc immediately before `at`. For a
+// spelling the tree no longer carries, the case has to supply its own carrier —
+// a rule with no live input is shown to fire or it is not shown at all.
+const inject = (dir, file, at, line) => {
+	const direct = docText(dir, file);
+	if (!direct || !at.test(direct.text)) {
+		throw new Error(`self-test is stale: ${file} has no ${at} to inject before`);
+	}
+	const m = direct.text.match(at);
+	fs.writeFileSync(direct.p, direct.text.replace(m[0], `${line}\n\n${m[0]}`));
+	return { line };
+};
+
 // The control. Without it, every mutation below "passing" would also be
 // explained by the harness failing on any input at all.
 withCorpus(
@@ -325,18 +338,21 @@ withCorpus(
 // counting something other than ratchet entries sits under a partition of 0 in
 // `matrix-known-failures.md`, and 22 of the 24 reports the unscoped rule produced
 // were that one doc.
+// This one INJECTS its carrier instead of mutating a live sentence, because the
+// spelling has no live carrier left: #4165 retired the entries the two `The
+// other N` lines described and the prose that replaced them states no residue.
+// The two survivors in the tree are mid-line, which the rule's `^` does not
+// match, so mutating either would have measured nothing.
 let seen;
 withCorpus(
 	(d) => {
-		seen = bump(d, 'known-failures.md', /The other (\d[\d,]*) arrived with the wave-2 enrolment/, 999, (whole, n) =>
-			whole.replace(n, '999'),
-		);
+		seen = inject(d, 'known-failures.md', /^All remaining [\d,]+ arrived/m, 'The other 999 arrived with the wave-2 enrolment.');
 	},
 	(r) =>
 		check(
 			'a stale `The other N` fails',
-			[r.code, new RegExp(`"The other 999".*leaving ${seen.real}`, 's').test(r.out)],
-			[1, true],
+			[r.code, /"The other 999".*leaving (\d+)/s.test(r.out), /"The other 999".*leaving 999/s.test(r.out)],
+			[1, true, false],
 		),
 );
 

--- a/scripts/dev/test-known-failures-md-check.mjs
+++ b/scripts/dev/test-known-failures-md-check.mjs
@@ -198,6 +198,33 @@ const edit = (dir, file, from, to) => {
 	fs.writeFileSync(found.p, found.text.replace(from, to));
 };
 
+// Every literal in a case below is a count that the tree moves under it, and a
+// self-test whose input has drifted throws instead of failing the thing it
+// checks. `bump` locates the number by its surrounding words and derives the
+// wrong value from the right one, so the case keeps meaning what it meant.
+const bump = (dir, file, re, wrong, replace) => {
+	// `findDoc` matches a literal needle; this one has to search by pattern,
+	// because the number in it is exactly what moves.
+	const direct = docText(dir, file);
+	let found = direct && re.test(direct.text) ? direct : null;
+	if (!found) {
+		for (const f of fs.readdirSync(dir)) {
+			if (!f.endsWith('.md')) continue;
+			const q = path.join(dir, f);
+			const text = fs.readFileSync(q, 'utf8');
+			if (re.test(text)) {
+				found = { p: q, text };
+				break;
+			}
+		}
+	}
+	if (!found) throw new Error(`self-test is stale: no doc holds ${re} (looked for ${file} first)`);
+	const m = found.text.match(re);
+	const real = Number(m[1].replace(/,/g, ''));
+	fs.writeFileSync(found.p, found.text.replace(m[0], replace(m[0], m[1], wrong)));
+	return { real, wrong };
+};
+
 // The control. Without it, every mutation below "passing" would also be
 // explained by the harness failing on any input at all.
 withCorpus(
@@ -298,18 +325,37 @@ withCorpus(
 // counting something other than ratchet entries sits under a partition of 0 in
 // `matrix-known-failures.md`, and 22 of the 24 reports the unscoped rule produced
 // were that one doc.
+let seen;
 withCorpus(
-	(d) => edit(d, 'known-failures.md', 'The other 2 arrived with the wave-2 enrolment', 'The other 21 arrived with the wave-2 enrolment'),
-	(r) => check('a stale `The other N` fails', [r.code, /"The other 21".*leaving 2/s.test(r.out)], [1, true]),
+	(d) => {
+		seen = bump(d, 'known-failures.md', /The other (\d[\d,]*) arrived with the wave-2 enrolment/, 999, (whole, n) =>
+			whole.replace(n, '999'),
+		);
+	},
+	(r) =>
+		check(
+			'a stale `The other N` fails',
+			[r.code, new RegExp(`"The other 999".*leaving ${seen.real}`, 's').test(r.out)],
+			[1, true],
+		),
 );
 
 withCorpus(
-	(d) => edit(d, 'known-failures.md', 'All remaining 40 arrived', 'All 13 arrived'),
-	(r) => check('a stale `All N` fails', [r.code, /"All 13".*partition sums to 40/s.test(r.out)], [1, true]),
+	(d) => {
+		seen = bump(d, 'known-failures.md', /All remaining (\d[\d,]*) arrived/, 999, () => 'All 999 arrived');
+	},
+	(r) =>
+		check(
+			'a stale `All N` fails',
+			[r.code, new RegExp(`"All 999".*partition sums to ${seen.real}`, 's').test(r.out)],
+			[1, true],
+		),
 );
 
 withCorpus(
-	(d) => edit(d, 'matrix-known-failures.md', 'All 1,976 generated comparisons', 'All 1,977 generated comparisons'),
+	(d) => {
+		bump(d, 'matrix-known-failures.md', /All ([\d,]+) generated comparisons/, 999, () => 'All 999 generated comparisons');
+	},
 	(r) => check('`All N` under an empty partition is not an entry count', [r.code], [0]),
 );
 

--- a/scripts/dev/test-known-failures-md-check.mjs
+++ b/scripts/dev/test-known-failures-md-check.mjs
@@ -202,22 +202,25 @@ const edit = (dir, file, from, to) => {
 // self-test whose input has drifted throws instead of failing the thing it
 // checks. `bump` locates the number by its surrounding words and derives the
 // wrong value from the right one, so the case keeps meaning what it meant.
-const bump = (dir, file, re, wrong, replace) => {
-	// `findDoc` matches a literal needle; this one has to search by pattern,
-	// because the number in it is exactly what moves.
+// `findDoc` matches a literal needle; these callers search by PATTERN, because
+// the number in the sentence is exactly what moves. The directory scan is not a
+// fallback but the load-bearing half: the names passed in are lowercase and the
+// files on disk are not, so `docText` finds them on a case-insensitive
+// filesystem and returns null on Linux.
+const findDocByPattern = (dir, file, re) => {
 	const direct = docText(dir, file);
-	let found = direct && re.test(direct.text) ? direct : null;
-	if (!found) {
-		for (const f of fs.readdirSync(dir)) {
-			if (!f.endsWith('.md')) continue;
-			const q = path.join(dir, f);
-			const text = fs.readFileSync(q, 'utf8');
-			if (re.test(text)) {
-				found = { p: q, text };
-				break;
-			}
-		}
+	if (direct && re.test(direct.text)) return direct;
+	for (const f of fs.readdirSync(dir)) {
+		if (!f.endsWith('.md')) continue;
+		const q = path.join(dir, f);
+		const text = fs.readFileSync(q, 'utf8');
+		if (re.test(text)) return { p: q, text };
 	}
+	return null;
+};
+
+const bump = (dir, file, re, wrong, replace) => {
+	const found = findDocByPattern(dir, file, re);
 	if (!found) throw new Error(`self-test is stale: no doc holds ${re} (looked for ${file} first)`);
 	const m = found.text.match(re);
 	const real = Number(m[1].replace(/,/g, ''));
@@ -229,12 +232,10 @@ const bump = (dir, file, re, wrong, replace) => {
 // spelling the tree no longer carries, the case has to supply its own carrier —
 // a rule with no live input is shown to fire or it is not shown at all.
 const inject = (dir, file, at, line) => {
-	const direct = docText(dir, file);
-	if (!direct || !at.test(direct.text)) {
-		throw new Error(`self-test is stale: ${file} has no ${at} to inject before`);
-	}
-	const m = direct.text.match(at);
-	fs.writeFileSync(direct.p, direct.text.replace(m[0], `${line}\n\n${m[0]}`));
+	const found = findDocByPattern(dir, file, at);
+	if (!found) throw new Error(`self-test is stale: no doc holds ${at} (looked for ${file} first)`);
+	const m = found.text.match(at);
+	fs.writeFileSync(found.p, found.text.replace(m[0], `${line}\n\n${m[0]}`));
 	return { line };
 };
 

--- a/scripts/dev/test-known-failures-md-check.mjs
+++ b/scripts/dev/test-known-failures-md-check.mjs
@@ -292,6 +292,27 @@ withCorpus(
 	(r) => check('a stale restatement fails', [r.code, /states 5 entries/.test(r.out)], [1, true]),
 );
 
+// The two spellings (c) added. Both were unchecked while (a) and (b) were green,
+// and both had gone stale by an order of magnitude — `The other 21` and `All 13`
+// against a 4-entry ratchet. The negative control is the scoping: an `All N` line
+// counting something other than ratchet entries sits under a partition of 0 in
+// `matrix-known-failures.md`, and 22 of the 24 reports the unscoped rule produced
+// were that one doc.
+withCorpus(
+	(d) => edit(d, 'known-failures.md', 'The other 2 arrived with the wave-2 enrolment', 'The other 21 arrived with the wave-2 enrolment'),
+	(r) => check('a stale `The other N` fails', [r.code, /"The other 21".*leaving 2/s.test(r.out)], [1, true]),
+);
+
+withCorpus(
+	(d) => edit(d, 'known-failures.md', 'All remaining 40 arrived', 'All 13 arrived'),
+	(r) => check('a stale `All N` fails', [r.code, /"All 13".*partition sums to 40/s.test(r.out)], [1, true]),
+);
+
+withCorpus(
+	(d) => edit(d, 'matrix-known-failures.md', 'All 1,976 generated comparisons', 'All 1,977 generated comparisons'),
+	(r) => check('`All N` under an empty partition is not an entry count', [r.code], [0]),
+);
+
 if (failed) {
 	console.error(`\n${failed} failure(s)`);
 	process.exit(1);


### PR DESCRIPTION
Ten commits of documentation that was wrong in a way nothing checks, plus the two
gate changes that stop three of those spellings from rotting again.

## What was wrong

`AGENTS.md`'s `parse()` AST parity paragraph carried **304** entries with a cluster
split that does not sum to it; the JSON holds **301**, `loc-presence` is **6** not 9,
and the base × axis decomposition is **163 / 138 / 25** (`138×2 + 25 = 301`), not
165 / 139 / 26. So the **defect ceiling is 163**, not 165. The collapse factor is
measured per cluster (1.00–2.00x against a whole-file 1.847x), which is why the
paragraph now says a per-cluster estimate cannot be had by scaling the total —
`css-shape` scaled gives 7.6 against an actual 9.

The old sentence blamed this on "the count and the split go stale together and
neither checks the other". That is not what happened: `known-failures-md-check.mjs`
gates the **partition line** and gates **no prose**, so one half is checked and the
other rots alone. Three confirmed instances of exactly that are now recorded
(`fmt` off by 241, `parse-ast` off by 3, and `svelte2tsx-mechanisms.json` with 0
readers).

## Three things measured today and added

- **A verdict over a set must state the set's size.** A check-run monitor printed
  `COMPLETE seen=0 total_count=0 fail=0` for two PRs — a green sentence about a
  commit with no checks. One of the two is structural: a Changesets release PR is
  opened with `GITHUB_TOKEN`, which does not trigger `pull_request` workflows, so
  **that PR has zero check-runs and no gate has ever seen it**. The check-runs API
  also pages at 30, so `seen == total_count` has to be asserted, not assumed.
- **A gate can be written, unit-tested, self-tested and wired to nothing.**
  `scripts/ci/attribution-check.mjs` owns "is every ratchet entry attributed",
  ships 8 passing controls, and `grep -rn 'attribution-check' .github/workflows/`
  returns **0**. Both people who published a census of that question that day had
  built it by hand from the prose instead of running the checker — one of them in
  the same report that named that prose as ungated. Their two censuses agreed to
  within an explainable 16, and **two readings of one document are one
  measurement**.
- **A census is a measurement of a tree.** A ratchet count run in the primary
  checkout reported `known-failures.client.json` at 17 where `origin/main` reads
  14, because that checkout was parked on a docs branch cut before three merges.
  No build, no arm, no binary — just `readFileSync`, of the wrong tree.

## Gate changes

`known-failures-md-check.mjs` gains the two count spellings it never read
(`The other N` and `All N`), scoped so an `All N` line counting something other
than ratchet entries does not report — 22 of the 24 findings the unscoped rule
produced were one doc.

`test-known-failures-md-check.mjs` gains those cases **and** stops holding the
counts it mutates as literals. The first version spelled `All remaining 40`, which
the tree moved to 28 under it; a self-test whose input has drifted throws
`self-test is stale` where a failing check was meant to be. It now locates the
number by its surrounding words and derives the wrong value from the right one, so
the assertion (`partition sums to 28`) is computed rather than typed.

Verified: `corpus:known-failures-check` EXIT=0, `test:known-failures-md-check`
EXIT=0 with all 17 cases named in the output.



Closes #4166.

**Sequencing.** #4166 notes the widening must land after #4165, which retires the entries the
`The other N` / `All N` sentences describe (`server` 4 → 2, `server-dev` 4 → 2). This PR is
therefore rebased onto #4165 before merge, and its self-test derives the counts it mutates
rather than holding them as literals — which is what makes that rebase a re-run rather than a
re-write.
