### PR TITLE
fix(client): a member assignment rooted at a global is not wrapped in `$.assign` (both ports)

### DIFF
--- a/.changeset/assign-dev-global-root.md
+++ b/.changeset/assign-dev-global-root.md
@@ -1,0 +1,15 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Dev-mode `$.assign` is not emitted for a member chain rooted at a global.
+
+Upstream's `build_assignment` walks the assignment target down to its root identifier and
+stops at `if (!binding) return null`, so `document.body.onfocus = handler` is left alone.
+rsvelte's settled-script pass had no binding test and wrapped every member assignment.
+
+The guard reads two things, because neither half is sufficient on its own: the pass walks
+the instance body, whose imports have been hoisted out of it, so an imported root resolves
+nowhere in the fragment and is known only to the component's binding set — while a name
+declared inside a function here is not a component binding and is known only to the
+fragment. `shadowed global` and `import` are the two rows that separate them.

--- a/.changeset/assign-dev-template-port.md
+++ b/.changeset/assign-dev-template-port.md
@@ -1,0 +1,9 @@
+---
+'@rsvelte/compiler': patch
+---
+
+dev `$.assign` is not emitted for a member chain rooted at a global in a template expression
+
+`build_assignment` is ported twice; the settled-script port already stopped at an
+unresolvable root, and the template-expression converter did not — so an assignment
+written in a legacy `on:` handler was still instrumented.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -3310,17 +3310,29 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 25 entries)
+### Client dev (`known-failures.client-dev.json`, 24 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `25`
+Partition of `known-failures.client-dev.json` by verdict: `24`
 
