### PR TITLE
fix(client): a module script reaches the dev `$.assign` rule too

### DIFF
--- a/.changeset/module-script-dev-assign.md
+++ b/.changeset/module-script-dev-assign.md
@@ -1,0 +1,10 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A module script's member assignment in value position is now wrapped in dev's
+`$.assign(...)`, as upstream's one `AssignmentExpression` visitor does for every
+script. rsvelte ran that collector only over a settled instance script, so a
+`.svelte.js`, a `.svelte.ts` and a component's `<script module>` all emitted the
+bare assignment and lost the proxy warning it exists to give
+(`(object.items ??= []).push(x)`).

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -3332,17 +3332,30 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 22 entries)
+### Client dev (`known-failures.client-dev.json`, 18 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `22`
+Partition of `known-failures.client-dev.json` by verdict: `18`
 
-- **22 — the generated JS differs.**
+- **18 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 22 arrived with the wave-2 enrolment (#3176); this target was at 0 before
-it, and it is the largest of the four — 11 JS entries that `client` does not
+All remaining 18 arrived with the wave-2 enrolment (#3176); this target was at 0 before
+it, and it is the largest of the four — 7 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
+
+Four entries left this target when a module script started reaching the dev `$.assign` rule.
+Upstream has one `AssignmentExpression` visitor and no module/component split, so
+`obj.prop = value` in a `.svelte.js` / `.svelte.ts` or a `<script module>` is wrapped exactly
+as it is in an instance script; rsvelte's `transform_module_dev_tail_ast` collected the
+`$.strict_equals` / `await` / `console.*` / `$.tag` edits and not this one, so the whole module
+surface emitted the bare assignment. The axis is not "is this a module" but **whether the
+assignment sits in value position** — a 65-cell grid crossing the three entry points
+(`.svelte.js`, `.svelte.ts`, `<script module>`) with the assignment's position and the operator
+reads 7/16, 7/16, 7/16 and 15/16 per host before the fix and 16/16 on all four after it. The
+component host is in the grid as the control that is nearly green throughout, and an arm with
+the root-binding guard removed emits `$.assign(globalThis, …)` on **all four** hosts, which is
+what keeps the guard from being deleted along with the bug.
 
 `huly/…/SelectAvatarPopup.svelte` left it when a member assignment whose root resolves to
 no binding stopped being wrapped. Upstream's `build_assignment` opens with `if (!binding)

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,5 +1,4 @@
 [
-	"chatgpt-web/src/lib/ChatCompletionResponse.svelte",
 	"ha-fusion/src/lib/Modal/VisibilityConfig/Index.svelte",
 	"headscale-ui/src/lib/settings/ServerSettings.svelte",
 	"huly/plugins/workbench-resources/src/components/HelpAndSupport.svelte",
@@ -7,9 +6,7 @@
 	"immich/web/src/lib/components/timeline/Timeline.svelte",
 	"mathesar/mathesar_ui/src/components/sort-entry/SortEntry.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
-	"photon/src/lib/app/auth/profile.svelte.ts",
 	"photon/src/lib/ui/navbar/Profile.svelte",
-	"photon/src/lib/ui/navbar/commands/actions.svelte.ts",
 	"primo/src/lib/builder/ui/Button.svelte",
 	"svelte-bits/src/lib/components/library/Animations/MetallicPaint/MetallicPaint.svelte",
 	"svelte-lexical/demos/qalam/src/lib/notesStore.svelte.ts",
@@ -19,6 +16,5 @@
 	"svelteui/packages/svelteui-demos/src/demos/core/Modal/ModalForm.svelte",
 	"svelvet/src/lib/components/Edge/Edge.svelte",
 	"syntaxfm-website/src/routes/(site)/guests/+page.svelte",
-	"threlte/packages/extras/src/lib/hooks/useGamepad/useGamepad.svelte.ts",
 	"trakt-web/projects/client/src/lib/sections/navbar/_internal/NavbarHeader.svelte"
 ]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_dev_tail_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_dev_tail_ast.rs
@@ -110,6 +110,10 @@ pub(super) fn transform_module_dev_tail_ast(
         && !trace_thunks.is_empty()
         && super::inspect_rune_ast::source_has_inspect_trace(source);
     let has_await = dev && super::await_reactivity_loss_ast::source_has_await(source);
+    // Upstream's `AssignmentExpression` visitor is one map entry for every
+    // script, so a module script reaches the same rule as an instance one.
+    let has_assign =
+        dev && analysis.is_some() && super::assign_dev_ast::source_has_assignment(source);
     let experimental_async = analysis.is_some_and(|a| a.experimental_async);
     // A rune call whose callee resolves to a declaration is a plain call
     // (upstream `get_rune`). Only a module that declares such a name pays for
@@ -121,7 +125,14 @@ pub(super) fn transform_module_dev_tail_ast(
             .any(|b| rune_shadow::is_rune_name(&b.name))
     });
 
-    if !has_effect && !has_strict && !has_console && !has_tag && !has_inspect && !has_await {
+    if !has_effect
+        && !has_strict
+        && !has_console
+        && !has_tag
+        && !has_inspect
+        && !has_await
+        && !has_assign
+    {
         return None;
     }
     let _ = has_trace;
@@ -185,6 +196,18 @@ pub(super) fn transform_module_dev_tail_ast(
                         experimental_async,
                     ),
                 );
+            }
+            if has_assign && let Some(analysis) = analysis {
+                // A module script's whole program is the fragment, so every
+                // name it declares is resolved here; the instance path's
+                // second resolver exists only because its fragment is a body.
+                edits.extend(super::assign_dev_ast::collect_assign_edits(
+                    program,
+                    src,
+                    &analysis.source,
+                    &analysis.filename,
+                    &rustc_hash::FxHashSet::default(),
+                ));
             }
             edits
         },

