### PR TITLE
docs(lsp): the `initialize` capability cluster reaches four terminal states, not one

### DIFF
--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -885,6 +885,45 @@ only ones with live discriminating power.
 **Evidence [D]:** the file counts and the key distribution above are measured; the suppression
 follows from the key's own definition at `ratchet.mjs:55`.
 
+
+### Blind spot 27p — a rejected request and an unchanged document are the same empty response [D]
+
+`on_formatting` answers a params deserialization failure with `respond_no_edits`
+(`server.rs:736-742`), and `worker.rs:659` states the same rule for the pass below it —
+"Formatting is never an error to the client: a failure yields no edits". So four distinct
+outcomes — the session has no formatter config, the formatter panicked, the formatter errored,
+and the document was already formatted — all reach the client as `[]`. The ratchet key records
+the response, so **it cannot say which of the four produced it**, and a malformed request is
+indistinguishable from agreement about a document that needs no change.
+
+That is not hypothetical here: the harness's own `textDocument/formatting` request omits
+`options`, which `lsp-types` declares without `#[serde(default)]`
+(`DocumentFormattingParams`, `formatting.rs:27-33`), because `suites.mjs:150-179` adds extra
+params only for `completion` / `hover` / `linkedEditingRange` (position), `selectionRange`
+(positions) and `codeAction` (range + context). Measured against the debug server on the ten
+`plugin-format-*` fixture documents' text:
+
+| request | response | stderr |
+|---|---|---|
+| `{textDocument}` — what the gate sends | `[]` | ``textDocument/formatting: missing field `options` `` |
+| `{textDocument, options}` | one edit, `newText: "unformatted\n"` | — |
+
+The twenty `differential:fixtures/plugin-format-*|textDocument/formatting` entries therefore
+measure the harness, not the compiler, and their recorded payload confirms it: the entry's
+`hash=f411dae2ecdd` is `digest(["item-" + digest(edit)])` over official's single edit, and
+recomputing that chain from the *measured rsvelte* edit reproduces `f411dae2ecdd` exactly — so
+the two edits are byte-identical and supplying `options` retires all twenty rather than
+converting them. The same omission reaches `documentHighlight`, whose `position` is likewise
+never sent although the ratchet key displays one (`|0:13|`): `request()`'s third argument is a
+label, not a parameter.
+
+**Evidence [D]:** the two responses and the stderr line are one measured probe against
+`target/debug/rsvelte-language-server`; the digest reconstruction is arithmetic over the
+committed ratchet. Note the population this does **not** settle — `prepareRename` (4 cases) and
+`colorPresentation` (3) also declare a manifest `params` that `suites.mjs` never reads, and both
+hold **zero** ratchet entries; that zero is consistent with both servers returning nothing, so it
+is not evidence they are unaffected.
+
 ---
 
 ## 1. Compiler output parity — `scripts/compat-corpus/verify.mjs`

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -946,6 +946,44 @@ reported, because it does not discriminate — `formatting` and `documentHighlig
 `colorPresentation` and `prepareRename` are 0% in the same group, and those two zeroes may be
 empty denominators rather than agreement.
 
+### Blind spot 27q — the cache cleanup spares exactly the caches that matter [D]
+
+`rsvelte-language-server` digs an overlay cache at whatever project root it is pointed at
+(`CACHE_DIRECTORY = ".rsvelte-language-server"`, `tsgo_overlay.rs:26`), and this gate points it at
+fixtures inside the pinned `submodules/language-tools`. The harness does clean up: `verify.mjs`
+snapshots the caches that exist before the run and, in a `finally`, deletes the ones that appeared
+(`verify.mjs:1120-1135`, `removeNewServerCaches`). A completed run therefore leaves the submodule
+byte-clean — measured, 5 created and 5 removed, `git status --porcelain` empty afterwards.
+
+**The gap is that it deletes only the caches it created.** One that is already present when the run
+starts is classified as pre-existing and spared — by every subsequent run, permanently. So a cache
+that survives once, because a run was interrupted or aborted between creating it and reaching the
+`finally`, is never collected again. That is not hypothetical: one checkout carried a `tsgo/` two
+days older than the run that noticed it, while another was clean, and the difference was whether a
+run had ever been killed part-way.
+
+A survivor is not inert. `build` (`tsgo_overlay.rs:222-258`) calls `create_dir_all` on the shadow
+directory and **never clears it**, rewriting a shadow per `.svelte` it finds — so a shadow whose
+source is gone, renamed, or no longer discovered simply stays. And the generated tsconfig includes
+that directory by **glob**, `"include": ["svelte/**/*", …]` (`write_tsconfig`,
+`tsgo_overlay.rs:963-1001`), so whatever remains is in the next run's program. Nothing in the path,
+the file names or the config records which binary produced them, and there is no `tsBuildInfoFile`
+in this crate (grep returns none; positive control: `rootDirs` is present). **A measurement taken
+after changing the binary can therefore read a projection the previous binary wrote** — the input
+side of the rule that an artifact's name, path and branch never establish what it is.
+
+Delete any surviving cache before measuring across a binary change, and treat "does the answer move
+when it is deleted" as its own measurement.
+
+**Evidence [D]:** the create-and-remove counts, the empty `git status` after a completed run, and
+the globbed `include` are read from one run's own output; the spare-the-pre-existing rule from
+`removeNewServerCaches`, and the never-cleared and not-binary-keyed properties from `build` and
+`write_tsconfig`. **Unmeasured:** whether a stale shadow has ever actually changed a recorded
+answer here, and whether the corpus suite writes the same cache — only the fixture suite was
+observed. And a count of zero untracked directories proves nothing on its own: it is equally what a
+checkout shows *before* a run reaches its first fixture, which is how this was first reported as
+reproducing on one machine and not another.
+
 ---
 
 ## 1. Compiler output parity — `scripts/compat-corpus/verify.mjs`

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -5360,7 +5360,9 @@ sample of one tree's output, not an enumeration of the shapes upstream emits.
 
 ## 42. Deliberate-divergence pinning — `scripts/dev/deliberate-divergences-check.mjs`
 
-**Unit.** One `## ` section of `compatibility/deliberate-divergences.md`, 20 of them. The check is
+**Unit.** One section of the `deliberate-divergences` anchor, 25 of them. The document was
+consolidated into `compatibility/GATES.md`, so `locate()` falls back to that anchor and the
+heading it parses is `### `; `compatibility/deliberate-divergences.md` no longer exists. The check is
 that each names at least one repository path that (a) exists on disk and (b) is a test — under a
 `tests/` directory, in `compatibility/pattern-corpus/`, or a `scripts/**/test-*.mjs` harness.
 Run by `ci.yml`'s `Corpus verify baseline-flag contract` job and `pnpm run
