### PR TITLE
chore(lsp-gate): a divergence's mechanism is a SET, so it rides beside the ratchet

### DIFF
--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -4535,6 +4535,66 @@ The third row is not a defect on either side and is the first candidate for
 `deliberate-divergences` in this ratchet — but only once it is pinned by a test, which it is not
 yet.
 
+### The mechanism of a divergence is carried beside the ratchet, not in its key
+
+`compatibility/lsp-mechanisms.json` holds two maps: `entries` takes a ratchet id to the **set** of
+mechanisms measured on it, and `mechanisms` takes a label to where it is answered — an
+`upstream_issues/` path that exists on disk, the literal `deliberate-divergences`, or `null` for a
+terminal not yet established. `scripts/compat-lsp/mechanism.mjs` is the classifier and the
+vocabulary; `scripts/ci/lsp-mechanisms-check.mjs` checks the two files against each other and
+against the ratchet, and `scripts/dev/test-lsp-mechanisms-check.mjs` is its positive control —
+including the case that a well-formed sidecar **passes**, which a suite of red-only cases never
+measures.
+
+**Why a set, and why beside rather than inside.** An `aggregate:` entry is a
+`(file, method, phase)`, and every mechanism that fires anywhere in that one response is a
+separate label on the same entry. Measured on 931 records of one corpus shard (bits-ui, shard 8
+of 16, 52 components, 151 `(file, method)` groups): **6.17 distinct labels per entry on average**,
+median 5, max 22, and **88.7% of entries carry more than one** — `textDocument/completion` alone
+averages 11.13. Putting a label in the ratchet key would therefore multiply one entry into its
+six, which is the same "one identifier, one key, a six-figure file" judgement the corpus half is
+aggregated to avoid. Picking *one* label per entry would need a precedence rule, and a rule
+choosing among six co-occurring labels encodes its author's ordering — the hazard AGENTS.md
+records for a classifier that stops at its first matching predicate.
+
+**What the set costs to read.** For each label, the entries on which it is the *only* label — the
+ones that would actually leave the ratchet if that mechanism were fixed — are almost all zero:
+
+| label | entries it appears on | entries where it is the only label |
+|---|---|---|
+| `completion-item-set-extra-html` | 42 | **0** |
+| `completion-item-pairing-key-kind+sort-text-ts` | 42 | **0** |
+| `completion-item-set-missing-ts` | 42 | **0** |
+| `completion-item-set-missing-mixed` | 42 | **0** |
+| `completion-item-set-missing-html` | 41 | **0** |
+| `completion-commit-characters-value-extra-paren` | 37 | **0** |
+| `rsvelte-empty` | 31 | **0** |
+| `ts-render` | 30 | **0** |
+| `projection-target-position-declaration` | 30 | 3 |
+| `projection-origin-range` | 27 | 5 |
+
+Nine of the shard's 62 labels are ever the sole label of an entry, together covering **17 of 151
+(11.3%)**; the eleven largest are all zero. Repairing `completion-item-set-extra-html` on every
+file it names removes **no entry**, because each of those files still diverges on five other
+mechanisms in the same response. **A per-label count sizes an investigation and never a shrink**,
+and the two differ here by a factor of zero for the largest labels.
+
+The sets are structure rather than noise, which was predicted before it was measured: an empty
+answer cannot have an item-level difference, and of the 66 groups carrying `rsvelte-empty` or
+`rsvelte-empty-import-only`, **0** also carry an item-level label.
+
+**Two absences are spelled rather than left blank.** `classifyDivergence` runs on the corpus
+branch only — its context is that branch's source text — so every `differential:` and `expected:`
+entry carries the explicit label `unclassified`. And a label whose terminal has not been
+established carries `null`, which is **not** `rsvelte`: an unestablished terminal and a defect of
+ours are different facts, and writing one as the other puts a sign on an unmeasured quantity.
+Either one blocks its entry from an attribution table, and the checker reports how many entries
+are blocked rather than folding them into a pass — a blank and a zero render the same.
+
+The scope of these figures: 151 entries from one of sixteen corpus shards, so the *counts* are not
+convertible into ratchet-wide ones and none of them has been. What is established is structural,
+and on the corpus half only.
+
 Normalization removes only these non-parity fields and path-specific values:
 
 - `initialize.result.serverInfo`

--- a/compatibility/lsp-mechanisms.json
+++ b/compatibility/lsp-mechanisms.json
@@ -1,0 +1,432 @@
+{
+	"$schema-note": "Two maps beside `lsp-known-failures.json`, never inside its key. `entries` maps a ratchet id to the SET of mechanisms measured on it: an entry carries several (mean 6.17 on a corpus shard), so a label is not a partition of the entries, and one label per entry would need a precedence rule the data cannot supply. `mechanisms` maps a label to where it is answered — an `upstream_issues/` path that exists on disk, the literal `deliberate-divergences`, or `null` for a terminal that has not been established yet. `null` is not `rsvelte`: an unestablished terminal and a defect of ours are different facts, and writing one as the other puts a sign on an unmeasured quantity. An id whose set contains `unclassified`, or any label whose terminal is `null`, cannot appear in an attribution table. A label's prose lives in `scripts/compat-lsp/mechanism.mjs` beside the rule that assigns it; restating it here would be a second port that can disagree with the classifier.",
+	"mechanisms": {
+		"ts-lib-copy": {
+			"terminal": null
+		},
+		"ts-render-union-order": {
+			"terminal": null
+		},
+		"ts-render-quote-style": {
+			"terminal": null
+		},
+		"ts-render-local-modifier": {
+			"terminal": null
+		},
+		"ts-render-jsdoc-tag": {
+			"terminal": null
+		},
+		"ts-render-import-line": {
+			"terminal": null
+		},
+		"ts-render-overload-count": {
+			"terminal": null
+		},
+		"ts-render-declaration-order": {
+			"terminal": null
+		},
+		"rsvelte-empty-import-only": {
+			"terminal": null
+		},
+		"official-empty-target-is-the-request": {
+			"terminal": null
+		},
+		"ts-render-multiple": {
+			"terminal": null
+		},
+		"ts-type-any": {
+			"terminal": null
+		},
+		"ts-render": {
+			"terminal": null
+		},
+		"ts-symbol-kind": {
+			"terminal": null
+		},
+		"ts-symbol-name": {
+			"terminal": null
+		},
+		"official-defect-svelte-ts-shadow": {
+			"terminal": null
+		},
+		"css-data": {
+			"terminal": null
+		},
+		"html-data": {
+			"terminal": null
+		},
+		"provider-routing": {
+			"terminal": null
+		},
+		"rsvelte-empty": {
+			"terminal": null
+		},
+		"official-empty": {
+			"terminal": null
+		},
+		"projection-origin-range": {
+			"terminal": null
+		},
+		"projection-target-position-declaration": {
+			"terminal": null
+		},
+		"projection-target-position-workspace": {
+			"terminal": null
+		},
+		"projection-response-range": {
+			"terminal": null
+		},
+		"target-component-vs-import": {
+			"terminal": null
+		},
+		"target-declaration-vs-source": {
+			"terminal": null
+		},
+		"target-file-mismatch": {
+			"terminal": null
+		},
+		"completion-item-set-missing-ts": {
+			"terminal": null
+		},
+		"completion-item-set-missing-html": {
+			"terminal": null
+		},
+		"completion-item-set-missing-html-close-tag": {
+			"terminal": null
+		},
+		"completion-item-set-missing-css": {
+			"terminal": null
+		},
+		"completion-item-set-missing-svg": {
+			"terminal": null
+		},
+		"completion-item-set-missing-emmet": {
+			"terminal": null
+		},
+		"completion-item-set-missing-other": {
+			"terminal": null
+		},
+		"completion-item-set-missing-mixed": {
+			"terminal": null
+		},
+		"completion-item-set-extra-ts": {
+			"terminal": null
+		},
+		"completion-item-set-extra-html": {
+			"terminal": null
+		},
+		"completion-item-set-extra-html-close-tag": {
+			"terminal": null
+		},
+		"completion-item-set-extra-css": {
+			"terminal": null
+		},
+		"completion-item-set-extra-svg": {
+			"terminal": null
+		},
+		"completion-item-set-extra-emmet": {
+			"terminal": null
+		},
+		"completion-item-set-extra-other": {
+			"terminal": null
+		},
+		"completion-item-set-extra-mixed": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind-ts": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind-html": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind-html-close-tag": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind-css": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind-svg": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind-emmet": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind-other": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind-mixed": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text-ts": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text-html": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text-html-close-tag": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text-css": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text-svg": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text-emmet": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text-other": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text-mixed": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text-ts": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text-html": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text-html-close-tag": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text-css": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text-svg": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text-emmet": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text-other": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text-mixed": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-filter-text-ts": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-filter-text-html": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-filter-text-html-close-tag": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-filter-text-css": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-filter-text-svg": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-filter-text-emmet": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-filter-text-other": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-filter-text-mixed": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+filter-text-ts": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+filter-text-html": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+filter-text-html-close-tag": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+filter-text-css": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+filter-text-svg": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+filter-text-emmet": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+filter-text-other": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+filter-text-mixed": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text+filter-text-ts": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text+filter-text-html": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text+filter-text-html-close-tag": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text+filter-text-css": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text+filter-text-svg": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text+filter-text-emmet": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text+filter-text-other": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-sort-text+filter-text-mixed": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text+filter-text-ts": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text+filter-text-html": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text+filter-text-html-close-tag": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text+filter-text-css": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text+filter-text-svg": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text+filter-text-emmet": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text+filter-text-other": {
+			"terminal": null
+		},
+		"completion-item-pairing-key-kind+sort-text+filter-text-mixed": {
+			"terminal": null
+		},
+		"completion-item-duplicate-label": {
+			"terminal": null
+		},
+		"completion-commit-characters-value-extra-paren": {
+			"terminal": null
+		},
+		"completion-commit-characters-value-other": {
+			"terminal": null
+		},
+		"completion-commit-characters-presence-rsvelte-only": {
+			"terminal": null
+		},
+		"completion-commit-characters-presence-official-only": {
+			"terminal": null
+		},
+		"completion-command-presence-rsvelte-only": {
+			"terminal": null
+		},
+		"completion-command-presence-official-only": {
+			"terminal": null
+		},
+		"completion-command-value": {
+			"terminal": null
+		},
+		"completion-text-edit-presence-rsvelte-only": {
+			"terminal": null
+		},
+		"completion-text-edit-presence-official-only": {
+			"terminal": null
+		},
+		"completion-text-edit-range-start": {
+			"terminal": null
+		},
+		"completion-text-edit-range-end": {
+			"terminal": null
+		},
+		"completion-text-edit-range-other": {
+			"terminal": null
+		},
+		"completion-text-edit-other": {
+			"terminal": null
+		},
+		"completion-text-edit-new-text-ts": {
+			"terminal": null
+		},
+		"completion-text-edit-new-text-html": {
+			"terminal": null
+		},
+		"completion-text-edit-new-text-html-close-tag": {
+			"terminal": null
+		},
+		"completion-text-edit-new-text-css": {
+			"terminal": null
+		},
+		"completion-text-edit-new-text-svg": {
+			"terminal": null
+		},
+		"completion-text-edit-new-text-emmet": {
+			"terminal": null
+		},
+		"completion-text-edit-new-text-other": {
+			"terminal": null
+		},
+		"completion-text-edit-new-text-mixed": {
+			"terminal": null
+		},
+		"completion-additional-text-edits-presence-rsvelte-only": {
+			"terminal": null
+		},
+		"completion-additional-text-edits-presence-official-only": {
+			"terminal": null
+		},
+		"completion-additional-text-edits-other": {
+			"terminal": null
+		},
+		"completion-item-data-source-rsvelte-only": {
+			"terminal": null
+		},
+		"completion-item-data-source-official-only": {
+			"terminal": null
+		},
+		"completion-item-data-uri": {
+			"terminal": null
+		},
+		"completion-item-data-position": {
+			"terminal": null
+		},
+		"completion-item-data-name": {
+			"terminal": null
+		},
+		"completion-item-data-other": {
+			"terminal": null
+		},
+		"completion-is-incomplete": {
+			"terminal": null
+		},
+		"completion-item-detail-presence-rsvelte-only": {
+			"terminal": null
+		},
+		"completion-item-detail-presence-official-only": {
+			"terminal": null
+		},
+		"completion-item-detail-value": {
+			"terminal": null
+		},
+		"completion-item-documentation-presence-rsvelte-only": {
+			"terminal": null
+		},
+		"completion-item-documentation-presence-official-only": {
+			"terminal": null
+		},
+		"completion-item-documentation-value": {
+			"terminal": null
+		},
+		"completion-item-label-details-presence-rsvelte-only": {
+			"terminal": null
+		},
+		"completion-item-label-details-presence-official-only": {
+			"terminal": null
+		},
+		"completion-item-label-details-value": {
+			"terminal": null
+		},
+		"unclassified": {
+			"terminal": null
+		}
+	},
+	"entries": {}
+}

--- a/package.json
+++ b/package.json
@@ -173,6 +173,8 @@
 		"release": "pnpm run sync-version && pnpm run build:wasm && pnpm run finalize-pkg && pnpm run publish-platform-binaries && pnpm run build:language-server && changeset publish",
 		"corpus:scss": "node scripts/compat-corpus/scss-verify.mjs",
 		"check:attribution": "node scripts/ci/attribution-check.mjs",
+		"check:lsp-mechanisms": "node scripts/ci/lsp-mechanisms-check.mjs",
+		"test:lsp-mechanisms-check": "node scripts/dev/test-lsp-mechanisms-check.mjs",
 		"test:attribution-check": "node scripts/ci/test-attribution-check.mjs",
 		"check:ratchet-unit-delta": "node scripts/ci/ratchet-unit-delta.mjs"
 	},

