### PR TITLE
fix(client): dev `console.*` does not wrap an argument whose value is known

### DIFF
--- a/.changeset/console-wrap-known-value.md
+++ b/.changeset/console-wrap-known-value.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Dev-mode `console.*` no longer wraps an argument whose value is known. A `$state` / `$derived` declaration is resolved through the rune's argument the way upstream's `scope.evaluate` does, in the lowered spellings the script passes see, and a declarator's verdict is keyed by the symbol it declares rather than by its name — so two declarations sharing a name no longer silence each other.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -3287,17 +3287,23 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 26 entries)
+### Client dev (`known-failures.client-dev.json`, 25 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `26`
+Partition of `known-failures.client-dev.json` by verdict: `25`
 
-- **26 — the generated JS differs.**
+- **25 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 26 arrived with the wave-2 enrolment (#3176); this target was at 0 before
+All remaining 25 arrived with the wave-2 enrolment (#3176); this target was at 0 before
 it, and it is the largest of the four — 15 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
+
+`musicat/…/InternetArchiveView.svelte` left this target when the dev `console.*` wrap started
+asking whether an argument's **value** is known rather than whether its name is a state binding.
+The pass reads lowered text, so `$state(0)` had reached it as an opaque `$.state(0)` call; upstream
+evaluates the rune's argument (`scope.js:465-500`). A two-arm sweep over 139,252 `(id, target)`
+pairs moved this unit and no other.
 
 The `client-dev` target is the `client` target with `dev: true`. It is a
 separate ratchet because `dev` gates 18 client codegen files plus the CSS

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -10,7 +10,6 @@
 	"immich/web/src/lib/components/timeline/Timeline.svelte",
 	"mathesar/mathesar_ui/src/components/sort-entry/SortEntry.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
-	"musicat/src/lib/views/InternetArchiveView.svelte",
 	"photon/src/lib/app/auth/profile.svelte.ts",
 	"photon/src/lib/ui/navbar/Profile.svelte",
 	"photon/src/lib/ui/navbar/commands/actions.svelte.ts",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_wrap.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_wrap.rs
@@ -133,14 +133,18 @@ pub(super) fn args_text_need_wrap(
 /// program.
 #[derive(Default)]
 pub(super) struct LocalConsts {
-    /// Names declared exactly once in the whole program by a `const` declarator
-    /// with an initializer, mapped to that initializer's verdict. A name
-    /// declared more than once is absent: the text alone cannot say which
-    /// declaration a reference reaches.
-    verdicts: FxHashMap<String, bool>,
-    /// Identifier-reference starts that resolve below the generated program's
-    /// root scope. These must not fall through to a same-named instance binding:
-    /// a parameter or local declaration shadows it exactly as it does upstream.
+    /// Declarator verdicts keyed by the SYMBOL they declare. Keying by name
+    /// drops every duplicated name, and the fallback for a missing verdict is
+    /// `UNKNOWN` — so `let c = 0` at the root and `let c = 1` in a function
+    /// silenced each other and both wrapped, where upstream resolves each
+    /// reference to its own declaration.
+    verdicts: FxHashMap<oxc_semantic::SymbolId, bool>,
+    /// Reference start -> the symbol it resolves to, for every reference that
+    /// resolves at all. A reference below the generated program's root scope
+    /// must not fall through to a same-named instance binding: a parameter or
+    /// local declaration shadows it exactly as it does upstream.
+    resolved: FxHashMap<u32, oxc_semantic::SymbolId>,
+    /// The subset of `resolved` whose symbol is declared below the root scope.
     local_references: FxHashSet<u32>,
 }
 
@@ -152,39 +156,37 @@ pub(super) fn collect_local_consts(
     let semantic = &semantic_ret.semantic;
     let mut references = LocalReferenceCollector {
         semantic,
+        resolved: FxHashMap::default(),
         starts: FxHashSet::default(),
     };
     references.visit_program(program);
-    // The index is built with the reference set but no verdicts: whether a name is
+    let mut writes = LoweredWriteCollector {
+        semantic,
+        written: FxHashSet::default(),
+    };
+    writes.visit_program(program);
+    // The index is built with the reference sets but no verdicts: whether a name is
     // locally BOUND is what disqualifies a global keypath (`const Math = …` shadows
     // `Math.random()`), and unlike a verdict that answer does not depend on visit
     // order. A chained `const a = b` still stays unresolved.
     let index_locals = LocalConsts {
         verdicts: FxHashMap::default(),
-        local_references: references.starts.clone(),
+        resolved: references.resolved,
+        local_references: references.starts,
     };
     let mut collector = ConstCollector {
         analysis,
         semantic,
-        index_locals: &index_locals,
-        counts: FxHashMap::default(),
-        verdicts: FxHashMap::default(),
+        lowered_writes: &writes.written,
+        running: index_locals,
     };
     collector.visit_program(program);
-    let ConstCollector {
-        counts,
-        mut verdicts,
-        ..
-    } = collector;
-    verdicts.retain(|name, _| counts.get(name) == Some(&1));
-    LocalConsts {
-        verdicts,
-        local_references: references.starts,
-    }
+    collector.running
 }
 
 struct LocalReferenceCollector<'sem> {
     semantic: &'sem Semantic<'sem>,
+    resolved: FxHashMap<u32, oxc_semantic::SymbolId>,
     starts: FxHashSet<u32>,
 }
 
@@ -197,8 +199,54 @@ impl<'a> Visit<'a> for LocalReferenceCollector<'_> {
         let Some(symbol_id) = scoping.get_reference(reference_id).symbol_id() else {
             return;
         };
+        self.resolved.insert(it.span.start, symbol_id);
         if scoping.symbol_scope_id(symbol_id) != scoping.root_scope_id() {
             self.starts.insert(it.span.start);
+        }
+    }
+}
+
+/// Symbols a lowered write names. `c = 1` reaches this pass as `$.set(c, 1)`,
+/// so oxc scores the only occurrence of `c` a READ and `is_never_written` says
+/// yes — where upstream, which sees the source, has `binding.updated` set and
+/// evaluates the declaration to `UNKNOWN`. The helper names are the oracle's
+/// own: `$.set` for every assignment operator, `$.update` for a postfix and
+/// `$.update_pre` for a prefix update.
+struct LoweredWriteCollector<'sem> {
+    semantic: &'sem Semantic<'sem>,
+    written: FxHashSet<oxc_semantic::SymbolId>,
+}
+
+impl<'a> Visit<'a> for LoweredWriteCollector<'_> {
+    fn visit_call_expression(&mut self, it: &oxc_ast::ast::CallExpression<'a>) {
+        walk::walk_call_expression(self, it);
+        let oxc_ast::ast::Expression::StaticMemberExpression(member) = &it.callee else {
+            return;
+        };
+        let oxc_ast::ast::Expression::Identifier(obj) = &member.object else {
+            return;
+        };
+        if obj.name != "$"
+            || !matches!(
+                member.property.name.as_str(),
+                "set" | "update" | "update_pre"
+            )
+        {
+            return;
+        }
+        let Some(oxc_ast::ast::Expression::Identifier(target)) =
+            it.arguments.first().and_then(|a| a.as_expression())
+        else {
+            return;
+        };
+        if let Some(reference_id) = target.reference_id.get()
+            && let Some(symbol_id) = self
+                .semantic
+                .scoping()
+                .get_reference(reference_id)
+                .symbol_id()
+        {
+            self.written.insert(symbol_id);
         }
     }
 }