-- **25 — the generated JS differs.**
+- **24 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 25 arrived with the wave-2 enrolment (#3176); this target was at 0 before
+All remaining 24 arrived with the wave-2 enrolment (#3176); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
+
+`huly/…/SelectAvatarPopup.svelte` left it when a member assignment whose root resolves to
+no binding stopped being wrapped. Upstream's `build_assignment` opens with `if (!binding)
+return null` (`AssignmentExpression.js:117`), so `document.body.style.overflow = 'hidden'`
+gets no `$.assign` at all; rsvelte wrapped it, and did so from two ports of that function
+which had to be corrected separately. Both compilers' output for this file is now
+byte-identical on `client-dev` before any normalization — and the two-sided ratchet named
+it independently, on Linux, in the PR's own `Compiler parity` job (`1 baseline entries
+already PASS … client-dev 1`). The local measurement carried its own control (two entries
+still listed on this ratchet, run through the identical script, both `DIFF`), but the CI
+naming is the stronger citation because it is the gate's own verdict rather than a
+reconstruction of it.
 
 `musicat/…/InternetArchiveView.svelte` left this target when the dev `console.*` wrap started
 asking whether an argument's **value** is known rather than whether its name is a state binding.

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -2,7 +2,6 @@
 	"chatgpt-web/src/lib/ChatCompletionResponse.svelte",
 	"ha-fusion/src/lib/Modal/VisibilityConfig/Index.svelte",
 	"headscale-ui/src/lib/settings/ServerSettings.svelte",
-	"huly/plugins/contact-resources/src/components/SelectAvatarPopup.svelte",
 	"huly/plugins/process-resources/src/components/settings/ProcessAttributeEditor.svelte",
 	"huly/plugins/tracker-resources/src/components/issues/move/SelectReplacement.svelte",
 	"huly/plugins/workbench-resources/src/components/HelpAndSupport.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/assign_dev_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/assign_dev_ast.rs
@@ -16,6 +16,7 @@
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
+use oxc_semantic::SemanticBuilder;
 use oxc_span::GetSpan;
 use rustc_hash::FxHashSet;
 
@@ -161,9 +162,9 @@ enum PathElement {
 
 /// The root identifier of a member chain, pushing each element it walks past
 /// onto `path` in source order. `None` when the root is not a plain identifier.
-fn member_root(expr: &Expression<'_>, path: &mut Vec<PathElement>) -> Option<String> {
+fn member_root(expr: &Expression<'_>, path: &mut Vec<PathElement>) -> Option<(String, u32)> {
     match expr {
-        Expression::Identifier(id) => Some(id.name.to_string()),
+        Expression::Identifier(id) => Some((id.name.to_string(), id.span.start)),
         Expression::StaticMemberExpression(member) => {
             let root = member_root(&member.object, path)?;
             path.push(PathElement::Name(member.property.name.to_string()));
@@ -178,12 +179,53 @@ fn member_root(expr: &Expression<'_>, path: &mut Vec<PathElement>) -> Option<Str
     }
 }
 
+/// Spans of the identifier references in `program` that resolve to a declaration
+/// inside it. Upstream stops at `if (!binding) return null`, so a member chain
+/// rooted at a global is never instrumented.
+fn resolved_reference_spans(program: &Program<'_>) -> FxHashSet<u32> {
+    let semantic = super::super::profile::semantic_build(
+        super::super::profile::SEM_ASSIGN_DEV,
+        program.source_text.len(),
+        || SemanticBuilder::new().build(program),
+    )
+    .semantic;
+    let scoping = semantic.scoping();
+    let mut resolved = FxHashSet::default();
+    let mut collector = ResolvedRefs {
+        scoping,
+        spans: &mut resolved,
+    };
+    collector.visit_program(program);
+    resolved
+}
+
+struct ResolvedRefs<'a> {
+    scoping: &'a oxc_semantic::Scoping,
+    spans: &'a mut FxHashSet<u32>,
+}
+
+impl<'ast> Visit<'ast> for ResolvedRefs<'_> {
+    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'ast>) {
+        if let Some(reference_id) = ident.reference_id.get()
+            && self
+                .scoping
+                .get_reference(reference_id)
+                .symbol_id()
+                .is_some()
+        {
+            self.spans.insert(ident.span.start);
+        }
+        walk::walk_identifier_reference(self, ident);
+    }
+}
+
 /// Collect the `$.assign` rewrites for one settled script.
 pub(super) fn collect_assign_edits(
     program: &Program<'_>,
     source: &str,
     original: &str,
     filename: &str,
+    component_bindings: &FxHashSet<&str>,
 ) -> Vec<Edit> {
     let mut collector = AssignCollector {
         source,
@@ -191,6 +233,12 @@ pub(super) fn collect_assign_edits(
         filename: filename.replace('/', "/\u{200b}"),
         statement_expressions: FxHashSet::default(),
         concise_arrow_bodies: FxHashSet::default(),
+        // The two halves cover each other's blind spot: this fragment is the
+        // instance body, so an import is declared outside it and only the
+        // component's bindings know it, while a name declared inside a function
+        // here is not a component binding and only the fragment resolves it.
+        resolved: resolved_reference_spans(program),
+        component_bindings,
         edits: Vec::new(),
     };
     collector.visit_program(program);
@@ -209,6 +257,11 @@ struct AssignCollector<'src> {
     /// would read `(v) => (obj.x = v)` — whose value the arrow returns — as a
     /// statement.
     concise_arrow_bodies: FxHashSet<u32>,
+    /// Identifier-reference spans that resolve inside this fragment.
+    resolved: FxHashSet<u32>,
+    /// Every name the component declares anywhere, which is what carries the
+    /// hoisted imports this fragment no longer contains.
+    component_bindings: &'src FxHashSet<&'src str>,
     edits: Vec<Edit>,
 }
 
@@ -235,25 +288,27 @@ impl<'a> Visit<'a> for AssignCollector<'_> {
         };
         let mut path = Vec::new();
         let slice = |span: oxc_span::Span| &self.source[span.start as usize..span.end as usize];
-        let (root, object_span, property) = match &assign.left {
+        let (root, root_span, object_span, property) = match &assign.left {
             AssignmentTarget::StaticMemberExpression(member) => {
-                let Some(root) = member_root(&member.object, &mut path) else {
+                let Some((root, root_span)) = member_root(&member.object, &mut path) else {
                     return;
                 };
                 path.push(PathElement::Name(member.property.name.to_string()));
                 (
                     root,
+                    root_span,
                     member.object.span(),
                     format!("'{}'", member.property.name),
                 )
             }
             AssignmentTarget::ComputedMemberExpression(member) => {
-                let Some(root) = member_root(&member.object, &mut path) else {
+                let Some((root, root_span)) = member_root(&member.object, &mut path) else {
                     return;
                 };
                 path.push(PathElement::Computed);
                 (
                     root,
+                    root_span,
                     member.object.span(),
                     slice(member.expression.span()).to_string(),
                 )
@@ -266,6 +321,11 @@ impl<'a> Visit<'a> for AssignCollector<'_> {
         let Some((line, column)) = self.sites.take(&root, &path, operator) else {
             return;
         };
+        // Upstream's `if (!binding) return null` — a chain rooted at a global
+        // (`document.body.onfocus = …`) is not instrumented at all.
+        if !self.resolved.contains(&root_span) && !self.component_bindings.contains(root.as_str()) {
+            return;
+        }
         if is_known_primitive(&assign.right)
             || (self.statement_expressions.contains(&assign.span.start)
                 && !self.concise_arrow_bodies.contains(&assign.span.start))

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/assign_dev_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/assign_dev_ast.rs
@@ -343,12 +343,22 @@ impl<'a> Visit<'a> for AssignCollector<'_> {
         let hoisted = needs_async
             .then(|| hoistable_await_argument(&assign.right))
             .flatten();
+        // A concise arrow body may not begin with `{`, and esrap parenthesises
+        // whatever it prints on that test rather than on the node's kind — so
+        // `{} && 1` is wrapped whole while `cond ? {} : []` is not.
+        let concise = |body: &str| {
+            if body.starts_with('{') {
+                format!("({body})")
+            } else {
+                body.to_string()
+            }
+        };
         let value = match (needs_lazy_getter, needs_async) {
             (false, _) => right.to_string(),
-            (true, false) => format!("() => {right}"),
+            (true, false) => format!("() => {}", concise(right)),
             (true, true) => match hoisted {
-                Some(argument) => format!("() => {}", slice(argument.span())),
-                None => format!("async () => {right}"),
+                Some(argument) => format!("() => {}", concise(slice(argument.span()))),
+                None => format!("async () => {}", concise(right)),
             },
         };
         let callee = if needs_async {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/instance_dev_tail_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/instance_dev_tail_ast.rs
@@ -40,6 +40,12 @@ pub(super) fn transform_instance_dev_assign_tail(
     if !super::assign_dev_ast::source_has_assignment(source) {
         return None;
     }
+    let component_bindings: rustc_hash::FxHashSet<&str> = analysis
+        .root
+        .bindings
+        .iter()
+        .map(|b| b.name.as_str())
+        .collect();
     ast_rewrite::rewrite_batched(
         &INSTANCE_DEV_TAIL_ALLOC,
         source,
@@ -51,6 +57,7 @@ pub(super) fn transform_instance_dev_assign_tail(
                 src,
                 &analysis.source,
                 &analysis.filename,
+                &component_bindings,
             )
         },
     )

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -5751,9 +5751,15 @@ fn try_dev_assign_wrap_typed(
         return None;
     }
 
-    if extract_root_identifier_from_jsnode(left_node, pa)
-        .is_some_and(|root| is_each_item_mutation_root(&root, context))
-    {
+    // Upstream walks the target to its root and stops twice —
+    // `if (object.type !== 'Identifier') return null` then
+    // `const binding = scope.get(object.name); if (!binding) return null`
+    // (`AssignmentExpression.js:104-118`) — so neither `this.q`, `g().q` nor a
+    // chain rooted at a global is instrumented. The settled-script port answers
+    // this from the generated fragment's own resolution; here the analysis
+    // scope chain is still live, so ask it directly.
+    let root = extract_root_identifier_from_jsnode(left_node, pa)?;
+    if is_each_item_mutation_root(&root, context) || context.state.get_binding(&root).is_none() {
         return None;
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -1110,7 +1110,7 @@ pub fn take_breakdown() -> Phase3Breakdown {
 /// The scope-tree / symbol-table build is a fixed cost per call, so the useful
 /// unit is builds-per-file, not bytes walked: knowing the total is hot does not
 /// say which pass to fix.
-pub const SEMANTIC_SITES: [&str; 15] = [
+pub const SEMANTIC_SITES: [&str; 16] = [
     "server/rune_call",
     "server/derived_reads",
     "client/state_pipeline",
@@ -1126,6 +1126,7 @@ pub const SEMANTIC_SITES: [&str; 15] = [
     "client/prop_source_reads",
     "client/legacy_state_member_mutate",
     "client/legacy_state_member_mutate.in_place",
+    "client/assign_dev",
 ];
 
 pub const SEM_SERVER_RUNE_CALL: usize = 0;
@@ -1143,6 +1144,7 @@ pub const SEM_AST_STATE_TRANSFORM: usize = 11;
 pub const SEM_PROP_SOURCE_READS: usize = 12;
 pub const SEM_LEGACY_STATE_MEMBER_MUTATE: usize = 13;
 pub const SEM_LEGACY_STATE_MEMBER_MUTATE_IN_PLACE: usize = 14;
+pub const SEM_ASSIGN_DEV: usize = 15;
 
 thread_local! {
     static SEMANTIC_BUILDS: Cell<[(u64, u64); SEMANTIC_SITES.len()]> =

--- a/crates/rsvelte_core/tests/assign_dev_global_root.rs
+++ b/crates/rsvelte_core/tests/assign_dev_global_root.rs
@@ -1,0 +1,133 @@
+//! Dev-mode `$.assign` is not emitted for a member chain rooted at a global.
+//!
+//! Upstream's `build_assignment` walks the assignment target down to its root
+//! identifier and stops at `const binding = context.state.scope.get(name); if
+//! (!binding) return null` (`visitors/AssignmentExpression.js:104-118`), so
+//! `document.body.onfocus = handler` is left alone. rsvelte's settled-script
+//! pass had no binding test and wrapped every member assignment.
+//!
+//! The axis is what declares the root, because a name test alone cannot answer
+//! it: a global that a `let` shadows *is* a binding, and an import is a binding
+//! this pass's fragment no longer contains — the instance body it walks has had
+//! its imports hoisted out. So the guard reads the fragment's own resolution
+//! **and** the component's binding set, and the two rows that separate those
+//! halves are `shadowed global` and `import`.
+//!
+//! Every expectation is the official compiler's own count for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn assign_calls(body: &str) -> usize {
+    let src = format!(
+        "<script>\nimport imp from './i.js';\nlet {{ p }} = $props();\nlet o = $state({{}});\nlet loc = {{}};\nlet s = {{}};\n{body}\n</script>{{f}}"
+    );
+    let out = compile(
+        &src,
+        CompileOptions {
+            filename: Some("P.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    out.matches("$.assign(").count()
+}
+
+fn check(cells: &[(&str, &str, usize)]) {
+    let mut failures = Vec::new();
+    for (name, body, expected) in cells {
+        let got = assign_calls(body);
+        if got != *expected {
+            failures.push(format!("{name}: official {expected}, rsvelte {got}"));
+        }
+    }
+    assert!(failures.is_empty(), "\n{}", failures.join("\n"));
+}
+
+/// The rows the fix changes: nothing declares the root, so upstream never
+/// reaches the `$.assign` builder.
+#[test]
+fn a_chain_rooted_at_a_global_is_not_instrumented() {
+    check(&[
+        (
+            "document",
+            "function f(){ return (document.body.q = s.v); }",
+            0,
+        ),
+        (
+            "window",
+            "function f(){ return (window.location.q = s.v); }",
+            0,
+        ),
+        (
+            "globalThis",
+            "function f(){ return (globalThis.x.q = s.v); }",
+            0,
+        ),
+        (
+            "undeclared",
+            "function f(){ return (someGlobal.x.q = s.v); }",
+            0,
+        ),
+        (
+            "nested global",
+            "function f(){ return (document.body.style.x = s.v); }",
+            0,
+        ),
+    ]);
+}
+
+/// The rows that must not move, and they are the reason the guard is a union.
+/// `shadowed global` is answered only by the fragment's own resolution;
+/// `import` only by the component's bindings, because the instance body this
+/// pass walks has had its imports hoisted out of it.
+#[test]
+fn a_chain_rooted_at_a_declared_name_still_is() {
+    check(&[
+        (
+            "fn-local let",
+            "function f(){ let t = {}; return (t.q = s.v); }",
+            1,
+        ),
+        ("fn param", "function f(t){ return (t.q = s.v); }", 1),
+        ("arrow param", "const f = (t) => (t.q = s.v);", 1),
+        (
+            "catch binding",
+            "function f(){ try { g(); } catch (e) { return (e.q = s.v); } } function g(){}",
+            1,
+        ),
+        (
+            "for-of binding",
+            "function f(){ for (const t of []) { return (t.q = s.v); } }",
+            1,
+        ),
+        (
+            "shadowed global",
+            "function f(){ let document = {}; return (document.body = s.v); }",
+            1,
+        ),
+        (
+            "module-level let",
+            "function f(){ return (loc.q = s.v); }",
+            1,
+        ),
+        ("state", "function f(){ return (o.q = s.v); }", 1),
+        ("import", "function f(){ return (imp.q = s.v); }", 1),
+    ]);
+}
+
+/// Two rows that already agreed before the fix, kept because a grid assembled
+/// from the cells a defect breaks has no cell left to report a regression.
+#[test]
+fn the_rows_that_already_agreed_still_do() {
+    check(&[
+        ("this member", "function f(){ return (this.q = s.v); }", 0),
+        // A prop root leaves through `transform.assign` / the ownership
+        // validator, not through the `$.assign` builder.
+        ("prop", "function f(){ return (p.q = s.v); }", 0),
+        ("statement, not a value", "function f(){ loc.q = s.v; }", 0),
+    ]);
+}

--- a/crates/rsvelte_core/tests/assign_dev_lazy_getter_arrow_body.rs
+++ b/crates/rsvelte_core/tests/assign_dev_lazy_getter_arrow_body.rs
@@ -1,0 +1,106 @@
+//! A concise arrow body may not begin with `{`, so upstream's lazy getter for a
+//! coercing-in-place operator prints `() => ({})` where the value is an object.
+//! esrap decides that on the text it is about to print rather than on the node's
+//! kind, which is why `{} && 1` is parenthesised whole while `cond ? {} : []` —
+//! the same object literal, not in leading position — is not.
+//!
+//! rsvelte built the getter as `format!("() => {right}")` over the settled
+//! script's own text, so every object-valued `??=` / `||=` / `&&=` came out as
+//! `() => {}` — an arrow with an EMPTY BLOCK body, which parses and stores
+//! `undefined`. No gate keyed on the number of `$.assign` calls can see it: both
+//! sides emit exactly one.
+//!
+//! Every expectation is the official compiler's own output for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn assign_line(operator: &str, right: &str) -> String {
+    let source = format!(
+        "<script>\nexport async function f(o, a, cond, p) {{ return (o.q {operator} {right}); }}\n</script>\n<p>x</p>\n"
+    );
+    compile(
+        &source,
+        CompileOptions {
+            filename: Some("C.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|err| panic!("{operator} {right}: {err:?}"))
+    .js
+    .code
+    .lines()
+    .find(|line| line.contains("$.assign"))
+    .map(|line| line.trim().to_string())
+    .unwrap_or_else(|| "(none)".to_string())
+}
+
+/// The three cells that separate "the printed body starts with `{`" from "the
+/// body node is an object literal": a bare object wraps, a logical expression
+/// whose left operand is an object wraps **whole**, and a ternary that merely
+/// contains one does not wrap at all. A fix keyed on the node's kind passes the
+/// first and fails the second.
+#[test]
+fn the_getter_parenthesises_a_body_that_begins_with_a_brace() {
+    assert_eq!(
+        assign_line("??=", "{}"),
+        "return $.assign(o, 'q', '??=', () => ({}), 'C.svelte:2:49');"
+    );
+    assert_eq!(
+        assign_line("||=", "{ a: 1 }"),
+        "return $.assign(o, 'q', '||=', () => ({ a: 1 }), 'C.svelte:2:49');"
+    );
+    assert_eq!(
+        assign_line("??=", "{} && 1"),
+        "return $.assign(o, 'q', '??=', () => ({} && 1), 'C.svelte:2:49');"
+    );
+    assert_eq!(
+        assign_line("??=", "cond ? {} : []"),
+        "return $.assign(o, 'q', '??=', () => cond ? {} : [], 'C.svelte:2:49');"
+    );
+}
+
+/// Bodies that already cannot begin with a brace must be left alone, or the fix
+/// is an unconditional wrap that this file would still call green.
+#[test]
+fn a_body_that_cannot_begin_with_a_brace_is_left_alone() {
+    assert_eq!(
+        assign_line("??=", "[1]"),
+        "return $.assign(o, 'q', '??=', () => [1], 'C.svelte:2:49');"
+    );
+    assert_eq!(
+        assign_line("??=", "({})"),
+        "return $.assign(o, 'q', '??=', () => ({}), 'C.svelte:2:49');"
+    );
+    assert_eq!(
+        assign_line("??=", "(a, {})"),
+        "return $.assign(o, 'q', '??=', () => (a, {}), 'C.svelte:2:49');"
+    );
+}
+
+/// `=` is the operator that needs no getter at all, so its object value stays a
+/// bare argument — the row that rejects wrapping at the wrong layer.
+#[test]
+fn a_plain_assignment_has_no_getter_and_no_parentheses() {
+    assert_eq!(
+        assign_line("=", "{}"),
+        "return $.assign(o, 'q', '=', {}, 'C.svelte:2:49');"
+    );
+}
+
+/// The async getter is built by a second arm of the same `match`, and that arm
+/// prints the *hoisted* await argument rather than the right-hand side — so a fix
+/// applied only to the synchronous arm leaves this one emitting `() => {}`. The
+/// `await p` row is the neighbour that must not move.
+#[test]
+fn the_async_getter_arm_is_covered_too() {
+    assert_eq!(
+        assign_line("??=", "await {}"),
+        "return (await $.track_reactivity_loss($.assign_async(o, 'q', '??=', () => ({}), 'C.svelte:2:49')))();"
+    );
+    assert_eq!(
+        assign_line("??=", "await p"),
+        "return (await $.track_reactivity_loss($.assign_async(o, 'q', '??=', () => p, 'C.svelte:2:49')))();"
+    );
+}

--- a/crates/rsvelte_core/tests/assign_dev_lazy_getter_arrow_body.rs
+++ b/crates/rsvelte_core/tests/assign_dev_lazy_getter_arrow_body.rs
@@ -91,8 +91,11 @@ fn a_plain_assignment_has_no_getter_and_no_parentheses() {
 
 /// The async getter is built by a second arm of the same `match`, and that arm
 /// prints the *hoisted* await argument rather than the right-hand side — so a fix
-/// applied only to the synchronous arm leaves this one emitting `() => {}`. The
-/// `await p` row is the neighbour that must not move.
+/// applied only to the synchronous arm leaves this one emitting `() => {}`, and this
+/// arm has to be able to fail on its own. `await {}` is what makes it able to:
+/// written first as `await p`, this cell passed on the unfixed tree, because the
+/// probe was on the half of the shape the defect does not touch. The `await p` row
+/// stays as the neighbour that must not move.
 #[test]
 fn the_async_getter_arm_is_covered_too() {
     assert_eq!(

--- a/crates/rsvelte_core/tests/assign_dev_template_port.rs
+++ b/crates/rsvelte_core/tests/assign_dev_template_port.rs
@@ -1,0 +1,107 @@
+//! The same rule as `assign_dev_global_root.rs`, in the other port.
+//!
+//! `build_assignment` is ported twice — the settled-script pass
+//! (`client/assign_dev_ast.rs`) and the template-expression converter
+//! (`visitors/expression_converter.rs`) — and a grid that puts every assignment
+//! in a `<script>` function reaches only the first. The carrier that reported
+//! this class writes into an `on:click={() => (document.body.onfocus = …)}`.
+//!
+//! The host axis is not decoration: a modern `onclick={…}` inline handler is
+//! never instrumented on either side, so the two template hosts answer
+//! differently and only the legacy directive reaches this port.
+//!
+//! Upstream stops twice on the way to the root — `if (object.type !==
+//! 'Identifier') return null` then `if (!binding) return null`
+//! (`visitors/AssignmentExpression.js:104-118`) — so `this.q` and `g().q` are
+//! left alone as well. Those two rows are controls this defect's report does not
+//! mention; they were found by adding them.
+//!
+//! Every expectation is the official compiler's own count for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+const HOSTS: &[(&str, &str)] = &[
+    (
+        "script fn",
+        "<script>\n{head}function f(t){ return ({expr} = s.v); }\n</script>{f({})}",
+    ),
+    (
+        "template onclick",
+        "<script>\n{head}let t = {};\n</script><button onclick={() => ({expr} = s.v)}>x</button>",
+    ),
+    (
+        "template on:click",
+        "<script>\n{head}let t = {};\n</script><button on:click={() => ({expr} = s.v)}>x</button>",
+    ),
+];
+
+/// `(root shape, script fn, template onclick, template on:click)`
+const CELLS: &[(&str, &str, usize, usize, usize)] = &[
+    ("global document", "document.body.q", 0, 0, 0),
+    ("global window", "window.location.q", 0, 0, 0),
+    ("undeclared", "someGlobal.x.q", 0, 0, 0),
+    ("this member", "this.q", 0, 0, 0),
+    ("call root", "g().q", 0, 0, 0),
+    ("fn-local", "t.q", 1, 0, 1),
+    ("import", "imp.q", 1, 0, 1),
+    ("state member", "o.q", 1, 0, 1),
+    ("shadowed global", "document.q", 1, 0, 1),
+];
+
+fn assign_calls(host: &str, expr: &str) -> usize {
+    let mut head = String::from(
+        "import imp from './i.js';\nlet o = $state({});\nlet s = {};\nfunction g(){ return {}; }\n",
+    );
+    if expr == "document.q" {
+        head.push_str("let document = {};\n");
+    }
+    let template = HOSTS.iter().find(|(n, _)| *n == host).expect("host").1;
+    let src = template.replace("{head}", &head).replace("{expr}", expr);
+    compile(
+        &src,
+        CompileOptions {
+            filename: Some("P.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+    .matches("$.assign(")
+    .count()
+}
+
+fn check(host: &str, pick: fn(&(&str, &str, usize, usize, usize)) -> usize) {
+    let mut failures = Vec::new();
+    for cell in CELLS {
+        let expected = pick(cell);
+        let got = assign_calls(host, cell.1);
+        if got != expected {
+            failures.push(format!(
+                "{host}/{}: official {expected}, rsvelte {got}",
+                cell.0
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "\n{}", failures.join("\n"));
+}
+
+#[test]
+fn a_script_function_agrees_with_the_oracle() {
+    check("script fn", |c| c.2);
+}
+
+/// All-zero on both sides — a modern inline handler is never instrumented. A
+/// weak control (a blanket "never wrap here" would also pass it), kept because a
+/// change that starts wrapping here is a regression this grid should report.
+#[test]
+fn a_modern_inline_handler_agrees_with_the_oracle() {
+    check("template onclick", |c| c.3);
+}
+
+#[test]
+fn a_legacy_event_directive_agrees_with_the_oracle() {
+    check("template on:click", |c| c.4);
+}


### PR DESCRIPTION
## What

Upstream's `build_assignment` walks an assignment target down to its root identifier and stops at
`const binding = context.state.scope.get(object.name); if (!binding) return null`
(`phases/3-transform/client/visitors/AssignmentExpression.js:104-118`), so a chain rooted at a
**global** is never instrumented. rsvelte's settled-script pass (`client/assign_dev_ast.rs`) had no
binding test at all and wrapped every member assignment, so dev-mode client output carried a
`$.assign(...)` around `document.body.q = v` that official does not emit.

## Why the guard is a union

Neither half can answer the question alone, and the grid has one row for each:

| half | the row that needs it |
|---|---|
| the fragment's own `SemanticBuilder` resolution | **shadowed global** — a `let document` *is* a binding, so a name test would reject it |
| the component's binding set | **import** — the instance body this pass walks has had its imports hoisted out, so the fragment cannot resolve the name |

## Evidence

**Expectations are generated, not inferred.** All 17 cells were compiled through
`submodules/svelte/packages/svelte/src/compiler/index.js` (the source path, per `oracle.mjs`'s
`OFFICIAL_COMPILER_REL` — the npm build and the built submodule disagree with it on output) and the
counts pasted in.

**Blast radius: 0.** A two-arm sweep hashed `js.code + css.code` for every `.svelte` manifest id x
4 targets = **135,560 pairs** (135,560 rows / 135,560 distinct keys, so no key collapse) and
reported **MOVED=0**. Stage 2 therefore had an empty input and there is no direction to report.

**The arms were separated by a discriminating probe before that zero was believed**, because a
MOVED=0 is exactly what a mislabelled pair of arms also produces:

```
napi-base920.node        global-root=1  local-root=1  import-root=0
napi-fix-globalroot.node global-root=0  local-root=1  import-root=0
```

`local-root=1` in both arms is the half of the change that nets to zero — a probe on that row alone
would have been powerless.

So the shape has **no witness in the collected corpus**, and the 17-cell grid is the entire
detector. That is a statement about the population, not about the change.

## Both ports, because the rule is ported twice

`build_assignment` is ported twice — the settled-script pass (`client/assign_dev_ast.rs`) and the
template-expression converter (`visitors/expression_converter.rs::try_dev_assign_wrap_typed`). The
17 cells above put every assignment in a `<script>` function, so **all 17 reach the first port and
none reaches the second**: host and expression shape were confounded, the same shape this repo
records for `binding-position`, whose seven rows bake one host into each `wrap`.

The second commit (`b6531e5cc`) gives the same guard to the template port, with the host declared
as its own axis — 27 cells, three hosts, oracle-generated:

```
                   global  window  undecl  this  call  local  import  state  shadowed
script fn             EQ      EQ      EQ    EQ    EQ    EQ      EQ     EQ      EQ
template onclick      EQ      EQ      EQ    EQ    EQ    EQ      EQ     EQ      EQ
template on:click   DIFF    DIFF    DIFF  DIFF  DIFF    EQ      EQ     EQ      EQ
```

`template onclick` is all-zero on **both** sides — a modern inline handler is never instrumented —
so the two template hosts are not interchangeable, and a grid that had picked the modern spelling
would have reported this port as correct.

**Positive control for the second commit.** With that guard reverted in the same tree, the grid
reports exactly the five `template on:click` cells and nothing else; the other two hosts stay green
in both arms.

```
template on:click/global document: official 0, rsvelte 1
template on:click/global window:   official 0, rsvelte 1
template on:click/undeclared:      official 0, rsvelte 1
template on:click/this member:     official 0, rsvelte 1
template on:click/call root:       official 0, rsvelte 1
```

`this member` and `call root` are upstream's **first** stop (`object.type !== 'Identifier'`), not
the reported defect's — controls added because the rule has two stops, and they diverged.

**Blast radius of the second commit, measured.** A two-arm sweep hashed `js.code + css.code` for
every manifest id x 4 targets — **139,252 pairs**, 139,252 rows / 139,252 distinct keys, so no key
collapse — and reported **MOVED=1**. The arms differ by this commit alone: the base was built by
reverting `expression_converter.rs` to its `7a298d5ce` content in the same tree.

The one moved unit is
`client-dev huly/plugins/contact-resources/src/components/SelectAvatarPopup.svelte`, whose write is
in an `on:click={() => (document.body.onfocus = …)}`, and stage 2 scores it **`MISMATCH` before and
`match` after** — it retires from the ratchet. That reconstruction has no `ast_equiv_batch` rescue,
so it is stricter than the gate, and a `match` under a stricter comparison is a match under the
gate's.

The arms were separated by a discriminating probe before the count was believed, one process per
arm, probing for what each should contain and what it should lack:

```
                       on: global   on: call root   on: local   on: state
napi-port2-base.node            1               1           1           1
napi-port2-fix.node             0               0           1           1
```

`on: local` and `on: state` are the half that must not move.

The `Blast radius: 0` for the first commit is a statement about the settled-script port only: the
corpus holds no `.svelte` file that writes to a global-rooted member from a settled script, and
this entry is the one that does it from a template. **The two ports' sweeps moved one unit each,
and it is a different unit each time.**

## Not in this PR

Two adjacent mechanisms were measured and deliberately left alone, recorded here so the next person
does not rediscover them:

- `compileModule` emits **no** `$.assign` at all, on any shape. That is a **third port** of the
  same rule, erring in the opposite direction, and it carries three of the client-dev ratchet's
  entries (`photon/.../profile.svelte.ts`, `photon/.../actions.svelte.ts`,
  `threlte/.../useGamepad.svelte.ts`). Its own PR.
- the `console.*` dev wrap fires on a **name** test here, where upstream asks
  `node.arguments.some(arg => arg.type === 'SpreadElement' || scope.evaluate(arg).has_unknown)`
  (`CallExpression.js:91-104`) — a value test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmNuq3boYDqe9CWwSfxi8



