### PR TITLE
fix(server): a TypeScript-only statement is upstream's output, not a compile error

### DIFF
--- a/.changeset/server-ts-only-statements.md
+++ b/.changeset/server-ts-only-statements.md
@@ -1,0 +1,19 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A TypeScript-only statement form no longer fails the server compile with a code-less error.
+
+`import x = require(…)`, `export = a` and `export as namespace N` are TypeScript module
+syntax, not type annotations, so upstream's eraser leaves them alone and copies each one
+verbatim into the generated JavaScript. rsvelte's server ran its classification parse in
+plain-JS mode, rejected the erased text, and returned `TransformError::CodeGen` — an error
+whose `code` is `null`, which is the one shape the error ratchets cannot classify, since
+`error-message` / `error-position` / `error-end` / `error-frame` are all chained behind it.
+
+The classification parse and the statement re-home now retry in TypeScript mode, so those
+three statements are classified and emitted rather than failing the compile. Measured
+against `submodules/svelte`, the server output is byte-identical to upstream's on all three
+— including the fact that neither output parses, which is upstream's half and is filed
+separately. A rejection by both parsers is still a compile failure, so the retry widens the
+accepted set by exactly the population that used to throw.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -1119,12 +1119,24 @@ impl<'a> ServerTransformState<'a> {
     /// statements) from the throwaway classification arena into the output AST.
     pub fn reparse_statement(&self, src: &str) -> Option<Statement<'a>> {
         let owned = self.allocator.alloc_str(src.trim());
-        let ret =
+        let mut ret =
             oxc_parser::Parser::new(self.allocator, owned, oxc_span::SourceType::mjs()).parse();
         comment_stats::bump::REPARSE_STMT_CALLS(1);
         comment_stats::bump::REPARSE_STMT_DROPPED_COMMENTS(ret.program.comments.len() as u64);
         if !ret.diagnostics.is_empty() {
-            return None;
+            // The classification parse accepts the TypeScript-only statement forms
+            // upstream emits verbatim, so the re-home has to accept them too or the
+            // statement is silently dropped from a component that still compiles.
+            let ts = oxc_parser::Parser::new(
+                self.allocator,
+                owned,
+                oxc_span::SourceType::mjs().with_typescript(true),
+            )
+            .parse();
+            if !ts.diagnostics.is_empty() {
+                return None;
+            }
+            ret = ts;
         }
         ret.program.body.into_iter().next()
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -900,6 +900,32 @@ fn record_classification_failure(
     ));
 }
 
+/// Classify the erased script. Upstream erases type ANNOTATIONS and leaves the
+/// TypeScript-only statement forms (`import x = require(…)`, `export =`,
+/// `export as namespace`) in its output verbatim, so a TypeScript retry here is
+/// parity rather than leniency; a rejection by BOTH parsers is still a failure.
+fn classification_parse<'p>(
+    alloc: &'p oxc_allocator::Allocator,
+    owned: &'p str,
+    state: &ServerTransformState<'_>,
+    is_instance: bool,
+) -> Option<oxc_parser::ParserReturn<'p>> {
+    let ret = oxc_parser::Parser::new(alloc, owned, oxc_span::SourceType::mjs()).parse();
+    if ret.diagnostics.is_empty() {
+        return Some(ret);
+    }
+    let ts = oxc_parser::Parser::new(
+        alloc,
+        owned,
+        oxc_span::SourceType::mjs().with_typescript(true),
+    )
+    .parse();
+    if ts.diagnostics.is_empty() {
+        return Some(ts);
+    }
+    record_classification_failure(state, is_instance, &ret.diagnostics);
+    None
+}
 /// Prepare a TypeScript script for the server's independent JavaScript
 /// classification parse. Phase 1 accepts one deprecated import-attributes
 /// spelling through a same-length parser-only repair, so every server port must
@@ -971,11 +997,9 @@ fn transform_script<'a>(
     // allocator instead.
     let alloc = oxc_allocator::Allocator::default();
     let owned = alloc.alloc_str(src);
-    let ret = oxc_parser::Parser::new(&alloc, owned, oxc_span::SourceType::mjs()).parse();
-    if !ret.diagnostics.is_empty() {
-        record_classification_failure(state, is_instance, &ret.diagnostics);
+    let Some(ret) = classification_parse(&alloc, owned, state, is_instance) else {
         return Vec::new();
-    }
+    };
 
     classify_comments(&ret.program.body, &ret.program.comments);
 
@@ -3731,11 +3755,9 @@ fn transform_script_legacy<'a>(
 
     let alloc = oxc_allocator::Allocator::default();
     let owned = alloc.alloc_str(src);
-    let ret = oxc_parser::Parser::new(&alloc, owned, oxc_span::SourceType::mjs()).parse();
-    if !ret.diagnostics.is_empty() {
-        record_classification_failure(state, is_instance, &ret.diagnostics);
+    let Some(ret) = classification_parse(&alloc, owned, state, is_instance) else {
         return Vec::new();
-    }
+    };
 
     classify_comments(&ret.program.body, &ret.program.comments);
 