--- a/crates/rsvelte_core/tests/module_script_dev_assign.rs
+++ b/crates/rsvelte_core/tests/module_script_dev_assign.rs
@@ -1,0 +1,157 @@
+//! Upstream's `AssignmentExpression` visitor is one entry in the client visitor
+//! map, so a module script reaches the same `$.assign` rule as an instance one:
+//! `dev && path.at(-1) !== 'ExpressionStatement' && is_non_coercive_operator(op)
+//! && !scope.evaluate(right).is_primitive`, with a `MemberExpression` left whose
+//! root resolves to a binding (`AssignmentExpression.js:189-193`, `:117`).
+//!
+//! rsvelte ran that collector only over a settled *instance* script, so every
+//! module script emitted a bare assignment. Three entry points share the code —
+//! `.svelte.js`, `.svelte.ts` and a component's `<script module>`, the last of
+//! which is `compile()` rather than `compileModule()` — and a fix that reaches
+//! one leaves the others green, so there is one cell per entry point.
+//!
+//! The controls are the four conditions of that guard plus the root's binding.
+//! Removing the binding check alone makes every `global root` row emit
+//! `$.assign(globalThis, …)`, measured on all three entry points.
+//!
+//! Every expectation is the official compiler's own output for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_module};
+
+fn assigns(code: &str) -> Vec<String> {
+    code.lines()
+        .filter(|line| line.contains("$.assign"))
+        .map(|line| line.trim().to_string())
+        .collect()
+}
+
+fn module(filename: &str, source: &str) -> Vec<String> {
+    let out = compile_module(
+        source,
+        ModuleCompileOptions {
+            filename: Some(filename.to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|err| panic!("{filename}: {err:?}"));
+    assigns(&out.js.code)
+}
+
+fn component(source: &str) -> Vec<String> {
+    let out = compile(
+        source,
+        CompileOptions {
+            filename: Some("C.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|err| panic!("{source}: {err:?}"));
+    assigns(&out.js.code)
+}
+
+/// One cell per entry point. `<script module>` is the one that is not
+/// `compileModule` at all, which is why its position is the `.svelte` file's.
+#[test]
+fn all_three_module_entry_points_wrap_a_member_assignment_in_value_position() {
+    assert_eq!(
+        module(
+            "M.svelte.js",
+            "export function f(o) { return (o.q = {}); }\n"
+        ),
+        ["return $.assign(o, 'q', '=', {}, 'M.svelte.js:1:31');"]
+    );
+    assert_eq!(
+        module(
+            "M.svelte.ts",
+            "export function f(o) { return (o.q = {}); }\n"
+        ),
+        ["return $.assign(o, 'q', '=', {}, 'M.svelte.ts:1:31');"]
+    );
+    assert_eq!(
+        component(
+            "<script module>\nexport function f(o) { return (o.q = {}); }\n</script>\n<p>x</p>\n"
+        ),
+        ["return $.assign(o, 'q', '=', {}, 'C.svelte:2:31');"]
+    );
+}
+
+/// A module's top level is not exempt. This row exists because a grid that held
+/// the right-hand side at a literal reported it as `0` on both sides — the
+/// primitive test, not the position, is what silences that shape.
+#[test]
+fn a_module_top_level_assignment_in_value_position_is_wrapped_too() {
+    assert_eq!(
+        module(
+            "M.svelte.js",
+            "const o = {};\nexport const z = (o.q = {});\n"
+        ),
+        ["export const z = $.assign(o, 'q', '=', {}, 'M.svelte.js:2:18');"]
+    );
+}
+
+/// The computed-key form takes the property expression rather than a string
+/// literal, so it is a separate branch of the same builder.
+#[test]
+fn a_computed_member_passes_its_key_expression() {
+    assert_eq!(
+        module(
+            "M.svelte.js",
+            "export function f(o, k) { return (o[k] = {}); }\n"
+        ),
+        ["return $.assign(o, k, '=', {}, 'M.svelte.js:1:34');"]
+    );
+}
+
+/// Each condition of upstream's guard, one row each: a whole-statement
+/// assignment, a primitive value, and a coercing operator are all left alone.
+/// A pass added without them wraps all three.
+#[test]
+fn each_condition_of_the_guard_still_silences_the_wrap() {
+    let empty: [String; 0] = [];
+    assert_eq!(
+        module("M.svelte.js", "export function f(o) { o.q = {}; }\n"),
+        empty
+    );
+    assert_eq!(
+        module(
+            "M.svelte.js",
+            "export function f(o) { return (o.q = 1); }\n"
+        ),
+        empty
+    );
+    assert_eq!(
+        module(
+            "M.svelte.js",
+            "export function f(o) { return (o.q += {}); }\n"
+        ),
+        empty
+    );
+}
+
+/// Upstream's `if (!binding) return null`: a chain rooted at a global is not
+/// instrumented. This is the row that fails when the resolution guard is
+/// dropped — measured, dropping it emits `$.assign(globalThis, 'q', …)` on every
+/// entry point, which is why the module pass passes an EMPTY set of component
+/// bindings rather than no guard: a module's whole program is the fragment, so
+/// its own resolver already answers for every name it declares.
+#[test]
+fn a_chain_rooted_at_a_global_is_not_instrumented_in_a_module() {
+    let empty: [String; 0] = [];
+    assert_eq!(
+        module(
+            "M.svelte.js",
+            "export function f() { return (globalThis.q = {}); }\n"
+        ),
+        empty
+    );
+    assert_eq!(
+        component(
+            "<script module>\nexport function f() { return (globalThis.q = {}); }\n</script>\n<p>x</p>\n"
+        ),
+        empty
+    );
+}


### PR DESCRIPTION
## The defect

Upstream's `AssignmentExpression` visitor is **one entry** in the client visitor map, so a
module script reaches the same `$.assign` rule as an instance one
(`AssignmentExpression.js:189-193`):

```js
let should_transform =
  dev &&
  path.at(-1) !== 'ExpressionStatement' &&
  is_non_coercive_operator(operator) &&
  !context.state.scope.evaluate(right).is_primitive;
```

rsvelte runs that collector only over a settled **instance** script
(`instance_dev_tail_ast::transform_instance_dev_assign_tail`), so every module script emitted
the bare assignment and lost the proxy warning the wrap exists to give
(`(object.items ??= []).push(x)`).

## Three entry points, not one

`.svelte.js`, `.svelte.ts` and a component's `<script module>` are three different ways in — and
the last is `compile()`, not `compileModule()`. They share `transform_module_dev_tail_ast`, which
is why one change reaches all three and why the grid has one cell per entry point: a fix that
reaches one leaves the others green, which is the shape #2547 shipped.

## The grid is enumerated from upstream's condition, not from the reported files

65 cells: 4 hosts (the three module entry points + an instance script as the live control) × 16
bodies, plus one two-script cell. **Every expectation is generated by compiling the input through
`submodules/svelte/.../compiler/index.js`.**

The key is the **whole `$.assign(...)` call text**, not the number of calls. That is not
cosmetic: keying on the count reported two live divergences as agreement — a lazy getter printing
`() => {}` instead of `() => ({})`, and a wrong location argument. Both sides emit exactly one
call in each.

### Three arms

Per host, EQ out of 16 (the 65th cell is the two-script one, counted separately):

| arm | `.svelte.js` | `.svelte.ts` | `<script module>` | instance | both scripts | total |
|---|---|---|---|---|---|---|
| base `5dc32eac2`, before this change | 7 | 7 | 7 | **16** | 0/1 | 37 EQ / 28 DIFF |
| this pass, **binding guard removed** | 15 | 15 | 15 | **15** | 0/1 | 60 EQ / 5 DIFF |
| this pass, empty `component_bindings` | **16** | **16** | **16** | **16** | 0/1 | **64 EQ / 1 DIFF** |

All three rows are measured on `5dc32eac2`, the base this PR sits on; an earlier version of this
table was measured one merge older and read 36/29 on the first row, because the instance host's
lazy-getter cell was still open there and is now on `main`.

The first row is what says the defect is module-only: each module host answers 7 of 16 while the
instance host already answers 16.

The middle row is the control for the design decision. Upstream ends `build_assignment` with
`if (!binding) return null`, so a chain rooted at a global is not instrumented — and **dropping
that guard emits `$.assign(globalThis, 'q', '=', …)` on all four hosts, the instance one
included** (`global root, value, ={}`: official emits nothing, rsvelte emits
`$.assign(globalThis, 'q', '=', {}, 'C.svelte:2:30')`), which is a host this PR otherwise does not
move at all. Keeping it with an
**empty** set of component bindings is enough because a module's whole program *is* the fragment
`resolved_reference_spans` walks, where the instance path's second resolver exists only because
its fragment is a function body.

The seven negative cells — statement position, primitive value, coercing operator, global root,
module top level in statement position, a bare identifier target — agree on both sides in all
four hosts, in the first and third arms. In the middle arm exactly one of them moves, the global
root, which is the cell that arm exists to expose.

### One measurement corrected a premise

A module's **top level in value position** is wrapped (`export const z = $.assign(o, 'q', '=', {},
…)`). An earlier grid reported it as `0` on both sides and read that as "only inside a function" —
because that grid held the right-hand side at a literal, and `!evaluate(right).is_primitive` is
the condition that silences the shape. The cell is in the test file with that note.

### Positive control

Removing the pass turns the three positive tests red and leaves both control tests green.

## Blast radius

Re-measured on this branch rebased onto `8cf5b7202` (after #4192 merged), with both arms rebuilt
on that base. Arms identified two ways, because a `MOVED` count answers neither question on its
own: distinct `sha256` (`53467d0abd0f2cb4` / `7026c358aa837f04`), and a probe that asks what each
arm should **contain** and what it should **lack** — the module fingerprint present only in
`after`, #4184's global-root fix present in **both**, and the sibling site-order fix (a separate
branch, not this one) absent from both. One arm per process; two `.node` modules in one process
segfault.

The sweep names its own population, because that is where this measurement failed first:

```
EMPTY submodules/svelte.dev
EMPTY submodules/bits-ui
… 84 lines …
[sweep] sources populated=20/104 empty=84
[sweep] files=14990
[sweep] rows=59960 distinct-keys=59960 live-units=55950 error-units=4010
[diff] arms 1303f2d2e4a0bc30 / decb96792418d1b0 distinct   (5dc32eac2 arms; see the note below)
[diff] MOVED = 5     (all client-dev; the wrap is dev-only)
```

The 59,960-key sweep above was run on the `5dc32eac2` arms, before #4192 merged. It is quoted for
the blast radius — which units this change touches at all — and the *verdict* half was re-run on
`8cf5b7202` arms after the rebase, below. The five ids are the same on both bases.

An earlier run of this measurement reported `files=7142`, which was a **true number that could
not be checked**: a submodule that is not checked out contributes no files and no error, so it
only makes the denominator smaller. It was 8 of 104 sources. Printing one `EMPTY` line per absent
source is the whole fix, and it is why the population is now readable off the run rather than off
this paragraph. `rows` beside `distinct-keys` is the other half — a key collapse and a real zero
print the same number otherwise.

Stage 2 takes only those five and runs them through the gate's own stages — flatten template
holes, `oxfmt` both trees with `compatibility/.oxfmtrc.json`, `stripBlankLines`, then
`ast_equiv_batch` on every byte-different pair:

```
before (8cf5b7202) : 5 failing, 0 already-pass
after  (this PR)   : 1 failing, 4 already-pass
match -> MISMATCH  : 0
```

**Four `client-dev` ratchet entries retire** — `chatgpt-web/.../ChatCompletionResponse.svelte`,
`photon/.../profile.svelte.ts`, `photon/.../actions.svelte.ts`,
`threlte/.../useGamepad.svelte.ts` — taking `known-failures.client-dev.json` from **22 to 18**.
The same check run over **every** entry of all four output ratchets reports these four and
nothing else, with `measured == listed` on each target (no entry without a carrier) — on the
rebased tree: `client 11 / server 2 / server-dev 2 / client-dev 18`, `total ALREADY-PASS = 0`. Its
positive control is a retired entry added back to the list, which it then names in that target and
alone.

**18 is read off the run, not subtracted.** #4192 took this ratchet to 22 while this branch was
open, so the branch was rebased onto `8cf5b7202`, both arms were rebuilt there, and the stage-2
check was re-run: `5 failing, 0 already-pass` before and `1 failing, 4 already-pass` after, the
same four ids. The `7 JS entries that client does not carry` in the section header is likewise a
set difference computed from the two JSON files rather than from the previous sentence's
arithmetic.

**This number is the stale side only.** The new-failure side over the 84 unpopulated sources is
the CI job's, not this body's.

### The fifth moves without retiring

`svelte-bits/.../MetallicPaint.svelte` changes output and stays divergent, on one line:

```
off: outData.data[px] = $.assign(outData.data, px + 1, '=', outData.data[px + 2] = gray, '…:223:22');
rsv: outData.data[px] = $.assign(outData.data, px + 1, '=', $.assign(outData.data, px + 2, '=', gray, '…:223:3'), '…:223:3');
```

**This PR neither causes nor fixes it.** The same chained assignment placed in an *instance*
script reproduces it on the arm without this change:

```
before, instance host : o.a[0] = $.assign(o.a, 1, '=', $.assign(o.a, 2, '=', gray, 'C.svelte:2:29'), 'C.svelte:2:29');
official              : o.a[0] = $.assign(o.a, 1, '=', $.assign(o.a, 2, '=', gray, 'C.svelte:2:47'), 'C.svelte:2:38');
```

Both location arguments carry the same wrong column. It is the shared `AssignSites` position
recovery, and the module pass reaches it because the code is shared — so it is listed here rather
than folded in.

### The same mechanism, second cell

A component with the same assignment shape in **both** scripts:

```
official : 'C.svelte:2:31' and 'C.svelte:5:31'
this PR  : 'C.svelte:2:31' twice
```

`AssignSites` scans the original source for same-shaped sites and consumes them in order, and the
two passes each start a fresh scan — so both take site 1. Before this change the instance pass
already took the module script's site and emitted the only call at `2:31`; the instance side's
answer is therefore **unchanged**, and the module side is newly correct. That is the one cell of
the 65 this PR does not close.

`mod.rs:6044` already carries a note that a `<script module>` "reaches here with an
already-processed `pre_class_script`, so its positions are not the source's (#3543)". It is worth
citing as a line that describes the neighbouring problem this plumbing now sits on top of — not
as a survey of it.

## Two zeros this sweep produced before it produced a five

Recorded because both read as answers:

1. The first sweep reported `MOVED = 0` over 22,544 keys. **None of the four carrier
   repositories was checked out in this worktree** — `find` returned 0 files for photon, threlte,
   chatgpt-web and svelte-bits — so the population contained no known carrier and the zero was
   forced.
2. With them checked out it reported `MOVED = 2`. The three `.svelte.ts` carriers hashed to the
   **same value across all four targets**: `compileModule` parses plain JS, so 93 of photon and
   threlte's 104 module files were an identical `js_parse_error` in both arms. Mirroring
   `compile.mjs:94`'s esbuild strip made them live (0/4 → 4/4 units each) and the sweep reported
   5.

The sweep now prints `live-units` beside `keys`, because an error hash compares equal to itself
and a dead unit is therefore scored as agreement.

The same shape has a waiting-side twin, found the same day by @rsvelte-75 while building the
other arm of a different measurement: a loop that waited for a build by polling `pgrep cargo`
ran before `cargo` had started (the command began with `git checkout`), fell straight through,
and staged the *previous* build as the baseline arm. **"The process is not there yet" and "the
process has finished" look identical to `pgrep`** — which is the same function as this
repository's note that `pkill -f <path>` cannot match `cargo`, read in the other direction: there
you cannot kill it, here you cannot wait for it. Recording both, because either one alone reads
as a narrow fact about `cargo`'s command line.

## Checks

- `cargo test --release -p rsvelte_core --lib --test module_script_dev_assign --test
  assign_dev_lazy_getter_arrow_body --test assign_dev_global_root --test dev_assign_script --test
  assign_dev_template_port`: `Running unittests src/lib.rs` present in the log (the `--lib`
  fingerprint — a `--test` list alone does not run it), `1962 passed; 1 ignored` from the lib, and
  `5 / 4 / 3 / 2 / 3 passed` from the five suites, **0** failures.
- `cargo fmt --check` clean; `cargo clippy -p rsvelte_core --all-targets --all-features
  -- -D warnings` clean.
- The 65-cell grid on the rebased arm reads **64 EQ / 1 DIFF**. The one DIFF is `both scripts` —
  an instance script and a `<script module>` holding the same assignment, which the two passes'
  site scans take from each other. That is a **different** defect with its own branch and its own
  cells; it is deliberately left failing here rather than folded in, so each fix has cells that
  fall on their own.
- `known-failures.client-dev.json` **24 → 20**, with the `KNOWN-FAILURES.md` section counts
  updated and `node scripts/compat-corpus/known-failures-md-check.mjs` exiting 0.
