### PR TITLE
fix(client): the template port of `build_assignment` also stops at an unresolvable root

### DIFF
--- a/.changeset/assign-dev-template-port.md
+++ b/.changeset/assign-dev-template-port.md
@@ -1,0 +1,9 @@
+---
+'@rsvelte/compiler': patch
+---
+
+dev `$.assign` is not emitted for a member chain rooted at a global in a template expression
+
+`build_assignment` is ported twice; the settled-script port already stopped at an
+unresolvable root, and the template-expression converter did not — so an assignment
+written in a legacy `on:` handler was still instrumented.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -5751,9 +5751,15 @@ fn try_dev_assign_wrap_typed(
         return None;
     }
 
-    if extract_root_identifier_from_jsnode(left_node, pa)
-        .is_some_and(|root| is_each_item_mutation_root(&root, context))
-    {
+    // Upstream walks the target to its root and stops twice —
+    // `if (object.type !== 'Identifier') return null` then
+    // `const binding = scope.get(object.name); if (!binding) return null`
+    // (`AssignmentExpression.js:104-118`) — so neither `this.q`, `g().q` nor a
+    // chain rooted at a global is instrumented. The settled-script port answers
+    // this from the generated fragment's own resolution; here the analysis
+    // scope chain is still live, so ask it directly.
+    let root = extract_root_identifier_from_jsnode(left_node, pa)?;
+    if is_each_item_mutation_root(&root, context) || context.state.get_binding(&root).is_none() {
         return None;
     }
 

--- a/crates/rsvelte_core/tests/assign_dev_template_port.rs
+++ b/crates/rsvelte_core/tests/assign_dev_template_port.rs
@@ -1,0 +1,107 @@
+//! The same rule as `assign_dev_global_root.rs`, in the other port.
+//!
+//! `build_assignment` is ported twice — the settled-script pass
+//! (`client/assign_dev_ast.rs`) and the template-expression converter
+//! (`visitors/expression_converter.rs`) — and a grid that puts every assignment
+//! in a `<script>` function reaches only the first. The carrier that reported
+//! this class writes into an `on:click={() => (document.body.onfocus = …)}`.
+//!
+//! The host axis is not decoration: a modern `onclick={…}` inline handler is
+//! never instrumented on either side, so the two template hosts answer
+//! differently and only the legacy directive reaches this port.
+//!
+//! Upstream stops twice on the way to the root — `if (object.type !==
+//! 'Identifier') return null` then `if (!binding) return null`
+//! (`visitors/AssignmentExpression.js:104-118`) — so `this.q` and `g().q` are
+//! left alone as well. Those two rows are controls this defect's report does not
+//! mention; they were found by adding them.
+//!
+//! Every expectation is the official compiler's own count for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+const HOSTS: &[(&str, &str)] = &[
+    (
+        "script fn",
+        "<script>\n{head}function f(t){ return ({expr} = s.v); }\n</script>{f({})}",
+    ),
+    (
+        "template onclick",
+        "<script>\n{head}let t = {};\n</script><button onclick={() => ({expr} = s.v)}>x</button>",
+    ),
+    (
+        "template on:click",
+        "<script>\n{head}let t = {};\n</script><button on:click={() => ({expr} = s.v)}>x</button>",
+    ),
+];
+
+/// `(root shape, script fn, template onclick, template on:click)`
+const CELLS: &[(&str, &str, usize, usize, usize)] = &[
+    ("global document", "document.body.q", 0, 0, 0),
+    ("global window", "window.location.q", 0, 0, 0),
+    ("undeclared", "someGlobal.x.q", 0, 0, 0),
+    ("this member", "this.q", 0, 0, 0),
+    ("call root", "g().q", 0, 0, 0),
+    ("fn-local", "t.q", 1, 0, 1),
+    ("import", "imp.q", 1, 0, 1),
+    ("state member", "o.q", 1, 0, 1),
+    ("shadowed global", "document.q", 1, 0, 1),
+];
+
+fn assign_calls(host: &str, expr: &str) -> usize {
+    let mut head = String::from(
+        "import imp from './i.js';\nlet o = $state({});\nlet s = {};\nfunction g(){ return {}; }\n",
+    );
+    if expr == "document.q" {
+        head.push_str("let document = {};\n");
+    }
+    let template = HOSTS.iter().find(|(n, _)| *n == host).expect("host").1;
+    let src = template.replace("{head}", &head).replace("{expr}", expr);
+    compile(
+        &src,
+        CompileOptions {
+            filename: Some("P.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+    .matches("$.assign(")
+    .count()
+}
+
+fn check(host: &str, pick: fn(&(&str, &str, usize, usize, usize)) -> usize) {
+    let mut failures = Vec::new();
+    for cell in CELLS {
+        let expected = pick(cell);
+        let got = assign_calls(host, cell.1);
+        if got != expected {
+            failures.push(format!(
+                "{host}/{}: official {expected}, rsvelte {got}",
+                cell.0
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "\n{}", failures.join("\n"));
+}
+
+#[test]
+fn a_script_function_agrees_with_the_oracle() {
+    check("script fn", |c| c.2);
+}
+
+/// All-zero on both sides — a modern inline handler is never instrumented. A
+/// weak control (a blanket "never wrap here" would also pass it), kept because a
+/// change that starts wrapping here is a regression this grid should report.
+#[test]
+fn a_modern_inline_handler_agrees_with_the_oracle() {
+    check("template onclick", |c| c.3);
+}
+
+#[test]
+fn a_legacy_event_directive_agrees_with_the_oracle() {
+    check("template on:click", |c| c.4);
+}


### PR DESCRIPTION
## What

Follow-up to #4184, on the **other** port of the same upstream function.

`build_assignment` walks an assignment target down to its root and stops twice —
`if (object.type !== 'Identifier') return null`, then
`const binding = scope.get(object.name); if (!binding) return null`
(`phases/3-transform/client/visitors/AssignmentExpression.js:104-118`). #4184 gave that guard to the
settled-script pass (`client/assign_dev_ast.rs`). The template-expression converter
(`visitors/expression_converter.rs::try_dev_assign_wrap_typed`) is a **second port of the same
function** and still had no binding test, so an assignment written in a legacy `on:` handler was
instrumented where official emits nothing.

## Why #4184's grid could not see this

All 17 of its cells put the assignment in a `<script>` function. Host and expression shape were
confounded — the same shape this repo records for `binding-position`, whose seven rows bake one
host into each `wrap`. Declaring the host as its own axis is the whole finding:

```
                   global  window  undecl  this  call  local  import  state  shadowed
script fn (#4184)     EQ      EQ      EQ    EQ    EQ    EQ      EQ     EQ      EQ
template onclick      EQ      EQ      EQ    EQ    EQ    EQ      EQ     EQ      EQ
template on:click   DIFF    DIFF    DIFF  DIFF  DIFF    EQ      EQ     EQ      EQ
```

`template onclick` is all-zero on **both** sides — a modern inline handler is never instrumented —
so the two template hosts are not interchangeable, and a grid that had picked the modern spelling
would have reported this port as correct.

## Evidence

**Expectations are generated, not inferred.** All 27 cells were compiled through
`submodules/svelte/packages/svelte/src/compiler/index.js` (the source path, per `oracle.mjs`'s
`OFFICIAL_COMPILER_REL`) by a generator that mirrors the test's own source construction, and the
counts pasted in.

**Positive control.** With the guard reverted in the same tree, the grid reports exactly the five
`template on:click` cells and nothing else; the other two hosts stay green in both arms, so the
change does not reach them:

```
template on:click/global document: official 0, rsvelte 1
template on:click/global window:   official 0, rsvelte 1
template on:click/undeclared:      official 0, rsvelte 1
template on:click/this member:     official 0, rsvelte 1
template on:click/call root:       official 0, rsvelte 1
```

`this member` and `call root` are upstream's **first** stop, not the reported defect's — they are
controls added because the rule has two stops, and they diverged.

**Blast radius: UNMEASURED at the time of opening.** A two-arm corpus sweep is running and this
section will be replaced with its numbers before merge. The ratchet entry this is expected to
retire is `client-dev huly/plugins/contact-resources/src/components/SelectAvatarPopup.svelte`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmNuq3boYDqe9CWwSfxi8