--- a/scripts/ci/lsp-mechanisms-check.mjs
+++ b/scripts/ci/lsp-mechanisms-check.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// DoD companion to `attribution-check.mjs` for `lsp-known-failures.json`, whose
+// entries cannot be attributed one row per label: an entry carries a SET of
+// mechanisms, so the label is a key into the ratchet rather than a partition of
+// it, and a rule picking one label per entry would encode its author's ordering.
+//
+// The sidecar carries the set instead, and this checks that it is a set the
+// attribution table can be derived from:
+//
+//   1. every ratchet id has a mechanism set, and the sidecar names no id the
+//      ratchet does not list (the two are written by one command, so a drift
+//      here means one of them was edited by hand);
+//   2. every label used is declared, and every declared label is one the
+//      classifier can actually emit;
+//   3. a declared terminal is either an `upstream_issues/` path that exists on
+//      disk or the literal `deliberate-divergences`.
+//
+// `null` is a legal terminal and is NOT a pass: it says the terminal has not
+// been established, which is a different fact from "this is ours". What it
+// costs is that the id cannot be written into an attribution table, and that
+// is reported rather than tolerated — a check that let an unestablished
+// terminal through would make an empty sidecar the bar it clears.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { MECHANISMS, UNCLASSIFIED } from "../compat-lsp/mechanism.mjs";
+
+const ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+// Overridable so the self-test can drive the whole checker against a synthetic
+// tree: a guard only ever run on inputs it fails has not been shown to pass.
+const DIR = process.env.LSP_MECHANISMS_DIR || path.join(ROOT, "compatibility");
+const RATCHET = path.join(DIR, "lsp-known-failures.json");
+const SIDECAR = path.join(DIR, "lsp-mechanisms.json");
+const ANCHOR = "deliberate-divergences";
+
+const problems = [];
+const fail = (message) => problems.push(message);
+const cap = (values, limit = 5) =>
+  values.length <= limit
+    ? values.join(", ")
+    : `${values.slice(0, limit).join(", ")} … and ${values.length - limit} more`;
+
+const ratchet = JSON.parse(fs.readFileSync(RATCHET, "utf8"));
+const sidecar = JSON.parse(fs.readFileSync(SIDECAR, "utf8"));
+const declared = sidecar.mechanisms ?? {};
+const entries = sidecar.entries ?? {};
+const vocabulary = new Set(MECHANISMS);
+
+const listed = new Set(ratchet);
+const covered = new Set(Object.keys(entries));
+const uncovered = [...listed].filter((id) => !covered.has(id));
+const unlisted = [...covered].filter((id) => !listed.has(id));
+if (uncovered.length)
+  fail(
+    `${uncovered.length} of ${listed.size} ratchet entries carry no mechanism set: ${cap(uncovered)}`,
+  );
+if (unlisted.length)
+  fail(
+    `${unlisted.length} sidecar entries name an id the ratchet does not list: ${cap(unlisted)}`,
+  );
+
+const used = new Set();
+for (const [id, labels] of Object.entries(entries)) {
+  if (!Array.isArray(labels) || !labels.length) {
+    fail(`${id} has an empty mechanism set; an absence must be spelled`);
+    continue;
+  }
+  for (const label of labels) used.add(label);
+}
+const undeclared = [...used].filter((label) => !(label in declared));
+if (undeclared.length)
+  fail(`undeclared mechanism label(s): ${cap([...undeclared].sort())}`);
+const unknown = Object.keys(declared).filter((label) => !vocabulary.has(label));
+if (unknown.length)
+  fail(
+    `declared label(s) the classifier cannot emit: ${cap(unknown.sort())} — mechanism.mjs is the vocabulary`,
+  );
+
+for (const [label, value] of Object.entries(declared)) {
+  const terminal = value?.terminal ?? null;
+  if (terminal === null) continue;
+  if (terminal === ANCHOR) continue;
+  if (
+    typeof terminal !== "string" ||
+    !terminal.startsWith("upstream_issues/")
+  ) {
+    fail(
+      `${label} has terminal ${JSON.stringify(terminal)}; expected an upstream_issues/ path, "${ANCHOR}", or null`,
+    );
+    continue;
+  }
+  if (!fs.existsSync(path.join(ROOT, terminal)))
+    fail(`${label} names ${terminal}, which does not exist`);
+}
+
+// The count the attribution table can actually reach today. Reported whether or
+// not it is zero: a table that cannot be written yet must say so with a number,
+// because a missing row and a zero row render the same.
+const blocked = new Set();
+for (const [id, labels] of Object.entries(entries)) {
+  if (!Array.isArray(labels)) continue;
+  for (const label of labels) {
+    if (
+      label === UNCLASSIFIED ||
+      (declared[label]?.terminal ?? null) === null
+    ) {
+      blocked.add(id);
+      break;
+    }
+  }
+}
+const writable = Object.keys(entries).length - blocked.size;
+console.log(
+  `[lsp-mechanisms-check] ${listed.size} ratchet entries, ${Object.keys(entries).length} with a mechanism set, ${Object.keys(declared).length} labels declared, ${writable} entries attributable today (${blocked.size} blocked by an unclassified or unestablished terminal)`,
+);
+
+if (problems.length) {
+  for (const problem of problems) console.error(problem);
+  console.error(
+    `\n[lsp-mechanisms-check] ${problems.length} problem(s). The sidecar is regenerated with the ratchet by\n` +
+      "  node scripts/compat-lsp/merge-current.mjs <artifact-dir> --update-baseline\n" +
+      "from the complete 17-artifact set of one lsp-corpus run; it cannot be filled in by hand.",
+  );
+  process.exit(1);
+}

--- a/scripts/compat-lsp/artifacts.mjs
+++ b/scripts/compat-lsp/artifacts.mjs
@@ -5,7 +5,9 @@ import { execFileSync } from "node:child_process";
 import { corpusShardIndex } from "./ratchet.mjs";
 import { CORPUS_REPOS } from "./suites.mjs";
 