--- a/crates/rsvelte_core/tests/ts_only_statements_4196.rs
+++ b/crates/rsvelte_core/tests/ts_only_statements_4196.rs
@@ -1,0 +1,73 @@
+//! Three TypeScript-only STATEMENT forms are not type annotations, so upstream's
+//! eraser leaves them alone and emits them verbatim into the generated
+//! JavaScript — output that no JS parser accepts, on both targets, measured
+//! against `submodules/svelte`. rsvelte's server instead ran its classification
+//! parse in plain-JS mode, rejected the erased text, and failed the compile with
+//! an error carrying no `code` (issue #4196).
+//!
+//! The assertion is that the compile SUCCEEDS and the statement survives, which
+//! is what parity means here: matching upstream's unparseable output is the
+//! goal, and refusing to emit it is the divergence. The control is an ordinary
+//! `import`, which both targets already emitted.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+/// `import x = require(…)`, `export =` and `export as namespace` are TypeScript
+/// module syntax with no runtime erasure — upstream copies each one through.
+const TS_ONLY_STATEMENTS: [&str; 3] = [
+    "import fs = require('fs');",
+    "export = a;",
+    "export as namespace N;",
+];
+
+/// An ordinary import is the control: it must keep compiling, and it reaches the
+/// same classification parse.
+const CONTROL: &str = "import { b } from './b';";
+
+fn source(statement: &str) -> String {
+    format!("<script lang=\"ts\">\n\tlet a = 1;\n\t{statement}\n</script>\n{{a}}\n")
+}
+
+fn compile_to(statement: &str, generate: GenerateMode) -> Result<String, String> {
+    compile(
+        &source(statement),
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .map_err(|e| {
+        let d = e.diagnostic();
+        format!("{:?}: {}", d.code, d.message)
+    })
+}
+
+#[test]
+fn a_typescript_only_statement_compiles_on_both_targets() {
+    for statement in TS_ONLY_STATEMENTS {
+        for generate in [GenerateMode::Client, GenerateMode::Server] {
+            let code = compile_to(statement, generate)
+                .unwrap_or_else(|e| panic!("{statement:?} on {generate:?} failed to compile: {e}"));
+            assert!(
+                code.contains(statement),
+                "{statement:?} on {generate:?} did not survive into the output:\n{code}"
+            );
+        }
+    }
+}
+
+#[test]
+fn an_ordinary_import_still_compiles_on_both_targets() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let code = compile_to(CONTROL, generate)
+            .unwrap_or_else(|e| panic!("the control on {generate:?} failed to compile: {e}"));
+        assert!(
+            code.contains("from './b'"),
+            "the control's import is missing from the {generate:?} output:\n{code}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #4196 の server 側。

## 何が起きていたか

`import x = require(…)` / `export = a` / `export as namespace N` は**型注釈ではなく TypeScript のモジュール構文**で、上流の eraser は消しません。official は 3 つとも生成 JS に**そのままコピー**します（どちらのターゲットでも出力はパースできませんが、それは上流側の半分で別に filed されています）。

rsvelte の server は分類パースを plain-JS モードで走らせ、消し残ったこの文で失敗し、`TransformError::CodeGen` でコンパイルを落としていました。そのエラーは **`code` が `null`** — `error-message` / `error-position` / `error-end` / `error-frame` が全部 `code` の後ろに連鎖しているので、**エラーのラチェットが分類できない唯一の形**です。

## 修正

分類パース（`transform_script` と legacy 側の双子、2 箇所）と `reparse_statement` に、TypeScript モードの retry を足しました。**どちらの retry も plain-JS パースが既に失敗した後にしか到達しません**ので、広がった受理集合は「今まで throw していた母集団」そのものです。両方のパーサが拒否したものは今までどおりコンパイル失敗です。

`reparse_statement` 側も要ります — 分類だけ通しても、re-home が plain-JS のままだと文が**黙って落ちて**、コンパイルは成功したまま `<script>` の一部が消えます。

## 測定（`submodules/svelte` に対して）

server は 3 形すべて**バイト一致**:

| source | server |
|---|---|
| `import fs = require('fs');` | **EQ** |
| `export = a;` | **EQ** |
| `export as namespace N;` | **EQ** |

client は 3 形とも **DIFF のまま**で、これはこの PR が触っていません。差は 1 行で、official は文の前に空行を入れ rsvelte は入れません（`let a = 1;` の直後に隣接）。それ以降は 1 行ずれるだけです。**測った残差として issue に書き戻します** — 「client の半分は上流の半分」という issue の記述は「どちらもパースできない」についてであって、バイト一致については何も言っていませんでした。

## テスト

`crates/rsvelte_core/tests/ts_only_statements_4196.rs` — 3 形 × 2 ターゲットで「コンパイルが成功し、文が出力に残る」ことと、通常の `import` の対照。期待値は official をこのツリーの `submodules/svelte` から実際に走らせて出しています。

- `--test ssr` (`test_ssr`)、`--test compiler_errors` (`test_compiler_errors`)、`ssr_typescript_erasure`、`module_compile_ts_strip`、`import_export_parser_shapes`、`module_ts_class_modifier_3538` — 全て緑
- `--lib` — `running 1963 tests` / `1962 passed; 0 failed; 1 ignored`
- `cargo fmt --check` EXIT=0、`cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` EXIT=0

## corpus の担い手

issue が記録しているとおり、この 3 形は checkout 済みコーパスに 1 件も現れません（**分母は 104 corpus source のうち 20**）。「担い手がいない」ではなく「見える母集団に証人がいない」なので、検出器はこのユニットテストです。
