### PR TITLE
ci: wire the attribution gate that P3 depends on, and say which ratchets have no table yet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1209,6 +1209,13 @@ jobs:
         if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
         run: node scripts/dev/deliberate-divergences-check.mjs
 
+      # The controls for the attribution gate wired below. A gate whose only
+      # observed outcome is the one it was written to produce has not been shown
+      # to discriminate.
+      - name: Check the attribution gate's own controls
+        if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
+        run: node scripts/ci/test-attribution-check.mjs
+
       # The CSS-prune sweep's comparison key. Same reason it lives here: the
       # comparator is a pure module, so it needs neither the NAPI binding nor
       # submodules that the sweep itself does.
@@ -1404,3 +1411,13 @@ jobs:
       # submodules nor a build, so it lives here instead.
       - name: Verify known-failures.md matches the JSON ratchets
         run: node scripts/compat-corpus/known-failures-md-check.mjs
+
+      # `known-failures-md-check` does not read the attribution tables at all, so
+      # a table whose `n` stopped summing to its ratchet shipped green through
+      # three of its invocations. `--gate-known` asks about the attribution that
+      # EXISTS and exempts `attribution-pending.json` from the one question it
+      # cannot answer yet — which ratchets still have no block. The default mode
+      # is the DoD and stays red until that list is empty; it is not run here.
+      - name: Verify the attribution tables that exist
+        if: ${{ !cancelled() }}
+        run: node scripts/ci/attribution-check.mjs --gate-known

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2665,6 +2665,142 @@ from the manifest by set difference. Ninety-six such lines are unmissable. The n
 7,142 is not.
 
 