-export const ARTIFACT_SCHEMA = 1;
+// 2 adds `mechanisms`: an artifact that predates it cannot populate the sidecar,
+// and a merge that silently accepted one would write a short map rather than fail.
+export const ARTIFACT_SCHEMA = 2;
 export const CORPUS_SHARDS = 16;
 export const FIXTURE_SUITES = [
   "fixtures",
@@ -38,6 +40,7 @@ export function createCurrentArtifact({
   population,
   current,
   counts,
+  mechanisms = {},
   diagnosticDetails = {},
 }) {
   const sourceRevisions = {
@@ -58,6 +61,13 @@ export function createCurrentArtifact({
     population,
     counts,
     current: [...current].sort(),
+    // Always written, even when empty: an absent map and an unclassified run
+    // are different facts, and only one of them is a wiring failure.
+    mechanisms: Object.fromEntries(
+      Object.entries(mechanisms)
+        .map(([id, labels]) => [id, [...new Set(labels)].sort()])
+        .sort(([left], [right]) => left.localeCompare(right)),
+    ),
     ...(Object.keys(diagnosticDetails).length ? { diagnosticDetails } : {}),
   };
 }
@@ -77,6 +87,16 @@ function requireArtifact(value, label) {
   for (const field of ["suites", "repos", "measuredIds", "current"])
     if (!Array.isArray(value[field]))
       throw new Error(`${label} lacks ${field}`);
+  if (!value.mechanisms || typeof value.mechanisms !== "object")
+    throw new Error(`${label} lacks mechanisms`);
+  // Coverage is asserted per artifact rather than on the union: a shard that
+  // classified nothing is otherwise invisible once sixteen maps are merged.
+  for (const id of value.current)
+    if (!Array.isArray(value.mechanisms[id]) || !value.mechanisms[id].length)
+      throw new Error(`${label} carries no mechanism for ${id}`);
+  for (const id of Object.keys(value.mechanisms))
+    if (!value.current.includes(id))
+      throw new Error(`${label} carries a mechanism for unlisted ${id}`);
 }
 
 export function mergeCurrentArtifacts(artifacts, populationFloor) {
@@ -189,7 +209,18 @@ export function mergeCurrentArtifacts(artifacts, populationFloor) {
   const current = artifacts.flatMap((artifact) => artifact.current).sort();
   if (new Set(current).size !== current.length)
     throw new Error("current artifacts contain duplicate ratchet keys");
-  return { current, population, projectRevision: reference.projectRevision };
+  const mechanisms = {};
+  for (const artifact of artifacts)
+    for (const [id, labels] of Object.entries(artifact.mechanisms))
+      mechanisms[id] = [
+        ...new Set([...(mechanisms[id] ?? []), ...labels]),
+      ].sort();
+  return {
+    current,
+    mechanisms,
+    population,
+    projectRevision: reference.projectRevision,
+  };
 }
 
 export function readArtifacts(directory) {

--- a/scripts/compat-lsp/artifacts.test.mjs
+++ b/scripts/compat-lsp/artifacts.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  ARTIFACT_SCHEMA,
   CONFIGURATION_ID,
   CORPUS_SHARDS,
   FIXTURE_SUITES,
@@ -24,7 +25,7 @@ function artifacts() {
   );
   const universe = ids.flat();
   const common = {
-    schemaVersion: 1,
+    schemaVersion: ARTIFACT_SCHEMA,
     projectRevision: "project",
     configurationId: CONFIGURATION_ID,
     sourceRevisions: {
@@ -43,6 +44,11 @@ function artifacts() {
       population: {},
       counts: { compared: 1 },
       current: ["differential:fixtures/a|initialize|/capabilities:value"],
+      mechanisms: {
+        "differential:fixtures/a|initialize|/capabilities:value": [
+          "unclassified",
+        ],
+      },
     },
     ...ids.map((measuredIds, index) => ({
       ...common,
@@ -59,6 +65,9 @@ function artifacts() {
       ),
       counts: { compared: 12 },
       current: [`aggregate:corpus/repo/${index}|hover|digest=${index}`],
+      mechanisms: {
+        [`aggregate:corpus/repo/${index}|hover|digest=${index}`]: ["ts-render"],
+      },
     })),
   ];
 }
@@ -109,9 +118,12 @@ test("unknown artifacts and control keys in corpus artifacts are rejected", () =
     new RegExp(`exactly ${CORPUS_SHARDS + 1}`),
   );
   const contaminated = artifacts();
-  contaminated[1].current.push(
-    "differential:fixtures/ts-backend-positive|textDocument/hover|/contents:value",
-  );
+  const foreign =
+    "differential:fixtures/ts-backend-positive|textDocument/hover|/contents:value";
+  contaminated[1].current.push(foreign);
+  // Classified too, so the artifact is well-formed and the scope check is the
+  // only thing left that can reject it.
+  contaminated[1].mechanisms[foreign] = ["unclassified"];
   assert.throws(
     () => mergeCurrentArtifacts(contaminated, floor),
     /out-of-scope ratchet key/,
@@ -147,5 +159,37 @@ test("a deleted baseline file remains owned by one stable shard", () => {
       (_, index) => corpusShardIndex(id, CORPUS_SHARDS) === index,
     ).filter(Boolean).length,
     1,
+  );
+});
+
+test("an artifact whose mechanism map does not cover its keys is rejected", () => {
+  const short = artifacts();
+  short[0].mechanisms = {};
+  assert.throws(
+    () => mergeCurrentArtifacts(short, floor),
+    /carries no mechanism for/,
+  );
+  const extra = artifacts();
+  extra[0].mechanisms["differential:fixtures/b|initialize|/x:value"] = ["ts-render"];
+  assert.throws(
+    () => mergeCurrentArtifacts(extra, floor),
+    /carries a mechanism for unlisted/,
+  );
+  const absent = artifacts();
+  delete absent[0].mechanisms;
+  assert.throws(() => mergeCurrentArtifacts(absent, floor), /lacks mechanisms/);
+});
+
+test("the merged mechanism map is the union over the artifact set", () => {
+  const values = artifacts();
+  const merged = mergeCurrentArtifacts(values, floor);
+  assert.equal(
+    Object.keys(merged.mechanisms).length,
+    merged.current.length,
+    "every merged key carries a mechanism set",
+  );
+  assert.deepEqual(
+    merged.mechanisms["differential:fixtures/a|initialize|/capabilities:value"],
+    ["unclassified"],
   );
 });

--- a/scripts/compat-lsp/diff.mjs
+++ b/scripts/compat-lsp/diff.mjs
@@ -5,7 +5,9 @@ const digest = (value) =>
 const pointerPart = (value) =>
   String(value).replaceAll("~", "~0").replaceAll("/", "~1");
 
-function identity(method, pointer, value) {
+// Exported so a classifier can resolve a `@`-segment back to the item it names
+// without a second copy of this digest.
+export function identity(method, pointer, value) {
   if (value === null || typeof value !== "object") {
     const readable = pointerPart(String(value))
       .replace(/[^\w.~+-]/g, "_")
@@ -66,14 +68,18 @@ function walk(method, left, right, pointer, differences) {
       for (let index = common; index < rightValues.length; index++)
         extraRsvelte.push(key);
     }
+    // `-element` and `-field` name the two mechanisms an unqualified
+    // `extra-rsvelte` collapsed: an array that carries one more entry, and an
+    // object the other side has no such key on. The ratchet key keeps the
+    // suffix and drops the bracket, so the kind survives and the amount does not.
     if (missingRsvelte.length) {
       differences.push(
-        `${pointer}:missing-rsvelte[count=${missingRsvelte.length},hash=${digest(missingRsvelte.sort())}]`,
+        `${pointer}:missing-rsvelte-element[count=${missingRsvelte.length},hash=${digest(missingRsvelte.sort())}]`,
       );
     }
     if (extraRsvelte.length) {
       differences.push(
-        `${pointer}:extra-rsvelte[count=${extraRsvelte.length},hash=${digest(extraRsvelte.sort())}]`,
+        `${pointer}:extra-rsvelte-element[count=${extraRsvelte.length},hash=${digest(extraRsvelte.sort())}]`,
       );
     }
     return;
@@ -89,9 +95,9 @@ function walk(method, left, right, pointer, differences) {
     for (const key of new Set([...Object.keys(left), ...Object.keys(right)])) {
       const child = `${pointer}/${pointerPart(key)}`;
       if (!(key in left))
-        differences.push(`${child}:extra-rsvelte[hash=${digest(right[key])}]`);
+        differences.push(`${child}:extra-rsvelte-field[hash=${digest(right[key])}]`);
       else if (!(key in right))
-        differences.push(`${child}:missing-rsvelte[hash=${digest(left[key])}]`);
+        differences.push(`${child}:missing-rsvelte-field[hash=${digest(left[key])}]`);
       else walk(method, left[key], right[key], child, differences);
     }
     return;

--- a/scripts/compat-lsp/diff.test.mjs
+++ b/scripts/compat-lsp/diff.test.mjs
@@ -56,3 +56,27 @@ test("completion arrays match by semantic identity instead of index", () => {
     [],
   );
 });
+
+// An unqualified `extra-rsvelte` collapsed two mechanisms: one more entry in an
+// array, and a key the other side does not carry at all.
+test("an extra array entry and an absent field are different verdicts", () => {
+  const item = (extra) => ({
+    items: [{ label: "a", kind: 6, ...extra }],
+  });
+  assert.deepEqual(
+    diffJson(
+      "textDocument/completion",
+      item({ commitCharacters: [".", ","] }),
+      item({ commitCharacters: [".", ",", "("] }),
+    ).map((value) => value.replace(/\[.*\]$/, "")),
+    ["/items/@completion-f121f598ae7d/commitCharacters:extra-rsvelte-element"],
+  );
+  assert.deepEqual(
+    diffJson(
+      "textDocument/completion",
+      item({}),
+      item({ commitCharacters: [".", ",", "("] }),
+    ).map((value) => value.replace(/\[.*\]$/, "")),
+    ["/items/@completion-f121f598ae7d/commitCharacters:extra-rsvelte-field"],
+  );
+});

--- a/scripts/compat-lsp/mechanism.mjs
+++ b/scripts/compat-lsp/mechanism.mjs
@@ -1,0 +1,695 @@
+// One mechanism label per divergence, drawn from a closed vocabulary.
+//
+// The label goes into the ratchet key, so it must be derived from the OBSERVED
+// pair alone and must not encode the measured content: a key carrying a digest
+// of the difference changes the moment a mechanism is partly fixed, and CI
+// reads the new key as a NEW failure instead of as progress.
+// The pairing key `diff.mjs` uses, minus `label` (a differing label is a real
+// set difference and is classified as one).
+import { identity } from "./diff.mjs";
+const PAIRING_KEY_FIELDS = ["kind", "sortText", "filterText"];
+const PAIRING_KEY_SLUG = { kind: "kind", sortText: "sort-text", filterText: "filter-text" };
+const COMPLETION_PROVIDERS = ["ts", "html", "html-close-tag", "css", "svg", "emmet", "other", "mixed"];
+function pairingKeyLabelSpace() {
+  const space = [];
+  for (let mask = 1; mask < 1 << PAIRING_KEY_FIELDS.length; mask += 1)
+    space.push(
+      PAIRING_KEY_FIELDS.filter((_, index) => mask & (1 << index))
+        .map((field) => PAIRING_KEY_SLUG[field])
+        .join("+"),
+    );
+  return space;
+}
+
+// The label a divergence carries when no rule in this file claims it, and the
+// one every non-corpus entry carries because the classifier does not run there.
+// Spelled once so a caller outside this file cannot drift from it.
+export const UNCLASSIFIED = "unclassified";
+
+export const MECHANISMS = [
+  // Architectural: rsvelte proxies tsgo, official bundles `typescript`.
+  "ts-lib-copy",
+  // The four renderings a `tsgo --lsp` hover spells differently from `tsc`'s
+  // quick info, each pinned by one probe position in
+  // `upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md`.
+  "ts-render-union-order",
+  "ts-render-quote-style",
+  "ts-render-local-modifier",
+  "ts-render-jsdoc-tag",
+  "ts-render-import-line",
+  "ts-render-overload-count",
+  "ts-render-declaration-order",
+  // Official's whole hover is the import origin line, which tsgo drops -- so
+  // dropping it leaves tsgo with nothing to answer.
+  "rsvelte-empty-import-only",
+  // rsvelte answers a definition with the very token the request sat on.
+  "official-empty-target-is-the-request",
+  // Two of the renderings at once. Named for the pair rather than for either
+  // one, because a label that a rule wins by its position in the table makes
+  // the ratchet key depend on the order the rules were written in.
+  "ts-render-multiple",
+  // Not a rendering difference at all: the same declaration, typed.
+  "ts-type-any",
+  // The residual: a hover text none of those four rules explains. It is NOT
+  // attributed to tsgo -- the same probe shows `tsc` and `tsgo` agreeing on the
+  // shapes this bucket holds, so which side is wrong is unmeasured.
+  "ts-render",
+  "ts-symbol-kind",
+  "ts-symbol-name",
+  // official answers about a `*.svelte.ts` shadow that exists in no editor.
+  "official-defect-svelte-ts-shadow",
+  // Language-data providers (CSS / HTML) rather than TypeScript.
+  "css-data",
+  "html-data",
+  "provider-routing",
+  // One side declines to answer.
+  "rsvelte-empty",
+  "official-empty",
+  // rsvelte's `.svelte` <-> `.tsx` position projection.
+  "projection-origin-range",
+  ...["declaration", "workspace"].map((where) => `projection-target-position-${where}`),
+  "projection-response-range",
+  // official resolves an imported component to its file; rsvelte stops at the
+  // import specifier in the requesting document.
+  "target-component-vs-import",
+  // official lands in a package's `.d.ts`, rsvelte in the package source.
+  "target-declaration-vs-source",
+  "target-file-mismatch",
+  // completion payload fields. The item set splits by the PROVIDER the differing
+  // items come from, because one `/items` difference hid TypeScript, HTML tag,
+  // HTML attribute and CSS data gaps under one name.
+  ...["missing", "extra"].flatMap((direction) =>
+    ["ts", "html", "html-close-tag", "css", "svg", "emmet", "other", "mixed"].map(
+      (provider) => `completion-item-set-${direction}-${provider}`,
+    ),
+  ),
+  // Measured on melt-ui: the arrays differ (18.9% of label-paired items, upstream
+  // omits the `(` at a new-identifier location) and upstream omits the field
+  // outright (8.1%) are two mechanisms one label hid.
+  // `diff.mjs` pairs items by a digest of (label, kind, sortText, filterText),
+  // so an item whose label matches and whose pairing-key field does not is
+  // unpaired in BOTH directions while the label sets agree. Which fields
+  // disagree is the mechanism; it says nothing about which side is right.
+  // Crossed with the provider, because the same differing FIELD carries two
+  // different terminals: a TypeScript item's `kind` is the recorded tsgo
+  // divergence, and an HTML tag's `kind` is rsvelte's own completion falling
+  // through. One label cannot take both.
+  ...pairingKeyLabelSpace().flatMap((suffix) =>
+    COMPLETION_PROVIDERS.map((provider) => `completion-item-pairing-key-${suffix}-${provider}`),
+  ),
+  "completion-item-duplicate-label",
+  "completion-commit-characters-value-extra-paren",
+  "completion-commit-characters-value-other",
+  "completion-commit-characters-presence-rsvelte-only",
+  "completion-commit-characters-presence-official-only",
+  ...[
+    "presence-rsvelte-only",
+    "presence-official-only",
+    "value",
+  ].map((suffix) => `completion-command-${suffix}`),
+  // Two labels each hid two mechanisms: a field one side never writes, and a
+  // value both sides write and compute differently. The sub-key is read off
+  // the difference pointer, so it names what diverged and not who is right.
+  ...[
+    "presence-rsvelte-only",
+    "presence-official-only",
+    "range-start",
+    "range-end",
+    "range-other",
+    "other",
+  ].map((suffix) => `completion-text-edit-${suffix}`),
+  // `new-text` carries the provider, because the two arms measured on it are an
+  // HTML attribute snippet (`accesskey="$1"`) and a module specifier trimmed to
+  // the part after the word range -- two builders, not two spellings.
+  ...COMPLETION_PROVIDERS.map((provider) => `completion-text-edit-new-text-${provider}`),
+  ...["presence-rsvelte-only", "presence-official-only", "other"].map(
+    (suffix) => `completion-additional-text-edits-${suffix}`,
+  ),
+  ...[
+    "source-rsvelte-only",
+    "source-official-only",
+    "uri",
+    "position",
+    "name",
+    "other",
+  ].map((suffix) => `completion-item-data-${suffix}`),
+  "completion-is-incomplete",
+  // `detail`, `documentation` and `labelDetails` are three fields with three
+  // producers; one label reported an extra `detail` and an absent
+  // `documentation` as the same thing.
+  ...["detail", "documentation", "label-details"].flatMap((field) =>
+    ["presence-rsvelte-only", "presence-official-only", "value"].map(
+      (suffix) => `completion-item-${field}-${suffix}`,
+    ),
+  ),
+  UNCLASSIFIED,
+];
+
+const MECHANISM_SET = new Set(MECHANISMS);
+
+const isEmptyResult = (value) =>
+  value === null ||
+  value === undefined ||
+  (Array.isArray(value) && value.length === 0);
+
+const asList = (value) =>
+  Array.isArray(value) ? value : value === null || value === undefined ? [] : [value];
+
+const targetUri = (item) => String(item.targetUri ?? item.uri ?? "");
+const targetStart = (item) => (item.targetSelectionRange ?? item.range ?? {}).start;
+
+// The two servers load two different copies of the TypeScript lib: official
+// resolves `typescript/lib/lib.*.d.ts`, rsvelte gets the copy tsgo ships.
+const isLibFile = (uri) => /\/lib\/lib\.[^/]*\.d\.ts$/.test(uri);
+const isSvelteShadow = (uri) => /\.svelte\.ts$/.test(uri);
+
+// rsvelte's CSS hover is a name-only stub; official serves the MDN description.
+const RSVELTE_CSS_STUB = /^`[^`]+` CSS property$|^`:global\(\.\.\.\)` prevents/;
+// A hover body whatever its shape: TypeScript sends a bare string here and
+// `plaintextOf` answers only for the language-data payloads.
+const markupTextOf = (contents) =>
+  typeof contents === "string"
+    ? contents
+    : contents && !Array.isArray(contents) && typeof contents.value === "string"
+      ? contents.value
+      : null;
+
+const plaintextOf = (contents) =>
+  contents && typeof contents === "object" && !Array.isArray(contents) &&
+  contents.kind === "plaintext"
+    ? contents.value
+    : null;
+
+function hoverDataKind(hover) {
+  if (!hover) return null;
+  const contents = hover.contents;
+  // A CSS selector hover is upstream's only array-shaped payload.
+  if (Array.isArray(contents)) return "css";
+  const text = plaintextOf(contents);
+  if (text === null) return null;
+  if (RSVELTE_CSS_STUB.test(text)) return "css";
+  if (text.includes("developer.mozilla.org/docs/Web/CSS/")) return "css";
+  if (text.includes("developer.mozilla.org/docs/Web/HTML/")) return "html";
+  // The MDN reference line is the only reliable discriminator; a plaintext
+  // payload without one is language data of an unknown flavour.
+  return "data";
+}
+
+// `(method) String.replace`, `var undefined`, `module "svelte/elements"` — the
+// leading declaration line names the symbol the server resolved, which
+// separates "the same symbol rendered differently" from "a different symbol".
+function declarationHead(text) {
+  const fenced = /```typescript\n([\s\S]*?)(?:\n```|$)/.exec(text);
+  const first = (fenced ? fenced[1] : text).split("\n")[0];
+  const tagged = /^\(([^)]*)\)\s*(.*)$/.exec(first);
+  if (tagged) {
+    const name = /^([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)/.exec(tagged[2]);
+    return { kind: tagged[1], name: name ? name[1] : "" };
+  }
+  const keyword =
+    /^(var|let|const|function|class|interface|type|namespace|module|enum|import|new|abstract class)\s+(.*)$/.exec(
+      first,
+    );
+  if (keyword) {
+    const name = /^(["'][^"']*["']|[A-Za-z_$][\w$]*)/.exec(keyword[2]);
+    return { kind: keyword[1], name: name ? name[1] : "" };
+  }
+  return { kind: "?", name: first.slice(0, 32) };
+}
+
+// The four `tsgo` renderings `upstream_issues/tsgo-lsp-hover-renders-four-
+// things-differently-from-tsc.md` reproduces, each written as the rewrite that
+// makes the two texts equal. The rewrite decides the LABEL only -- it never
+// decides whether the entry diverges -- so it cannot hide a difference.
+const sortUnions = (text) =>
+  text.replace(/(?:"[^"]*"|'[^']*'|[\w.$<>[\]]+)(?:\s*\|\s*(?:"[^"]*"|'[^']*'|[\w.$<>[\]]+))+/g, (run) =>
+    run
+      .split("|")
+      .map((part) => part.trim())
+      .sort()
+      .join(" | "),
+  );
+const normalizeImportQuotes = (text) =>
+  text.replace(/import\('([^']*)'\)/g, 'import("$1")');
+// `(local function) f()` against `function f()`: the qualifier is dropped, the
+// kind word is not.
+const dropLocalModifier = (text) =>
+  text.replace(/\(local (function|var|let|const|class|method|property)\)/g, "$1");
+// tsc names the import a symbol came through on its own line; tsgo omits it.
+const dropImportLine = (text) =>
+  text
+    .split("\n")
+    .filter((line) => !/^import [\w$]+$/.test(line))
+    .join("\n");
+// `(+3 overloads)` / `(+1 overload)`: tsc counts the overloads it did not print.
+const dropOverloadCount = (text) => text.replace(/ \(\+\d+ overloads?\)/g, "");
+// A merged symbol prints one line per declaration, and the two disagree on the
+// order. Only the fenced code block is sorted, so prose cannot be reordered into
+// equality.
+const sortDeclarationLines = (text) =>
+  text.replace(/```typescript\n([\s\S]*?)\n```/, (block, body) =>
+    block.replace(body, body.split("\n").sort().join("\n")),
+  );
+const dropJsdocTags = (text) =>
+  text
+    .split("\n")
+    .filter((line) => !/^\s*\*@[A-Za-z]+\*/.test(line))
+    .join("\n")
+    .trimEnd();
+
+// Applied in a fixed order so one input cannot land on two labels; the first
+// rewrite that makes the two texts equal names the mechanism.
+const TS_RENDER_RULES = [
+  ["ts-render-union-order", sortUnions],
+  ["ts-render-quote-style", normalizeImportQuotes],
+  ["ts-render-local-modifier", dropLocalModifier],
+  ["ts-render-jsdoc-tag", dropJsdocTags],
+  ["ts-render-import-line", dropImportLine],
+  ["ts-render-overload-count", dropOverloadCount],
+  ["ts-render-declaration-order", sortDeclarationLines],
+];
+
+// The same declaration with the type erased: rsvelte answers `any` where
+// official names a type, which no rewrite can express because it is not a
+// rendering difference. Every differing line must have the shape, so a genuinely
+// different symbol whose type happens to be `any` cannot match.
+function differsOnlyByAny(official, rsvelte) {
+  const left = official.split("\n");
+  const right = rsvelte.split("\n");
+  if (left.length !== right.length) return false;
+  let differing = 0;
+  for (let i = 0; i < left.length; i += 1) {
+    if (left[i] === right[i]) continue;
+    differing += 1;
+    if (!right[i].endsWith("any")) return false;
+    if (left[i].slice(0, right[i].length - 3) !== right[i].slice(0, -3)) return false;
+  }
+  return differing > 0;
+}
+
+// Order-free by construction: a rule never wins because of where it sits in the
+// table, so the ratchet key cannot change when a rule is added above another.
+function classifyTsRender(left, right) {
+  const sufficient = TS_RENDER_RULES.filter(([, rewrite]) => rewrite(left) === rewrite(right));
+  if (sufficient.length === 1) return sufficient[0][0];
+  if (sufficient.length > 1) return "ts-render-multiple";
+  const all = (text) => TS_RENDER_RULES.reduce((acc, [, rewrite]) => rewrite(acc), text);
+  if (all(left) === all(right)) return "ts-render-multiple";
+  if (differsOnlyByAny(left, right)) return "ts-type-any";
+  return "ts-render";
+}
+
+// The whole answer is the `import <Name>` line `ts-render-import-line` names,
+// so this is that omission with nothing left behind it rather than a second
+// mechanism that happens to be empty.
+function importOnlyBody(text) {
+  const fenced = /^```typescript\n([\s\S]*?)\n```$/.exec(text.trim());
+  if (!fenced) return false;
+  const lines = fenced[1].split("\n");
+  return lines.length === 1 && /^import [\w$]+$/.test(lines[0]);
+}
+
+function classifyHover(official, rsvelte) {
+  if (isEmptyResult(official) && !isEmptyResult(rsvelte)) return "official-empty";
+  if (!isEmptyResult(official) && isEmptyResult(rsvelte)) {
+    const kind = hoverDataKind(official);
+    if (kind === "css") return "css-data";
+    if (kind === "html") return "html-data";
+    // The subject's NAME, not any `$$` in the text: a real symbol's type often
+    // mentions `$$ComponentProps` while the hover is about the user's own
+    // declaration, and only the former is official answering about the shadow.
+    const subject = markupTextOf(official.contents);
+    if (subject !== null && importOnlyBody(subject)) return "rsvelte-empty-import-only";
+    if (subject !== null && declarationHead(subject).name.startsWith("$$"))
+      return "official-defect-svelte-ts-shadow";
+    return "rsvelte-empty";
+  }
+  if (isEmptyResult(official) || isEmptyResult(rsvelte)) return UNCLASSIFIED;
+  const left = official.contents;
+  const right = rsvelte.contents;
+  const leftKind = hoverDataKind(official);
+  const rightKind = hoverDataKind(rsvelte);
+  if (JSON.stringify(left) === JSON.stringify(right)) return "projection-response-range";
+  // One side answered with language data and the other with TypeScript.
+  if ((leftKind === null) !== (rightKind === null)) return "provider-routing";
+  if (leftKind !== null) {
+    if (leftKind === "css" || rightKind === "css") return "css-data";
+    if (leftKind === "html" || rightKind === "html") return "html-data";
+    return UNCLASSIFIED;
+  }
+  if (typeof left !== "string" || typeof right !== "string") return UNCLASSIFIED;
+  // Ahead of the head comparison, because `(local function) f()` vs `function
+  // f()` reads as a KIND disagreement and is one of the four renderer rules.
+  // Each rule demands full equality after its rewrite, so a genuinely different
+  // symbol cannot match one.
+  const rendered = classifyTsRender(left, right);
+  if (rendered !== "ts-render") return rendered;
+  const leftHead = declarationHead(left);
+  const rightHead = declarationHead(right);
+  if (leftHead.name !== rightHead.name) return "ts-symbol-name";
+  if (leftHead.kind !== rightHead.kind) return "ts-symbol-kind";
+  return "ts-render";
+}
+
+// Whether rsvelte's own answer covers the position that was asked about. The
+// alternative -- listing the words official resolves nothing at -- needs a
+// vocabulary, and the document is three languages at once: the sampled residue
+// is `type`, `as` and Svelte's `snippet`.
+function targetCoversRequest(rsvelte, position) {
+  if (!position) return false;
+  const first = asList(rsvelte)[0];
+  const range = first?.targetSelectionRange ?? first?.range;
+  if (!range) return false;
+  const { line, character } = position;
+  if (range.start.line > line || range.end.line < line) return false;
+  if (range.start.line === line && range.start.character > character) return false;
+  if (range.end.line === line && range.end.character < character) return false;
+  return true;
+}
+
+function classifyDefinition(official, rsvelte, difference, position) {
+  if (isEmptyResult(official) && !isEmptyResult(rsvelte))
+    return targetCoversRequest(rsvelte, position)
+      ? "official-empty-target-is-the-request"
+      : "official-empty";
+  if (!isEmptyResult(official) && isEmptyResult(rsvelte)) return "rsvelte-empty";
+  const left = asList(official);
+  const right = asList(rsvelte);
+  if (!left.length || !right.length) return UNCLASSIFIED;
+  // A field-level pointer names the field directly.
+  if (difference.includes("originSelectionRange")) return "projection-origin-range";
+  const identity = (item) => {
+    const start = targetStart(item) ?? {};
+    return `${targetUri(item)}|${start.line}:${start.character}`;
+  };
+  const leftKeys = new Set(left.map(identity));
+  const rightKeys = new Set(right.map(identity));
+  const onlyLeft = [...leftKeys].filter((key) => !rightKeys.has(key));
+  const onlyRight = [...rightKeys].filter((key) => !leftKeys.has(key));
+  if (!onlyLeft.length && !onlyRight.length) return "projection-origin-range";
+  const uriOf = (key) => key.slice(0, key.lastIndexOf("|"));
+  const all = [...onlyLeft, ...onlyRight];
+  if (all.every((key) => isLibFile(uriOf(key)))) return "ts-lib-copy";
+  if (onlyLeft.some((key) => isSvelteShadow(uriOf(key))))
+    return "official-defect-svelte-ts-shadow";
+  if (new Set(all.map(uriOf)).size === 1)
+    return /\.d\.ts$/.test(uriOf(all[0]))
+      ? "projection-target-position-declaration"
+      : "projection-target-position-workspace";
+  const isComponent = (uri) => /\.svelte$/.test(uri);
+  if (onlyLeft.every((key) => isComponent(uriOf(key))) &&
+      onlyRight.every((key) => isComponent(uriOf(key))))
+    return "target-component-vs-import";
+  if (onlyLeft.every((key) => /\.d\.ts$/.test(uriOf(key))) &&
+      onlyRight.every((key) => !/\.d\.ts$/.test(uriOf(key))))
+    return "target-declaration-vs-source";
+  return "target-file-mismatch";
+}
+
+// Which embedded region an offset sits in. A completion item that cites no MDN
+// page cannot be attributed from its own fields, and WHERE the request was made
+// is an input property, so it cannot encode which side is correct.
+const REGION_TAG = /<(style|script)\b[^>]*>|<\/(style|script)\s*>/gi;
+export function regionAt(text, offset) {
+  let region = "markup";
+  let open = null;
+  REGION_TAG.lastIndex = 0;
+  for (let match; (match = REGION_TAG.exec(text)); ) {
+    // The boundary is the outside edge of both tags: an offset inside `<style>`
+    // has not entered the region and one inside `</style>` has not left it.
+    if (match.index + match[0].length > offset) break;
+    if (match[1]) {
+      open = match[1].toLowerCase();
+      region = open;
+    } else if (match[2] && match[2].toLowerCase() === open) {
+      open = null;
+      region = "markup";
+    }
+  }
+  return region;
+}
+
+export function offsetAt(text, position) {
+  const lines = text.split("\n");
+  let offset = 0;
+  for (let line = 0; line < position.line && line < lines.length; line += 1)
+    offset += lines[line].length + 1;
+  return offset + position.character;
+}
+
+export function requestRegion(context) {
+  if (!context?.text || !context?.position) return "unknown";
+  return regionAt(context.text, offsetAt(context.text, context.position));
+}
+
+const COMPLETION_POINTERS = [
+  [
+    /\/commitCharacters:(extra|missing)-rsvelte-field/,
+    (difference) => `completion-commit-characters-presence${directionSuffix(difference)}`,
+  ],
+  [/\/commitCharacters(:|$)/, commitCharacterValueLabel],
+  [/\/command(:|$)/, completionCommandLabel],
+  [/\/(textEdit|additionalTextEdits)(\/|:|$)/, completionTextEditLabel],
+  [/\/data(\/|:|$)/, completionItemDataLabel],
+  [/^\/isIncomplete:/, "completion-is-incomplete"],
+  [/\/(detail|documentation|labelDetails)(\/|:|$)/, completionItemDetailLabel],
+];
+
+// Which provider produced a completion item, read off the item itself: the TS
+// server is the only one that attaches `data`, and the language-data providers
+// cite MDN. A close tag is its own mechanism (rsvelte has no `</` path at all),
+// and its label spelling is the one thing that separates it from an open tag.
+function completionProvider(item, region) {
+  if (item?.data !== undefined) return "ts";
+  // Emmet names itself, and nothing else about the item does: an abbreviation
+  // carries no `kind` and no MDN prose, so the region would read it as html.
+  if (item?.detail === "Emmet Abbreviation") return "emmet";
+  if (typeof item?.label === "string" && item.label.startsWith("/"))
+    return "html-close-tag";
+  const documentation =
+    typeof item?.documentation === "string"
+      ? item.documentation
+      : (item?.documentation?.value ?? "");
+  // Only the `MDN Reference:` line names the item's own area. The HTML `class`
+  // attribute's prose links to `/docs/Web/CSS/Class_selectors`, so a bare
+  // substring test reads it as CSS.
+  const reference = /^MDN Reference: https:\/\/developer\.mozilla\.org\/docs\/Web\/(CSS|HTML|SVG)\//m.exec(
+    documentation,
+  );
+  if (reference) return reference[1].toLowerCase();
+  if (region === "style") return "css";
+  if (region === "markup") return "html";
+  return "other";
+}
+
+const completionItems = (value) =>
+  Array.isArray(value?.items) ? value.items : Array.isArray(value) ? value : [];
+
+function classifyCompletionItemSet(official, rsvelte, difference, region) {
+  const direction = difference.includes(":missing-rsvelte") ? "missing" : "extra";
+  const officialItems = completionItems(official);
+  const rsvelteItems = completionItems(rsvelte);
+  const otherSide = new Set(
+    (direction === "missing" ? rsvelteItems : officialItems).map((item) => item?.label),
+  );
+  const differing = (direction === "missing" ? officialItems : rsvelteItems).filter(
+    (item) => !otherSide.has(item?.label),
+  );
+  // No label is missing: the arrays differ because an item is unpaired on a
+  // pairing-key field, and then NONE of that item's other fields is compared.
+  if (differing.length === 0)
+    return classifyPairingKey(officialItems, rsvelteItems, region);
+  return `completion-item-set-${direction}-${providerOf(differing, region)}`;
+}
+
+// Direction is deliberately absent: one unpaired item produces a `missing` and
+// an `extra` pointer from the same cause, so a directional label would count
+// one mechanism twice under two names.
+function providerOf(items, region) {
+  const providers = new Set(items.map((item) => completionProvider(item, region)));
+  return providers.size === 1 ? [...providers][0] : providers.size === 0 ? "other" : "mixed";
+}
+
+function classifyPairingKey(officialItems, rsvelteItems, region) {
+  const byLabel = new Map();
+  for (const item of officialItems)
+    if (item?.label !== undefined && !byLabel.has(item.label))
+      byLabel.set(item.label, item);
+  const fields = new Set();
+  const differing = [];
+  for (const item of rsvelteItems) {
+    const match = byLabel.get(item?.label);
+    if (!match) continue;
+    let differs = false;
+    for (const field of PAIRING_KEY_FIELDS)
+      if (
+        JSON.stringify(match[field] ?? null) !== JSON.stringify(item[field] ?? null)
+      ) {
+        fields.add(field);
+        differs = true;
+      }
+    // The OFFICIAL item, because `completionProvider` reads `data` and the
+    // language-data prose, and rsvelte is the side that may have dropped them.
+    if (differs) differing.push(match);
+  }
+  if (fields.size === 0) return "completion-item-duplicate-label";
+  const suffix = PAIRING_KEY_FIELDS.filter((field) => fields.has(field))
+    .map((field) => PAIRING_KEY_SLUG[field])
+    .join("+");
+  return `completion-item-pairing-key-${suffix}-${providerOf(differing, region)}`;
+}
+
+// The `@`-segment of a pointer is `identity()` of the item, so the item it
+// names can be recovered on both sides rather than guessed from the response.
+// The index is memoised per payload: one response carries thousands of items
+// and thousands of differences, and hashing the items per difference is
+// quadratic in a place where the run never finishes.
+const itemIndex = new WeakMap();
+function itemsByIdentity(payload) {
+  if (payload === null || typeof payload !== "object") return undefined;
+  let index = itemIndex.get(payload);
+  if (index) return index;
+  index = new Map();
+  for (const item of completionItems(payload)) {
+    const key = identity("textDocument/completion", "/items", item);
+    if (!index.has(key)) index.set(key, item);
+  }
+  itemIndex.set(payload, index);
+  return index;
+}
+
+function itemAtPointer(payload, difference) {
+  const match = /\/items\/@([^/:]+)/.exec(difference);
+  if (!match) return undefined;
+  return itemsByIdentity(payload)?.get(match[1]);
+}
+
+// Upstream appends `(` only at a call location and otherwise passes TypeScript's
+// list through; rsvelte synthesizes one list for every item. The two failures
+// look the same in the pointer and are different mechanisms: one adds a
+// character to the same base, the other has a different base.
+function commitCharacterValueLabel(difference, official, rsvelte) {
+  const left = itemAtPointer(official, difference)?.commitCharacters;
+  const right = itemAtPointer(rsvelte, difference)?.commitCharacters;
+  if (!Array.isArray(left) || !Array.isArray(right))
+    return "completion-commit-characters-value-other";
+  const extra = right.filter((character) => !left.includes(character));
+  const missing = left.filter((character) => !right.includes(character));
+  return missing.length === 0 && extra.length === 1 && extra[0] === "("
+    ? "completion-commit-characters-value-extra-paren"
+    : "completion-commit-characters-value-other";
+}
+
+// A presence divergence has a free direction and the pointer does not carry it,
+// so one label would cover "rsvelte writes a field upstream omits" and its
+// opposite. A ratchet entry suppresses everything its key cannot tell apart.
+function directionSuffix(difference) {
+  if (/:extra-rsvelte-field/.test(difference)) return "-rsvelte-only";
+  if (/:missing-rsvelte-field/.test(difference)) return "-official-only";
+  return "-rsvelte-only";
+}
+
+function completionCommandLabel(difference) {
+  return /\/command:(extra|missing)-rsvelte-field/.test(difference)
+    ? `completion-command-presence${directionSuffix(difference)}`
+    : "completion-command-value";
+}
+
+function completionItemDetailLabel(difference) {
+  const match = /\/(detail|documentation|labelDetails)(:(extra|missing)-rsvelte-field)?/.exec(
+    difference,
+  );
+  const field = match[1] === "labelDetails" ? "label-details" : match[1];
+  return match[2]
+    ? `completion-item-${field}-presence${directionSuffix(difference)}`
+    : `completion-item-${field}-value`;
+}
+
+// `textEdit` and `additionalTextEdits` are separate fields with separate
+// producers, and a range's two endpoints move independently -- a shift and a
+// length change are one key only while both endpoints share a label.
+// The `@completion-<hash>` segment names one item; `diff.mjs` exports the digest
+// so the provider can be read off the item itself rather than off the region,
+// which is only a proxy -- a TypeScript completion inside a `{...}` expression
+// sits in markup.
+function itemForPointer(difference, official, rsvelte) {
+  const named = /\/items\/@(completion-[0-9a-f]+)(\/|:|$)/.exec(difference);
+  if (!named) return null;
+  for (const side of [rsvelte, official])
+    for (const item of completionItems(side))
+      if (identity("textDocument/completion", "/items", item) === named[1]) return item;
+  return null;
+}
+
+function completionTextEditLabel(difference, official, rsvelte, region) {
+  const additional = /\/additionalTextEdits(\/|:|$)/.test(difference);
+  if (/\/(textEdit|additionalTextEdits):(extra|missing)-rsvelte-field/.test(difference))
+    return additional
+      ? `completion-additional-text-edits-presence${directionSuffix(difference)}`
+      : `completion-text-edit-presence${directionSuffix(difference)}`;
+  if (additional) return "completion-additional-text-edits-other";
+  if (/\/newText(:|$)/.test(difference)) {
+    const item = itemForPointer(difference, official, rsvelte);
+    return `completion-text-edit-new-text-${item ? completionProvider(item, region) : "other"}`;
+  }
+  if (/\/(range|insert|replace)\/start(\/|:|$)/.test(difference))
+    return "completion-text-edit-range-start";
+  if (/\/(range|insert|replace)\/end(\/|:|$)/.test(difference))
+    return "completion-text-edit-range-end";
+  if (/\/(range|insert|replace)(\/|:|$)/.test(difference))
+    return "completion-text-edit-range-other";
+  return "completion-text-edit-other";
+}
+
+function completionItemDataLabel(difference) {
+  const match = /\/data\/([^/:[]+)/.exec(difference);
+  switch (match?.[1]) {
+    case "source":
+      return `completion-item-data-source${directionSuffix(difference)}`;
+    case "uri":
+      return "completion-item-data-uri";
+    case "position":
+      return "completion-item-data-position";
+    case "name":
+      return "completion-item-data-name";
+    default:
+      return "completion-item-data-other";
+  }
+}
+
+function classifyCompletion(official, rsvelte, difference, region) {
+  for (const [pattern, label] of COMPLETION_POINTERS)
+    if (pattern.test(difference))
+      return typeof label === "function"
+        ? label(difference, official, rsvelte, region)
+        : label;
+  if (/^\/items:(extra|missing)-rsvelte/.test(difference))
+    return classifyCompletionItemSet(official, rsvelte, difference, region);
+  if (isEmptyResult(official?.items) && !isEmptyResult(rsvelte?.items))
+    return "official-empty";
+  if (!isEmptyResult(official?.items) && isEmptyResult(rsvelte?.items))
+    return "rsvelte-empty";
+  return UNCLASSIFIED;
+}
+
+export function classifyDivergence(method, official, rsvelte, difference, context) {
+  let label;
+  if (method === "textDocument/hover") label = classifyHover(official, rsvelte);
+  else if (method === "textDocument/definition")
+    label = classifyDefinition(official, rsvelte, difference, context?.position);
+  else if (method === "textDocument/completion")
+    label = classifyCompletion(official, rsvelte, difference, requestRegion(context));
+  else label = "unclassified";
+  // A label outside the vocabulary would silently create ratchet keys nobody
+  // can enumerate, so it is a defect in this module rather than a new class.
+  if (!MECHANISM_SET.has(label))
+    throw new Error(`mechanism "${label}" is not in the declared vocabulary`);
+  return label;
+}
+
+export function classifyDivergences(method, official, rsvelte, differences, context) {
+  const labels = new Set();
+  for (const difference of differences)
+    labels.add(classifyDivergence(method, official, rsvelte, difference, context));
+  return [...labels].sort();
+}

--- a/scripts/compat-lsp/mechanism.test.mjs
+++ b/scripts/compat-lsp/mechanism.test.mjs
@@ -1,0 +1,610 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { MECHANISMS, classifyDivergence, regionAt, offsetAt } from "./mechanism.mjs";
+import { identity } from "./diff.mjs";
+
+const hover = (contents) => ({ contents });
+const ts = (text) => hover("```typescript\n" + text + "\n```");
+const plain = (value) => hover({ kind: "plaintext", value });
+const CSS_DOC = plain(
+  "The scale CSS property ...\n\nMDN Reference: https://developer.mozilla.org/docs/Web/CSS/scale",
+);
+const HTML_DOC = plain(
+  "The div element ...\n\nMDN Reference: https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/div",
+);
+const classify = (method, left, right, difference = "/contents:value-mismatch", context) =>
+  classifyDivergence(method, left, right, difference, context);
+
+test("every label the classifier can emit is declared", () => {
+  assert.equal(new Set(MECHANISMS).size, MECHANISMS.length);
+  assert.ok(MECHANISMS.includes("unclassified"));
+});
+
+test("hover: the two language-data providers are told apart", () => {
+  assert.equal(classify("textDocument/hover", CSS_DOC, plain("`scale` CSS property")), "css-data");
+  assert.equal(classify("textDocument/hover", CSS_DOC, null), "css-data");
+  assert.equal(classify("textDocument/hover", HTML_DOC, null), "html-data");
+});
+
+test("hover: language data on one side and TypeScript on the other is routing", () => {
+  assert.equal(classify("textDocument/hover", HTML_DOC, ts("const a: number")), "provider-routing");
+  assert.equal(classify("textDocument/hover", ts("const a: number"), HTML_DOC), "provider-routing");
+});
+
+test("hover: a different symbol is not a rendering difference", () => {
+  assert.equal(
+    classify("textDocument/hover", ts("(method) String.replace(): string"), ts("(method) String.replace(x): string")),
+    "ts-render",
+  );
+  assert.equal(
+    classify("textDocument/hover", ts("var undefined"), ts("(property) undefined: undefined")),
+    "ts-symbol-kind",
+  );
+  assert.equal(
+    classify("textDocument/hover", ts('module "svelte/elements.js"'), ts('module "svelte/elements"')),
+    "ts-symbol-name",
+  );
+});
+
+test("hover: an equal payload leaves only the response range", () => {
+  assert.equal(
+    classify(
+      "textDocument/hover",
+      { contents: "```typescript\nconst a: number\n```", range: { start: { line: 1, character: 0 } } },
+      { contents: "```typescript\nconst a: number\n```", range: { start: { line: 1, character: 4 } } },
+    ),
+    "projection-response-range",
+  );
+});
+
+const link = (uri, line, character) => ({
+  targetUri: uri,
+  targetRange: { start: { line, character }, end: { line, character } },
+  targetSelectionRange: { start: { line, character }, end: { line, character } },
+  originSelectionRange: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+});
+
+test("definition: the TypeScript lib copy is not a target mismatch", () => {
+  assert.equal(
+    classify(
+      "textDocument/definition",
+      [link("file:///nm/typescript/lib/lib.es5.d.ts", 10, 4)],
+      [link("file:///nm/native-preview/lib/lib.es5.d.ts", 10, 4)],
+      ":extra-rsvelte",
+    ),
+    "ts-lib-copy",
+  );
+});
+
+test("definition: a shadow official alone answers about is its own class", () => {
+  assert.equal(
+    classify(
+      "textDocument/definition",
+      [link("file:///ws/a.svelte.ts", 3, 1)],
+      [link("file:///ws/a.svelte", 3, 1)],
+      ":extra-rsvelte",
+    ),
+    "official-defect-svelte-ts-shadow",
+  );
+});
+
+test("definition: same file is a position defect, another file is a target defect", () => {
+  assert.equal(
+    classify("textDocument/definition", [link("file:///ws/a.svelte", 71, 28)], [link("file:///ws/a.svelte", 71, 1)], ":extra-rsvelte"),
+    "projection-target-position-workspace",
+  );
+  // A position inside a `.d.ts` is not the `.svelte` -> `.tsx` projection at all.
+  assert.equal(
+    classify("textDocument/definition", [link("file:///ws/a.d.ts", 71, 28)], [link("file:///ws/a.d.ts", 71, 1)], ":extra-rsvelte"),
+    "projection-target-position-declaration",
+  );
+  assert.equal(
+    classify("textDocument/definition", [link("file:///ws/types.ts", 0, 12)], [link("file:///ws/a.svelte", 71, 1)], ":extra-rsvelte"),
+    "target-file-mismatch",
+  );
+  assert.equal(classify("textDocument/definition", [], [link("file:///ws/a.svelte", 1, 1)], ":extra-rsvelte"), "official-empty");
+  assert.equal(classify("textDocument/definition", [link("file:///ws/a.svelte", 1, 1)], [], ":missing-rsvelte"), "rsvelte-empty");
+});
+
+test("completion: the field the pointer names decides the label", () => {
+  const both = { items: [{ label: "a" }] };
+  // Two mechanisms shared one label: rsvelte appending `(` to upstream's own
+  // list, and the two lists having different bases. The pointer is identical,
+  // so the arrays themselves are what separates them -- and the `@` segment is
+  // `diff.mjs`'s own `identity()`, so the item is recovered rather than guessed.
+  const parenOfficial = { items: [{ label: "a", commitCharacters: [".", ",", ";"] }] };
+  const parenRsvelte = { items: [{ label: "a", commitCharacters: [".", ",", ";", "("] }] };
+  const parenPointer = `/items/@${identity("textDocument/completion", "/items", parenOfficial.items[0])}/commitCharacters:extra-rsvelte-element[count=1,hash=x]`;
+  assert.equal(
+    classify("textDocument/completion", parenOfficial, parenRsvelte, parenPointer),
+    "completion-commit-characters-value-extra-paren",
+  );
+  const baseOfficial = { items: [{ label: "a", commitCharacters: [".", ";"] }] };
+  const basePointer = `/items/@${identity("textDocument/completion", "/items", baseOfficial.items[0])}/commitCharacters:extra-rsvelte-element[count=1,hash=x]`;
+  assert.equal(
+    classify("textDocument/completion", baseOfficial, parenRsvelte, basePointer),
+    "completion-commit-characters-value-other",
+  );
+  // A presence divergence has a free direction the pointer does not carry, so
+  // both directions have to reach different labels or one entry suppresses both.
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/commitCharacters:extra-rsvelte-field[hash=x]"),
+    "completion-commit-characters-presence-rsvelte-only",
+  );
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/commitCharacters:missing-rsvelte-field[hash=x]"),
+    "completion-commit-characters-presence-official-only",
+  );
+  // A `textEdit` and a `data` each carry two mechanisms, and the sub-key is what
+  // separates "a field rsvelte never writes" from "a value both sides compute".
+  // A range's two endpoints move independently: under one label a shift and a
+  // length change are the same key.
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/textEdit/range/end/character:value-mismatch"),
+    "completion-text-edit-range-end",
+  );
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/textEdit/range/start/character:value-mismatch"),
+    "completion-text-edit-range-start",
+  );
+  // `additionalTextEdits` is a different field with a different producer.
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/additionalTextEdits:missing-rsvelte-field[hash=x]"),
+    "completion-additional-text-edits-presence-official-only",
+  );
+  // `detail` and `documentation` reached one label in both directions.
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/detail:extra-rsvelte-field[hash=x]"),
+    "completion-item-detail-presence-rsvelte-only",
+  );
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/documentation:missing-rsvelte-field[hash=x]"),
+    "completion-item-documentation-presence-official-only",
+  );
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/labelDetails/description:value-mismatch"),
+    "completion-item-label-details-value",
+  );
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/command:extra-rsvelte-field[hash=x]"),
+    "completion-command-presence-rsvelte-only",
+  );
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/command:missing-rsvelte-field[hash=x]"),
+    "completion-command-presence-official-only",
+  );
+  // `@x` names no item, so the provider cannot be read and must not be guessed.
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/textEdit/newText:value-mismatch"),
+    "completion-text-edit-new-text-other",
+  );
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/textEdit:extra-rsvelte-field[hash=x]"),
+    "completion-text-edit-presence-rsvelte-only",
+  );
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/data/source:missing-rsvelte-field[hash=x]"),
+    "completion-item-data-source-official-only",
+  );
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/data/uri:value-mismatch[official=a,rsvelte=b]"),
+    "completion-item-data-uri",
+  );
+  assert.equal(
+    classify("textDocument/completion", both, both, "/items/@x/data:missing-rsvelte-field[hash=x]"),
+    "completion-item-data-other",
+  );
+  // A real set difference: the label is on one side only, so the item-set
+  // classifier runs. Identical arrays would route to the pairing-key branch.
+  assert.equal(
+    classify(
+      "textDocument/completion",
+      { items: [{ label: "a" }, { label: "b" }] },
+      both,
+      "/items:missing-rsvelte-element[count=1,hash=x]",
+    ),
+    "completion-item-set-missing-other",
+  );
+  assert.equal(classify("textDocument/completion", both, both, "/isIncomplete:value-mismatch"), "completion-is-incomplete");
+});
+
+const mdn = (area, name) => ({
+  kind: "plaintext",
+  value: `MDN Reference: https://developer.mozilla.org/docs/Web/${area}/Reference/${name}`,
+});
+
+test("completion item set: the provider of the differing items names the mechanism", () => {
+  const tagItem = (label) => ({ label, kind: 10, documentation: mdn("HTML", label) });
+  const cssItem = (label) => ({ label, kind: 10, documentation: mdn("CSS", label) });
+  const tsItem = (label) => ({ label, kind: 6, data: { name: label } });
+  const set = (...items) => ({ items });
+
+  // A provider each, missing on the rsvelte side.
+  assert.equal(
+    classify("textDocument/completion", set(tagItem("nav")), set(), "/items:missing-rsvelte-element[count=1,hash=x]"),
+    "completion-item-set-missing-html",
+  );
+  assert.equal(
+    classify("textDocument/completion", set(cssItem("float")), set(), "/items:missing-rsvelte-element[count=1,hash=x]"),
+    "completion-item-set-missing-css",
+  );
+  assert.equal(
+    classify("textDocument/completion", set(tsItem("Window")), set(), "/items:missing-rsvelte-element[count=1,hash=x]"),
+    "completion-item-set-missing-ts",
+  );
+  // A close tag carries HTML documentation too, so only the `/` separates it.
+  assert.equal(
+    classify("textDocument/completion", set(tagItem("/nav")), set(), "/items:missing-rsvelte-element[count=1,hash=x]"),
+    "completion-item-set-missing-html-close-tag",
+  );
+  // Direction is part of the mechanism: the same item on the other side.
+  assert.equal(
+    classify("textDocument/completion", set(), set(cssItem("-webkit-alt")), "/items:extra-rsvelte-element[count=1,hash=x]"),
+    "completion-item-set-extra-css",
+  );
+  // Two providers in one difference is its own label, not either one of them.
+  assert.equal(
+    classify("textDocument/completion", set(tagItem("nav"), tsItem("Window")), set(), "/items:missing-rsvelte-element[count=1,hash=x]"),
+    "completion-item-set-missing-mixed",
+  );
+  // Emmet names itself in `detail`. Nothing else does: the abbreviation has no
+  // `kind` and no MDN prose, so the region alone would file it under html and it
+  // would land in `mixed` beside a real tag gap.
+  const emmetItem = (label) => ({ label, detail: "Emmet Abbreviation", insertTextFormat: 2 });
+  assert.equal(
+    classify("textDocument/completion", set(emmetItem("Card.Title>R")), set(), "/items:missing-rsvelte-element[count=1,hash=x]"),
+    "completion-item-set-missing-emmet",
+  );
+  // The control that makes the marker load-bearing: the same shape without it.
+  assert.equal(
+    classifyDivergence(
+      "textDocument/completion",
+      set({ label: "Card.Title>R", insertTextFormat: 2 }),
+      set(),
+      "/items:missing-rsvelte-element[count=1,hash=x]",
+      { text: "<div a></div>\n", position: { line: 0, character: 5 } },
+    ),
+    "completion-item-set-missing-html",
+  );
+  // And an emmet item beside a real tag gap is `mixed`, not either one.
+  assert.equal(
+    classify("textDocument/completion", set(emmetItem("s"), tagItem("nav")), set(), "/items:missing-rsvelte-element[count=1,hash=x]"),
+    "completion-item-set-missing-mixed",
+  );
+});
+
+test("ts-render: each of the four tsgo renderings is its own label", () => {
+  const hover = (text) => ({ contents: text });
+  const render = (left, right) =>
+    classify("textDocument/hover", hover(left), hover(right), "/contents:value-mismatch");
+  assert.equal(
+    render('const a: "value" | "highlighted"', 'const a: "highlighted" | "value"'),
+    "ts-render-union-order",
+  );
+  assert.equal(
+    render('const a: ReturnType<import("svelte").Snippet>', "const a: ReturnType<import('svelte').Snippet>"),
+    "ts-render-quote-style",
+  );
+  assert.equal(
+    render("(local function) classes(list: string): string[]", "function classes(list: string): string[]"),
+    "ts-render-local-modifier",
+  );
+  assert.equal(
+    render("const flagged: false", "const flagged: false\n\n*@default* — false"),
+    "ts-render-jsdoc-tag",
+  );
+  // Not one of the renderings: the two agree on how to print a type and disagree
+  // about which type it is. Naming the shape is not attributing it -- the label
+  // says what differs, and the terminal is decided separately.
+  assert.equal(render("const controls: Writable<{", "const controls: any"), "ts-type-any");
+});
+
+test("definition target: a component import and a declaration file are two mechanisms", () => {
+  const at = (uri, line) => ({ uri, range: { start: { line, character: 0 } } });
+  assert.equal(
+    classify(
+      "textDocument/definition",
+      [at("file:///ws/components/preview.svelte", 0)],
+      [at("file:///ws/previews/SpatialMenu.svelte", 2)],
+      ":extra-rsvelte",
+    ),
+    "target-component-vs-import",
+  );
+  assert.equal(
+    classify(
+      "textDocument/definition",
+      [at("file:///ws/node_modules/svelte/types/index.d.ts", 1876)],
+      [at("file:///ws/node_modules/svelte/src/easing/index.js", 9)],
+      ":extra-rsvelte",
+    ),
+    "target-declaration-vs-source",
+  );
+});
+
+test("definition: an empty official answer splits on whether rsvelte pointed at the request", () => {
+	const link = (startLine, startChar, endLine, endChar) => [
+		{
+			targetUri: "file:///a.svelte",
+			targetSelectionRange: {
+				start: { line: startLine, character: startChar },
+				end: { line: endLine, character: endChar },
+			},
+		},
+	];
+	const at = (line, character) => ({ text: "", position: { line, character } });
+	// `{...restProps}` at 14:6 -- rsvelte answers with `restProps` itself.
+	assert.equal(
+		classifyDivergence("textDocument/definition", [], link(14, 5, 14, 14), ":extra-rsvelte-element[count=1,hash=x]", at(14, 6)),
+		"official-empty-target-is-the-request",
+	);
+	// `type ListItemProps = {` asked at the `type` keyword -- rsvelte answers with
+	// the NAME, which does not cover the keyword. The sampled residue is exactly
+	// this shape: `type`, `as`, and Svelte's `snippet`.
+	assert.equal(
+		classifyDivergence("textDocument/definition", [], link(42, 6, 42, 19), ":extra-rsvelte-element[count=1,hash=x]", at(42, 2)),
+		"official-empty",
+	);
+	// With no position the split cannot be made, and must not be guessed.
+	assert.equal(
+		classifyDivergence("textDocument/definition", [], link(14, 5, 14, 14), ":extra-rsvelte-element[count=1,hash=x]", { text: "" }),
+		"official-empty",
+	);
+});
+
+test("completion new text: the provider comes from the item the pointer names", () => {
+	const mdn = (area, name) => ({
+		kind: "plaintext",
+		value: `MDN Reference: https://developer.mozilla.org/docs/Web/${area}/Reference/Global_attributes/${name}`,
+	});
+	// The two arms measured on this label: an HTML attribute whose official
+	// `newText` carries the `="$1"` snippet, and a module specifier official
+	// trims to the part after the word range.
+	const attribute = { label: "accesskey", kind: 12, documentation: mdn("HTML", "accesskey") };
+	const specifier = { label: "components", kind: 9, data: { name: "components" } };
+	const pointerFor = (item) =>
+		`/items/@${identity("textDocument/completion", "/items", item)}/textEdit/newText:value-mismatch`;
+	const list = (...items) => ({ items });
+	assert.equal(
+		classifyDivergence(
+			"textDocument/completion",
+			list(attribute),
+			list(attribute),
+			pointerFor(attribute),
+			{ text: "<div a></div>\n", position: { line: 0, character: 5 } },
+		),
+		"completion-text-edit-new-text-html",
+	);
+	// The same request position, a different item: the region is markup for both,
+	// so a region-based split would call this one html too.
+	assert.equal(
+		classifyDivergence(
+			"textDocument/completion",
+			list(specifier),
+			list(specifier),
+			pointerFor(specifier),
+			{ text: "<div a></div>\n", position: { line: 0, character: 5 } },
+		),
+		"completion-text-edit-new-text-ts",
+	);
+});
+
+test("hover: an empty rsvelte answer whose official half is only an import line", () => {
+	const ts = (...lines) => ({ contents: ["```typescript", ...lines, "```"].join("\n") });
+	// 21 of 23 sampled `rsvelte-empty` hovers are this: official's entire answer
+	// is the origin line tsgo drops, so dropping it leaves nothing to send.
+	assert.equal(
+		classify("textDocument/hover", ts("import NavigationMenu"), null),
+		"rsvelte-empty-import-only",
+	);
+	// One more line and it is not the same thing: tsgo had something to answer
+	// with and answered nothing anyway.
+	assert.equal(
+		classify("textDocument/hover", ts('(alias) const Example: Component<{}, {}, "">', "import Example"), null),
+		"rsvelte-empty",
+	);
+	// And a declaration that merely mentions an import is not an import line.
+	assert.equal(
+		classify("textDocument/hover", ts("const imported: number"), null),
+		"rsvelte-empty",
+	);
+});
+
+test("ts render: a rewrite names the mechanism only when it is the only one that fits", () => {
+	const hover = (contents) => ({ contents });
+	const ts = (...lines) => hover(["```typescript", ...lines, "```"].join("\n"));
+
+	// tsc names the import a symbol came through; tsgo omits the line.
+	assert.equal(
+		classify(
+			"textDocument/hover",
+			ts("(alias) type SelectGroupProps = any", "import SelectGroupProps"),
+			ts("(alias) type SelectGroupProps = any"),
+		),
+		"ts-render-import-line",
+	);
+	// tsc counts the overloads it did not print.
+	assert.equal(
+		classify(
+			"textDocument/hover",
+			ts("function $state<false>(initial: false): false (+1 overload)"),
+			ts("function $state<false>(initial: false): false"),
+		),
+		"ts-render-overload-count",
+	);
+	// Both at once. This is the order-freeness control: under a first-match loop
+	// this input took whichever label sat higher in the table, so the ratchet key
+	// depended on the order the rules happened to be written in.
+	const compound = () =>
+		classify(
+			"textDocument/hover",
+			ts("(method) Array.from<unknown>(): unknown[] (+3 overloads)", "import Array"),
+			ts("(method) Array.from<unknown>(): unknown[]"),
+		);
+	assert.equal(compound(), "ts-render-multiple");
+	// Neither constituent label may claim it.
+	for (const label of ["ts-render-overload-count", "ts-render-import-line"])
+		assert.notEqual(compound(), label);
+	// A merged symbol prints one line per declaration and the two disagree on the
+	// order. `svelte/types/index.d.ts` declares every rune as a function plus a
+	// namespace, so this reaches a hover on `$props` in any component.
+	assert.equal(
+		classify(
+			"textDocument/hover",
+			ts("namespace $props", "function $props(): any"),
+			ts("function $props(): any", "namespace $props"),
+		),
+		"ts-render-declaration-order",
+	);
+	// Only the fenced block is sorted: prose below it cannot be reordered into
+	// equality, or two different explanations would read as one mechanism.
+	assert.equal(
+		classify(
+			"textDocument/hover",
+			hover(ts("namespace $props").contents + "\n---\nalpha\nbeta"),
+			hover(ts("namespace $props").contents + "\n---\nbeta\nalpha"),
+		),
+		"ts-render",
+	);
+	// The same declaration with the type erased is not a rendering difference.
+	assert.equal(
+		classify(
+			"textDocument/hover",
+			ts("let className: ClassValue | null | undefined"),
+			ts("let className: any"),
+		),
+		"ts-type-any",
+	);
+	// The control that keeps `ts-type-any` from swallowing a different symbol:
+	// the name differs too, so no rewrite and no `any` rule may claim it.
+	assert.equal(
+		classify("textDocument/hover", ts("let className: any"), ts("let other: any")),
+		"ts-symbol-name",
+	);
+});
+
+test("region: the boundary is the outside edge of both tags", () => {
+  const text = '<div a></div>\n<style>\n  a { }\n</style>\n<script>\n  let x;\n</script>\n';
+  const at = (line, character) => regionAt(text, offsetAt(text, { line, character }));
+  assert.equal(at(0, 5), "markup");
+  assert.equal(at(2, 4), "style");
+  assert.equal(at(5, 7), "script");
+  // Inside `<style` the region has not been entered yet, and inside `</style`
+  // it has not been left: the same rule read from both sides.
+  assert.equal(at(1, 3), "markup");
+  assert.equal(at(3, 2), "style");
+});
+
+test("completion item set: the same MDN-less item is css in a style block and html in markup", () => {
+  // `initial` and `data-` cite no MDN page, so nothing on the item itself can
+  // attribute them -- only where the request was made.
+  const official = { items: [{ label: "initial", kind: 12 }] };
+  const rsvelte = { items: [] };
+  const difference = "/items:missing-rsvelte[count=1,hash=0]";
+  const text = '<div a></div>\n<style>\n  a { color: i }\n</style>\n';
+  const inStyle = classifyDivergence("textDocument/completion", official, rsvelte, difference, {
+    text,
+    position: { line: 2, character: 13 },
+  });
+  const inMarkup = classifyDivergence("textDocument/completion", official, rsvelte, difference, {
+    text,
+    position: { line: 0, character: 6 },
+  });
+  assert.equal(inStyle, "completion-item-set-missing-css");
+  assert.equal(inMarkup, "completion-item-set-missing-html");
+  // Without the context the axis is unavailable, and the item stays in the
+  // residual class -- which is what the arm before this one measured.
+  assert.equal(
+    classifyDivergence("textDocument/completion", official, rsvelte, difference),
+    "completion-item-set-missing-other",
+  );
+});
+
+test("hover: an empty rsvelte answer splits on whether official hovered the shadow", () => {
+  const ts = (text) => ({ contents: "```typescript\n" + text + "\n```" });
+  // official hovers svelte2tsx's own synthesized function, which exists in no
+  // editor the user has open.
+  assert.equal(
+    classify("textDocument/hover", ts("function $$render(): { props: $$ComponentProps; }"), null),
+    "official-defect-svelte-ts-shadow",
+  );
+  // The same `$$` appears in a real symbol's TYPE, and that hover is about the
+  // user's own declaration -- a text-wide `$$` test would take both.
+  assert.equal(
+    classify("textDocument/hover", ts('(alias) const Example: Component<$$ComponentProps, {}, "">'), null),
+    "rsvelte-empty",
+  );
+  // An import-only body is its own label: the shadow test must not claim it.
+  assert.equal(
+    classify("textDocument/hover", ts("import RadioGroup"), null),
+    "rsvelte-empty-import-only",
+  );
+});
+
+test("completion: a label on both sides with a differing pairing-key field is its own mechanism", () => {
+  const pointer = "/items:missing-rsvelte-element[count=1,hash=x]";
+  // `diff.mjs` never pairs these two, so the arrays differ while the label sets
+  // agree -- and none of the item's other fields is ever compared.
+  // The provider is part of the key: a TypeScript item's `kind` is the recorded
+  // tsgo divergence and an HTML tag's `kind` is rsvelte's own defect, and one
+  // label cannot carry both terminals.
+  assert.equal(
+    classify(
+      "textDocument/completion",
+      { items: [{ label: "name", kind: 21, sortText: "16", data: { name: "name" } }] },
+      { items: [{ label: "name", kind: 6, sortText: "16", data: { name: "name" } }] },
+      pointer,
+    ),
+    "completion-item-pairing-key-kind-ts",
+  );
+  assert.equal(
+    classify(
+      "textDocument/completion",
+      { items: [{ label: "hr", kind: 6 }] },
+      { items: [{ label: "hr", kind: 10 }] },
+      pointer,
+      { text: "<div></div>", position: { line: 0, character: 5 } },
+    ),
+    "completion-item-pairing-key-kind-html",
+  );
+  assert.equal(
+    classify(
+      "textDocument/completion",
+      { items: [{ label: "name", kind: 21, sortText: "z16", data: { name: "name" } }] },
+      { items: [{ label: "name", kind: 6, sortText: "16", data: { name: "name" } }] },
+      pointer,
+    ),
+    "completion-item-pairing-key-kind+sort-text-ts",
+  );
+  // Same key on every shared label: the arrays can then only differ by how many
+  // times a label appears.
+  assert.equal(
+    classify(
+      "textDocument/completion",
+      { items: [{ label: "name", kind: 6 }, { label: "name", kind: 6 }] },
+      { items: [{ label: "name", kind: 6 }] },
+      pointer,
+    ),
+    "completion-item-duplicate-label",
+  );
+});
+
+test("completion item set: an HTML attribute whose prose links to CSS is still html", () => {
+  // Real documentation for the `class` attribute: the body cites
+  // `/docs/Web/CSS/Class_selectors` and only the reference line names its area.
+  const documentation = [
+    "A space-separated list of the classes of the element. Classes allows CSS and",
+    "JavaScript to select and access specific elements via the",
+    "[class selectors](https://developer.mozilla.org/docs/Web/CSS/Class_selectors).",
+    "",
+    "MDN Reference: https://developer.mozilla.org/docs/Web/HTML/Reference/Global_attributes/class",
+  ].join("\n");
+  assert.equal(
+    classify(
+      "textDocument/completion",
+      { items: [] },
+      { items: [{ label: "class", kind: 12, documentation: { kind: "plaintext", value: documentation } }] },
+      "/items:extra-rsvelte-element[count=1,hash=x]",
+    ),
+    "completion-item-set-extra-html",
+  );
+});