@@ -206,16 +254,17 @@ impl<'a> Visit<'a> for LocalReferenceCollector<'_> {
 struct ConstCollector<'an, 'sem> {
     analysis: Option<&'an ComponentAnalysis>,
     semantic: &'sem Semantic<'sem>,
-    index_locals: &'sem LocalConsts,
-    counts: FxHashMap<String, u32>,
-    verdicts: FxHashMap<String, bool>,
+    lowered_writes: &'sem FxHashSet<oxc_semantic::SymbolId>,
+    /// The verdicts collected so far, consulted while collecting the next one.
+    /// A declarator's initializer can name an earlier declaration
+    /// (`let d = $.derived(() => c)`), and upstream resolves that chain because
+    /// it evaluates the ORIGINAL binding's initial; carrying the map forward
+    /// reproduces it for every reference a `let`/`const` can legally make,
+    /// which is one declared above it.
+    running: LocalConsts,
 }
 
 impl<'a> Visit<'a> for ConstCollector<'_, '_> {
-    fn visit_binding_identifier(&mut self, it: &BindingIdentifier<'a>) {
-        *self.counts.entry(it.name.to_string()).or_insert(0) += 1;
-    }
-
     fn visit_variable_declarator(&mut self, it: &VariableDeclarator<'a>) {
         walk::walk_variable_declarator(self, it);
         let BindingPattern::BindingIdentifier(id) = &it.id else {
@@ -224,15 +273,16 @@ impl<'a> Visit<'a> for ConstCollector<'_, '_> {
         let Some(init) = &it.init else {
             return;
         };
+        let Some(symbol_id) = id.symbol_id.get() else {
+            return;
+        };
         // Upstream evaluates a binding's initializer when `!binding.updated` —
         // the test is whether the name is ever written, not whether it is `const`.
         if !self.is_never_written(id) {
             return;
         }
-        self.verdicts.insert(
-            id.name.to_string(),
-            shape_can_be_unknown(init, self.analysis, Some(self.index_locals)),
-        );
+        let verdict = shape_can_be_unknown(init, self.analysis, Some(&self.running));
+        self.running.verdicts.insert(symbol_id, verdict);
     }
 }
 
@@ -241,6 +291,9 @@ impl ConstCollector<'_, '_> {
         let Some(symbol_id) = id.symbol_id.get() else {
             return false;
         };
+        if self.lowered_writes.contains(&symbol_id) {
+            return false;
+        }
         !self
             .semantic
             .scoping()
@@ -263,17 +316,16 @@ fn identifier_can_be_unknown(
     if name == "undefined" {
         return false;
     }
-    if locals.is_some_and(|l| l.local_references.contains(&reference_start)) {
-        // A unique const retains the value verdict collected below. Every
-        // other local binding (parameters, lets, duplicate const names) is
-        // UNKNOWN to upstream's evaluator.
-        return locals
-            .and_then(|l| l.verdicts.get(name))
-            .copied()
-            .unwrap_or(true);
+    // The declaration this reference actually resolves to, which is the
+    // question upstream's `scope.get(name)` asks. A parameter and every other
+    // binding with no evaluated initializer has no verdict and stays UNKNOWN.
+    if let Some(l) = locals
+        && let Some(symbol_id) = l.resolved.get(&reference_start)
+    {
+        return l.verdicts.get(symbol_id).copied().unwrap_or(true);
     }
-    if let Some(&verdict) = locals.and_then(|l| l.verdicts.get(name)) {
-        return verdict;
+    if locals.is_some_and(|l| l.local_references.contains(&reference_start)) {
+        return true;
     }
     let Some(analysis) = analysis else {
         return true;
@@ -336,16 +388,24 @@ pub(super) fn shape_can_be_unknown(
         // rsvelte lowers `a === b` / `a == b` to these helpers *after* upstream
         // has already evaluated the original `BinaryExpression` to `{true,
         // false}`, and reads of a `$state` declaration to `$.get(name)`.
-        E::CallExpression(call) => match state_read_operand(call) {
-            Some(id) => identifier_can_be_unknown(&id.name, id.span.start, analysis, locals),
-            // A call upstream's `globals` table types contributes NUMBER or
-            // STRING to the value set even when it folds nothing (`Math.random()`),
-            // so it is never UNKNOWN.
-            None => {
-                !is_never_unknown_call(&call.callee)
-                    && !global_keypath(&call.callee, analysis, locals)
-                        .is_some_and(|k| server_evaluate::is_global_keypath(&k))
-            }
+        E::CallExpression(call) => match rune_operand(call) {
+            // Upstream's `CallExpression` rune arm evaluates the ARGUMENT of
+            // `$state` / `$state.raw` / `$derived`, so a declaration this pass
+            // still sees in its rune or lowered spelling must be unwrapped
+            // rather than read as an opaque call.
+            Some(RuneOperand::Expr(inner)) => recur(inner),
+            Some(RuneOperand::Undefined) => false,
+            None => match state_read_operand(call) {
+                Some(id) => identifier_can_be_unknown(&id.name, id.span.start, analysis, locals),
+                // A call upstream's `globals` table types contributes NUMBER or
+                // STRING to the value set even when it folds nothing (`Math.random()`),
+                // so it is never UNKNOWN.
+                None => {
+                    !is_never_unknown_call(&call.callee)
+                        && !global_keypath(&call.callee, analysis, locals)
+                            .is_some_and(|k| server_evaluate::is_global_keypath(&k))
+                }
+            },
         },
         // `Math.PI` and its siblings are `global_constants` upstream: a known value.
         E::StaticMemberExpression(_) => global_keypath(expr, analysis, locals)
@@ -401,6 +461,64 @@ fn binding_exists(
             b.name == name && (b.scope_index == 0 || b.scope_index == a.root.instance_scope_index)
         })
     })
+}
+
+/// What a rune call contributes to the value set: its argument, or `undefined`
+/// for the argument-less `$state()`.
+enum RuneOperand<'a> {
+    Expr(&'a oxc_ast::ast::Expression<'a>),
+    Undefined,
+}
+
+/// `$state(x)` / `$state.raw(x)` / `$derived(x)`, and the shapes rsvelte lowers
+/// them to before this text pass runs (`$.state(x)`, `$.derived(() => x)`,
+/// `$.tag(inner, 'name')`). Upstream evaluates all of them by evaluating the
+/// argument; this pass sees whichever spelling its caller's pipeline stage has
+/// reached, so both are inverted here.
+fn rune_operand<'a>(call: &'a oxc_ast::ast::CallExpression<'a>) -> Option<RuneOperand<'a>> {
+    use oxc_ast::ast::Expression as E;
+
+    let arg = |i: usize| call.arguments.get(i).and_then(|a| a.as_expression());
+    let first_or_undefined = || match arg(0) {
+        Some(e) => Some(RuneOperand::Expr(e)),
+        None => Some(RuneOperand::Undefined),
+    };
+
+    match &call.callee {
+        // `$state(x)`, `$derived(x)`
+        E::Identifier(id) if matches!(id.name.as_str(), "$state" | "$derived") => {
+            first_or_undefined()
+        }
+        E::StaticMemberExpression(member) => {
+            let E::Identifier(obj) = &member.object else {
+                return None;
+            };
+            match (obj.name.as_str(), member.property.name.as_str()) {
+                // `$state.raw(x)`
+                ("$state", "raw") => first_or_undefined(),
+                // `$derived.by(() => x)` — upstream only unwraps an expression
+                // body; a block body stays UNKNOWN, which is the default here.
+                ("$derived", "by") => match arg(0) {
+                    Some(E::ArrowFunctionExpression(a)) => {
+                        a.get_expression().map(RuneOperand::Expr)
+                    }
+                    _ => None,
+                },
+                // The lowered spellings.
+                ("$", "state") => first_or_undefined(),
+                ("$", "derived" | "derived_safe_equal") => match arg(0) {
+                    Some(E::ArrowFunctionExpression(a)) => {
+                        a.get_expression().map(RuneOperand::Expr)
+                    }
+                    _ => None,
+                },
+                // `$.tag(inner, 'name')` only names the value it wraps.
+                ("$", "tag") => arg(0).map(RuneOperand::Expr),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
 }
 
 /// The declaration name behind a lowered reactive read (`$.get(count)` /

--- a/crates/rsvelte_core/tests/console_wrap_known_value.rs
+++ b/crates/rsvelte_core/tests/console_wrap_known_value.rs
@@ -1,0 +1,188 @@
+//! Dev-mode `console.*` is wrapped only when an argument can evaluate to
+//! `UNKNOWN`.
+//!
+//! Upstream asks `node.arguments.some(arg => arg.type === 'SpreadElement' ||
+//! context.state.scope.evaluate(arg).has_unknown)`
+//! (`visitors/CallExpression.js:91-104`), and `scope.evaluate` resolves a rune
+//! declaration by evaluating the rune's ARGUMENT (`scope.js:465-500`), so
+//! `let c = $state(0); console.log(c)` is left alone.
+//!
+//! rsvelte's script paths rewrite generated text, where the same declaration
+//! has been lowered, and they read the lowered call as an opaque one. Two
+//! things went wrong at once and only a grid separates them: the lowered
+//! spellings were never inverted, and the declarator verdicts were keyed by
+//! NAME — so two declarations sharing a name silenced each other's verdict and
+//! the missing-verdict fallback is `UNKNOWN`.
+//!
+//! The host axis is what localises the defect: the same body inside an arrow or
+//! a template expression already agreed, so the cells here are the two script
+//! hosts. There is no `.svelte.ts` host because there is no such input class —
+//! `compileModule` rejects TS syntax on both sides (`0 as number` and `import
+//! type` are `js_parse_error` for official and for rsvelte alike), so the
+//! toolchain strips types before the compiler sees the file.
+//!
+//! Every expectation is the official compiler's own count for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_module};
+
+fn opts(filename: &str) -> CompileOptions {
+    CompileOptions {
+        filename: Some(filename.to_string()),
+        generate: GenerateMode::Client,
+        dev: true,
+        ..Default::default()
+    }
+}
+
+fn wrap_calls_component(body: &str) -> usize {
+    let src = format!("<script>\nimport imported from './i.js';\n{body}\n</script>");
+    compile(&src, opts("P.svelte"))
+        .expect("compile")
+        .js
+        .code
+        .matches("$.log_if_contains_state(")
+        .count()
+}
+
+fn wrap_calls_module(body: &str) -> usize {
+    let src = format!("import imported from './i.js';\n{body}\n");
+    let options = ModuleCompileOptions {
+        filename: Some("m.svelte.js".to_string()),
+        generate: GenerateMode::Client,
+        dev: true,
+        ..Default::default()
+    };
+    compile_module(&src, options)
+        .expect("compile_module")
+        .js
+        .code
+        .matches("$.log_if_contains_state(")
+        .count()
+}
+
+fn check(host: &str, f: fn(&str) -> usize, cells: &[(&str, &str, usize)]) {
+    let mut failures = Vec::new();
+    for (name, body, expected) in cells {
+        let got = f(body);
+        if got != *expected {
+            failures.push(format!("{host}/{name}: official {expected}, rsvelte {got}"));
+        }
+    }
+    assert!(failures.is_empty(), "\n{}", failures.join("\n"));
+}
+
+/// The rows the fix moves, plus the ones that pin each half of it.
+/// `state, unknown initializer` and `fn-local shadowing, unknown` are the
+/// controls: they share the shape of the rows above them and must keep their
+/// wrap, so a fix that simply stops wrapping runes cannot pass.
+const CELLS: &[(&str, &str, usize)] = &[
+    (
+        "state, known literal",
+        "let c = $state(0); console.log(c);",
+        0,
+    ),
+    (
+        "derived of a known state",
+        "let c = $state(0); let d = $derived(c * 2); console.log(d);",
+        0,
+    ),
+    (
+        "derived.by, expression body",
+        "let c = $state(0); let d = $derived.by(() => c + 1); console.log(d);",
+        0,
+    ),
+    ("state, no argument", "let c = $state(); console.log(c);", 0),
+    (
+        "state, unknown initializer",
+        "function g() { return 1; } let c = $state(g()); console.log(c);",
+        1,
+    ),
+    // Every lowered write spelling. The lowering turns a write into a CALL
+    // (`$.set` / `$.update` / `$.update_pre`), which oxc scores as a read — so
+    // the whole row set exists because a fix for the rows above it silently
+    // dropped upstream's `!binding.updated` test on this one.
+    (
+        "state, written",
+        "let c = $state(0); c = 1; console.log(c);",
+        1,
+    ),
+    (
+        "state, compound-assigned",
+        "let c = $state(0); c += 2; console.log(c);",
+        1,
+    ),
+    (
+        "state, postfix update",
+        "let c = $state(0); c++; console.log(c);",
+        1,
+    ),
+    (
+        "state, prefix update",
+        "let c = $state(0); ++c; console.log(c);",
+        1,
+    ),
+    (
+        "state, logical-assigned",
+        "let c = $state(0); c &&= 1; console.log(c);",
+        1,
+    ),
+    (
+        "state, nullish-assigned",
+        "let c = $state(0); c ??= 1; console.log(c);",
+        1,
+    ),
+    (
+        "derived, never written",
+        "let c = $state(0); let d = $derived(c); console.log(d);",
+        0,
+    ),
+    (
+        "raw state, known literal",
+        "let c = $state.raw(0); console.log(c);",
+        0,
+    ),
+    (
+        "fn-local shadowing a state",
+        "let c = $state(0); function f() { let c = 1; console.log(c); } f();",
+        0,
+    ),
+    (
+        "fn-local shadowing, unknown",
+        "let c = $state(0); function f(q) { let c = q; console.log(c); } f(1);",
+        1,
+    ),
+    (
+        "two locals, same name, both known",
+        "function f() { let c = 1; console.log(c); } function g() { let c = 2; console.log(c); } f(); g();",
+        0,
+    ),
+    ("fn param", "function f(a) { console.log(a); } f(1);", 1),
+    ("plain let, never written", "let n = 1; console.log(n);", 0),
+    ("plain let, written", "let n = 1; n = 2; console.log(n);", 1),
+    ("import", "console.log(imported);", 1),
+    ("spread", "const a = [1]; console.log(...a);", 1),
+    ("global call", "console.log(Math.random());", 0),
+    (
+        "shadowed Math",
+        "const Math = { random: () => 1 }; console.log(Math.random());",
+        1,
+    ),
+    (
+        "unknown call",
+        "function g() { return 1; } console.log(g());",
+        1,
+    ),
+];
+
+#[test]
+fn an_instance_script_agrees_with_the_oracle() {
+    let mut cells = CELLS.to_vec();
+    // `$props()` has no module spelling, so it rides only on this host.
+    cells.push(("prop", "let { p } = $props(); console.log(p);", 1));
+    check("instance", wrap_calls_component, &cells);
+}
+
+#[test]
+fn a_module_agrees_with_the_oracle() {
+    check("module", wrap_calls_module, CELLS);
+}


### PR DESCRIPTION
## What

Upstream wraps a dev-mode `console.*` call only when

```js
node.arguments.some(arg => arg.type === 'SpreadElement' || context.state.scope.evaluate(arg).has_unknown)
```

and `scope.evaluate` resolves a rune declaration by evaluating **the rune's argument**
(`scope.js:465-500`), so `let c = $state(0); console.log(c)` is left alone. rsvelte wrapped it.

## Four mechanisms, all from the same premise: this pass reads LOWERED text

Upstream's evaluator sees the source. These passes rewrite *generated* text, where the declaration
is already a call, the write is already a call, and the names have already been through the
component's own scoping. Every row is one consequence of that:

| what the pass saw | what it concluded | what upstream concludes |
|---|---|---|
| `$.state(0)` | an opaque call → `UNKNOWN` | evaluate `0` → known |
| `$.tag($.derived(() => c * 2), 'd')` | an opaque call → `UNKNOWN` | evaluate `c * 2` → known |
| two declarations named `c` | **no verdict for either** (the map was keyed by name) → `UNKNOWN` | each reference resolves to its own declaration |
| `$.set(c, 1)` | oxc scores the only `c` a **read**, so "never written" → known | `binding.updated` is set → `UNKNOWN` |
| `let d = $derived(c * 2)` after `let c = $state(0)` | `c`'s verdict was not yet in the map when `d` was judged | the scope answers for `c` at any point |

`rune_operand` inverts the lowerings (`$state` / `$state.raw` / `$derived` / `$derived.by` and their
`$.state` / `$.derived` / `$.derived_safe_equal` / `$.tag` spellings); `LocalConsts::verdicts` is
keyed by the `SymbolId` the declarator binds and read through the reference's own resolved symbol;
`LoweredWriteCollector` restores `binding.updated` by matching the three helper names the lowering
actually emits — and those three were **enumerated from the oracle**, not guessed: `=`, `+=`, `&&=`
and `??=` all lower to `$.set(`, `c++` / `c--` to `$.update(`, and `++c` to `$.update_pre(`.

The last two rows are not decoration. Each was found by a cell the previous fix made reachable —
the write row by `module/state, written`, which the first version of `rune_operand` turned from
correct-by-accident into wrong, and the chained row by `derived, never written`. A fix that removes
an over-rejection makes whatever was behind it reachable.

## Evidence

**Expectations are generated, not inferred** — every cell compiled through
`submodules/svelte/packages/svelte/src/compiler/index.js` (the source path, per `oracle.mjs`'s
`OFFICIAL_COMPILER_REL`) and the counts pasted in.

**The host axis localises it.** A 68-cell grid over four hosts reported **5 divergences, every one
an rsvelte over-wrap and every one on a script host** — `arrow body` and `template expression`
already agreed, which is what says the template port was right and the script port was not.

That grid's first version called its second host `template` while the console call was still inside
`<script>` (in an arrow body). It reported the same 5, so the **count was right and the
localisation was wrong**; splitting the hosts is what turns "the template port is correct" into a
measurement.

**Blast radius, measured.** A two-arm sweep hashed `js.code + css.code` for every manifest id x
4 targets — **139,252 pairs**, 139,252 rows / 139,252 distinct keys, so no key collapse — and
reported **MOVED=1**. The arms differ by this commit alone: the base was built by reverting
`console_wrap.rs` to its `f49e16216` content in the same tree, so the `Compiling rsvelte_core`
line names the same path in both and only this file's bytes differ.

The population includes the **923 `.svelte.(js|ts)` module entries** as well as the 33,890
components, which an earlier sweep of this class did not: the module path is a different API
(`compileModule`) and four of the client-dev ratchet's entries live there. TypeScript modules are
type-stripped with esbuild first, because `compileModule` rejects TS syntax on both sides and a raw
`.svelte.ts` would score `ERR` on both arms — a comparison that cannot move.

The one moved unit is `client-dev musicat/src/lib/views/InternetArchiveView.svelte`, and stage 2
scores it `match` — **it retires from the ratchet**. That reconstruction has no `ast_equiv_batch`
rescue stage, so it is stricter than the gate, and a `match` under a stricter comparison is a match
under the gate's.

**The arms were separated by a discriminating probe before that count was believed**, run one
process per arm (two `.node` files with the same napi module name collide in one process):

```
                       state  shadow  unknown  import  written  chained
napi-base-f49e.node        1       1        1       1        1        1
napi-consolefix2.node      0       0        1       1        1        0
```

`unknown init` and `import` are the half that must not move. `written state` cannot discriminate
the arms — the base wraps everything, so it reads 1 for the opposite reason — but it does check
that the lowered-write mechanism below is present in the fix arm, which is a different question
and needed its own row.

## A third mechanism, measured and deliberately not fixed here

The other `console.*` ratchet entry (`svelte/.../delegated-locally-declared-shadowed`) does **not**
move, and it is a different defect: a binding declared **inside a template-hosted function** is
filtered out by the template port's `evaluate_identifier`, whose scope filter is documented as
"bindings inside script functions can never be referenced from a template expression" — true of a
script function, false of a function written in the template. A 7-cell grid:

```
EQ    each index, no shadow                  official=0 rsvelte=0
DIFF  each index, shadowed by a known call   official=0 rsvelte=1
DIFF  each index, shadowed by a literal      official=0 rsvelte=1
EQ    each index, shadowed by an unknown     official=1 rsvelte=1
DIFF  plain template arrow local, known      official=0 rsvelte=1
EQ    plain template arrow local, unknown    official=1 rsvelte=1
EQ    template arrow param                   official=1 rsvelte=1
```

The three `EQ` rows are the controls: the fix for this must not stop wrapping a genuinely unknown
local. It lives in the **shared server evaluator's** scope filter, so it needs its own grid and its
own sweep rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmNuq3boYDqe9CWwSfxi8