@@ -8325,6 +8327,91 @@ the divergence is real, no ratchet holds it, and the only thing standing between
 Remove this entry when upstream subtracts `node.pos`
 (`nodeText.substring(tag.pos - node.pos, tag.end - node.pos)`); rows 2 and 3 both collapse into
 row 1 at that point and the pinned test fails.
+
+### The completion trigger characters include a space
+
+**Pinned by** `crates/rsvelte_language_server/tests/protocol.rs` (the `triggerCharacters`
+assertion, which lists `" "`) and `scripts/compat-lsp/capability-hashes.test.mjs`.
+**Ratchet.** `lsp-known-failures.json`, the
+`/capabilities/completionProvider/triggerCharacters:extra-rsvelte` entry.
+
+Upstream excludes whitespace from `completionProvider.triggerCharacters` and says why
+(`server.ts:299-301`): *"No whitespace because it makes for weird/too many completions of other
+completion providers"*. rsvelte includes `" "`.
+
+That comment is upstream's own product judgement, not an assessment of rsvelte, and the two
+servers do not have the same thing to trade away. rsvelte answers a completion request at a
+position immediately after the space in a start tag with the element's HTML attributes —
+`completions_with_strict_mode("<div ", 5, …)` returns `class`, pinned in
+`crates/rsvelte_language_server/src/completions.rs`. A character absent from this list never
+reaches the server at all, so dropping `" "` would not merely align the advertisement, it would
+make that behaviour unreachable from a real client while the code answering it stayed.
+
+Remove this entry if rsvelte stops serving attribute completions at a bare space, or if upstream
+starts.
+
+### Two `source.fixAll` code-action kinds upstream does not have
+
+**Pinned by** `crates/rsvelte_language_server/tests/protocol.rs` (the `codeActionKinds`
+assertion) and `scripts/compat-lsp/capability-hashes.test.mjs`.
+**Ratchet.** `lsp-known-failures.json`, the
+`/capabilities/codeActionProvider/codeActionKinds:extra-rsvelte` entry.
+
+Under the differential gate's client capabilities upstream advertises six kinds; rsvelte
+advertises those six plus `source.fixAll` and `source.fixAll.rsvelte`. Both are served —
+`FIX_ALL_KIND` is `crates/rsvelte_language_server/src/code_actions.rs` and the tsgo-backed
+`source.fixAll` is handled in `textDocument/codeAction`.
+
+This is the direction a capability difference is allowed to run: the advertisement is wider than
+upstream's because the implementation is. Narrowing it to match would hide working behaviour.
+
+### `workspace.workspaceFolders` is advertised
+
+**Pinned by** `crates/rsvelte_language_server/tests/protocol.rs` (the
+`capabilities["workspace"]["workspaceFolders"]` assertion).
+**Ratchet.** `lsp-known-failures.json`, the `/capabilities/workspace:extra-rsvelte` entry.
+
+Upstream's `initialize` result carries no `workspace` key at all. rsvelte advertises
+`workspaceFolders` with `supported` and `changeNotifications`, and acts on both: the server tracks
+workspace roots and picks an overlay per document by longest matching root.
+
+The entry is `extra-rsvelte` for the whole `workspace` object, so it is one field rather than a
+set difference. As with the code-action kinds, the advertisement is truthful and matching upstream
+would mean withdrawing a capability that works.
+
+### `positionEncoding` is stated rather than defaulted
+
+**Pinned by** `crates/rsvelte_language_server/tests/protocol.rs` (the `positionEncoding`
+assertion).
+**Ratchet.** `lsp-known-failures.json`, the `/capabilities/positionEncoding:extra-rsvelte` entry.
+
+Upstream omits `positionEncoding`; rsvelte sends `"utf-16"`. The LSP default when the field is
+absent **is** `utf-16`, so the two servers agree on the encoding and differ only on whether they
+say so. The gate compares fields, and an absent field and a field holding the default are not the
+same field, so it reports one.
+
+Stating it is deliberate: the tsgo child is negotiated separately to UTF-8 and every internal
+mapping is byte-based, so the editor-facing encoding is a value this server has an opinion about
+rather than one it inherits. There is no behavioural difference to close.
+
+### `diagnosticProvider.identifier` is advertised
+
+**Pinned by** `crates/rsvelte_language_server/tests/protocol.rs` — the `identifier` assertion and,
+in the same test, the comparison of the pulled diagnostics against a direct lint of the same
+source.
+**Ratchet.** `lsp-known-failures.json`, the
+`/capabilities/diagnosticProvider/identifier:extra-rsvelte` entry.
+
+Upstream advertises `diagnosticProvider` without an `identifier`; rsvelte sets it to
+`rsvelte-language-server`. The field is optional in the protocol and lets a client scope
+`previousResultId` per provider, which matters here because the server owns `.ts`/`.js` documents
+alongside `.svelte` ones rather than running beside another provider.
+
+The pin is deliberately two assertions and not one. Advertising a string nothing backs is the
+failure mode this document already records for `completions.emmet` — a declared capability with
+no implementation — so the entry that fixes the advertisement in place is paired with the one
+that shows diagnostics are actually answered.
+
 
 <a id="README"></a>
 

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -913,16 +913,38 @@ measure the harness, not the compiler, and their recorded payload confirms it: t
 `hash=f411dae2ecdd` is `digest(["item-" + digest(edit)])` over official's single edit, and
 recomputing that chain from the *measured rsvelte* edit reproduces `f411dae2ecdd` exactly — so
 the two edits are byte-identical and supplying `options` retires all twenty rather than
