### PR TITLE
fix(client): `$$ownership_validator` is declared for a mutation that was seen, not one that was wrapped

### DIFF
--- a/.changeset/ownership-validator-unspellable-path.md
+++ b/.changeset/ownership-validator-unspellable-path.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/compiler": patch
+---
+
+`$$ownership_validator` is declared for a prop mutation that was SEEN, not only for one that could be wrapped
+
+Upstream latches `analysis.needs_mutation_validation` before it builds the mutation's
+property path (`shared/utils.js:406`), so a computed key it cannot spell — anything but an
+identifier or a literal — leaves the mutation unwrapped and still emits the preamble.
+rsvelte derived the flag from a text scan for `$$ownership_validator.mutation`, which by
+construction can only find a mutation that *was* wrapped, so
+`object[objectKey ?? key] = v` emitted neither.
+
+A second divergence sat one level further out: `scan_member_chain_names` bailed on a root
+wrapped in plain parentheses, because the helper that steps over a parenthesised root only
+accepted an `as` / `satisfies` assertion inside them and acorn erases an empty pair. The
+two are not orthogonal — the scan builds `PropMutationSites`, which `source_has_member_write`
+reads, which gates the latch — so a fix for the index alone is dead on a parenthesised root.
+Ablating each half separately measures it: the latch alone falls on 15 of the grid's 24
+cells, the root arm alone on all 8 parenthesised ones including the three whose wrap the
+latch never touches.

--- a/.changeset/ownership-validator-unspellable-path.md
+++ b/.changeset/ownership-validator-unspellable-path.md
@@ -19,3 +19,13 @@ reads, which gates the latch — so a fix for the index alone is dead on a paren
 Ablating each half separately measures it: the latch alone falls on 15 of the grid's 24
 cells, the root arm alone on all 8 parenthesised ones including the three whose wrap the
 latch never touches.
+
+The latch itself then had to learn the other half of upstream's condition. Upstream reaches
+the validator through `scope.get(name)` (`shared/utils.js:396`), so a name that is a prop
+but resolves to something else declares nothing; this pass asked only whether the name
+matched a prop, so `list.forEach((p) => { p.x = 1 })` latched on the parameter. The
+generated instance body parses as a top-level statement list, which makes the props the
+root scope's bindings and a shadow any other scope — the test `state_pipeline_ast` already
+makes. Deriving the answer from the binder rather than from a list of shadowing syntaxes is
+what closes it: `for (const p of …)`, `catch (p)` and a block-scoped `let p` are not
+parameters, and `is_shadowed_by_function_param` declines all three.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -3332,16 +3332,16 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 24 entries)
+### Client dev (`known-failures.client-dev.json`, 22 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `24`
+Partition of `known-failures.client-dev.json` by verdict: `22`
 