--- a/scripts/compat-lsp/merge-current.mjs
+++ b/scripts/compat-lsp/merge-current.mjs
@@ -27,6 +27,7 @@ const merged = mergeCurrentArtifacts(
   floor,
 );
 const baseline = path.join(ROOT, "compatibility/lsp-known-failures.json");
+const sidecar = path.join(ROOT, "compatibility/lsp-mechanisms.json");
 if (UPDATE) {
   const temporary = `${baseline}.${process.pid}.tmp`;
   fs.writeFileSync(
@@ -36,6 +37,27 @@ if (UPDATE) {
   fs.renameSync(temporary, baseline);
   console.log(
     `[lsp-merge] wrote ${merged.current.length} entries to ${path.relative(ROOT, baseline)}`,
+  );
+  // The two files are written by one command on purpose: a sidecar refreshed
+  // separately from the ratchet is a map of a population that no longer exists,
+  // and nothing downstream could tell the two apart.
+  const document = JSON.parse(fs.readFileSync(sidecar, "utf8"));
+  const labels = new Set(Object.values(merged.mechanisms).flat());
+  for (const label of [...labels].sort())
+    document.mechanisms[label] ??= { terminal: null };
+  document.entries = Object.fromEntries(
+    Object.entries(merged.mechanisms).sort(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  );
+  const sidecarTemporary = `${sidecar}.${process.pid}.tmp`;
+  fs.writeFileSync(
+    sidecarTemporary,
+    JSON.stringify(document, null, "\t") + "\n",
+  );
+  fs.renameSync(sidecarTemporary, sidecar);
+  console.log(
+    `[lsp-merge] wrote ${Object.keys(document.entries).length} mechanism sets over ${labels.size} labels to ${path.relative(ROOT, sidecar)}`,
   );
 } else {
   const known = JSON.parse(fs.readFileSync(baseline, "utf8"));

--- a/scripts/compat-lsp/ratchet.mjs
+++ b/scripts/compat-lsp/ratchet.mjs
@@ -4,20 +4,25 @@ import { OPEN_PHASE } from "./edits.mjs";
 const digest = (value) =>
   createHash("sha256").update(JSON.stringify(value)).digest("hex").slice(0, 16);
 
-export function compactCorpusObservation(method, position, differences) {
+export function compactCorpusObservation(
+  method,
+  position,
+  differences,
+  mechanisms = [],
+) {
   return {
     method,
     position,
     diffDigest: digest([...differences].sort()),
     fieldCount: differences.length,
+    mechanisms: [...mechanisms].sort(),
   };
 }
 
-export function aggregateCorpusDifferences(
-  fileId,
-  observations,
-  phase = OPEN_PHASE,
-) {
+// One grouping serves both public projections: an id and its mechanism set are
+// two readings of the same aggregate, and deriving them separately would be two
+// ports of one rule.
+function aggregateCorpus(fileId, observations, phase) {
   const byMethod = new Map();
   for (const observation of observations) {
     byMethod.set(observation.method, [
@@ -29,21 +34,9 @@ export function aggregateCorpusDifferences(
   for (const [method, values] of [...byMethod].sort(([left], [right]) =>
     left.localeCompare(right),
   )) {
-    const normalized = values
-      .map((value) =>
-        value.diffDigest
-          ? {
-              position: value.position,
-              diffDigest: value.diffDigest,
-              fieldCount: value.fieldCount,
-            }
-          : compactCorpusObservation(
-              value.method,
-              value.position,
-              value.differences,
-            ),
-      )
-      .sort((left, right) => left.position.localeCompare(right.position));
+    const mechanisms = new Set();
+    for (const value of values)
+      for (const mechanism of value.mechanisms ?? []) mechanisms.add(mechanism);
     // The request count does not reproduce either, and it never discriminated:
     // `fileId|method|phase` is already unique, so dropping it leaves all 23,890
     // committed keys. Two CI runs whose merge refs share a `main` parent and
@@ -52,9 +45,31 @@ export function aggregateCorpusDifferences(
     // of the key the same pair of runs is 0 and 0. It was sensitivity without
     // direction: a shrink and a growth are both one NEW and one STALE.
     const stage = phase === OPEN_PHASE ? "" : `|phase=${phase}`;
-    entries.push(`aggregate:${fileId}|${method}${stage}`);
+    entries.push({
+      id: `aggregate:${fileId}|${method}${stage}`,
+      mechanisms: [...mechanisms].sort(),
+    });
   }
   return entries;
+}
+
+export function aggregateCorpusDifferences(
+  fileId,
+  observations,
+  phase = OPEN_PHASE,
+) {
+  return aggregateCorpus(fileId, observations, phase).map((entry) => entry.id);
+}
+
+// The mechanism set is a property of the aggregate, not of the key: it is
+// carried beside the ratchet rather than inside it, because a label in the key
+// would multiply one entry into its ~6 mechanisms.
+export function aggregateCorpusMechanisms(
+  fileId,
+  observations,
+  phase = OPEN_PHASE,
+) {
+  return aggregateCorpus(fileId, observations, phase);
 }
 
 export function baselineRewriteReasons(

--- a/scripts/compat-lsp/verify.mjs
+++ b/scripts/compat-lsp/verify.mjs
@@ -25,7 +25,12 @@ import { createCurrentArtifact, recordsFixtureControls } from "./artifacts.mjs";
 import { EDIT_PHASES, OPEN_PHASE, editChanges } from "./edits.mjs";
 import { diffJson } from "./diff.mjs";
 import {
-  aggregateCorpusDifferences,
+  MECHANISMS,
+  UNCLASSIFIED,
+  classifyDivergence,
+} from "./mechanism.mjs";
+import {
+  aggregateCorpusMechanisms,
   assertNonemptySuites,
   baselineRewriteReasons,
   compactCorpusObservation,
@@ -54,6 +59,38 @@ if (UPDATE)
     "direct --update-baseline is disabled; merge the complete fixture and eight corpus artifacts with merge-current.mjs --update-baseline",
   );
 const SHOW = Number(argValue("--show") ?? 30);
+// One label per divergence, so the histogram sums to the divergent-field count
+// and a classifier that stops discriminating shows up as `unclassified` growth.
+const mechanismCounts = new Map();
+let corpusDivergentFields = 0;
+function countMechanism(method, mechanism) {
+  const key = `${method}|${mechanism}`;
+  mechanismCounts.set(key, (mechanismCounts.get(key) ?? 0) + 1);
+}
+function reportMechanisms() {
+  const total = [...mechanismCounts.values()].reduce((a, b) => a + b, 0);
+  if (total === 0) return;
+  // The labels must PARTITION the divergences: a classifier that drops or
+  // double-counts one reads as a mechanism that shrank.
+  if (total !== corpusDivergentFields) {
+    throw new Error(
+      `mechanism labels do not partition the corpus divergences: ${total} labelled, ${corpusDivergentFields} measured`,
+    );
+  }
+  const unclassified = [...mechanismCounts]
+    .filter(([key]) => key.endsWith("|unclassified"))
+    .reduce((a, [, value]) => a + value, 0);
+  console.log(
+    `[lsp-verify] corpus divergence mechanisms: ${total} labelled, ${unclassified} unclassified (${((100 * unclassified) / total).toFixed(1)}%), vocabulary ${MECHANISMS.length}`,
+  );
+  for (const [key, value] of [...mechanismCounts].sort(
+    (left, right) => right[1] - left[1],
+  )) {
+    console.log(
+      `[lsp-verify]   ${String(value).padStart(7)}  ${((100 * value) / total).toFixed(1).padStart(5)}%  ${key}`,
+    );
+  }
+}
 const CONCURRENCY = Number(
   argValue("--concurrency") ?? process.env.LSP_CONCURRENCY ?? 32,
 );
@@ -340,6 +377,15 @@ const ORACLE_REPRODUCTION_FLOOR = 0.7;
 const oracleCalibration = new Map();
 
 const current = [];
+// Beside the ratchet, never inside its key. An entry carries a SET of
+// mechanisms, so a label in the key would multiply the entry, and picking one
+// label per entry would need a precedence rule the data cannot supply.
+const mechanismsById = new Map();
+const recordMechanisms = (id, mechanisms) => {
+  const seen = mechanismsById.get(id) ?? new Set();
+  for (const mechanism of mechanisms) seen.add(mechanism);
+  mechanismsById.set(id, seen);
+};
 const newDiagnosticDetails = new Map();
 const counts = {
   total: population.skipped.length,
@@ -362,6 +408,15 @@ let completedRequests = 0;
 let progressStarted = 0;
 let lastProgressAt = 0;
 
+// One read per file: the completion classifier needs the region a request sits
+// in, and re-reading per request would be 72k reads.
+const sourceTexts = new WeakMap();
+function sourceOf(entry) {
+  if (!sourceTexts.has(entry))
+    sourceTexts.set(entry, entry.text ?? entry.loadText());
+  return sourceTexts.get(entry);
+}
+
 function record(
   kind,
   entry,
@@ -380,20 +435,41 @@ function record(
     counts.divergent++;
     counts.divergentFields += differences.length;
     if (entry.suite === "corpus") {
+      const mechanisms = new Set();
+      corpusDivergentFields += differences.length;
+      for (const difference of differences) {
+        const mechanism = classifyDivergence(
+          request.method,
+          left,
+          right,
+          difference,
+          { text: sourceOf(entry), position: request.params?.position },
+        );
+        countMechanism(request.method, mechanism);
+        mechanisms.add(mechanism);
+      }
       corpusObservations.push(
-        compactCorpusObservation(request.method, request.suffix, differences),
+        compactCorpusObservation(request.method, request.suffix, differences, [
+          ...mechanisms,
+        ].sort()),
       );
     } else {
       const requestKey = keyFor(kind, entry, request, phase);
       for (const difference of differences) {
-        const key = `${requestKey}|${difference}`;
+        // The classifier reads the `-element` / `-field` suffix and it must not
+        // reach the key: a respelling makes every committed entry stale at once,
+        // so it lands with its re-baseline rather than on its own.
+        const key = `${requestKey}|${difference.replace(/-rsvelte-(?:element|field)/, "-rsvelte")}`;
         current.push(key);
-        // A diagnostic array is collapsed to count + identity hash in the
-        // ratchet key. Keep the normalized values only for a newly observed
-        // fixture key, so CI says which diagnostic appeared instead of merely
-        // saying that the count changed. Corpus responses are intentionally
-        // excluded: they can contain project text and are aggregated before
-        // ratcheting anyway.
+        // `classifyDivergence` runs on the corpus branch only, and its context
+        // is that branch's source text. An empty set here would read as "no
+        // mechanism", which under the attribution rule reads as "nothing
+        // rsvelte-side", so the absence is spelled rather than left blank.
+        recordMechanisms(key, [UNCLASSIFIED]);
+        // Keep the normalized diagnostic values for a newly observed fixture
+        // key, so CI says which diagnostic appeared. Corpus responses are
+        // intentionally excluded: they can contain project text and are
+        // aggregated before ratcheting anyway.
         if (
           request.method === "textDocument/diagnostic" &&
           !knownBaselineSet.has(key)
@@ -889,9 +965,14 @@ async function main() {
         phase,
       );
       if (entry.suite === "corpus")
-        current.push(
-          ...aggregateCorpusDifferences(entry.id, corpusObservations, phase),
-        );
+        for (const aggregate of aggregateCorpusMechanisms(
+          entry.id,
+          corpusObservations,
+          phase,
+        )) {
+          current.push(aggregate.id);
+          recordMechanisms(aggregate.id, aggregate.mechanisms);
+        }
     }
     const close = {
       jsonrpc: "2.0",
@@ -949,6 +1030,8 @@ async function main() {
     `[lsp-verify] ${cases.length} cases; ${counts.compared}/${counts.total} compared, ${counts.divergent} divergent requests / ${counts.divergentFields} divergent fields, ${counts.skipped} skipped`,
   );
 
+  reportMechanisms();
+
   // Before the artifact, not after: a run measured against a degraded oracle
   // must leave nothing that `merge-current.mjs` could accept.
   assertOracleCalibration(calibration);
@@ -964,6 +1047,9 @@ async function main() {
       population: measuredPopulation,
       current,
       counts,
+      mechanisms: Object.fromEntries(
+        [...mechanismsById].map(([id, labels]) => [id, [...labels]]),
+      ),
       diagnosticDetails: Object.fromEntries(newDiagnosticDetails),
     });
     fs.mkdirSync(path.dirname(path.resolve(WRITE_CURRENT)), {

--- a/scripts/dev/test-lsp-mechanisms-check.mjs
+++ b/scripts/dev/test-lsp-mechanisms-check.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// Positive control for `scripts/ci/lsp-mechanisms-check.mjs`. The checker's
+// only observable pass is silence, so each case introduces exactly one defect
+// and asserts the checker reddens on it — and one case asserts a well-formed
+// sidecar passes, which is the half a red-only suite never measures.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const CHECKER = path.join(ROOT, "scripts/ci/lsp-mechanisms-check.mjs");
+const EXISTING_REPORT = "upstream_issues/README.md";
+
+function run(ratchet, sidecar) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lsp-mech-"));
+  fs.writeFileSync(
+    path.join(dir, "lsp-known-failures.json"),
+    JSON.stringify(ratchet),
+  );
+  fs.writeFileSync(
+    path.join(dir, "lsp-mechanisms.json"),
+    JSON.stringify(sidecar),
+  );
+  const result = spawnSync(process.execPath, [CHECKER], {
+    encoding: "utf8",
+    env: { ...process.env, LSP_MECHANISMS_DIR: dir },
+  });
+  fs.rmSync(dir, { recursive: true, force: true });
+  return { code: result.status, out: `${result.stdout}${result.stderr}` };
+}
+
+const wellFormed = {
+  ratchet: ["aggregate:corpus/a.svelte|textDocument/hover"],
+  sidecar: {
+    mechanisms: {
+      "ts-render": { terminal: EXISTING_REPORT },
+      "ts-lib-copy": { terminal: "deliberate-divergences" },
+      unclassified: { terminal: null },
+    },
+    entries: {
+      "aggregate:corpus/a.svelte|textDocument/hover": [
+        "ts-render",
+        "ts-lib-copy",
+      ],
+    },
+  },
+};
+
+const cases = [
+  ["a well-formed sidecar passes", wellFormed, 0, /1 ratchet entries/],
+  [
+    "an uncovered ratchet entry fails",
+    { ...wellFormed, ratchet: [...wellFormed.ratchet, "differential:x|y|z:v"] },
+    1,
+    /carry no mechanism set/,
+  ],
+  [
+    "a sidecar id the ratchet does not list fails",
+    { ...wellFormed, ratchet: [] },
+    1,
+    /the ratchet does not list/,
+  ],
+  [
+    "an empty mechanism set fails",
+    {
+      ...wellFormed,
+      sidecar: {
+        ...wellFormed.sidecar,
+        entries: { "aggregate:corpus/a.svelte|textDocument/hover": [] },
+      },
+    },
+    1,
+    /an absence must be spelled/,
+  ],
+  [
+    "an undeclared label fails",
+    {
+      ...wellFormed,
+      sidecar: {
+        ...wellFormed.sidecar,
+        mechanisms: { "ts-render": { terminal: EXISTING_REPORT } },
+      },
+    },
+    1,
+    /undeclared mechanism label/,
+  ],
+  [
+    "a label outside the classifier's vocabulary fails",
+    {
+      ...wellFormed,
+      sidecar: {
+        ...wellFormed.sidecar,
+        mechanisms: {
+          ...wellFormed.sidecar.mechanisms,
+          "invented-label": { terminal: null },
+        },
+      },
+    },
+    1,
+    /the classifier cannot emit/,
+  ],
+  [
+    "a terminal naming a file that does not exist fails",
+    {
+      ...wellFormed,
+      sidecar: {
+        ...wellFormed.sidecar,
+        mechanisms: {
+          ...wellFormed.sidecar.mechanisms,
+          "ts-render": { terminal: "upstream_issues/not-a-report.md" },
+        },
+      },
+    },
+    1,
+    /which does not exist/,
+  ],
+  [
+    "a terminal that is neither a path nor the anchor fails",
+    {
+      ...wellFormed,
+      sidecar: {
+        ...wellFormed.sidecar,
+        mechanisms: {
+          ...wellFormed.sidecar.mechanisms,
+          "ts-render": { terminal: "rsvelte" },
+        },
+      },
+    },
+    1,
+    /expected an upstream_issues\/ path/,
+  ],
+];
+
+let failures = 0;
+for (const [name, input, expected, pattern] of cases) {
+  const { code, out } = run(input.ratchet, input.sidecar);
+  try {
+    assert.equal(code, expected, `${name}: exit ${code}, expected ${expected}`);
+    assert.match(out, pattern, `${name}: output did not match ${pattern}`);
+    console.log(`ok   ${name}`);
+  } catch (error) {
+    failures++;
+    console.error(`FAIL ${name}\n${error.message}\n${out}`);
+  }
+}
+
+// An unestablished terminal is legal and still blocks the table; the count has
+// to be reported rather than folded into the pass.
+const blocked = run(wellFormed.ratchet, {
+  ...wellFormed.sidecar,
+  mechanisms: {
+    ...wellFormed.sidecar.mechanisms,
+    "ts-render": { terminal: null },
+  },
+});
+try {
+  assert.equal(blocked.code, 0, "a null terminal is legal");
+  assert.match(blocked.out, /0 entries attributable today \(1 blocked/);
+  console.log("ok   a null terminal passes the checker and blocks the table");
+} catch (error) {
+  failures++;
+  console.error(
+    `FAIL a null terminal is counted\n${error.message}\n${blocked.out}`,
+  );
+}
+
+if (failures) {
+  console.error(`\n${failures} case(s) failed`);
+  process.exit(1);
+}
+console.log("\nall lsp-mechanisms-check cases pass");


### PR DESCRIPTION
Splits the classifier and the mechanism sidecar out of #4154 so the re-baseline is reachable. #4154's `lsp-corpus` dispatch needs artifacts that carry a mechanism per entry; the classifier that produces one lives only in #4154, which is blocked on the re-baseline — a cycle. This PR is the half that can land from `main`.

**The ratchet keys do not change.** `diff.mjs` splits `extra-rsvelte` into `-element` / `-field` so the classifier can tell an array's extra entry from an object's extra key, and `verify.mjs` strips the suffix back out before building the key. Every one of the 23,746 committed entries stays.

## Why the mechanism is a set, and why it rides beside the ratchet

An `aggregate:` entry is a `(file, method, phase)`, and every mechanism that fires anywhere in that one response is a separate label on the same entry. Measured on 931 records of one corpus shard (bits-ui, shard 8 of 16, 52 components, 151 `(file, method)` groups):

```
distinct labels per entry   min 1 / median 5 / mean 6.17 / max 22
entries carrying >1 label   134 / 151 = 88.7%
by method                   completion 11.13 · hover 3.84 · definition 3.27
```

So a label in the ratchet key would multiply one entry into its six — the same "one identifier, one key, a six-figure file" judgement the corpus half is aggregated to avoid — and picking one label per entry would need a precedence rule, which for six co-occurring labels is just the author's ordering written into the ratchet.

The set is structure rather than noise, and that was predicted before it was measured: an empty answer cannot carry an item-level difference, and of the 66 groups carrying `rsvelte-empty` / `rsvelte-empty-import-only`, **0** also carry an item-level label.

### What the set changes about reading a count

Per label, the entries on which it is the *only* label — the ones that would actually leave the ratchet if that mechanism were fixed:

| label | entries it appears on | entries where it is the only label |
|---|---|---|
| `completion-item-set-extra-html` | 42 | **0** |
| `completion-item-pairing-key-kind+sort-text-ts` | 42 | **0** |
| `completion-item-set-missing-ts` | 42 | **0** |
| `completion-item-set-missing-mixed` | 42 | **0** |
| `completion-item-set-missing-html` | 41 | **0** |
| `completion-commit-characters-value-extra-paren` | 37 | **0** |
| `rsvelte-empty` | 31 | **0** |
| `ts-render` | 30 | **0** |
| `projection-target-position-declaration` | 30 | 3 |
| `projection-origin-range` | 27 | 5 |

Nine of the shard's 62 labels are ever the sole label of an entry, covering 17 of 151 (11.3%); the eleven largest are all zero. **Repairing `completion-item-set-extra-html` on every file it names removes no entry from the ratchet**, because each of those files still diverges on five other mechanisms in the same response. A per-label count sizes an investigation and never a shrink.

## What is in the box

- `compatibility/lsp-mechanisms.json` — `entries` (id → set) and `mechanisms` (label → terminal). Written by `merge-current.mjs --update-baseline` **in the same command as the ratchet**, because a sidecar refreshed separately maps a population that no longer exists and nothing downstream could tell the two apart.
- `scripts/compat-lsp/mechanism.mjs` — the classifier and the 142-label vocabulary (moved from #4154).
- `scripts/ci/lsp-mechanisms-check.mjs` — checks the sidecar against the ratchet and against the classifier's vocabulary, and verifies each declared terminal resolves.
- `scripts/dev/test-lsp-mechanisms-check.mjs` — its positive control: 9 cases, **including that a well-formed sidecar passes**, which a suite of red-only cases never measures.
- The artifact schema goes to 2, carrying `mechanisms`, with coverage asserted **per artifact** rather than on the union — a shard that classified nothing is otherwise invisible once sixteen maps are merged.

## Two absences are spelled, not left blank

`classifyDivergence` runs on the corpus branch only (its context is that branch's source text), so every `differential:` and `expected:` entry carries the explicit label `unclassified`. And a label whose terminal is not yet established carries `null`, which is **not** `rsvelte`: an unestablished terminal and a defect of ours are different facts, and writing one as the other puts a sign on an unmeasured quantity. Either blocks its entry from an attribution table, and the checker prints how many entries are blocked instead of folding them into a pass.

## `entries` is empty until the dispatch, and the checker is red on purpose

The sidecar cannot be filled in by hand — it comes from the complete 17-artifact set of one `lsp-corpus` run, and that run belongs to #4154's tree (which also carries Rust changes to `completions.rs` / `server.rs` that move the answers being measured). So `pnpm run check:lsp-mechanisms` reports:

```
23746 ratchet entries, 0 with a mechanism set, 142 labels declared, 0 entries attributable today
23746 of 23746 ratchet entries carry no mechanism set
```

That is the correct state, and it is **not** made conditional: "pass when `entries` is empty" is the empty-baseline trap, where the bar becomes zero. The checker is therefore **not wired into CI** here — the same treatment `check:attribution` already has — and gets wired in the last PR of the campaign.

Sequence: this lands → #4154 rebases onto it → `lsp-corpus` is dispatched against #4154 → sidecar and ratchet are re-baselined by one command → the attribution table is derived → #4154 lands.

## Verification

```
pnpm run test:lsp-ratchet            55 tests, 55 pass          (mechanism/diff/ratchet/artifacts)
pnpm run test:lsp-mechanisms-check    9 cases, all pass
pnpm run check:lsp-mechanisms         EXIT=1, by design (see above)
node scripts/ci/attribution-check.mjs EXIT=1, 7 problems — unchanged from main
node scripts/compat-corpus/known-failures-md-check.mjs   EXIT=0
node scripts/dev/deliberate-divergences-check.mjs        EXIT=0, 20 pinned
node scripts/ci/check-upstream-issues.mjs                EXIT=0
```

## The coverage assertion, measured on a real 17-artifact set

The synthetic self-test above is the checker's control. The *merge*'s new per-artifact assertion
was additionally run against a real preserved `lsp-corpus` set (run 33574653550, 17 artifacts,
23,744 of today's 23,746 ids), with the mechanism map varied in four arms:

```
schema 2, no mechanisms       rejected — artifact 0 lacks mechanisms
schema 2, empty mechanisms    rejected — artifact 0 carries no mechanism for aggregate:corpus/bits-ui/.../data-attrs-value-content.svelte|textDocument/completion
schema 2, fully covered       ACCEPTED (17 artifacts)
schema 2, one shard one hole  rejected — artifact 3 carries no mechanism for aggregate:corpus/bits-ui/.../button-demo.svelte|textDocument/completion
```

The last arm is the one the assertion exists for: **one missing entry in one of sixteen shards is
rejected**, where a coverage check written against the merged union would have absorbed it. The
third arm is the half a red-only control never measures — the check can pass.

Unmodified, that set is rejected at `artifact 0 has an unsupported artifact schema`, which is the
schema bump doing its job: an artifact predating `mechanisms` cannot quietly populate a short map.

## Note on the title

Retitled from `feat(lsp-gate):` to `chore(lsp-gate):`. The `Changeset` gate keys on the PR title
prefix and never reads the diff, and this PR changes no published package — `scripts/` and
`compatibility/` only — so a changeset here would publish a version for a change no user can
observe. The commit's own subject still says `feat`; if this merges as a merge commit rather than
a squash, that subject is worth correcting first.