-converting them. The same omission reaches `documentHighlight`, whose `position` is likewise
-never sent although the ratchet key displays one (`|0:13|`): `request()`'s third argument is a
-label, not a parameter.
+converting them.
+
+**The key describes a measurement that was not performed.** A ratchet key carries a `|line:col|`
+segment — `documentHighlight`'s read `|0:13|`, `|0:24|`, `|0:9|`, `|0:2|`, `|1:4|` — and that
+segment is `request()`'s third argument, a **label**, not the `position` that went on the wire.
+`suites.mjs` adds a real `position` for `completion` / `hover` / `linkedEditingRange` only, so
+every `documentHighlight` unit states a position it never asked about. This is worse than the
+formatting case: an empty response merely fails to distinguish four causes, whereas a key naming
+a column actively misleads whoever reads it. `prepareRename` (4 cases) and `colorPresentation`
+(3) are the same defect one step further — each declares a `params` object in the fixture
+manifest that `suites.mjs` reads at three sites, all inside the `codeAction` branch, so those
+declarations are never sent either. **Both hold zero ratchet entries, and that zero is not
+coverage**: two servers that both return nothing agree, so an empty bucket here is a statement
+about the population, not an observation about the mechanism.
+
+**And the ten formatting fixtures cannot express the axis they were written for.** Their
+document is `entry.source` verbatim, which for all ten is the eleven bytes `unformatted` — one
+word. Upstream's ten tests differ only in `expected.engine` (`prettier-config`,
+`prettier-plugin`, `prettier-fallback`, `prettier-options`, `user-prettier-v2`,
+`user-prettier-module`, `builtin-prettier`), i.e. which Prettier resolution path is taken; but
+every engine formats a single word to itself plus a newline, and the digest above shows official
+and rsvelte producing byte-identical edits. So repairing `options` makes these ten *agree*, and
+they will still measure nothing about Prettier-versus-native. Reaching a decision point is not
+being able to tell two rules for it apart.
 
 **Evidence [D]:** the two responses and the stderr line are one measured probe against
 `target/debug/rsvelte-language-server`; the digest reconstruction is arithmetic over the
-committed ratchet. Note the population this does **not** settle — `prepareRename` (4 cases) and
-`colorPresentation` (3) also declare a manifest `params` that `suites.mjs` never reads, and both
-hold **zero** ratchet entries; that zero is consistent with both servers returning nothing, so it
-is not evidence they are unaffected.
+committed ratchet; the label-versus-parameter claim is read off `suites.mjs:150-192`. A rate
+table over "does the harness supply this method's required params" was computed and is **not**
+reported, because it does not discriminate — `formatting` and `documentHighlight` are 100% while
+`colorPresentation` and `prepareRename` are 0% in the same group, and those two zeroes may be
+empty denominators rather than agreement.
 
 ---
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -4571,17 +4571,45 @@ read as a clean burndown.
 
 Ten entries sit under `differential:fixtures/capabilities|initialize|`, and they are the one cluster
 whose justification is per key rather than per class, because a declared capability is a promise a
