### PR TITLE
docs(gates): a dropped node kind, and a code-less error, are invisible to every gate at once

### DIFF
--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -1365,6 +1365,25 @@ compilers raise an uncoded `Not implemented: LetDirective`). The guard has there
 degraded a real divergence in this corpus — and the message comparison covers that pair anyway,
 since it treats two `null` codes as agreeing. **[D]**
 
+### Blind spot 4f — the one-sided code-less error, which 4b measured at 0 and a constructed input produces — **[D]**
+
+4b measures a `null` code on **1** both-reject pair and on **0** pairs one-sidedly, and reads as
+closed on that basis. The one-sided direction is the one the corpus cannot reach rather than the
+one that does not exist: `<script lang="ts">export = a;</script>` on `generate: 'server'` makes
+rsvelte throw with `code: null` and a message naming a pass and a diagnostic count
+(`server instance script classification parse rejected the erased source (1 diagnostics): …`)
+while official does **not** reject at all — it emits output, which happens not to parse (#4196).
+That is `error-presence` on the output ratchet, and every other error field is chained behind
+`code`: `message`, `start`, `end` are compared only where both sides reject, and `frame` only
+where both endpoints already agree. So a code-less error is the single shape this family of
+gates cannot classify, and its one-sided form is invisible here for want of a carrier, not for
+want of the shape — the three TypeScript statement forms that produce it occur in 0 of the
+corpus sources checked out (a denominator of 20 of 104).
+
+The general form is worth separating from the instance: **a gate that keys on a field cannot see
+an error that has no such field**, and "reachability measured at 0" over a collected corpus is a
+statement about the population. The detector is a constructed input, as for 39i.
+
 ### Blind spot 4c — entries only one side rejects have nothing to compare
 
 The message/position comparisons skip any pair where one side compiles, or where the two codes
@@ -4628,6 +4647,37 @@ ratchet, subject to 39a and 39b; treating them as owner movements would make a s
 node-presence defect look like comment traversal. The join also uses one `Map` entry per comment
 range, so two independently represented comments with exactly the same range would collapse into
 one observation.
+
+### 39i — a node kind rsvelte's serializer drops has no corpus carrier, so this gate never sees it — **[D]**
+
+The unit is a corpus entry, so a kind rsvelte omits from `parse()` is only observable where a
+collected component contains one. Three catch-all arms in the program serialization each end
+`_ => None` and drop whatever their explicit arms do not name:
+`1_parse/read/expression.rs:9681` `convert_statement_for_program`,
+`:12085` `convert_class_element_for_program`, `:5654` `convert_class_element_for_expr`. The
+residues, computed as the scrutinee enum's variants (with `INHERIT` resolved) minus the handled
+ones, are `TSImportEqualsDeclaration`, `TSExportAssignment`, `TSNamespaceExportDeclaration` and
+`TSIndexSignature` once the kinds both compilers reject earlier (`with`, `accessor`) are removed.
+Measured: official's AST carries all four and rsvelte's carries none, with `IfStatement` and a
+class `static {}` present in both as controls (#4195).
+
+None has a carrier in the corpus sources checked out here — class-body index signatures are 0 of
+31 index signatures found (19 `interface`, 7 `type`, 1 a class field's type annotation), and the
+three statement forms are TS module syntax a component does not use. That denominator is 20 of
+the 104 sources, so this is "no witness in the population measured", not "no carrier". The
+detector for this class is a unit test, the same argument
+`crates/rsvelte_core/tests/import_export_parser_shapes.rs` already carries for two shapes no
+corpus can hold.
+
+**What generalizes past these four.** The blind spot is not the four kinds, it is that a dropped
+kind is invisible to *every* gate at once: `compile()` may still be correct (it is, for
+`TSIndexSignature`), so the output ratchets report nothing, while `rsvelte_lint` and svelte2tsx
+consume rsvelte's AST without ever diffing it. An inventory of the 1,316 catch-all arms under
+`crates/` found something worth recording about how to screen them — a syntactic filter that
+discards an arm whose sibling heads are literals throws away **149 of the 590 it discards
+(25%)** that are node-kind dispatches spelled as strings (`match node_type(e) { Some("Identifier")
+… }`), which are exactly the JSON-walking lint rules. The screen's error is only visible in the
+pile it rejects.
 
 ---
 

--- a/upstream_issues/4197-svelte-class-index-signature-typeerror.md
+++ b/upstream_issues/4197-svelte-class-index-signature-typeerror.md
@@ -1,0 +1,41 @@
+# A class-body TypeScript index signature crashes the compiler with a raw TypeError
+
+A class body containing a TypeScript **index signature** — legal TypeScript — makes the Svelte
+compiler throw a raw `TypeError` rather than an `InternalCompileError` with a code.
+
+```svelte
+<script lang="ts">
+	class C { [k: string]: number }
+</script>
+```
+
+```
+TypeError: Cannot read properties of undefined (reading 'type')
+```
+
+Reproduced on `generate: 'client'` and `generate: 'server'`, against both the repository source
+(`packages/svelte/src/compiler/index.js`) and the published `svelte/compiler`, both reporting
+`VERSION` 5.56.10.
+
+## Control
+
+The same index signature inside an `interface` compiles cleanly on both targets, as does an empty
+class — so it is the class-body member kind, not the syntax and not TypeScript erasure in
+general.
+
+```svelte
+<script lang="ts">
+	interface I { [k: string]: number }
+	class C {}
+</script>
+```
+
+## Why the error shape matters as much as the crash
+
+A raw `TypeError` carries no `code`, so a consumer that classifies compile failures by code — a
+build plugin, an editor integration, a differential harness — cannot tell this from an internal
+failure. Every other TypeScript-only class member checked alongside it (`declare`, `abstract`,
+`?`, `!`, the visibility modifiers, `override`, a typed method, a generic method, a typed getter)
+either compiles or raises a coded diagnostic.
+
+Tracked in this repository as #4197.

--- a/upstream_issues/README.md
+++ b/upstream_issues/README.md
@@ -82,6 +82,7 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `4111-svelte-await-catch-binding-transform-leaks-out-of-the-block.md` | sveltejs/svelte | #4111 | unrecorded |
 | `4117-svelte-class-shorthand-reaches-attributes-untransformed.md` | sveltejs/svelte | #4117 | unrecorded |
 | `4177-svelte2tsx-is-attribute-mustache-first-chunk-crash.md` | sveltejs/language-tools (svelte2tsx) | #4177 | unrecorded |
+| `4197-svelte-class-index-signature-typeerror.md` | sveltejs/svelte | #4197 | unrecorded |
 | `grass-css-color-4-relative-syntax.md` | connorskees/grass | — | unrecorded |
 | `grass-explicit-extension-specifier.md` | connorskees/grass | — | unrecorded |
 | `grass-hoists-a-declaration-written-after-a-nested-rule.md` | connorskees/grass | — | unrecorded |


### PR DESCRIPTION
Two blind-spot rows and one upstream report. No ratchet moves, no code changes.

## 39i — a node kind the serializer drops is invisible to every gate at once

Three catch-all arms in the program serialization end `_ => None` and drop whatever their
explicit arms do not name:

| site | what reaches `_` |
|---|---|
| `1_parse/read/expression.rs:9681` `convert_statement_for_program` | `TSImportEqualsDeclaration`, `TSExportAssignment`, `TSNamespaceExportDeclaration` (plus `WithStatement`, which both compilers reject earlier) |
| `:12085` `convert_class_element_for_program` | `TSIndexSignature` |
| `:5654` `convert_class_element_for_expr` | `TSIndexSignature`, `AccessorProperty` (rejected by both) |

The residues are computed, not guessed: the scrutinee enum's variants with `INHERIT` resolved,
minus the variants the sibling arms name. Measured, official's `parse()` AST carries all four
and rsvelte's carries none, with `IfStatement` and a class `static {}` present in both as
controls (#4195).

The row is about the gate, not the four kinds. **The `parse()` AST ratchet's unit is a corpus
entry**, and none of the four has a carrier here — class-body index signatures are 0 of the 31
index signatures found (19 `interface`, 7 `type`, 1 a class field's type annotation), and the
three statement forms are TS module syntax a component does not use. Meanwhile `compile()` stays
correct for `TSIndexSignature`, so the output ratchets report nothing either, and `rsvelte_lint`
and svelte2tsx consume rsvelte's AST without ever diffing it. The detector for this class is a
unit test, the same argument `import_export_parser_shapes.rs` already carries.

## 4f — the one-sided code-less error

4b measures a `null` `code` on 1 both-reject pair and **0 one-sided**, and reads as closed on
that basis. The one-sided direction is the one the corpus cannot reach rather than the one that
does not exist: `<script lang="ts">export = a;</script>` on `generate: 'server'` makes rsvelte
throw with `code: null` and an internal message while official does not reject at all (#4196).
Every other error field is chained behind `code` — `message`, `start`, `end` only where both
sides reject, `frame` only where both endpoints already agree — so a code-less error is the one
shape that family of gates cannot classify.

## What the inventory behind these rows measured

1,316 catch-all arms under `crates/`, screened by a syntactic filter that discards an arm whose
sibling heads are literals. **The filter's discard is unsound**: 149 of the 590 it discards
(25%) are node-kind dispatches spelled as strings (`match node_type(e) { Some("Identifier") … }`)
— the JSON-walking lint rules. That was found by sampling the **discarded** population, which is
the only place the error can be. A second screen ("is `_` reachable at all", from the enum table)
removes 1 of 714 and is recorded as non-discriminating rather than dropped silently.

## `upstream_issues/4197-…`

`class C { [k: string]: number }` in a `lang="ts"` script makes the official compiler throw a raw
`TypeError: Cannot read properties of undefined (reading 'type')` rather than an
`InternalCompileError` — on `client` and `server`, and in the repository source **and** the
published `svelte/compiler`, both reporting `VERSION` 5.56.10. The control is the same index
signature in an `interface`, which compiles. rsvelte strips the member and its output parses.

A side effect worth knowing before anyone re-measures #3422: **that issue's own repro crashes the
current official compiler**, so the oracle its fix was measured against no longer answers for
that input.

## Checks

- `node scripts/compat-corpus/known-failures-md-check.mjs` exits 0.
- No `compatibility/*known-failures*.json` touched; `compatibility/` keeps its two Markdown
  files, and the only new file is one report under `upstream_issues/`.
