### PR TITLE
docs(compat): the fmt-oracle-excluded attribution sums to what the ratchet holds

### DIFF
--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2716,7 +2716,7 @@ Attribution of `fmt-oracle-excluded.json`:
 | n | target | cluster |
 |---|---|---|
 | 3 | [`deliberate-divergences`](#deliberate-divergences) | the `$props()` comment slot the #3515 repros depend on |
-| 4 | [`deliberate-divergences`](#deliberate-divergences) | `engine-divergence` — oxc's line-breaking, not prettier's |
+| 3 | [`deliberate-divergences`](#deliberate-divergences) | `engine-divergence` — oxc's line-breaking, not prettier's |
 | 5 | [`deliberate-divergences`](#deliberate-divergences) | `invalid-input` and `migrate` — inputs no compiler accepts, and Svelte 4 migrator output |
 | 5 | [`deliberate-divergences`](#deliberate-divergences) | both texts compile to byte-identical client and server `js` **and** `css` |
 | 3 | [`deliberate-divergences`](#deliberate-divergences) | rsvelte reproduces `oxfmt <file>.css` byte-for-byte; the oracle's Svelte path disagrees with oxfmt itself |


### PR DESCRIPTION
`attribution-check` fails on `main`, and #4191 is the cause.

## What broke

#4191 removed `flowbite-svelte/src/routes/builder/range/+page.svelte` from `fmt-oracle-excluded.json` (26 → 25). It was filed `engine-divergence` — "oxc vs prettier … rsvelte delegates to `oxc_formatter`. Upstream oxc-alignment item" — and that attribution was wrong: on the `origin/main` arm it diverged `indent-only` at line 69, and it cleared against **the same oxc** once the script body was embedded as a Doc.

The entry went, and so did the prose bullet naming it. The **attribution table's** `engine-divergence` row kept its count of `4`:

```
KNOWN-FAILURES.md:2714  attribution of fmt-oracle-excluded.json sums to 26, the ratchet holds only 25
```

This changes that row to `3`. The table now sums to 25, and the `fmt-oracle-excluded.json` problem disappears from `attribution-check`.

## Why CI did not catch it

Two checkers read this file and neither closes the gap:

| checker | reads attribution tables? | run by a workflow? |
|---|---|---|
| `scripts/compat-corpus/known-failures-md-check.mjs` | no | **yes** — 3 call sites in `corpus-compat.yml` |
| `scripts/ci/attribution-check.mjs` | yes | **no** — `package.json` script only |

Verified with a positive control rather than a bare negative grep: `known-failures-md-check` matches 3 times under `.github/`, `attribution-check` matches 0 times.

So #4191 was green on the checker that runs and red on the checker that would have seen it. `pnpm run corpus:known-failures-check` and `pnpm run test:known-failures-md-check` both returned `EXIT=0` on that PR, which is exactly what they should have done — they were answering a different question.

## Scope

One line. The five remaining `attribution-check` problems are pre-existing missing blocks and are not touched here:

```
fmt-known-failures.json           524   no Attribution block
known-failures.client-dev.json     24   no Attribution block
known-failures.client.json         11   no Attribution block
lsp-known-failures.json         23746   no Attribution block
parse-ast-known-failures.json     301   no Attribution block
```

`lsp-known-failures.json` and `parse-ast-known-failures.json` are being written up separately.

**Wiring `attribution-check` into a workflow is deliberately not done here** — it would turn five pre-existing gaps into a red `main`, which is a sequencing decision for whoever owns the P3 burndown, not a drive-by.