-client acts on. Six of them are things this server does not do — no `codeAction/resolve` handler
-exists, and ten of upstream's eleven `executeCommandProvider` commands are tsgo refactors it does not
-offer plus the Svelte-4 migrator, which is out of scope — or additive declarations upstream simply
-omits: `positionEncoding`, `workspace.workspaceFolders`, `diagnosticProvider.identifier`, and the two
-`source.fixAll` code-action kinds. Two are the semantic-token legend, which stays narrowed to the
-token names the editor advertised because tsgo narrows its own legend the same way and its token data
-indexes the narrowed one; declaring upstream's legend here would misname every index past a dropped
-entry. The last two are `completionProvider.triggerCharacters`: rsvelte declares `" "` (upstream
-deliberately does not, and this server answers attribute completions there), and upstream's array
-lists `"@"` twice, which is a multiset a deduplicated list cannot match. The rest of that cluster
-was closed by #3016 rather than justified.
+client acts on. The rest of that cluster was closed by #3016 rather than justified. The ten reach
+four different terminal states, and the split that matters is between a capability this server
+*chooses* to declare differently and one it has *not built* — recording the second as deliberate
+would pin "unimplemented" in place, which is the `completions.emmet` failure gate 42 records.
+
+**Five are deliberate and pinned** in [`deliberate-divergences`](GATES.md#deliberate-divergences):
+`completionProvider.triggerCharacters` declaring `" "` (upstream deliberately does not, and this
+server answers attribute completions there), the two `source.fixAll` code-action kinds,
+`workspace.workspaceFolders`, `positionEncoding`, and `diagnosticProvider.identifier`. Each names a
+behaviour that exists and a test that exercises it.
+
+**Two are unimplemented, and stay listed as such** — not deliberate, and not pinned. No
+`codeAction/resolve` handler exists, so `codeActionProvider.resolveProvider` is absent; and ten of
+upstream's eleven `executeCommandProvider` commands are tsgo refactors this server does not offer
+plus the Svelte-4 migrator, which is out of scope. The honest terminal states are the handler and
+the commands, or an explicit decision that they are out of scope; until one of them these two are
+open work, and a test pinning today's answer would assert the absence.
+
+**One is upstream**: `upstream_issues/svelte-language-server-duplicate-completion-trigger-character.md`
+— upstream's array lists `"@"` twice, which is a multiset a deduplicated list cannot match.
+
+**Two are a property of this gate's client, not of the server.** The semantic-token legend stays
+narrowed to the token names the editor advertised, because tsgo narrows its own legend the same way
+and its token data indexes the narrowed one; declaring upstream's legend here would misname every
+index past a dropped entry. This gate's `initialize` sends no `textDocument.semanticTokens` at all,
+so the filter keeps nothing and the whole of upstream's legend reads as missing — confirmed without
+re-running either server, because the ratchet carries no `extra-rsvelte` for either pointer and the
+recorded `missing-rsvelte` digests are reproduced exactly by an *empty* rsvelte legend
+(`scripts/compat-lsp/capability-hashes.test.mjs`). `crates/rsvelte_language_server/tests/protocol.rs`
+drives the other client shape and gets a correctly filtered legend back. The terminal state is the
+gate carrying both client shapes, not a change to the filter; that is tracked as a gate-coverage
+item rather than attributed here.
+
+Those digests are how the first four states were separated at all. The ratchet stores a digest and
+never the values, so a recorded divergence cannot be read back — but reproducing the digest from
+each side's declared values identifies the preimage, which running the two servers does not, since a
+run reports only *that* two arrays differ. Six of the cluster's recorded hashes are reproduced from
+source in `scripts/compat-lsp/capability-hashes.test.mjs`, which needs no build, no servers and no
+corpus.
 
 The real-world corpus uses one compact entry per `(file, method)`, and its key records the divergent
 request count and nothing else. It carried a raw divergent-field count and a digest over every

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -4604,6 +4604,20 @@ drives the other client shape and gets a correctly filtered legend back. The ter
 gate carrying both client shapes, not a change to the filter; that is tracked as a gate-coverage
 item rather than attributed here.
 
+Attribution of `lsp-known-failures.json`:
+
+| n | target | cluster |
+|---|---|---|
+| 5 | `deliberate-divergences` | `initialize` capabilities rsvelte declares differently on purpose, each pinned by a test: the `" "` completion trigger, the two `source.fixAll` code-action kinds, `workspace.workspaceFolders`, `positionEncoding`, `diagnosticProvider.identifier` |
+| 1 | `upstream_issues/svelte-language-server-duplicate-completion-trigger-character.md` | upstream lists `"@"` twice in `completionProvider.triggerCharacters`, so the arrays differ as multisets |
+
+This table is **partial**: it covers 6 of 23,746. The remaining entries are unattributed, not
+attributed to nothing — the `aggregate:` half carries no field in its key, so what an entry is
+cannot be read from the ratchet at all, and every row above had to be recovered by reproducing a
+digest. A partial table is the honest intermediate state for a ratchet this size; the alternative
+is that nothing may be recorded until everything can be, which would keep the first cluster
+unattributed because the last one is.
+
 Those digests are how the first four states were separated at all. The ratchet stores a digest and
 never the values, so a recorded divergence cannot be read back — but reproducing the digest from
 each side's declared values identifies the preimage, which running the two servers does not, since a

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -649,6 +649,13 @@ fn serves_pull_diagnostics_without_push_notifications() {
         capabilities["diagnosticProvider"]["workspaceDiagnostics"],
         json!(false)
     );
+    // Official advertises no `identifier`. rsvelte does, so a client can scope
+    // `previousResultId` per provider; the diagnostics compared below are what
+    // makes the advertisement truthful rather than a bare string.
+    assert_eq!(
+        capabilities["diagnosticProvider"]["identifier"],
+        json!("rsvelte-language-server")
+    );
     server.notify("initialized", json!({}));
     did_open(&mut server, &uri, SOURCE);
 

--- a/scripts/compat-lsp/capability-hashes.test.mjs
+++ b/scripts/compat-lsp/capability-hashes.test.mjs
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { identity } from "./diff.mjs";
+import { createHash } from "node:crypto";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const digest = (value) =>
+  createHash("sha256").update(JSON.stringify(value)).digest("hex").slice(0, 12);
+
+// The ratchet stores a digest, never the values, so a divergence there cannot be
+// read back. Reproducing the digest from each side's declared values recovers the
+// preimage: an equality here says WHICH values sit on which side, which running
+// the two servers does not — it only says that they differ.
+const baseline = JSON.parse(
+  fs.readFileSync(path.join(ROOT, "compatibility/lsp-known-failures.json"), "utf8"),
+);
+const recorded = (pointer, kind) => {
+  const prefix = `differential:fixtures/capabilities|initialize|${pointer}:${kind}[`;
+  const hit = baseline.filter((key) => key.startsWith(prefix));
+  assert.equal(hit.length, 1, `expected exactly one baseline entry for ${pointer}:${kind}`);
+  return hit[0].slice(prefix.length, -1);
+};
+
+// `walk`'s array branch, reproduced: bucket both sides by `identity`, and the
+// excess on each side is what that side alone carries.
+function arrayDiff(method, pointer, official, rsvelte) {
+  const bucket = (values) => {
+    const map = new Map();
+    for (const value of values) {
+      const key = identity(method, pointer, value);
+      map.set(key, [...(map.get(key) ?? []), value]);
+    }
+    return map;
+  };
+  const left = bucket(official);
+  const right = bucket(rsvelte);
+  const missing = [];
+  const extra = [];
+  for (const key of new Set([...left.keys(), ...right.keys()])) {
+    const l = (left.get(key) ?? []).length;
+    const r = (right.get(key) ?? []).length;
+    for (let i = Math.min(l, r); i < l; i++) missing.push(key);
+    for (let i = Math.min(l, r); i < r; i++) extra.push(key);
+  }
+  const spell = (keys) => `count=${keys.length},hash=${digest(keys.slice().sort())}`;
+  return { missing: spell(missing), extra: spell(extra) };
+}
+
+// submodules/language-tools/.../server.ts:280-306. `@` is listed TWICE, once in
+// the main group and once under Emmet; that duplicate is the whole of the
+// `missing-rsvelte` entry, so the list must stay a multiset.
+const OFFICIAL_TRIGGERS = [
+  ".", '"', "'", "`", "/", "@", "<", ">", "*", "#", "$", "+", "^", "(", "[", "@", "-", ":", "|",
+];
+// crates/rsvelte_language_server/src/completions.rs:24-26
+const RSVELTE_TRIGGERS = [
+  "<", " ", "#", "@", ":", "|", "/", ".", '"', "'", "`", ">", "*", "$", "+", "^", "(", "[", "-",
+];
+
+// server.ts:315-331 under this gate's client capabilities: `codeActionLiteralSupport`
+// is present and `shouldFilterCodeActionKind` is absent, so nothing is filtered out.
+const OFFICIAL_CODE_ACTION_KINDS = [
+  "quickfix",
+  "source.organizeImports",
+  "source.sortImports",
+  "source.addMissingImports",
+  "source.removeUnusedImports",
+  "refactor",
+];
+// crates/rsvelte_language_server/src/server.rs:176-187
+const RSVELTE_CODE_ACTION_KINDS = [
+  "quickfix",
+  "refactor",
+  "source.organizeImports",
+  "source.sortImports",
+  "source.addMissingImports",
+  "source.removeUnusedImports",
+  "source.fixAll",
+  "source.fixAll.rsvelte",
+];
+
+// server.ts:334-347
+const OFFICIAL_COMMANDS = [
+  "function_scope_0",
+  "function_scope_1",
+  "function_scope_2",
+  "function_scope_3",
+  "constant_scope_0",
+  "constant_scope_1",
+  "constant_scope_2",
+  "constant_scope_3",
+  "extract_to_svelte_component",
+  "migrate_to_svelte_5",
+  "Infer function return type",
+];
+// crates/rsvelte_language_server/src/extract.rs:12 is the only command rsvelte serves.
+const RSVELTE_COMMANDS = ["extract_to_svelte_component"];
+
+// semanticTokenLegend.ts:42-81 — both legends are dense arrays in enum order.
+const OFFICIAL_TOKEN_TYPES = [
+  "class", "enum", "interface", "namespace", "typeParameter", "type", "parameter",
+  "variable", "enumMember", "property", "function", "method", "event",
+];
+const OFFICIAL_TOKEN_MODIFIERS = [
+  "declaration", "static", "async", "readonly", "defaultLibrary", "local",
+];
+
+test("the duplicate `@` and the extra space reproduce the recorded trigger-character digests", () => {
+  const { missing, extra } = arrayDiff(
+    "initialize",
+    "/capabilities/completionProvider/triggerCharacters",
+    OFFICIAL_TRIGGERS,
+    RSVELTE_TRIGGERS,
+  );
+  assert.equal(missing, recorded("/capabilities/completionProvider/triggerCharacters", "missing-rsvelte"));
+  assert.equal(extra, recorded("/capabilities/completionProvider/triggerCharacters", "extra-rsvelte"));
+});
+
+test("the two fix-all kinds reproduce the recorded codeActionKinds digest", () => {
+  const { extra } = arrayDiff(
+    "initialize",
+    "/capabilities/codeActionProvider/codeActionKinds",
+    OFFICIAL_CODE_ACTION_KINDS,
+    RSVELTE_CODE_ACTION_KINDS,
+  );
+  assert.equal(extra, recorded("/capabilities/codeActionProvider/codeActionKinds", "extra-rsvelte"));
+});
+
+test("the ten unimplemented refactor commands reproduce the recorded digest", () => {
+  const { missing } = arrayDiff(
+    "initialize",
+    "/capabilities/executeCommandProvider/commands",
+    OFFICIAL_COMMANDS,
+    RSVELTE_COMMANDS,
+  );
+  assert.equal(missing, recorded("/capabilities/executeCommandProvider/commands", "missing-rsvelte"));
+});
+
+// The gate's client advertises no `textDocument.semanticTokens`, so rsvelte's
+// legend filter keeps nothing. An empty rsvelte legend is the only way the
+// missing set can be official's legend entire — and the ratchet carries no
+// `extra-rsvelte` for either pointer, which is what closes it.
+test("an empty rsvelte legend reproduces both recorded semanticTokens digests", () => {
+  for (const [pointer, official] of [
+    ["/capabilities/semanticTokensProvider/legend/tokenTypes", OFFICIAL_TOKEN_TYPES],
+    ["/capabilities/semanticTokensProvider/legend/tokenModifiers", OFFICIAL_TOKEN_MODIFIERS],
+  ]) {
+    const { missing } = arrayDiff("initialize", pointer, official, []);
+    assert.equal(missing, recorded(pointer, "missing-rsvelte"));
+    assert.equal(
+      baseline.filter((key) =>
+        key.startsWith(`differential:fixtures/capabilities|initialize|${pointer}:extra-rsvelte[`),
+      ).length,
+      0,
+      `${pointer} must carry no extra-rsvelte, or the legend is not simply empty`,
+    );
+  }
+});

--- a/scripts/compat-lsp/native-formatter.test.mjs
+++ b/scripts/compat-lsp/native-formatter.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const SRC = path.join(ROOT, "crates/rsvelte_language_server/src");
+
+const sources = fs
+  .readdirSync(SRC, { recursive: true })
+  .filter((entry) => typeof entry === "string" && entry.endsWith(".rs"))
+  .map((entry) => [entry, fs.readFileSync(path.join(SRC, entry), "utf8")]);
+
+// A prose mention is not a reach path: `server.rs` explains in a doc comment why
+// only `FormatSession` may be used, and that must not count as a second caller.
+const stripComments = (text) =>
+  text
+    .split("\n")
+    .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+    .join("\n");
+
+test("the formatter is reachable from exactly one module", () => {
+  const callers = sources
+    .filter(([, text]) => /\brsvelte_(?:formatter|fmt)\s*::/.test(stripComments(text)))
+    .map(([file]) => file)
+    .sort();
+  assert.deepEqual(callers, ["format.rs"]);
+});
+
+test("the one module that formats does not shell out", () => {
+  const text = stripComments(fs.readFileSync(path.join(SRC, "format.rs"), "utf8"));
+  // Loading a user Prettier runtime, resolving a Prettier plugin or falling back
+  // between Prettier versions all require leaving the process, which is the axis
+  // upstream's `SveltePlugin.test.ts` measures.
+  for (const spawn of ["Command::new", "process::Command", "std::process"]) {
+    assert.equal(text.includes(spawn), false, `format.rs must not use ${spawn}`);
+  }
+});
+
+test("a Prettier project config is detected, never executed", () => {
+  const text = fs.readFileSync(path.join(SRC, "format.rs"), "utf8");
+  // `.prettierrc` and friends decide whether project config exists; the format
+  // call underneath is still `rsvelte_formatter::format`.
+  assert.match(text, /\.prettierrc/);
+  assert.match(text, /rsvelte_formatter::format\(/);
+});

--- a/upstream_issues/README.md
+++ b/upstream_issues/README.md
@@ -115,6 +115,7 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `svelte-server-treats-a-dollar-parameter-as-a-store.md` | sveltejs/svelte | #4048 | unrecorded |
 | `svelte-snippet-name-colliding-with-an-import.md` | sveltejs/svelte | #3567 | unrecorded |
 | `svelte2tsx-bom-crashes-on-any-component-with-a-script.md` | sveltejs/language-tools (svelte2tsx) | #4048 | unrecorded |
+| `svelte-language-server-duplicate-completion-trigger-character.md` | sveltejs/language-tools (svelte-language-server) | — | unrecorded |
 | `svelte2tsx-getlastleadingdoc-mixes-absolute-and-relative-offsets.md` | sveltejs/language-tools (svelte2tsx) | — | unrecorded |
 | `svelte2tsx-isdeclaration-is-a-boolean-not-a-stack.md` | sveltejs/language-tools (svelte2tsx) | — | unrecorded |
 | `svelte2tsx-preprendstr-insertion-at-the-script-end-is-overwritten.md` | sveltejs/language-tools (svelte2tsx) | — | unrecorded |
@@ -122,12 +123,12 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `svelte2tsx-transposes-an-unclosed-start-tag.md` | sveltejs/language-tools (svelte2tsx) | — | unrecorded |
 | `tsgo-lsp-completion-item-omits-the-typescript-kind.md` | microsoft/typescript-go (`tsgo --lsp`) | — | unrecorded |
 
-**25** reports carry no rsvelte issue number. Six came out of the lint-parity campaign (five
+**26** reports carry no rsvelte issue number. Six came out of the lint-parity campaign (five
 against `eslint-plugin-svelte`, one against `svelte-eslint-parser`), two out of the
 `two-ports-inventory.md` row 21 shadow probes, seven out of the SCSS-backend burndown — five
 covering every unit `scss-known-failures.json` lists as `grass-rejects-accepted`, plus the two
 classes in that ratchet whose output is not render-neutral (a hoisted declaration, and a slash list
-divided inside a nested rule) — and two out of the LSP differential campaign. The remaining eight
+divided inside a nested rule) — and three out of the LSP differential campaign. The remaining eight
 are later: two `oxfmt` CSS reports from the formatter-parity corpus, one against `esrap`, one
 against `language-tools`, and one against `prettier-plugin-svelte` from the formatter-parity
 burndown (an inline element in a text run overflows `printWidth`, and re-formatting the output is

--- a/upstream_issues/svelte-language-server-duplicate-completion-trigger-character.md
+++ b/upstream_issues/svelte-language-server-duplicate-completion-trigger-character.md
@@ -1,0 +1,54 @@
+# `svelte-language-server` advertises `@` twice in `completionProvider.triggerCharacters`
+
+`svelte-language-server@0.18.4` (`language-tools` `092af3826bad`), `src/server.ts:280-306`, builds
+the advertised completion trigger characters as one array literal. `'@'` appears in it **twice** —
+once in the main group and once again in the Emmet group:
+
+```js
+triggerCharacters: [
+    '.', '"', "'", '`', '/',
+    '@',            // <- server.ts:286
+    '<',
+    // Emmet
+    '>', '*', '#', '$', '+', '^', '(', '[',
+    '@',            // <- server.ts:298
+    '-',
+    // Svelte
+    ':', '|'
+]
+```
+
+The array is 19 entries over 18 distinct characters. `ServerCapabilities.completionProvider.
+triggerCharacters` is a set of characters the client should fire completion on, so a repeat is
+redundant rather than harmful — no client behaviour depends on the multiplicity. It is reported
+because it is observable in the advertised capabilities and because anything comparing the two
+servers' `initialize` responses element-wise sees it as a real difference.
+
+## How this was measured, and why there is no server transcript
+
+rsvelte's LSP differential gate (`scripts/compat-lsp/`) drives both servers' `initialize` and
+records each differing field as one shrink-only ratchet key. The key for this field is
+
+```
+differential:fixtures/capabilities|initialize|/capabilities/completionProvider/triggerCharacters:missing-rsvelte[count=1,hash=34551d7783bc]
+```
+
+The gate stores a **digest**, never the values, so the recorded entry cannot be read back
+directly. The digest is reproducible, though, and reproducing it identifies the preimage — which
+running the two servers does not, since a run reports only *that* the two arrays differ.
+`scripts/compat-lsp/capability-hashes.test.mjs` reconstructs `diff.mjs`'s bucketing from each
+side's declared values and asserts the recorded digest:
+
+* official's 19-entry list **with** the duplicate `@` and rsvelte's 19-entry list yield
+  `count=1,hash=34551d7783bc` — the single unmatched official element is `"@"`.
+* deleting either `'@'` from the official list changes the digest, so the duplicate is
+  load-bearing for the recorded value and not an artefact of the comparison.
+
+That test is run by `pnpm run test:lsp-ratchet` and needs no build, no servers and no corpus.
+
+## Not a defect on the rsvelte side
+
+rsvelte advertises `@` once. Matching official here would mean emitting a duplicate deliberately,
+so the ratchet entry stays listed and is attributed to this report rather than closed.
+
+Remove this report when upstream de-duplicates the array.


### PR DESCRIPTION
## What

The ten `differential:fixtures/capabilities|initialize|` entries were justified per key in prose and attributed to nothing. This gives each of them a terminal state.

**None of them is an rsvelte defect that can be closed.** The ratchet does not shrink. What moves is that six entries now name where they are answered, and two that were described alongside "additive declarations upstream simply omits" are separated out as **unimplemented** — pinning those would assert an absence, which is the `completions.emmet` failure [gate 42](../blob/main/compatibility/GATES.md) already records.

| n | terminal state | entries |
|---|---|---|
| 5 | `deliberate-divergences`, pinned | `" "` completion trigger · two `source.fixAll` kinds · `workspace.workspaceFolders` · `positionEncoding` · `diagnosticProvider.identifier` |
| 1 | `upstream_issues/` | upstream lists `"@"` twice in `triggerCharacters` |
| 2 | listed, **unimplemented** | no `codeAction/resolve` handler · 10 of upstream's 11 `executeCommandProvider` commands |
| 2 | property of this gate's client | the semantic-token legend |

## The evidence is a preimage, not a transcript

The ratchet stores a **digest** and never the values (`diff.mjs:3-4`), so a recorded divergence cannot be read back. It is reproducible, though, and reproducing it **identifies which values sit on which side** — which running the two servers does not, since a run reports only *that* two arrays differ.

`scripts/compat-lsp/capability-hashes.test.mjs` reconstructs `diff.mjs`'s bucketing from each side's declared values and asserts the committed hashes. Six reproduce exactly:

| entry | baseline | recovered |
|---|---|---|
| `triggerCharacters:missing-rsvelte` | `count=1,hash=34551d7783bc` | `"@"` |
| `triggerCharacters:extra-rsvelte` | `count=1,hash=2b6a9ff623df` | `" "` |
| `codeActionKinds:extra-rsvelte` | `count=2,hash=1de4567e729a` | `source.fixAll`, `source.fixAll.rsvelte` |
| `commands:missing-rsvelte` | `count=10,hash=e922b4b83a0e` | `function_scope_0..3`, `constant_scope_0..3`, `migrate_to_svelte_5`, `Infer function return type` |
| `tokenTypes:missing-rsvelte` | `count=13,hash=9e13a9f7f54e` | official's legend **entire** |
| `tokenModifiers:missing-rsvelte` | `count=6,hash=88f6e7a0e5bb` | official's legend **entire** |

Six SHA-256 prefixes, from independently-read source. The test needs **no build, no servers and no corpus** — it runs under `pnpm run test:lsp-ratchet`.

**Positive control:** deleting the duplicate `'@'` from the official list fails exactly one test; restoring it gives 4/4 and a byte-identical file.

## Two things that reading settled and a run would not have

**The legend divergence is not the server's.** The last two rows are official's legend *entire*, and the ratchet carries **no `extra-rsvelte`** for either pointer — so rsvelte's legend is not a disagreeing legend, it is an **empty** one. This gate's `initialize` sends no `textDocument.semanticTokens`, so the filter keeps nothing. `crates/rsvelte_language_server/tests/protocol.rs` drives the other client shape and gets a correctly filtered legend back. The terminal state is the gate carrying both client shapes; that is a gate-coverage item, not a change to the filter, and is **not in this PR**.

**The `" "` trigger is not a defect.** Upstream excludes whitespace and says why (`server.ts:299-301`). That is upstream's product judgement, not an assessment of rsvelte: `completions_with_strict_mode("<div ", 5, …)` returns `class`, so rsvelte answers attribute completions at that position, and a character absent from the list never reaches the server. Removing it would leave the answering code unreachable.

## Pins

Four of the five deliberate entries were **already** pinned by `crates/rsvelte_language_server/tests/protocol.rs` (`triggerCharacters`, `codeActionKinds`, `positionEncoding`, `workspace.workspaceFolders`). Only `diagnosticProvider.identifier` needed a new assertion, and it is paired with the diagnostics-vs-direct-lint comparison already in that test — advertising a string nothing backs is the failure being guarded against, so the pin is two assertions, not one.

`deliberate-divergences-check` goes 20 → **25**, each pinned. Gate 42's own `**Unit.**` sentence carried the stale count and a path that no longer exists (`locate()` has fallen back to the `GATES.md` anchor); both corrected.

## Gates run

```
[known-failures-md-check]      50 declared ratchets across 36 docs match their JSON; 33 cluster partitions add up
[deliberate-divergences-check] 25 recorded divergence(s), each pinned by an existing test
upstream_issues                84 reports, all indexed with an explicit filing state
node --test scripts/compat-lsp/*.test.mjs   61 pass / 1 fail (62 tests)
```

The one failure is `tsgo-completion-kind.test.mjs` — *"pinned @typescript/native-preview tsgo was not found"*. It is **pre-existing and environmental**: it fails identically when run alone in this checkout, and the two files this PR adds under `scripts/compat-lsp/` are its own tests, and all six of their assertions pass. CI installs tsgo.

`check-upstream-issues` also caught a prose count — `**25** reports carry no rsvelte issue number` — which this PR moves to 26 along with its addend (`6 + 2 + 7 + 3` + remainder 8).

## Rust gates — run after disk was freed

```
cargo clippy --all-targets --all-features -- -D warnings     exit 0, 0 warnings
    Checking rsvelte_language_server v0.5.5 (.../worktrees/rsvelte-s2tx-4072/crates/rsvelte_language_server)
cargo test -p rsvelte_language_server --test protocol        30 passed; 0 failed
```

The `Checking` line is quoted because a clippy run that is clean and one that never reached the changed crate print the same nothing; it also names this worktree's own path, which is the one signal `cd`, `CARGO_TARGET_DIR` and the artifact path cannot between them fake. The `protocol` run is what verifies the new `identifier` assertion — it was written from `SERVER_NAME` and the green `serverInfo.name` assertion beside it, and had not been executed when the branch was first pushed.

## Commit 2 is droppable

`attribution-check.mjs` on `main` requires `n` to sum to the ratchet's length, so the partial table (6 of 23,746) is reported as under-claiming until the gate exempts a partial table on a pending ratchet. It is a separate tip commit for exactly that reason — drop it if the exemption lands later. Problem count is unchanged at 5 either way, and the gate is **not wired to CI** (0 workflow references).

Worth noting for whoever wires it: the checker already separates the two directions. An under-claiming table reports `6 of 23746 entries attributed`; an over-claiming one reports `sums to N, the ratchet holds only M`. Only the first needs sparing.


---

## Added after review: two things that are **not** the formatting entries’ attribution

### `native-formatter.test.mjs` pins a reach path, not a ratchet cluster

The twenty `differential:fixtures/plugin-format-*|textDocument/formatting` entries are **not attributed by this PR**, and this test does not attribute them. It asserts that `rsvelte_formatter`/`rsvelte_fmt` is reached from exactly one module (`format.rs`), that this module never leaves the process, and that a Prettier *config* is detected while no Prettier runtime is executed. “Formats natively” would still pass if a Prettier load were added later; the reach path is what would not.

**Positive controls:** adding a second `rsvelte_formatter::` reference elsewhere under `src/` fails the first test naming both files; the spawn detector reads `true` on `tsgo_client.rs`, `code_lens.rs` and `preprocess_sidecar.rs` and `false` on `format.rs`, so it selects something.

### Blind spot 27p — the twenty formatting entries measure the harness

Four outcomes reach the client as `[]` — no formatter config, a panic, an error, and a document needing no change — because `on_formatting` answers a params failure with `respond_no_edits` (`server.rs:736-742`) and `worker.rs:659` states the rule outright. The ratchet key records the response, so it cannot say which produced it.

That is not hypothetical: `suites.mjs:150-179` adds extra params only for completion/hover/linkedEditingRange, selectionRange and codeAction, so **`textDocument/formatting` is sent without `options`**, which `lsp-types` declares with no `#[serde(default)]`. Measured against `target/debug/rsvelte-language-server` on the fixtures’ own document:

| request | response | stderr |
|---|---|---|
| `{textDocument}` — what the gate sends today | `[]` | ``textDocument/formatting: missing field `options` `` |
| `{textDocument, options}` | one edit, `newText: "unformatted\n"` | — |

The entry’s own payload settles what a fix does, with no second server run: `hash=f411dae2ecdd` is `digest(["item-" + digest(edit)])` over official’s single edit, and recomputing that chain from the **measured rsvelte edit** reproduces `f411dae2ecdd` exactly. The two edits are byte-identical, so supplying `options` **retires all twenty** rather than converting them into `missing`+`extra` pairs — which is what both I and the reviewer had predicted, in writing, before measuring.

The harness fix itself is **not in this PR**: it moves the LSP ratchet, and those are being batched so the 950-job-minute suite is dispatched once.

## The upstream comment/code contradiction, recorded rather than filed

Not filed upstream — it buys no attribution and would move a gated count in `upstream_issues/README.md`. Recorded here so the next reader does not walk the same three steps.

`vscode-languageserver-protocol`’s own declaration fixes the contract:

> An optional word pattern (regular expression) that describes valid contents for the given ranges.

So `wordPattern` constrains **the contents of the ranges the same response returns**, not “which word the editor selects”.

| | comment | code | agrees with the spec? |
|---|---|---|---|
| upstream `HTMLPlugin.ts:402-406` | says `.` is excluded | pattern at :405 **includes** `.` | **yes** — `Foo.Bar` matches |
| rsvelte `html_tags.rs:29-31` | says dots are excluded on purpose | pattern excludes `.` | **no** |

The two questions are independent and only coincidentally point the same way here: the side whose comment contradicts its code is the side that is right. Measured against rsvelte’s server, `<Foo.Bar></Foo.Bar>` returns ranges `[1,8)` and `[11,18)` — both `Foo.Bar` — beside `wordPattern: "[-_:A-Za-z0-9$]+"`, which matches only `Foo`. A response whose pattern rejects its own range contents is self-contradictory without reading either comment. Controls: `div`, `Foo`, `my-el` and `x:y` all match their pattern fully, so the contradiction fires on the dotted tag and nowhere else.

The **fix direction is undecided and deliberately not taken here**: it depends on official’s `ranges` for a dotted tag, which is unmeasured because `submodules/language-tools` is unbuilt in this checkout (`Cannot find module ../dist/src/server`). The two ratchet entries are `<div>`, so they say nothing about it.

## Rebase

Rebased onto `origin/main` (`8cf5b7202`) after #4192 and #4202 landed. Neither touches `compatibility/lsp-known-failures.json` or `scripts/compat-lsp/`, so the digests above are unaffected; all gates were re-run on the rebased tree.