-- **24 — the generated JS differs.**
+- **22 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 24 arrived with the wave-2 enrolment (#3176); this target was at 0 before
-it, and it is the largest of the four — 15 JS entries that `client` does not
+All remaining 22 arrived with the wave-2 enrolment (#3176); this target was at 0 before
+it, and it is the largest of the four — 11 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 
 `huly/…/SelectAvatarPopup.svelte` left it when a member assignment whose root resolves to
@@ -3361,6 +3361,26 @@ asking whether an argument's **value** is known rather than whether its name is 
 The pass reads lowered text, so `$state(0)` had reached it as an opaque `$.state(0)` call; upstream
 evaluates the rune's argument (`scope.js:465-500`). A two-arm sweep over 139,252 `(id, target)`
 pairs moved this unit and no other.
+
+#4192 retired two `huly` entries (`process-resources/.../ProcessAttributeEditor.svelte`,
+`tracker-resources/.../move/SelectReplacement.svelte`). Upstream latches
+`analysis.needs_mutation_validation` before it builds the mutation's property path
+(`shared/utils.js:406`), so a computed key it cannot spell still emits
+`$$ownership_validator`; rsvelte derived the flag from a text scan for the wrap, which by
+construction only finds a mutation that was wrapped. Measured on two arms sharing the merge
+base `c1af73536` (base sha256 `3c7a3ccb…`, fixed `ec564195…`): both entries read `PASSES`
+on the fixed arm and the base arm reports `PASSES on base: 0`, so the retirement is
+attributed rather than inherited.
+
+The same PR then narrowed the latch again — upstream reaches the validator through
+`scope.get(name)`, so a name that spells a prop but resolves to a parameter, a `for`
+binding or a `catch` binding declares nothing — and **that half was not re-measured
+locally**: the `PASSES` above was read on the pre-narrowing arm. The two-sided ratchet is
+the complete check for these two entries, because a listed-but-passing entry and a new
+failure both fail, so the verdict here is CI's rather than a local reconstruction's. The
+count of entries `client` does not carry was read as 15 while the file held 13; it is
+recomputed above rather than decremented, because the partition line is gated and this
+sentence is not.
 
 The `client-dev` target is the `client` target with `dev: true`. It is a
 separate ratchet because `dev` gates 18 client codegen files plus the CSS

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -2,8 +2,6 @@
 	"chatgpt-web/src/lib/ChatCompletionResponse.svelte",
 	"ha-fusion/src/lib/Modal/VisibilityConfig/Index.svelte",
 	"headscale-ui/src/lib/settings/ServerSettings.svelte",
-	"huly/plugins/process-resources/src/components/settings/ProcessAttributeEditor.svelte",
-	"huly/plugins/tracker-resources/src/components/issues/move/SelectReplacement.svelte",
 	"huly/plugins/workbench-resources/src/components/HelpAndSupport.svelte",
 	"immich/web/src/lib/components/asset-viewer/ActivityViewer.svelte",
 	"immich/web/src/lib/components/timeline/Timeline.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -521,6 +521,10 @@ pub(crate) fn transform_client(
 ) -> Result<CodegenResult, TransformError> {
     use crate::compiler::phases::phase3_transform::client::visitors::fragment::fragment;
 
+    // Set where the instance pass SAW a prop member write, which is a different
+    // question from whether it could wrap one.
+    let mut saw_prop_member_mutation = false;
+
     // Create initial node (anchor) for the transformation
     let initial_node = b::id("$$anchor");
 
@@ -756,6 +760,7 @@ pub(crate) fn transform_client(
             split_top_level_declarations,
             retained_instance,
             body_projection,
+            &mut saw_prop_member_mutation,
         );
         if let Some(comment) = repeated_projection_comment
             && let Some(start) = transformed.find(&comment)
@@ -1394,11 +1399,16 @@ pub(crate) fn transform_client(
 
         // If the text-based transform added ownership validation, set the flag
         // so that the $$ownership_validator declaration is emitted.
-        if memmem::find(
-            transformed_script.as_bytes(),
-            b"$$ownership_validator.mutation",
-        )
-        .is_some()
+        // Upstream latches the flag before it builds the mutation's path
+        // (`shared/utils.js:406`), so a path the pass could not spell — a computed
+        // key that is not an identifier or a literal — still declares the
+        // validator. The text scan alone only finds a mutation that was wrapped.
+        if saw_prop_member_mutation
+            || memmem::find(
+                transformed_script.as_bytes(),
+                b"$$ownership_validator.mutation",
+            )
+            .is_some()
         {
             context.state.needs_mutation_validation.set(true);
         }
@@ -6134,6 +6144,7 @@ pub(crate) fn transform_instance_script_for_visitors_pub(
         might_have_comma_separated_declaration(script),
         None,
         None,
+        &mut false,
     );
     super::profile::record_script_text(super::profile::timer_elapsed(_script_start));
     super::profile::record_parent_site(true);
@@ -7134,6 +7145,9 @@ fn transform_instance_script_for_visitors(
     split_top_level_declarations: bool,
     retained_program: Option<&crate::ast::oxc_program::RetainedProgram<'_>>,
     source_projection: Option<&ScriptProjection>,
+    // Set when a prop member write was SEEN. The caller's text scan only finds
+    // one this pass could wrap, and upstream declares the validator for either.
+    saw_prop_member_mutation: &mut bool,
 ) -> String {
     super::profile::record_st_entry();
     let _entry_guard = super::profile::EntryGuard::new();
@@ -9292,6 +9306,7 @@ fn transform_instance_script_for_visitors(
             &result,
             &prop_mutation_vars,
             &analysis.source,
+            saw_prop_member_mutation,
         )
         .unwrap_or_else(|| {
             wrap_prop_mutation_validation(&result, &prop_mutation_vars, &analysis.source)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_mutation_validation_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_mutation_validation_ast.rs
@@ -7,7 +7,9 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::{Visit, walk};
 use oxc_parser::ParseOptions;
+use oxc_semantic::SemanticBuilder;
 use oxc_span::{GetSpan, SourceType, Span};
+use rustc_hash::FxHashSet;
 
 use super::ast_rewrite::{self, Edit};
 use super::props_transforms::{PropMutationScan, PropMutationSites};
@@ -52,6 +54,7 @@ pub(super) fn wrap_prop_mutation_validation_ast(
                 source,
                 prop_vars,
                 sites,
+                shadowed: shadowed_prop_reads(program, prop_vars),
                 edits: Vec::new(),
                 skip: Vec::new(),
                 skip_calls: Vec::new(),
@@ -68,6 +71,57 @@ pub(super) fn wrap_prop_mutation_validation_ast(
     )
 }
 
+/// Offsets of the identifiers that spell a prop name and resolve to a binding
+/// other than the prop.
+///
+/// Upstream reaches the mutation validator through `scope.get(name)`
+/// (`shared/utils.js:396`), so a shadowed name answers with the shadowing
+/// binding and nothing is declared. This pass had only the name, which is the
+/// same question one axis short: `list.forEach((p) => { p.x = 1 })` writes
+/// through a `p` that is a parameter. The generated instance body parses as a
+/// top-level statement list, so the props are the root scope's bindings and a
+/// shadow is any other scope — the test `state_pipeline_ast` already makes.
+///
+/// Deriving the answer from the binder rather than from a list of shadowing
+/// syntaxes is the point: `for (const p of …)`, `catch (p)` and a block-scoped
+/// `let p` are not parameters, and enumerating them is a work log rather than a
+/// partition.
+fn shadowed_prop_reads(
+    program: &Program<'_>,
+    prop_vars: &[(String, Option<String>)],
+) -> FxHashSet<u32> {
+    let semantic = SemanticBuilder::new().build(program).semantic;
+    let mut collector = ShadowReads {
+        scoping: semantic.scoping(),
+        prop_vars,
+        starts: FxHashSet::default(),
+    };
+    collector.visit_program(program);
+    collector.starts
+}
+
+struct ShadowReads<'a> {
+    scoping: &'a oxc_semantic::Scoping,
+    prop_vars: &'a [(String, Option<String>)],
+    starts: FxHashSet<u32>,
+}
+
+impl<'ast> Visit<'ast> for ShadowReads<'_> {
+    fn visit_identifier_reference(&mut self, identifier: &IdentifierReference<'ast>) {
+        if self
+            .prop_vars
+            .iter()
+            .any(|(name, _)| name == identifier.name.as_str())
+            && let Some(reference_id) = identifier.reference_id.get()
+            && let Some(symbol_id) = self.scoping.get_reference(reference_id).symbol_id()
+            && self.scoping.symbol_scope_id(symbol_id) != self.scoping.root_scope_id()
+        {
+            self.starts.insert(identifier.span.start);
+        }
+        walk::walk_identifier_reference(self, identifier);
+    }
+}
+
 /// Whether `expression` is exactly the compiler-generated identifier `name`.
 fn is_generated_root(expression: &Expression<'_>, name: &str) -> bool {
     matches!(expression, Expression::Identifier(root) if root.name == name)
@@ -78,6 +132,9 @@ struct Collector<'a> {
     source: &'a str,
     prop_vars: &'a [(String, Option<String>)],
     sites: Vec<(String, Option<String>, PropMutationSites)>,
+    /// Generated-code offsets of identifiers that SPELL a prop and do not
+    /// resolve to it.
+    shadowed: FxHashSet<u32>,
     edits: Vec<Edit>,
     skip: Vec<Span>,
     skip_calls: Vec<Span>,
@@ -116,8 +173,12 @@ impl<'a> Collector<'a> {
     /// `needs_mutation_validation` before it builds the path
     /// (`shared/utils.js:406`), so a path this pass cannot spell still declares
     /// the validator.
-    fn note_prop_member_mutation(&self, name: &str, target_is_member: bool) {
-        if target_is_member && self.prop(name).is_some() && self.source_has_member_write(name) {
+    fn note_prop_member_mutation(&self, name: &str, root_start: u32, target_is_member: bool) {
+        if target_is_member
+            && !self.shadowed.contains(&root_start)
+            && self.prop(name).is_some()
+            && self.source_has_member_write(name)
+        {
             self.saw_prop_member_mutation.set(true);
         }
     }
@@ -126,7 +187,7 @@ impl<'a> Collector<'a> {
     /// the path between can be spelled. Upstream asks this question first
     /// (`AssignmentExpression.js:104-112` walks to the root, then looks the
     /// binding up), and only then builds the path.
-    fn target_root_name(&self, target: &AssignmentTarget<'_>) -> Option<String> {
+    fn target_root_name(&self, target: &AssignmentTarget<'_>) -> Option<(String, u32)> {
         let mut current = match target {
             AssignmentTarget::StaticMemberExpression(member) => &member.object,
             AssignmentTarget::ComputedMemberExpression(member) => &member.object,
@@ -137,12 +198,14 @@ impl<'a> Collector<'a> {
                 Expression::StaticMemberExpression(member) => current = &member.object,
                 Expression::ComputedMemberExpression(member) => current = &member.object,
                 Expression::ParenthesizedExpression(paren) => current = &paren.expression,
-                Expression::Identifier(identifier) => return Some(identifier.name.to_string()),
+                Expression::Identifier(identifier) => {
+                    return Some((identifier.name.to_string(), identifier.span.start));
+                }
                 Expression::CallExpression(call) if call.arguments.is_empty() => {
                     let Expression::Identifier(identifier) = &call.callee else {
                         return None;
                     };
-                    return Some(identifier.name.to_string());
+                    return Some((identifier.name.to_string(), identifier.span.start));
                 }
                 _ => return None,
             }
@@ -349,7 +412,8 @@ impl<'a> Collector<'a> {
             &assignment.left,
             AssignmentTarget::StaticMemberExpression(_)
                 | AssignmentTarget::ComputedMemberExpression(_)
-        ) && self.source_has_member_write(callee.name.as_str())
+        ) && !self.shadowed.contains(&callee.span.start)
+            && self.source_has_member_write(callee.name.as_str())
         {
             self.saw_prop_member_mutation.set(true);
         }
@@ -402,6 +466,7 @@ impl<'a, 'ast> Visit<'ast> for Collector<'a> {
                     self.skip.push(assignment.span);
                     self.note_prop_member_mutation(
                         callee.name.as_str(),
+                        callee.span.start,
                         matches!(
                             &assignment.left,
                             AssignmentTarget::StaticMemberExpression(_)
@@ -415,6 +480,7 @@ impl<'a, 'ast> Visit<'ast> for Collector<'a> {
                     self.skip.push(update.span);
                     self.note_prop_member_mutation(
                         callee.name.as_str(),
+                        callee.span.start,
                         matches!(
                             &update.argument,
                             SimpleAssignmentTarget::StaticMemberExpression(_)
@@ -455,7 +521,8 @@ impl<'a, 'ast> Visit<'ast> for Collector<'a> {
         if self.skip.contains(&assignment.span) {
             return;
         }
-        if let Some(root) = self.target_root_name(&assignment.left)
+        if let Some((root, root_start)) = self.target_root_name(&assignment.left)
+            && !self.shadowed.contains(&root_start)
             && self.prop(&root).is_some()
             && self.source_has_member_write(&root)
         {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_mutation_validation_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_mutation_validation_ast.rs
@@ -16,14 +16,20 @@ thread_local! {
     static PROP_MUTATION_VALIDATION_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
 }
 
+/// `saw_prop_member_mutation` reports whether a prop member write was *seen*,
+/// which is not the same question as whether one was wrapped: upstream latches
+/// the flag before it builds the path, so a computed key this pass cannot spell
+/// still declares `$$ownership_validator`.
 pub(super) fn wrap_prop_mutation_validation_ast(
     generated: &str,
     prop_vars: &[(String, Option<String>)],
     source: &str,
+    saw_prop_member_mutation: &mut bool,
 ) -> Option<String> {
     if prop_vars.is_empty() {
         return Some(generated.to_string());
     }
+    let saw = saw_prop_member_mutation;
     ast_rewrite::with_program(
         &PROP_MUTATION_VALIDATION_ALLOC,
         generated,
@@ -50,8 +56,12 @@ pub(super) fn wrap_prop_mutation_validation_ast(
                 skip: Vec::new(),
                 skip_calls: Vec::new(),
                 ownership: Vec::new(),
+                saw_prop_member_mutation: std::cell::Cell::new(false),
             };
             collector.visit_program(program);
+            if collector.saw_prop_member_mutation.get() {
+                *saw = true;
+            }
             ast_rewrite::splice(generated, collector.edits, false)
                 .or_else(|| Some(generated.to_string()))
         },
@@ -72,6 +82,11 @@ struct Collector<'a> {
     skip: Vec<Span>,
     skip_calls: Vec<Span>,
     ownership: Vec<Span>,
+    /// Upstream latches `needs_mutation_validation` before it builds the path
+    /// (`shared/utils.js:406`), so a path this pass cannot spell still declares
+    /// the validator. Interior mutability because the decision is made from
+    /// `&self`.
+    saw_prop_member_mutation: std::cell::Cell<bool>,
 }
 
 impl<'a> Collector<'a> {
@@ -95,6 +110,43 @@ impl<'a> Collector<'a> {
         let (root, mut path) = self.expression_root_and_path(expression)?;
         path.push(tail);
         Some((root, path))
+    }
+
+    /// Latch that a prop member write was seen. Upstream sets
+    /// `needs_mutation_validation` before it builds the path
+    /// (`shared/utils.js:406`), so a path this pass cannot spell still declares
+    /// the validator.
+    fn note_prop_member_mutation(&self, name: &str, target_is_member: bool) {
+        if target_is_member && self.prop(name).is_some() && self.source_has_member_write(name) {
+            self.saw_prop_member_mutation.set(true);
+        }
+    }
+
+    /// The root a member-expression target is written through, ignoring whether
+    /// the path between can be spelled. Upstream asks this question first
+    /// (`AssignmentExpression.js:104-112` walks to the root, then looks the
+    /// binding up), and only then builds the path.
+    fn target_root_name(&self, target: &AssignmentTarget<'_>) -> Option<String> {
+        let mut current = match target {
+            AssignmentTarget::StaticMemberExpression(member) => &member.object,
+            AssignmentTarget::ComputedMemberExpression(member) => &member.object,
+            _ => return None,
+        };
+        loop {
+            match current {
+                Expression::StaticMemberExpression(member) => current = &member.object,
+                Expression::ComputedMemberExpression(member) => current = &member.object,
+                Expression::ParenthesizedExpression(paren) => current = &paren.expression,
+                Expression::Identifier(identifier) => return Some(identifier.name.to_string()),
+                Expression::CallExpression(call) if call.arguments.is_empty() => {
+                    let Expression::Identifier(identifier) = &call.callee else {
+                        return None;
+                    };
+                    return Some(identifier.name.to_string());
+                }
+                _ => return None,
+            }
+        }
     }
 
     /// The path element a computed access contributes, or `None` where upstream
@@ -169,6 +221,7 @@ impl<'a> Collector<'a> {
                     path.reverse();
                     return Some((identifier.name.to_string(), path));
                 }
+                Expression::ParenthesizedExpression(paren) => current = &paren.expression,
                 _ => return None,
             }
         }
@@ -183,6 +236,15 @@ impl<'a> Collector<'a> {
             .iter()
             .find(|(candidate, _, _)| candidate == name)
             .is_none_or(|(_, _, sites)| !sites.is_empty())
+    }
+
+    /// The same question one step wider: upstream's latch fires for a member
+    /// write whose computed key it declines to spell, which is not a site.
+    fn source_has_member_write(&self, name: &str) -> bool {
+        self.sites
+            .iter()
+            .find(|(candidate, _, _)| candidate == name)
+            .is_none_or(|(_, _, sites)| sites.has_member_write())
     }
 
     fn location(&mut self, name: &str, path: &[String], value: &str) -> (usize, usize) {
@@ -283,6 +345,14 @@ impl<'a> Collector<'a> {
         let Argument::AssignmentExpression(assignment) = &call.arguments[0] else {
             return None;
         };
+        if matches!(
+            &assignment.left,
+            AssignmentTarget::StaticMemberExpression(_)
+                | AssignmentTarget::ComputedMemberExpression(_)
+        ) && self.source_has_member_write(callee.name.as_str())
+        {
+            self.saw_prop_member_mutation.set(true);
+        }
         let (name, path) = self.root_and_path(&assignment.left)?;
         Some((
             call.span,
@@ -330,11 +400,27 @@ impl<'a, 'ast> Visit<'ast> for Collector<'a> {
             match &call.arguments[0] {
                 Argument::AssignmentExpression(assignment) => {
                     self.skip.push(assignment.span);
+                    self.note_prop_member_mutation(
+                        callee.name.as_str(),
+                        matches!(
+                            &assignment.left,
+                            AssignmentTarget::StaticMemberExpression(_)
+                                | AssignmentTarget::ComputedMemberExpression(_)
+                        ),
+                    );
                     self.root_and_path(&assignment.left)
                         .map(|(name, path)| (name, path, Some(assignment.right.span())))
                 }
                 Argument::UpdateExpression(update) => {
                     self.skip.push(update.span);
+                    self.note_prop_member_mutation(
+                        callee.name.as_str(),
+                        matches!(
+                            &update.argument,
+                            SimpleAssignmentTarget::StaticMemberExpression(_)
+                                | SimpleAssignmentTarget::ComputedMemberExpression(_)
+                        ),
+                    );
                     self.simple_target_root_and_path(&update.argument)
                         .map(|(name, path)| (name, path, None))
                 }
@@ -369,6 +455,12 @@ impl<'a, 'ast> Visit<'ast> for Collector<'a> {
         if self.skip.contains(&assignment.span) {
             return;
         }
+        if let Some(root) = self.target_root_name(&assignment.left)
+            && self.prop(&root).is_some()
+            && self.source_has_member_write(&root)
+        {
+            self.saw_prop_member_mutation.set(true);
+        }
         if let Some((name, path)) = self.root_and_path(&assignment.left) {
             self.wrap(assignment.span, name, path, Some(assignment.right.span()));
         }
@@ -398,6 +490,7 @@ mod tests {
                 "item(item().name = /[,)]/.test(`x${key}`), true);",
                 &props,
                 source,
+                &mut false,
             ),
             Some("$$ownership_validator.mutation('item', ['item', 'name'], item(item().name = /[,)]/.test(`x${key}`), true), 3, 0);".to_string()),
         );
@@ -416,7 +509,7 @@ mod tests {
         ] {
             let generated = "items(items()[0] = $$array[0], true);";
             assert_eq!(
-                wrap_prop_mutation_validation_ast(generated, &props, source).as_deref(),
+                wrap_prop_mutation_validation_ast(generated, &props, source, &mut false).as_deref(),
                 Some(generated),
                 "{source}"
             );
@@ -429,9 +522,13 @@ mod tests {
     fn a_plain_member_write_in_the_source_still_wraps() {
         let source = "<script>\nexport let items;\nitems[0] = 1;\n</script>";
         let props = vec![("items".to_string(), None)];
-        let output =
-            wrap_prop_mutation_validation_ast("items(items()[0] = 1, true);", &props, source)
-                .unwrap();
+        let output = wrap_prop_mutation_validation_ast(
+            "items(items()[0] = 1, true);",
+            &props,
+            source,
+            &mut false,
+        )
+        .unwrap();
         assert!(
             output.starts_with("$$ownership_validator.mutation(null, ['items', 0]"),
             "{output}"
@@ -444,7 +541,8 @@ mod tests {
             "<script>\nlet { item } = $props();\nlet key = 'k';\nitem[key] = value;\n</script>";
         let props = vec![("item".to_string(), Some("item".to_string()))];
         let output =
-            wrap_prop_mutation_validation_ast("item()[key] = value;", &props, source).unwrap();
+            wrap_prop_mutation_validation_ast("item()[key] = value;", &props, source, &mut false)
+                .unwrap();
         assert!(output.starts_with(
             "$$ownership_validator.mutation('item', ['item', key], item()[key] = value"
         ));
@@ -467,7 +565,7 @@ mod tests {
             ),
         ] {
             assert_eq!(
-                wrap_prop_mutation_validation_ast(generated, &props, source).as_deref(),
+                wrap_prop_mutation_validation_ast(generated, &props, source, &mut false).as_deref(),
                 Some(generated),
             );
         }
@@ -482,6 +580,7 @@ mod tests {
             "collection(collection().items = collection().items.filter((it) => it.id !== id), true);\ncollection(collection().items = collection().items.filter((it) => it.kind === 'note'), true);",
             &[("collection".to_string(), None)],
             source,
+            &mut false,
         )
         .unwrap();
 
@@ -498,6 +597,7 @@ mod tests {
             "item.value = value;",
             &[("item".to_string(), Some("item".to_string()))],
             "<script>let { item = $bindable() } = $props(); item.value = value;</script>",
+            &mut false,
         )
         .unwrap();
         assert_eq!(output, "item.value = value;");
@@ -510,6 +610,7 @@ mod tests {
             "props(props().createDrawing = async () => { props(props().drawings = [1], true); }, true);",
             &[("props".to_string(), None)],
             source,
+            &mut false,
         )
         .unwrap();
 
@@ -526,6 +627,7 @@ mod tests {
             "filter(filter().value = filter().value.filter((p) => targets.has(p)), true);\nfilter(filter().value = filter().value.filter((p) => value ? p !== value.id : p != null), true);",
             &[("filter".to_string(), None)],
             source,
+            &mut false,
         )
         .unwrap();
 
@@ -540,6 +642,7 @@ mod tests {
             "step(step().params = params, true);",
             &[("step".to_string(), None)],
             source,
+            &mut false,
         )
         .unwrap();
 
@@ -553,6 +656,7 @@ mod tests {
             "result(result()[key] = true, true);\nstep(step().params._id = 'next', true);",
             &[("result".to_string(), None), ("step".to_string(), None)],
             source,
+            &mut false,
         )
         .unwrap();
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -4146,6 +4146,12 @@ struct PropMutationSite {
 /// The source mutations of one prop, in source order.
 pub(super) struct PropMutationSites {
     sites: Vec<PropMutationSite>,
+    /// A member write through this prop that the chain scan could not NAME —
+    /// a computed key that is neither an identifier nor a literal. It is not a
+    /// site (there is nothing to line the position up with) but it is still a
+    /// member write, which is a different question and the one upstream's
+    /// `needs_mutation_validation` latch asks.
+    unnameable_member_write: bool,
 }
 
 /// The two source-wide scans every prop's site collection needs. Neither
@@ -4173,6 +4179,7 @@ impl PropMutationScan {
 impl PropMutationSites {
     pub(super) fn collect(source: &str, var_name: &str, scan: &PropMutationScan) -> Self {
         let mut sites = Vec::new();
+        let mut unnameable_member_write = false;
         let reactive = &scan.reactive;
         let template_start = scan.template_start;
         let bytes = source.as_bytes();
@@ -4192,7 +4199,7 @@ impl PropMutationSites {
             {
                 continue;
             }
-            if let Some((after, chain)) = scan_prop_mutation_target(source, start, end)
+            if let Some((after, chain, nameable)) = scan_prop_mutation_target(source, start, end)
                 && let Some(value_start) = mutation_value_start(source, after).or_else(|| {
                     // A PREFIX update (`--p.deep.c`) has its operator before
                     // the identifier; the site's position stays the identifier.
@@ -4200,6 +4207,12 @@ impl PropMutationSites {
                     (head.ends_with("++") || head.ends_with("--")).then_some(after)
                 })
             {
+                if !nameable {
+                    // Not a site — there is nothing to line a position up with —
+                    // but the latch below needs to know it happened.
+                    unnameable_member_write = true;
+                    continue;
+                }
                 let (line, column) =
                     crate::compiler::phases::phase3_transform::utils::locate_in_source(
                         source, start,
@@ -4228,7 +4241,20 @@ impl PropMutationSites {
         // sites by emission region is what keeps them lined up with the output
         // when the value cannot tell two mutations of the same member apart.
         sites.sort_by_key(|site| site.region);
-        Self { sites }
+        Self {
+            sites,
+            unnameable_member_write,
+        }
+    }
+
+    /// Whether the source writes through a member of this prop, whether or not
+    /// the chain scan could name the member. Upstream latches
+    /// `needs_mutation_validation` before it builds the path
+    /// (`shared/utils.js:406`), so an unspellable computed key still declares
+    /// the validator — `is_empty` answers the narrower question of whether there
+    /// is a position to line the wrap up with.
+    pub(super) fn has_member_write(&self) -> bool {
+        !self.sites.is_empty() || self.unnameable_member_write
     }
 
     /// Whether the source writes through a member of this prop at all.
@@ -4404,24 +4430,27 @@ fn skip_non_null_assertions(bytes: &[u8], mut pos: usize) -> usize {
 /// Scan a prop mutation target, including a TypeScript assertion that wraps
 /// either the root or an intermediate member chain:
 /// `(result as any)[key] = value` and `(step.params as any)._id = value`.
+/// `(end, names, nameable)` for the member chain written through the root at
+/// `root_start..root_end`, or `None` when there is no member access at all.
 fn scan_prop_mutation_target(
     source: &str,
     root_start: usize,
     root_end: usize,
-) -> Option<(usize, Option<Vec<String>>)> {
+) -> Option<(usize, Option<Vec<String>>, bool)> {
     let bytes = source.as_bytes();
     let chain_start = skip_non_null_assertions(bytes, root_end);
-    let (mut after, mut chain, mut saw_member) = if starts_member_access(bytes, chain_start) {
-        let (after, chain) = scan_member_chain_names(source, chain_start)?;
-        (after, chain, true)
-    } else {
-        (chain_start, Some(Vec::new()), false)
-    };
+    let (mut after, mut chain, mut saw_member, mut nameable) =
+        if starts_member_access(bytes, chain_start) {
+            let (after, chain, nameable) = scan_member_chain_names(source, chain_start)?;
+            (after, chain, true, nameable)
+        } else {
+            (chain_start, Some(Vec::new()), false, true)
+        };
 
     if let Some(assertion_end) = parenthesized_ts_assertion_end(source, root_start, after) {
         after = skip_whitespace_chars(source, assertion_end);
         if starts_member_access(bytes, after) {
-            let (tail_end, tail_chain) = scan_member_chain_names(source, after)?;
+            let (tail_end, tail_chain, tail_nameable) = scan_member_chain_names(source, after)?;
             chain = match (chain, tail_chain) {
                 (Some(mut head), Some(tail)) => {
                     head.extend(tail);
@@ -4431,16 +4460,19 @@ fn scan_prop_mutation_target(
             };
             after = tail_end;
             saw_member = true;
+            nameable = nameable && tail_nameable;
         }
     }
 
-    saw_member.then_some((after, chain))
+    saw_member.then_some((after, chain, nameable))
 }
 
 /// Return the byte after the closing parenthesis when `root_start..expression_end`
-/// is parenthesized around a TypeScript `as` or `satisfies` assertion. Upstream
-/// never sees the wrapper — acorn-typescript erases the assertion, so the
-/// reported position is the chain root, not the `(`.
+/// is parenthesized — either around a TypeScript `as` / `satisfies` assertion or
+/// around nothing at all. Upstream never sees the wrapper: acorn-typescript
+/// erases the assertion and acorn erases the parentheses, so `(object as any).q`
+/// and `(object).q` are both a member write through `object`, reported at the
+/// chain root rather than at the `(`.
 fn parenthesized_ts_assertion_end(
     source: &str,
     root_start: usize,
@@ -4459,6 +4491,9 @@ fn parenthesized_ts_assertion_end(
         return None;
     }
     let assertion = source[expression_end..close].trim_start();
+    if assertion.is_empty() {
+        return Some(close + 1);
+    }
     let has_keyword = ["as", "satisfies"].into_iter().any(|keyword| {
         assertion.strip_prefix(keyword).is_some_and(|tail| {
             tail.chars()
@@ -4822,7 +4857,12 @@ mod code_spans_tests {
 
 /// Advance past `.name` / `[expr]` accessors, returning the offset just after
 /// the chain plus the names it reads — `None` once a computed access appears.
-fn scan_member_chain_names(source: &str, mut pos: usize) -> Option<(usize, Option<Vec<String>>)> {
+/// `(end, names, nameable)`. `nameable` is false when a computed key is one
+/// upstream declines to wrap, which leaves a member write that is not a site.
+fn scan_member_chain_names(
+    source: &str,
+    mut pos: usize,
+) -> Option<(usize, Option<Vec<String>>, bool)> {
     let bytes = source.as_bytes();
     let mut names = Some(Vec::new());
     loop {
@@ -4840,7 +4880,7 @@ fn scan_member_chain_names(source: &str, mut pos: usize) -> Option<(usize, Optio
             };
         }
         if pos >= bytes.len() {
-            return Some((pos, names));
+            return Some((pos, names, true));
         }
         match bytes[pos] {
             b'.' => {
@@ -4881,11 +4921,17 @@ fn scan_member_chain_names(source: &str, mut pos: usize) -> Option<(usize, Optio
                     }
                     pos += 1;
                 }
-                if depth != 0 || !is_nameable_computed_key(source[key_start..pos - 1].trim()) {
+                if depth != 0 {
                     return None;
                 }
+                if !is_nameable_computed_key(source[key_start..pos - 1].trim()) {
+                    // Upstream's `validate_mutation` returns the expression
+                    // unwrapped here, so this is not a site — but it IS a member
+                    // write, and the caller needs to tell the two apart.
+                    return Some((pos, names, false));
+                }
             }
-            _ => return Some((pos, names)),
+            _ => return Some((pos, names, true)),
         }
     }
 }
@@ -5669,7 +5715,7 @@ mod non_ascii_boundary_tests {
             ("item.\u{540D} = 5;", "\u{540D}"),
             ("item.\u{E0} = 5;", "\u{E0}"),
         ] {
-            let (after, names) = scan_member_chain_names(source, 4).unwrap();
+            let (after, names, _) = scan_member_chain_names(source, 4).unwrap();
             assert_eq!(names.as_deref(), Some([name.to_string()].as_slice()));
             assert!(source.is_char_boundary(after), "source {source:?}");
             assert!(is_mutation_operator(source, after), "source {source:?}");
@@ -5688,7 +5734,7 @@ mod non_ascii_boundary_tests {
             "item.name\u{A0}= 5;",
             "item.name\t= 5;",
         ] {
-            let (after, names) = scan_member_chain_names(source, 4).unwrap();
+            let (after, names, _) = scan_member_chain_names(source, 4).unwrap();
             assert_eq!(
                 names.as_deref(),
                 Some(["name".to_string()].as_slice()),

--- a/crates/rsvelte_core/tests/ownership_validator_unbuildable_path.rs
+++ b/crates/rsvelte_core/tests/ownership_validator_unbuildable_path.rs
@@ -1,0 +1,117 @@
+//! `$$ownership_validator` is declared for a prop mutation that was SEEN, not
+//! only for one that could be wrapped.
+//!
+//! Upstream latches `analysis.needs_mutation_validation` before it builds the
+//! mutation's property path (`shared/utils.js:406`), so a computed key it cannot
+//! spell — anything but an identifier or a literal — leaves the mutation
+//! unwrapped **and still emits the preamble**. rsvelte's instance-script pass
+//! derived the flag from a text scan for `$$ownership_validator.mutation`, which
+//! by construction can only find a mutation that *was* wrapped.
+//!
+//! The rule is ported twice. `expression_converter.rs` carries the latch and a
+//! comment saying why; `prop_mutation_validation_ast.rs` carried neither.
+//!
+//! Two axes, crossed, and they are NOT independent — that was predicted and the
+//! prediction was wrong, which is the reason the grid is worth keeping. The
+//! **index** axis is upstream's own `Literal | Identifier` test, so `[key]`,
+//! `["lit"]` and `[0]` wrap and the other five do not; those five are the
+//! controls that must keep `wrap == 0` while `decl == 1`. The **root** axis is a
+//! parenthesised object, and it sits UPSTREAM of the latch rather than beside
+//! it: `props_transforms`'s scan builds `PropMutationSites`, which
+//! `source_has_member_write` reads, which gates the latch. Ablating each half
+//! separately measures the difference — the latch alone falls on 15 cells (the
+//! five unspellable indices at every root, `decl=0 wrap=0`), while the root arm
+//! alone falls on all 8 `paren` cells with `decl=0`, including the three whose
+//! wrap the latch never touches. A fix for the index axis is dead on a
+//! parenthesised root.
+//!
+//! Every expectation is the official compiler's own count for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// `(root, index, declarations, wraps)`
+const CELLS: &[(&str, &str, usize, usize)] = &[
+    ("bare", "ident", 1, 1),
+    ("bare", "nullish", 1, 0),
+    ("bare", "logical-or", 1, 0),
+    ("bare", "binary", 1, 0),
+    ("bare", "string-lit", 1, 1),
+    ("bare", "number-lit", 1, 1),
+    ("bare", "call", 1, 0),
+    ("bare", "ternary", 1, 0),
+    ("as-any", "ident", 1, 1),
+    ("as-any", "nullish", 1, 0),
+    ("as-any", "logical-or", 1, 0),
+    ("as-any", "binary", 1, 0),
+    ("as-any", "string-lit", 1, 1),
+    ("as-any", "number-lit", 1, 1),
+    ("as-any", "call", 1, 0),
+    ("as-any", "ternary", 1, 0),
+    ("paren", "ident", 1, 1),
+    ("paren", "nullish", 1, 0),
+    ("paren", "logical-or", 1, 0),
+    ("paren", "binary", 1, 0),
+    ("paren", "string-lit", 1, 1),
+    ("paren", "number-lit", 1, 1),
+    ("paren", "call", 1, 0),
+    ("paren", "ternary", 1, 0),
+];
+
+fn root_text(root: &str) -> &str {
+    match root {
+        "bare" => "object",
+        "as-any" => "(object as any)",
+        _ => "(object)",
+    }
+}
+
+fn index_text(index: &str) -> &str {
+    match index {
+        "ident" => "key",
+        "nullish" => "objectKey ?? key",
+        "logical-or" => "objectKey || key",
+        "binary" => "key + \"\"",
+        "string-lit" => "\"lit\"",
+        "number-lit" => "0",
+        "call" => "f2()",
+        _ => "key ? key : key",
+    }
+}
+
+fn counts(root: &str, index: &str) -> (usize, usize) {
+    let src = format!(
+        "<script lang=\"ts\">\nexport let object: Record<string, any>;\nexport let key: string;\nexport let objectKey: string | undefined = undefined;\nfunction f2(){{ return key; }}\nfunction f(v: any){{ {}[{}] = v; }}\n</script>{{f}}",
+        root_text(root),
+        index_text(index)
+    );
+    let code = compile(
+        &src,
+        CompileOptions {
+            filename: Some("P.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    (
+        code.matches("create_ownership_validator").count(),
+        code.matches("$$ownership_validator.mutation(").count(),
+    )
+}
+
+#[test]
+fn every_cell_agrees_with_the_oracle() {
+    let mut failures = Vec::new();
+    for (root, index, decl, wrap) in CELLS {
+        let (got_decl, got_wrap) = counts(root, index);
+        if got_decl != *decl || got_wrap != *wrap {
+            failures.push(format!(
+                "{root}/{index}: official decl={decl} wrap={wrap}, rsvelte decl={got_decl} wrap={got_wrap}"
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "\n{}", failures.join("\n"));
+}

--- a/crates/rsvelte_core/tests/ownership_validator_unbuildable_path.rs
+++ b/crates/rsvelte_core/tests/ownership_validator_unbuildable_path.rs
@@ -115,3 +115,88 @@ fn every_cell_agrees_with_the_oracle() {
     }
     assert!(failures.is_empty(), "\n{}", failures.join("\n"));
 }
+
+/// The mirror direction of the grid above. Every cell writes through a member
+/// of a NAME that is a prop, in a scope where that name is bound to something
+/// else — so upstream's `scope.get(name)` answers with the shadowing binding and
+/// declares nothing. The two `CONTROL` rows are the cells that must keep
+/// `decl=1` / `decl=0` without any shadowing at all: a grid whose every cell
+/// moves one way cannot report an over-correction.
+///
+/// `(mode, form, declarations, wraps)` — every expectation is the official
+/// compiler's own count for the same source.
+const SHADOW_CELLS: &[(&str, &str, usize, usize)] = &[
+    ("legacy", "for-of", 0, 0),
+    ("legacy", "arrow-param", 0, 0),
+    ("legacy", "arrow-destr", 0, 0),
+    ("legacy", "fn-param", 0, 0),
+    ("legacy", "fn-expr-param", 0, 0),
+    ("legacy", "block-let", 0, 0),
+    ("legacy", "catch-param", 0, 0),
+    ("legacy", "CONTROL-write", 1, 1),
+    ("legacy", "CONTROL-none", 0, 0),
+    ("runes", "for-of", 0, 0),
+    ("runes", "arrow-param", 0, 0),
+    ("runes", "arrow-destr", 0, 0),
+    ("runes", "fn-param", 0, 0),
+    ("runes", "fn-expr-param", 0, 0),
+    ("runes", "block-let", 0, 0),
+    ("runes", "catch-param", 0, 0),
+    ("runes", "CONTROL-write", 1, 1),
+    ("runes", "CONTROL-none", 0, 0),
+];
+
+fn shadow_body(form: &str) -> &str {
+    match form {
+        "for-of" => "for (const p of list) { p.x = 1; }",
+        "arrow-param" => "list.forEach((p) => { p.x = 1; });",
+        "arrow-destr" => "const g = ({ p }) => { p.x = 1; }; g(list[0]);",
+        "fn-param" => "function h(p) { p.x = 1; } h(list[0]);",
+        "fn-expr-param" => "list.map(function (p) { p.x = 1; });",
+        "block-let" => "{ let p = list[0]; p.x = 1; }",
+        "catch-param" => "try { null; } catch (p) { p.x = 1; }",
+        "CONTROL-write" => "p.x = 1;",
+        _ => "const q = p;",
+    }
+}
+
+fn shadow_counts(mode: &str, form: &str) -> (usize, usize) {
+    let body = shadow_body(form);
+    let src = if mode == "legacy" {
+        format!("<script>\n\texport let p;\n\tlet list = [];\n\t{body}\n</script>\n{{p}}{{list}}")
+    } else {
+        format!(
+            "<script>\n\tlet {{ p }} = $props();\n\tlet list = $state([]);\n\t{body}\n</script>\n{{p}}{{list}}"
+        )
+    };
+    let code = compile(
+        &src,
+        CompileOptions {
+            filename: Some("P.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    (
+        code.matches("create_ownership_validator").count(),
+        code.matches("$$ownership_validator.mutation(").count(),
+    )
+}
+
+#[test]
+fn a_shadowed_prop_name_declares_no_validator() {
+    let mut failures = Vec::new();
+    for (mode, form, decl, wrap) in SHADOW_CELLS {
+        let (got_decl, got_wrap) = shadow_counts(mode, form);
+        if got_decl != *decl || got_wrap != *wrap {
+            failures.push(format!(
+                "{mode}/{form}: official decl={decl} wrap={wrap}, rsvelte decl={got_decl} wrap={got_wrap}"
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "\n{}", failures.join("\n"));
+}


### PR DESCRIPTION
Closes #4130.

Upstream latches `analysis.needs_mutation_validation` **before** it builds the mutation's
property path (`shared/utils.js:406`), so a computed key it cannot spell — anything but an
identifier or a literal — leaves the mutation unwrapped and **still emits the preamble**.
rsvelte derived the flag from a text scan for `$$ownership_validator.mutation`, which by
construction can only find a mutation that *was* wrapped, so
`object[objectKey ?? key] = v` emitted neither the declaration nor the wrap where official
emits the declaration alone.

A second divergence sat one level further out. `scan_member_chain_names` bailed on a root
wrapped in plain parentheses, because the helper that steps over a parenthesised root
accepted only an `as` / `satisfies` assertion inside them — and acorn erases an empty pair,
so `(object)[key] = v` is the same tree as `object[key] = v`.

## The two halves are NOT orthogonal, and that was predicted wrong

The prediction was that ablating the paren arm would leave the latch intact and cost 3 cells
(`decl=1 wrap=0`). Measured: **8 cells, all `decl=0`**. `props_transforms`'s scan builds
`PropMutationSites`, `source_has_member_write` reads it, and that gates the latch — so the
root arm sits *upstream* of the index rule rather than beside it, and a fix for the index
alone is dead on a parenthesised root. The wrong prediction is what named the dependency;
an ablation that only asked "does it go red" would not have.

## Grid — 24 cells, every expectation generated from the oracle

`crates/rsvelte_core/tests/ownership_validator_unbuildable_path.rs` crosses 3 roots
(`object`, `(object as any)`, `(object)`) with 8 computed-key shapes, and counts
`create_ownership_validator` **and** `$$ownership_validator.mutation(` separately per cell,
so "flag set but wrap missing" is observable rather than folded into one verdict. The five
non-nameable indices are the controls that must keep `wrap == 0` while `decl == 1` — they
reject a fix that simply wraps everything.

## Positive control

| arm | red cells | reading |
|---|---|---|
| latch ablated (`if false && …`) | **15** — the 5 unspellable indices at every root | `decl=0 wrap=0` |
| paren arm ablated (empty-assertion return removed) | **8** — every `paren` cell | `decl=0`, incl. the 3 whose wrap the latch never touches |
| both restored | **0** | 24/24, `git diff` against the kept copies empty |

## Population of the local checks

- `cargo clippy -p rsvelte_core --lib --tests --all-features -- -D warnings` — exit 0
- `cargo test -p rsvelte_core --lib` — `running 1959 tests`, **1958 passed, 0 failed, 1 ignored**
  (the four-digit count is the fingerprint that the `--lib` half ran; the first pass of this
  work compiled only the integration target and missed 13 broken in-lib call sites)
- `cargo fmt --all --check` — exit 0

## Not measured here

Which corpus ratchet entries this retires. Three `huly` client-dev entries are the census's
candidates for this mechanism; they are measured in a follow-up rather than asserted, and no
ratchet JSON is touched in this PR.