+### A SHA you did not resolve is an identifier you invented
+
+`AGENTS.md` records that an arm's *label* lies — the file name, `buildInfo()`, the
+artifact path, the branch. It does not record the cheaper failure one step earlier: the
+identifier itself being typed rather than resolved. Watching PR #4191, the only thing in
+hand was the 9-character `f8858d05d`; the loop was written with a full 40-character SHA
+that had never been printed by anything:
+
+```
+written:  f8858d05dbeb64df9d15c9a5aebf1b5c34d92da5
+actual:   f8858d05d0abcde3b42b718ae2375e69f2deb888
+```
+
+Nine characters agree, so re-reading the command shows nothing. This is the mirror of the
+abbreviated-SHA row already here (`?head_sha=23e06723a` returns `total_count=0` while the
+full SHA returns 10): that one is too short, this one is too long, and both name a commit
+the API does not have.
+
+What made it survivable was the shape of the predicate, not luck. `check-runs` on a
+non-existent commit returns an empty list, so `[…|select(.status!="completed")]|length`
+never reached `0` and the loop **hung** rather than reporting. Written the other way round
+— `completed == total_count`, or `pending == 0` — the same fabricated SHA reads `0 == 0`
+and prints a settled, zero-failure verdict for a commit that does not exist. So the rule
+is two-part: **resolve the identifier into a variable at launch (`H=$(gh pr view … --jq
+.headRefOid)`) and never retype it**, and **write the settle predicate so that an empty
+population fails to satisfy it** — the same "a verdict over a set must state the set's
+size" rule, applied to the identifier rather than to the rows.
+
+### A range endpoint spelled as a symbolic ref is not an endpoint
+
+`origin/main` is a name, and in this repository the thing it names moves without you: every
+worktree shares one `.git`, so another session's `fetch` — or an integrator's merge — advances
+it while your shell is idle. Two `git diff` invocations over what reads as the same range
+therefore answered differently within minutes:
+
+```
+git diff --stat      9693010f2..origin/main -- compatibility/ crates/rsvelte_formatter/   → empty
+git diff --name-only 9693010f2..origin/main -- compatibility/ crates/rsvelte_formatter/   → 5 files
+```
+
+Both were correct when they ran; `origin/main` had gone from `9c771271f` to `3a31d933b` in
+between, and the five files were the reader's own, newly merged. **The symptom is two
+measurements disagreeing, which invites declaring one of them wrong** — and that is what
+happened: the first reading was retracted, and the retraction was the error.
+
+This is the "an arm's label is not its identity" family with the moving part one level out. There
+the *artifact* a name resolves to changes; here the *endpoint of a range* does, so the two runs
+are not comparable even though the command text is identical. The fix is the same shape as the
+one for a fabricated SHA above: resolve once, then use the value — `MAIN=$(git rev-parse
+origin/main)` and `$MAIN` thereafter. A range whose ends are both immutable object names can be
+re-run tomorrow and mean the same thing; one written against a ref cannot be re-run at all.
+
+### An issue and a gate sharing a vocabulary is how a local defect gets attributed upstream
+
+`upstream_issues/3385-svelte-loose-parse-crashes.md` reports two inputs on which official's
+`parse(loose: true)` throws. The `parse-ast` gate has a source named `unclosed-element`, and the
+issue's second input is `</div>` — an unclosed element by any ordinary reading — so the ratchet key
+`loose:unclosed-element::RegularElement#span` reads as an instance of that upstream bug. Probed
+against the oracle instead of read:
+
+```
+gate source                text                        official parse(modern, loose)
+unclosed-element           "<div><b>x"                 OK, type=Root
+unclosed-attribute-quote   "<div class=\"a>text</div>"  THROW  An impossible situation occurred
+stray-closing-tag          "</div>"                    THROW  Cannot read properties of undefined
+```
+
+The gate's `unclosed-element` is a *different input* that official parses cleanly; the issue's
+`</div>` lives under the gate's `stray-closing-tag`, a both-reject control that is not in the
+ratchet at all. One of the two candidate keys was upstream's and the other was rsvelte's own.
+
+The direction of this error is the bad one. Attributing a local defect to upstream removes it from
+the burndown **and** stops anyone looking at it, and the citation never 404s because the report is
+real — it is the "a live but wrong citation" shape with the wrongness in the *match*, not the path.
+What separates the two cases is not more reading: both keys name a shape the report describes.
+Only the oracle, given the gate's own input text, tells them apart. So when an `upstream_issues/`
+report is proposed as a ratchet entry's target, **run the entry's own input through the oracle and
+paste the output** — which is what §6 already requires and what a name-level match invites you to
+skip.
+
+### A collapse ratio says how big the population is, not which way its entries point
+
+`parse-ast`'s 301 ratchet keys reduce to 163 defect bases (1.85x), and the reduction is
+readable straight off the keys. That number was then used to size the work, which is one
+question it can answer and one it cannot. Measured on the LSP gate's `differential:initialize`
+cluster: **10 entries, 10 distinct field paths, ratio exactly 1.00** — the cleanest resolution
+in the whole 23,746-entry ratchet, and therefore the first row anyone would pick up. Read
+against both servers, the ten split:
+
+| terminal state | n |
+|---|---|
+| rsvelte defect, closes by fixing | **0** |
+| upstream's own artifact (matching it would reproduce a bug) | 1 (official lists `@` twice) |
+| deliberate: rsvelte advertises something it implements | 5 |
+| **not deliberate: the capability is unimplemented** | 2 |
+| needs a product decision | 2 mechanisms |
+
+So a 1.00 ratio bought a correct count of *distinct* divergences and said nothing about how
+many are ours to close — **none of the ten**. The first reading of this table said one, a
+`space` trigger character that upstream omits with a comment explaining why. That comment is
+upstream's justification for upstream's product decision, not an assessment of rsvelte's; and
+`completions.rs:811` pins rsvelte returning `class` for `"<div "`, so removing `" "` from the
+trigger list would make a behaviour the tree already tests unreachable from a real client.
+Reading the oracle's comment and classifying before probing one's own implementation is the
+mirror of "a refusal justified by a comment is a place to probe the oracle" — here the comment
+was believed about the *wrong* side.
+
+The hole was not one person's. The gate's own limits table had a column for
+`entries per defect` and none for `how many of those are ours`, and the row was picked for
+work *because* its resolution was best — so the selection criterion and the analysis shared
+the missing column, and two people reached the same wrong expectation independently. When a
+table of limits is used to choose what to work on, read it for the column that is not there.
+
+**And the evidence for such a split does not have to be an execution.** The claim "the two
+servers actually answer differently, and here is which value sits on which side" looks like it
+needs both servers built and run — which was refused here on 24 GiB of disk with a 20 GiB
+floor. The ratchet stores no values, only `count=` and a 12-hex `digest()`; but re-implementing
+that digest and feeding it the value sets read out of each side's *source* reproduced six
+committed hashes exactly (`" "`, `"@"`, two code-action kinds, ten commands, and official's
+13-type / 6-modifier semantic-token legends). Six independent 48-bit agreements identify which
+value sits on which side, which a run does not: a run says the two differ. A gate that stores a
+digest is not storing less evidence than one that stores values — it is storing evidence that
+can only be produced by someone who already knows the answer. The reason `parse-ast` felt different is a control it
+happens to have: running the same comparator with the **official** compiler on both sides
+returns 0 keys, which is what licenses "every listed key is attributable to rsvelte's side."
+The LSP gate has no such self-compare, so its keys carry resolution and no direction.
+
+The second half is the one that costs a wrong terminal state. Two of the ten are capabilities
+rsvelte does not implement (`codeAction/resolve`, ten of official's eleven commands). Filing
+those as deliberate divergences and pinning them would assert *we choose not to close this*
+where the truth is *we have not built this* — the identical shape gate 42's own section
+records for `completions.emmet`, where pinning would freeze a product that declares a feature
+on while nothing implements it. **Before a cluster goes to `deliberate-divergences`, ask of
+each entry whether the behaviour exists**; the ones that do not stay listed and are described
+as unimplemented, which is the DoD working rather than failing.
+
 ### Working with Subagents
 
 Use the `Agent` tool for substantial work — feature implementation, multi-file refactors, broad code exploration, or anything likely to consume meaningful context.

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -5409,6 +5409,56 @@ Read those `n` in the ratchet's own key units and not as defects: `lsp-known-fai
 alone carries two conversions, `aggregate:` at 5.96 entries per diverging file and
 `differential:`/`expected:` at 1.87 per (unit, method, phase).
 
+Those six numbers are a measurement of `fd72d98f1` and nothing re-derives them, so read the
+live answer out of gate 43 below rather than out of this paragraph — it is the artifact that
+owns the question, and `compatibility/attribution-pending.json` is the list in machine-readable
+form. On `5dc32eac2` it is **five** ratchets and 24,606 entries (`lsp` 23,746, `fmt` 524,
+`parse-ast` 301, `client-dev` 24, `client` 11); `svelte2tsx-unparseable-known-failures.json`
+reached 0 and left the column, which is the terminal state this document keeps having to
+describe in prose.
+
+## 43. Attribution of ratchet entries — `scripts/ci/attribution-check.mjs`
+
+**Unit.** One ratchet JSON, and inside it one row of the `Attribution of \`<file>\`:` table that
+names it. Every ratchet with entries must carry exactly one block; the block's `n` column must sum
+to the JSON's length; each row must cite either a path under `upstream_issues/` that exists on disk
+or the literal `deliberate-divergences` (which gate 42 separately holds to naming a test). An empty
+ratchet must carry no block, and a block naming a file that is not a ratchet fails. Two modes:
+the default is the DoD and stays red while `compatibility/attribution-pending.json` is non-empty;
+`--gate-known` — the one CI runs — drops **exactly one question**, "does every ratchet have a block
+yet", for the ratchets that file names. Hard gate, no ratchet of its own. `pnpm run
+check:attribution` / `check:attribution-known`, and 16 controls under `pnpm run
+test:attribution-check`.
+
+**Why it exists, and why the pending list is not a fourth end state.** Three end states are
+allowed for a listed entry — it is gone, it is attributed to a filed upstream report, or it is
+attributed to a deliberate divergence — and an entry that is rsvelte's own unfixed defect has only
+the first. The pending list records that a ratchet has not been *placed* in one of the three, which
+is why the default mode keeps failing on it; measured on `5dc32eac2`, 24,606 entries across five
+ratchets sit there, and the self-compare control inside gate 39 (`0 keys from 28,178 self-compared
+pairs`) is what says 301 of them have no upstream target to name. Writing a table for those would
+not satisfy the requirement, it would fabricate the target column.
+
+**[D] and positive control.** The gate was written before it was wired, and in the interval a real
+defect shipped: #4191 retired one `fmt-oracle-excluded.json` entry, deleted the prose bullet and
+left the table's `n` at 4, so the table asserted 26 against a ratchet of 25. `known-failures-md-check`
+(C2) is wired in three places and **does not read attribution tables at all**, so both doc checks
+returned `EXIT=0` — correctly, about a different question. `--gate-known` reports that defect on
+the current tree, which is the control that says exempting the pending list did not exempt the
+thing the flag was built to catch. The self-test additionally pins both directions of the exemption:
+the same tree passes with `--gate-known` + a pending entry and fails with either one removed.
+
+**[S] What it does not look at.** It never opens the cited `upstream_issues/` report, so a citation
+that exists but describes a different defect passes — the "a live but wrong citation never 404s"
+shape, one level up from a path check. It cannot tell whether an `n` is apportioned to the right
+cluster: only the sum is compared, so moving 10 entries between two rows of the same table is
+invisible. It has no view of an entry that should be listed and is not, because its population is
+the ratchets on disk. And `--gate-known`'s exemption is per **file**, not per entry, so a ratchet
+on the pending list contributes nothing to any of the other checks either — a partial table for a
+pending ratchet is neither required nor validated.
+
+---
+
 ## Adding a gate, or a row here
 
 When you add a gate, add its row **before** the ratchet is first baselined, and answer the

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -4518,8 +4518,9 @@ it loads, and every assertion then measures a binary that predates the change un
 manifest. Axes: `modern` (`parse(src, { modern: true })`), `legacy` (`parse(src)` — the default
 shape), and `loose` (seven inline sources). Both sides are compared after
 `JSON.parse(JSON.stringify(...))`. Shrink-only ratchet
-`compatibility/parse-ast-known-failures.json`, 480 keys, justified per cluster in the paired
-`.md`. Runs as a step in the `corpus` job (~50s over 28,208 compared pairs).
+`compatibility/parse-ast-known-failures.json` — count the JSON, which is primary; this sentence
+has carried 480 while the file held 301 — justified per cluster in the paired `.md`. Runs as a
+step in the `corpus` job (~50s over 28,208 compared pairs).
 
 **Why it exists.** `parse()` is a documented export of `svelte/compiler`, distinct from
 `compile()`, and nothing here compared its return value to official's. It is the
@@ -4528,8 +4529,10 @@ for want of inputs: the pipeline had 14,331 components and never called the func
 
 **[D] The comparator manufactures nothing.** Running the gate's own `diffKeys` with the
 **official** compiler on both sides of the same population produces **0 keys from 28,178
-self-compared pairs**, so all 652 listed keys are attributable to rsvelte's side rather than to
-the harness. Two failure directions were also driven: deleting `modern::Root#span` from the
+self-compared pairs**, so every listed key is attributable to rsvelte's side rather than to
+the harness (the run that produced this was the 652-key first baseline; the conclusion is about
+the comparator, not about that number). Two failure directions were also driven: deleting
+`modern::Root#span` from the
 ratchet exits 1 with `NEW divergence (12,324 entries)`, and adding a key that no longer diverges
 exits 1 with `listed key no longer diverges`; restoring the file returns exit 0 and a
 byte-identical tree.

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -5428,10 +5428,18 @@ to the JSON's length; each row must cite either a path under `upstream_issues/` 
 or the literal `deliberate-divergences` (which gate 42 separately holds to naming a test). An empty
 ratchet must carry no block, and a block naming a file that is not a ratchet fails. Two modes:
 the default is the DoD and stays red while `compatibility/attribution-pending.json` is non-empty;
-`--gate-known` — the one CI runs — drops **exactly one question**, "does every ratchet have a block
-yet", for the ratchets that file names. Hard gate, no ratchet of its own. `pnpm run
-check:attribution` / `check:attribution-known`, and 16 controls under `pnpm run
+`--gate-known` — the one CI runs — drops **exactly one question**, "is this ratchet's attribution
+finished yet", for the ratchets that file names: it exempts a missing block and a table that covers
+only some of the entries, and nothing else. A table claiming MORE entries than the ratchet holds is
+never exempt — that is the shape that shipped through #4191 — and a pending ratchet whose table
+becomes complete must leave the list in the same change. Hard gate, no ratchet of its own. `pnpm run
+check:attribution` / `check:attribution-known`, and 19 controls under `pnpm run
 test:attribution-check`.
+
+The partial exemption is not slack, it is the middle state made legal. The first cluster of a
+23,746-entry ratchet is filed long before the last, and requiring a complete table before any row
+could be written would make a partial table *worse* than no table — which is exactly backwards for
+a document whose purpose is to record where each entry is answered.
 
 **Why it exists, and why the pending list is not a fourth end state.** Three end states are
 allowed for a listed entry — it is gone, it is attributed to a filed upstream report, or it is

--- a/compatibility/attribution-pending.json
+++ b/compatibility/attribution-pending.json
@@ -1,0 +1,7 @@
+[
+	"fmt-known-failures.json",
+	"known-failures.client-dev.json",
+	"known-failures.client.json",
+	"lsp-known-failures.json",
+	"parse-ast-known-failures.json"
+]

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
 		"release": "pnpm run sync-version && pnpm run build:wasm && pnpm run finalize-pkg && pnpm run publish-platform-binaries && pnpm run build:language-server && changeset publish",
 		"corpus:scss": "node scripts/compat-corpus/scss-verify.mjs",
 		"check:attribution": "node scripts/ci/attribution-check.mjs",
+		"check:attribution-known": "node scripts/ci/attribution-check.mjs --gate-known",
 		"check:lsp-mechanisms": "node scripts/ci/lsp-mechanisms-check.mjs",
 		"test:lsp-mechanisms-check": "node scripts/dev/test-lsp-mechanisms-check.mjs",
 		"test:attribution-check": "node scripts/ci/test-attribution-check.mjs",

--- a/scripts/ci/attribution-check.mjs
+++ b/scripts/ci/attribution-check.mjs
@@ -36,6 +36,16 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const DIR = process.env.ATTRIBUTION_DIR || path.join(ROOT, 'compatibility');
 const ANCHOR = 'deliberate-divergences';
 
+// `--gate-known` drops ONE question — "does every ratchet have a block yet" — and keeps
+// every other one. It exists so the structural half (a table whose `n` no longer sums to
+// its JSON, a target that does not exist, a block for a ratchet that is empty) can be
+// gated in CI today, while the backlog of ratchets with no block at all is still open.
+// The default mode is the DoD and stays red until `attribution-pending.json` is empty; the
+// flag's name is the claim about what it does not look at.
+const GATE_KNOWN = process.argv.includes('--gate-known');
+const PENDING_FILE = path.join(DIR, 'attribution-pending.json');
+const pending = fs.existsSync(PENDING_FILE) ? JSON.parse(fs.readFileSync(PENDING_FILE, 'utf8')) : [];
+
 const problems = [];
 const fail = (m) => problems.push(m);
 
@@ -93,9 +103,14 @@ for (const f of ratchets) {
 	}
 	const b = blocks.get(f);
 	if (!b) {
-		fail(`${f} has ${n} listed entr${n === 1 ? 'y' : 'ies'} and no \`Attribution of \\\`${f}\\\`:\` block`);
+		if (!(GATE_KNOWN && pending.includes(f))) {
+			fail(`${f} has ${n} listed entr${n === 1 ? 'y' : 'ies'} and no \`Attribution of \\\`${f}\\\`:\` block`);
+		}
 		continue;
 	}
+	// Two-sided, like every ratchet here: a file that has earned its block must leave the
+	// pending list in the same change, or the list stops describing the backlog.
+	if (pending.includes(f)) fail(`${f} carries an attribution block but is still listed in attribution-pending.json — remove it`);
 	const sum = b.rows.reduce((a, r) => a + r.n, 0);
 	if (sum < n) {
 		// A partial table is the honest shape while some clusters are still being
@@ -127,17 +142,30 @@ for (const k of blocks.keys()) {
 	if (!ratchets.includes(k)) fail(`${blocks.get(k).file}: attribution block names \`${k}\`, which is not a ratchet`);
 }
 
+for (const p of pending) {
+	if (!ratchets.includes(p)) fail(`attribution-pending.json names \`${p}\`, which is not a ratchet`);
+	else if (count(JSON.parse(fs.readFileSync(path.join(DIR, p), 'utf8'))) === 0)
+		fail(`attribution-pending.json names \`${p}\`, which is empty — remove it`);
+}
+
 if (problems.length) {
 	console.error(problems.join('\n'));
 	console.error(
-		`\n[attribution-check] ${problems.length} problem(s). Every listed ratchet entry must be eliminated,\n` +
-			'attributed to a filed `upstream_issues/` report, or attributed to `deliberate-divergences`\n' +
-			'(which must in turn be pinned by a test). Prose without a target is not an attribution.',
+		GATE_KNOWN
+			? `\n[attribution-check --gate-known] ${problems.length} problem(s) in the attribution that EXISTS.\n` +
+					'This mode does not ask whether every ratchet has a block yet — the ratchets listed in\n' +
+					'`attribution-pending.json` are exempt from that one question and from nothing else.'
+			: `\n[attribution-check] ${problems.length} problem(s). Every listed ratchet entry must be eliminated,\n` +
+					'attributed to a filed `upstream_issues/` report, or attributed to `deliberate-divergences`\n' +
+					'(which must in turn be pinned by a test). Prose without a target is not an attribution.',
 	);
 	process.exit(1);
 }
 
 console.log(
-	`[attribution-check] ${ratchets.length} ratchets: ${empty} empty, ` +
-		`${ratchets.length - empty} carrying ${attributed} attributed entries.`,
+	`[attribution-check${GATE_KNOWN ? ' --gate-known' : ''}] ${ratchets.length} ratchets: ${empty} empty, ` +
+		`${ratchets.length - empty} carrying ${attributed} attributed entries` +
+		(GATE_KNOWN && pending.length
+			? `; ${pending.length} still awaiting one (${pending.join(', ')}) — this mode does not gate that.`
+			: '.'),
 );

--- a/scripts/ci/attribution-check.mjs
+++ b/scripts/ci/attribution-check.mjs
@@ -108,16 +108,28 @@ for (const f of ratchets) {
 		}
 		continue;
 	}
-	// Two-sided, like every ratchet here: a file that has earned its block must leave the
-	// pending list in the same change, or the list stops describing the backlog.
-	if (pending.includes(f)) fail(`${f} carries an attribution block but is still listed in attribution-pending.json — remove it`);
 	const sum = b.rows.reduce((a, r) => a + r.n, 0);
+	// Two-sided, like every ratchet here: a file whose table is COMPLETE must leave the
+	// pending list in the same change, or the list stops describing the backlog. A partial
+	// table on a pending file is the expected middle state — the first cluster of a
+	// 23,746-entry ratchet is filed long before the last — so it is not an error, and
+	// requiring completeness before any row could be written would make a partial table
+	// worse than none.
+	if (pending.includes(f) && sum >= n) {
+		fail(`${f}'s attribution is complete but it is still listed in attribution-pending.json — remove it`);
+	}
 	if (sum < n) {
 		// A partial table is the honest shape while some clusters are still being
 		// filed, so say which entries are uncovered rather than reporting a
 		// bookkeeping mismatch — the two read very differently to whoever is next.
-		fail(`${b.file}:${b.line}  ${f}: ${sum} of ${n} entries attributed, ${n - sum} carry no target`);
+		// `--gate-known` exempts a pending ratchet from this for the same reason it
+		// exempts a missing block: the backlog is the thing it is not asking about.
+		if (!(GATE_KNOWN && pending.includes(f))) {
+			fail(`${b.file}:${b.line}  ${f}: ${sum} of ${n} entries attributed, ${n - sum} carry no target`);
+		}
 	} else if (sum > n) {
+		// Never exempt: a table claiming more entries than the ratchet holds is wrong
+		// whatever the backlog looks like, and it is the shape that shipped through #4191.
 		fail(`${b.file}:${b.line}  attribution of ${f} sums to ${sum}, the ratchet holds only ${n}`);
 	}
 	for (const r of b.rows) {

--- a/scripts/ci/test-attribution-check.mjs
+++ b/scripts/ci/test-attribution-check.mjs
@@ -134,7 +134,21 @@ const PENDING_TREE = (() => {
 {
 	const f = { ...PASSING, 'attribution-pending.json': JSON.stringify(['a-known-failures.json']) };
 	const r = run(f, undefined, ['--gate-known']);
-	check('a ratchet that has earned its block must leave the pending list', r.code === 1 && /still listed in attribution-pending\.json/.test(r.out), r.out);
+	check('a COMPLETE table must leave the pending list', r.code === 1 && /still listed in attribution-pending\.json/.test(r.out), r.out);
+}
+{
+	// The middle state: the first cluster of a large ratchet is filed while the rest is not.
+	// Requiring completeness before any row could be written would make a partial table
+	// worse than none, which is the opposite of what the pending list is for.
+	const f = {
+		...PASSING,
+		'a-known-failures.json': JSON.stringify(['one', 'two', 'three', 'four', 'five']),
+		'attribution-pending.json': JSON.stringify(['a-known-failures.json']),
+	};
+	const r = run(f, undefined, ['--gate-known']);
+	check('--gate-known accepts a PARTIAL table on a pending ratchet', r.code === 0, r.out);
+	const d = run(f);
+	check('the default mode still names the uncovered entries', d.code === 1 && /3 of 5 entries attributed, 2 carry no target/.test(d.out), d.out);
 }
 {
 	const f = { ...PASSING, 'attribution-pending.json': JSON.stringify(['b-known-failures.json']) };
@@ -151,4 +165,4 @@ if (failures) {
 	console.error(`\n[test-attribution-check] ${failures} control(s) did not behave as specified.`);
 	process.exit(1);
 }
-console.log('[test-attribution-check] 16 controls pass (2 positive, 13 negative, 1 empty-ratchet).');
+console.log('[test-attribution-check] 19 controls pass (3 positive, 15 negative, 1 empty-ratchet).');

--- a/scripts/ci/test-attribution-check.mjs
+++ b/scripts/ci/test-attribution-check.mjs
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const CHECK = path.join(HERE, 'attribution-check.mjs');
 
-function run(files, upstream = ['upstream_issues/x.md']) {
+function run(files, upstream = ['upstream_issues/x.md'], args = []) {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'attr-'));
 	const dir = path.join(root, 'compatibility');
 	fs.mkdirSync(dir);
@@ -19,7 +19,7 @@ function run(files, upstream = ['upstream_issues/x.md']) {
 	for (const u of upstream) fs.writeFileSync(path.join(root, u), '# report\n');
 	for (const [name, body] of Object.entries(files)) fs.writeFileSync(path.join(dir, name), body);
 	try {
-		const out = execFileSync(process.execPath, [CHECK], {
+		const out = execFileSync(process.execPath, [CHECK, ...args], {
 			env: { ...process.env, ATTRIBUTION_DIR: dir, ATTRIBUTION_ROOT: root },
 			encoding: 'utf8',
 			stdio: ['ignore', 'pipe', 'pipe'],
@@ -94,8 +94,61 @@ const check = (name, cond, detail) => {
 	check('a block for a non-ratchet fails', r.code === 1 && /is not a ratchet/.test(r.out), r.out);
 }
 
+// `--gate-known` drops exactly one question. Each case below differs from its neighbour by
+// one thing — the flag, or the pending list — so "it passed" cannot be satisfied by the
+// flag disabling more than it claims.
+const PENDING_TREE = (() => {
+	const f = { ...PASSING, 'c-known-failures.json': JSON.stringify(['x', 'y']) };
+	return f;
+})();
+{
+	const r = run(PENDING_TREE);
+	check('default mode fails on a ratchet with no block', r.code === 1 && /c-known-failures\.json has 2 listed/.test(r.out), r.out);
+}
+{
+	const r = run(PENDING_TREE, undefined, ['--gate-known']);
+	check('--gate-known without a pending list still fails', r.code === 1 && /c-known-failures\.json has 2 listed/.test(r.out), r.out);
+}
+{
+	const f = { ...PENDING_TREE, 'attribution-pending.json': JSON.stringify(['c-known-failures.json']) };
+	const r = run(f, undefined, ['--gate-known']);
+	check('--gate-known exempts a pending ratchet from the missing-block question', r.code === 0, r.out);
+	check('--gate-known says which ratchets it did not gate', /c-known-failures\.json/.test(r.out), r.out);
+}
+{
+	const f = { ...PENDING_TREE, 'attribution-pending.json': JSON.stringify(['c-known-failures.json']) };
+	const r = run(f);
+	check('the pending list does not exempt anything in default mode', r.code === 1 && /c-known-failures\.json has 2 listed/.test(r.out), r.out);
+}
+{
+	// The shape that shipped: a table whose `n` no longer sums to its JSON. `--gate-known`
+	// must still catch it, or wiring the flag into CI buys nothing.
+	const f = {
+		...PASSING,
+		'attribution-pending.json': JSON.stringify(['a-known-failures.json']),
+		'a-known-failures.json': JSON.stringify(['one', 'two']),
+	};
+	const r = run(f, undefined, ['--gate-known']);
+	check('--gate-known still catches a table that oversums its ratchet', r.code === 1 && /sums to 3, the ratchet holds only 2/.test(r.out), r.out);
+}
+{
+	const f = { ...PASSING, 'attribution-pending.json': JSON.stringify(['a-known-failures.json']) };
+	const r = run(f, undefined, ['--gate-known']);
+	check('a ratchet that has earned its block must leave the pending list', r.code === 1 && /still listed in attribution-pending\.json/.test(r.out), r.out);
+}
+{
+	const f = { ...PASSING, 'attribution-pending.json': JSON.stringify(['b-known-failures.json']) };
+	const r = run(f, undefined, ['--gate-known']);
+	check('an emptied ratchet must leave the pending list', r.code === 1 && /which is empty — remove it/.test(r.out), r.out);
+}
+{
+	const f = { ...PASSING, 'attribution-pending.json': JSON.stringify(['nope-known-failures.json']) };
+	const r = run(f, undefined, ['--gate-known']);
+	check('a pending entry that is not a ratchet fails', r.code === 1 && /is not a ratchet/.test(r.out), r.out);
+}
+
 if (failures) {
 	console.error(`\n[test-attribution-check] ${failures} control(s) did not behave as specified.`);
 	process.exit(1);
 }
-console.log('[test-attribution-check] 8 controls pass (1 positive, 6 negative, 1 empty-ratchet).');
+console.log('[test-attribution-check] 16 controls pass (2 positive, 13 negative, 1 empty-ratchet).');


### PR DESCRIPTION
P3 が問う「全 ratchet エントリが 3 つの終端のどれかに帰属しているか」を所有するのは `scripts/ci/attribution-check.mjs` です。書かれていて、8 本の対照つきで、**どのワークフローからも呼ばれていませんでした** (`grep -rn 'attribution-check\|check:attribution' .github/workflows/` → 0)。

この PR は 3 つを足します。

## 1. 存在する帰属表をゲートする

`--gate-known` を `ratchet-doc-guard` の `Ratchet doc parity` に、対照の自己テストを `deliberate-divergences-check.mjs` を既に走らせている job に配線しました。

`--gate-known` は `compatibility/attribution-pending.json` に載っている 5 本の ratchet について「表がまだ無い / 部分的である」ことだけを免除します。免除しないのは **`sum > n`** — 表が ratchet より多く主張している場合で、これは #4191 の形（表が実体より多く数えていた）なので、pending でも常に赤にします。表が完成したのに pending に残っていることも赤にします（中間状態から抜けたのに宣言が残る、を防ぐ）。

## 2. pending は 4 つ目の終端ではない

`attribution-pending.json` の 5 本は fmt / client / client-dev / lsp / parse-ast で、合計 24,600 件強。これらは「帰属先がある」と主張していません。**まだ表が無い**という宣言だけです。完成したら消す、が gate で強制されています。

なぜ部分表を許すかというと、最初の設計は許していませんでした。その設計だと LSP の 23,746 件の表が完成するまで 1 行も書けません。実際に 8 件を帰属させた PR が出てきて初めて分かりました。

## 3. GATES.md gate 43 と AGENTS.md の 4 行

gate 43 は unit / 陽性対照 / 4 つの盲点を書いています。AGENTS.md 側は今回の作業で踏んだもの:

- 捏造した full SHA は先頭 9 文字で一致するので再読で見えない
- `origin/main` は共有 `.git` で自分の fetch 無しに動くので、範囲の端点にすると再実行不能
- issue 番号と gate 番号の語彙衝突
- collapse ratio は解像度を答えるが方向は答えない（gate 39 の self-compare 対照があって初めて仕事量になる）

`GATES.md` の parse-ast の件数は「JSON を数えろ、この文は派生」に直しました。この段落は既に 2 回間違っています。

## 検証

- `node scripts/ci/test-attribution-check.mjs` → 19 controls pass (3 positive, 15 negative, 1 empty-ratchet)
- `node scripts/ci/attribution-check.mjs --gate-known` → EXIT=0
- `node scripts/compat-corpus/known-failures-md-check.mjs` → EXIT=0
- `node scripts/dev/deliberate-divergences-check.mjs` → EXIT=0

`--gate-known` が EXIT=0 になるのは #4202 が入ってからです（`fmt-oracle-excluded.json` の表が 4 と主張して ratchet が 3 だった）。この branch は #4202 のマージ後に rebase してあります。
