### PR TITLE
fix(parse): four node kinds reach the public AST instead of a catch-all

### DIFF
--- a/.changeset/parse-ast-ts-only-nodes.md
+++ b/.changeset/parse-ast-ts-only-nodes.md
@@ -1,0 +1,20 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Four node kinds reach the public `parse()` AST instead of being dropped by a catch-all.
+
+`TSImportEqualsDeclaration`, `TSExportAssignment` and `TSNamespaceExportDeclaration` fell
+through `convert_statement_for_program`'s `_ => None`, and a class-body `TSIndexSignature`
+fell through the two class-element converters' — so every consumer that reads rsvelte's AST
+without compiling (`rsvelte_lint`, svelte2tsx, the language server, the playground) saw a
+statement or a class member that is not there. Official's AST carries all four.
+
+Each is carried as its complete ESTree object, the same representation the neighbouring TS
+declarations already use, and the class-element converter that now names every `ClassElement`
+variant has lost its catch-all: a new oxc variant is a build error rather than a silently
+dropped node.
+
+The stand-in a namespace body used for an `import x = require(…)` — a `DebuggerStatement`
+with the right span, there only to keep the namespace non-type — is gone with it, so
+`parse()` no longer reports a node the source does not contain.

--- a/crates/rsvelte_bindings_support/src/napi_raw_parse.rs
+++ b/crates/rsvelte_bindings_support/src/napi_raw_parse.rs
@@ -2148,6 +2148,10 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
         JsNode::TSEnumDeclaration { start, end, .. }
         | JsNode::TSTypeAliasDeclaration { start, end, .. }
         | JsNode::TSInterfaceDeclaration { start, end, .. }
+        | JsNode::TSImportEqualsDeclaration { start, end, .. }
+        | JsNode::TSExportAssignment { start, end, .. }
+        | JsNode::TSNamespaceExportDeclaration { start, end, .. }
+        | JsNode::TSIndexSignature { start, end, .. }
         | JsNode::TSDeclareMethod { start, end, .. } => {
             write_json_node(w, *start, *end, node)?;
         }

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -788,6 +788,31 @@ pub enum JsNode {
         end: u32,
         value: Box<Value>,
     },
+    /// TypeScript-only STATEMENT forms. Upstream's parser emits each one and its
+    /// eraser leaves it alone, so the public parse() output has to carry it whole
+    /// for the same reason the declarations above do.
+    TSImportEqualsDeclaration {
+        start: u32,
+        end: u32,
+        value: Box<Value>,
+    },
+    TSExportAssignment {
+        start: u32,
+        end: u32,
+        value: Box<Value>,
+    },
+    TSNamespaceExportDeclaration {
+        start: u32,
+        end: u32,
+        value: Box<Value>,
+    },
+    /// A class-body index signature. Opaque for the same reason: nothing walks
+    /// into it and its shape is acorn-typescript's.
+    TSIndexSignature {
+        start: u32,
+        end: u32,
+        value: Box<Value>,
+    },
     /// An abstract method's bodyless `value`, retained whole for the same
     /// reason: nothing walks into it and its shape is acorn-typescript's, not
     /// a `FunctionExpression`'s.
@@ -2407,6 +2432,10 @@ impl Serialize for JsNode {
             Self::TSEnumDeclaration { value, .. }
             | Self::TSTypeAliasDeclaration { value, .. }
             | Self::TSInterfaceDeclaration { value, .. }
+            | Self::TSImportEqualsDeclaration { value, .. }
+            | Self::TSExportAssignment { value, .. }
+            | Self::TSNamespaceExportDeclaration { value, .. }
+            | Self::TSIndexSignature { value, .. }
             | Self::TSDeclareMethod { value, .. } => {
                 opaque_ts_with_comments(value).serialize(serializer)
             }
@@ -2701,6 +2730,10 @@ impl JsNode {
                             | "TSInterfaceDeclaration"
                             | "TSDeclareMethod"
                             | "TSEnumDeclaration"
+                            | "TSImportEqualsDeclaration"
+                            | "TSExportAssignment"
+                            | "TSNamespaceExportDeclaration"
+                            | "TSIndexSignature"
                     )
                 ) {
                     let start = owned_obj
@@ -2718,6 +2751,16 @@ impl JsNode {
                         }
                         Some("TSDeclareMethod") => Self::TSDeclareMethod { start, end, value },
                         Some("TSEnumDeclaration") => Self::TSEnumDeclaration { start, end, value },
+                        Some("TSImportEqualsDeclaration") => {
+                            Self::TSImportEqualsDeclaration { start, end, value }
+                        }
+                        Some("TSExportAssignment") => {
+                            Self::TSExportAssignment { start, end, value }
+                        }
+                        Some("TSNamespaceExportDeclaration") => {
+                            Self::TSNamespaceExportDeclaration { start, end, value }
+                        }
+                        Some("TSIndexSignature") => Self::TSIndexSignature { start, end, value },
                         _ => Self::TSInterfaceDeclaration { start, end, value },
                     };
                 }
@@ -3506,6 +3549,10 @@ impl JsNode {
             Self::TSTypeAliasDeclaration { .. } => Some("TSTypeAliasDeclaration"),
             Self::TSDeclareMethod { .. } => Some("TSDeclareMethod"),
             Self::TSInterfaceDeclaration { .. } => Some("TSInterfaceDeclaration"),
+            Self::TSImportEqualsDeclaration { .. } => Some("TSImportEqualsDeclaration"),
+            Self::TSExportAssignment { .. } => Some("TSExportAssignment"),
+            Self::TSNamespaceExportDeclaration { .. } => Some("TSNamespaceExportDeclaration"),
+            Self::TSIndexSignature { .. } => Some("TSIndexSignature"),
             Self::TSModuleDeclaration { .. } => Some("TSModuleDeclaration"),
             Self::TSAsExpression { .. } => Some("TSAsExpression"),
             Self::TSSatisfiesExpression { .. } => Some("TSSatisfiesExpression"),
@@ -4232,6 +4279,10 @@ impl JsNode {
             | Self::TSTypeAliasDeclaration { start, .. }
             | Self::TSDeclareMethod { start, .. }
             | Self::TSInterfaceDeclaration { start, .. }
+            | Self::TSImportEqualsDeclaration { start, .. }
+            | Self::TSExportAssignment { start, .. }
+            | Self::TSNamespaceExportDeclaration { start, .. }
+            | Self::TSIndexSignature { start, .. }
             | Self::TSModuleDeclaration { start, .. }
             | Self::TSAsExpression { start, .. }
             | Self::TSSatisfiesExpression { start, .. }
@@ -4323,6 +4374,10 @@ impl JsNode {
             | Self::TSTypeAliasDeclaration { end, .. }
             | Self::TSDeclareMethod { end, .. }
             | Self::TSInterfaceDeclaration { end, .. }
+            | Self::TSImportEqualsDeclaration { end, .. }
+            | Self::TSExportAssignment { end, .. }
+            | Self::TSNamespaceExportDeclaration { end, .. }
+            | Self::TSIndexSignature { end, .. }
             | Self::TSModuleDeclaration { end, .. }
             | Self::TSAsExpression { end, .. }
             | Self::TSSatisfiesExpression { end, .. }
@@ -4417,6 +4472,10 @@ impl JsNode {
             Self::TSTypeAliasDeclaration { .. } => "TSTypeAliasDeclaration",
             Self::TSDeclareMethod { .. } => "TSDeclareMethod",
             Self::TSInterfaceDeclaration { .. } => "TSInterfaceDeclaration",
+            Self::TSImportEqualsDeclaration { .. } => "TSImportEqualsDeclaration",
+            Self::TSExportAssignment { .. } => "TSExportAssignment",
+            Self::TSNamespaceExportDeclaration { .. } => "TSNamespaceExportDeclaration",
+            Self::TSIndexSignature { .. } => "TSIndexSignature",
             Self::TSModuleDeclaration { .. } => "TSModuleDeclaration",
             Self::TSAsExpression { .. } => "TSAsExpression",
             Self::TSSatisfiesExpression { .. } => "TSSatisfiesExpression",

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -5651,6 +5651,12 @@ fn convert_class_element_for_expr(
 
             Some(Value::Object(obj))
         }
+        oxc_ast::ast::ClassElement::TSIndexSignature(index) => Some(convert_ts_index_signature(
+            arena,
+            index,
+            offset,
+            line_offsets,
+        )),
         _ => None,
     }
 }
@@ -9677,8 +9683,162 @@ fn convert_statement_for_program(
             ))
         }
 
+        oxc_ast::ast::Statement::TSImportEqualsDeclaration(decl) => {
+            let start = offset + decl.span.start as usize;
+            let end = offset + decl.span.end as usize;
+            Some(JsNode::TSImportEqualsDeclaration {
+                start: start as u32,
+                end: end as u32,
+                value: Box::new(convert_ts_import_equals(decl, offset, line_offsets)),
+            })
+        }
+        oxc_ast::ast::Statement::TSExportAssignment(decl) => {
+            let start = offset + decl.span.start as usize;
+            let end = offset + decl.span.end as usize;
+            let mut obj = Map::new();
+            obj.set_field("type", Value::String("TSExportAssignment".to_string()));
+            push_span_fields(&mut obj, start, end, line_offsets);
+            obj.set_field(
+                "expression",
+                expr_to_node(convert_expression_for_program(
+                    arena,
+                    &decl.expression,
+                    offset,
+                    line_offsets,
+                ))
+                .to_value(),
+            );
+            Some(JsNode::TSExportAssignment {
+                start: start as u32,
+                end: end as u32,
+                value: Box::new(Value::Object(obj)),
+            })
+        }
+        oxc_ast::ast::Statement::TSNamespaceExportDeclaration(decl) => {
+            let start = offset + decl.span.start as usize;
+            let end = offset + decl.span.end as usize;
+            let mut obj = Map::new();
+            obj.set_field(
+                "type",
+                Value::String("TSNamespaceExportDeclaration".to_string()),
+            );
+            push_span_fields(&mut obj, start, end, line_offsets);
+            obj.set_field(
+                "id",
+                ts_identifier_value(
+                    &decl.id.name,
+                    offset + decl.id.span.start as usize,
+                    offset + decl.id.span.end as usize,
+                    line_offsets,
+                ),
+            );
+            Some(JsNode::TSNamespaceExportDeclaration {
+                start: start as u32,
+                end: end as u32,
+                value: Box::new(Value::Object(obj)),
+            })
+        }
+
         // Add more statement types as needed
         _ => None,
+    }
+}
+
+/// Build the ESTree TSImportEqualsDeclaration acorn-typescript emits. Upstream
+/// always writes isExport for the bare statement form; the exported spelling is
+/// a declaration inside an export, which never reaches here.
+fn convert_ts_import_equals(
+    decl: &oxc_ast::ast::TSImportEqualsDeclaration,
+    offset: usize,
+    line_offsets: &[usize],
+) -> Value {
+    let start = offset + decl.span.start as usize;
+    let end = offset + decl.span.end as usize;
+    let mut obj = Map::new();
+    obj.set_field(
+        "type",
+        Value::String("TSImportEqualsDeclaration".to_string()),
+    );
+    push_span_fields(&mut obj, start, end, line_offsets);
+    let kind = match decl.import_kind {
+        oxc_ast::ast::ImportOrExportKind::Type => "type",
+        oxc_ast::ast::ImportOrExportKind::Value => "value",
+    };
+    obj.set_field("importKind", Value::String(kind.to_string()));
+    obj.set_field("isExport", Value::Bool(false));
+    obj.set_field(
+        "id",
+        ts_identifier_value(
+            &decl.id.name,
+            offset + decl.id.span.start as usize,
+            offset + decl.id.span.end as usize,
+            line_offsets,
+        ),
+    );
+    obj.set_field(
+        "moduleReference",
+        convert_ts_module_reference(&decl.module_reference, offset, line_offsets),
+    );
+    Value::Object(obj)
+}
+
+/// A module reference is either require('m') or a (possibly qualified) name, and
+/// the name spelling is the same node the type positions already build.
+fn convert_ts_module_reference(
+    reference: &oxc_ast::ast::TSModuleReference,
+    offset: usize,
+    line_offsets: &[usize],
+) -> Value {
+    match reference {
+        oxc_ast::ast::TSModuleReference::ExternalModuleReference(external) => {
+            let start = offset + external.span.start as usize;
+            let end = offset + external.span.end as usize;
+            let mut obj = Map::new();
+            obj.set_field(
+                "type",
+                Value::String("TSExternalModuleReference".to_string()),
+            );
+            push_span_fields(&mut obj, start, end, line_offsets);
+            let lit = &external.expression;
+            let lit_start = offset + lit.span.start as usize;
+            let lit_end = offset + lit.span.end as usize;
+            let mut lit_obj = Map::new();
+            lit_obj.set_field("type", Value::String("Literal".to_string()));
+            push_span_fields(&mut lit_obj, lit_start, lit_end, line_offsets);
+            lit_obj.set_field("value", Value::String(lit.value.to_string()));
+            if let Some(raw) = &lit.raw {
+                lit_obj.set_field("raw", Value::String(raw.to_string()));
+            }
+            obj.set_field("expression", Value::Object(lit_obj));
+            Value::Object(obj)
+        }
+        oxc_ast::ast::TSModuleReference::IdentifierReference(id) => ts_identifier_value(
+            &id.name,
+            offset + id.span.start as usize,
+            offset + id.span.end as usize,
+            line_offsets,
+        ),
+        oxc_ast::ast::TSModuleReference::QualifiedName(qualified) => {
+            let start = offset + qualified.span.start as usize;
+            let end = offset + qualified.span.end as usize;
+            let mut obj = Map::new();
+            obj.set_field("type", Value::String("TSQualifiedName".to_string()));
+            push_span_fields(&mut obj, start, end, line_offsets);
+            obj.set_field(
+                "left",
+                convert_ts_type_name_adjusted(&qualified.left, offset, line_offsets),
+            );
+            obj.set_field(
+                "right",
+                ts_identifier_value(
+                    &qualified.right.name,
+                    offset + qualified.right.span.start as usize,
+                    offset + qualified.right.span.end as usize,
+                    line_offsets,
+                ),
+            );
+            Value::Object(obj)
+        }
     }
 }
 
@@ -9967,27 +10127,7 @@ fn convert_ts_module_declaration_as_node(
         let block_body: Vec<JsNode> = block
             .body
             .iter()
-            .filter_map(|stmt| {
-                if let Some(node) = convert_statement_for_program(arena, stmt, offset, line_offsets)
-                {
-                    return Some(node);
-                }
-                // The typed program has no variant for this one (issue #3681), so
-                // `convert_statement_for_program` drops it — but upstream's visitor
-                // leaves it in place, which makes the namespace non-type. Only this
-                // stands in: most of what it drops (a type alias, say) IS type-only
-                // and must keep stripping to empty.
-                if !matches!(stmt, oxc_ast::ast::Statement::TSImportEqualsDeclaration(_)) {
-                    return None;
-                }
-                let start = offset + stmt.span().start as usize;
-                let end = offset + stmt.span().end as usize;
-                Some(JsNode::DebuggerStatement {
-                    start: start as u32,
-                    end: end as u32,
-                    loc: create_typed_loc(start, end, line_offsets),
-                })
-            })
+            .filter_map(|stmt| convert_statement_for_program(arena, stmt, offset, line_offsets))
             .collect();
         arena.alloc_js_node(JsNode::BlockStatement {
             start: start as u32,
@@ -11909,8 +12049,20 @@ fn convert_class_element_for_program_as_node(
         oxc_ast::ast::ClassElement::AccessorProperty(_) => TypedClassElem::Bail,
         // No typed variant carries a static block; the Value blob emits it.
         oxc_ast::ast::ClassElement::StaticBlock(_) => TypedClassElem::Bail,
-        // TS-only members are dropped by the Value path (`_ => None`).
-        _ => TypedClassElem::Skip,
+        oxc_ast::ast::ClassElement::TSIndexSignature(index) => {
+            let start = offset + index.span.start as usize;
+            let end = offset + index.span.end as usize;
+            TypedClassElem::Node(JsNode::TSIndexSignature {
+                start: start as u32,
+                end: end as u32,
+                value: Box::new(convert_ts_index_signature(
+                    arena,
+                    index,
+                    offset,
+                    line_offsets,
+                )),
+            })
+        }
     }
 }
 
@@ -12082,7 +12234,14 @@ fn convert_class_element_for_program(
 
             Some(Value::Object(obj))
         }
-        _ => None,
+        // Exhaustive on purpose: this arm set now covers every `ClassElement`, so
+        // a new oxc variant is a build error rather than a silently dropped node.
+        oxc_ast::ast::ClassElement::TSIndexSignature(index) => Some(convert_ts_index_signature(
+            arena,
+            index,
+            offset,
+            line_offsets,
+        )),
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -3935,6 +3935,10 @@ pub(crate) fn for_each_js_child(node: &JsNode, arena: &ParseArena, f: &mut impl 
         | JsNode::TSEnumDeclaration { .. }
         | JsNode::TSTypeAliasDeclaration { .. }
         | JsNode::TSInterfaceDeclaration { .. }
+        | JsNode::TSImportEqualsDeclaration { .. }
+        | JsNode::TSExportAssignment { .. }
+        | JsNode::TSNamespaceExportDeclaration { .. }
+        | JsNode::TSIndexSignature { .. }
         | JsNode::TSDeclareMethod { .. }
         | JsNode::TSParameterProperty { .. }
         | JsNode::Comment { .. }
@@ -6436,6 +6440,10 @@ fn collect_identifier_names_in_node(
         }
         | JsNode::TSTypeAliasDeclaration { .. }
         | JsNode::TSInterfaceDeclaration { .. }
+        | JsNode::TSImportEqualsDeclaration { .. }
+        | JsNode::TSExportAssignment { .. }
+        | JsNode::TSNamespaceExportDeclaration { .. }
+        | JsNode::TSIndexSignature { .. }
         | JsNode::TSDeclareMethod { .. } => {}
         JsNode::TSModuleDeclaration {
             start: _,

--- a/crates/rsvelte_core/tests/ts_only_nodes_in_parse_ast_4195.rs
+++ b/crates/rsvelte_core/tests/ts_only_nodes_in_parse_ast_4195.rs
@@ -1,0 +1,137 @@
+//! Four node kinds were dropped from the public `parse()` AST by catch-all arms
+//! in the program serialization, so everything that reads rsvelte's AST without
+//! compiling — `rsvelte_lint`, svelte2tsx, the language server, the playground —
+//! saw a statement or a class member that is not there (issue #4195).
+//!
+//! The detector has to be a unit test: the `parse()` AST ratchet's population is
+//! the collected corpus, and none of these four constructs has a carrier there.
+//! Every expectation below was printed from official's own `parse()` in
+//! `submodules/svelte`, not inferred from rsvelte's output.
+//!
+//! `IfStatement` and a class `static {}` block are the controls the issue used,
+//! and they are here for the same reason: a serialization that dropped
+//! everything would pass a test that only asserts the four are present.
+
+use rsvelte_core::ast::arena::CommentCaptureGuard;
+use rsvelte_core::{ParseOptions, convert_to_legacy, parse};
+use serde_json::Value;
+
+fn instance_body(source: &str) -> Vec<Value> {
+    let _capture = CommentCaptureGuard::new();
+    let ast = parse(
+        source,
+        &oxc_allocator::Allocator::default(),
+        ParseOptions {
+            modern: true,
+            skip_expression_loc: true,
+            capture_comments: true,
+            ..Default::default()
+        },
+    )
+    .expect("parse should succeed");
+    let legacy = convert_to_legacy(source, ast);
+    legacy["instance"]["content"]["body"]
+        .as_array()
+        .expect("instance body")
+        .clone()
+}
+
+/// The same host every expectation was measured in: a `lang="ts"` instance
+/// script whose first statement is ordinary, so the subject is always last.
+fn last_statement(statement: &str) -> Value {
+    let source = format!("<script lang=\"ts\">\n\tlet a = 1;\n\t{statement}\n</script>\n");
+    instance_body(&source)
+        .pop()
+        .unwrap_or_else(|| panic!("{statement:?} produced no trailing statement"))
+}
+
+#[test]
+fn an_import_equals_declaration_reaches_the_program_body() {
+    let node = last_statement("import fs = require('fs');");
+    assert_eq!(node["type"], "TSImportEqualsDeclaration");
+    assert_eq!(node["start"], 32);
+    assert_eq!(node["end"], 58);
+    assert_eq!(node["importKind"], "value");
+    assert_eq!(node["isExport"], false);
+    assert_eq!(node["id"]["type"], "Identifier");
+    assert_eq!(node["id"]["name"], "fs");
+    assert_eq!(node["id"]["start"], 39);
+    assert_eq!(node["id"]["end"], 41);
+}
+
+#[test]
+fn an_external_module_reference_carries_its_literal() {
+    let node = last_statement("import fs = require('fs');");
+    let reference = &node["moduleReference"];
+    assert_eq!(reference["type"], "TSExternalModuleReference");
+    assert_eq!(reference["start"], 44);
+    assert_eq!(reference["end"], 57);
+    assert_eq!(reference["expression"]["type"], "Literal");
+    assert_eq!(reference["expression"]["value"], "fs");
+    // Official writes the source spelling, not the cooked value.
+    assert_eq!(reference["expression"]["raw"], "'fs'");
+    assert_eq!(reference["expression"]["start"], 52);
+    assert_eq!(reference["expression"]["end"], 56);
+}
+
+#[test]
+fn an_export_assignment_reaches_the_program_body() {
+    let node = last_statement("export = a;");
+    assert_eq!(node["type"], "TSExportAssignment");
+    assert_eq!(node["start"], 32);
+    assert_eq!(node["end"], 43);
+    assert_eq!(node["expression"]["type"], "Identifier");
+    assert_eq!(node["expression"]["name"], "a");
+    assert_eq!(node["expression"]["start"], 41);
+    assert_eq!(node["expression"]["end"], 42);
+}
+
+#[test]
+fn a_namespace_export_declaration_reaches_the_program_body() {
+    let node = last_statement("export as namespace N;");
+    assert_eq!(node["type"], "TSNamespaceExportDeclaration");
+    assert_eq!(node["start"], 32);
+    assert_eq!(node["end"], 54);
+    assert_eq!(node["id"]["type"], "Identifier");
+    assert_eq!(node["id"]["name"], "N");
+    assert_eq!(node["id"]["start"], 52);
+    assert_eq!(node["id"]["end"], 53);
+}
+
+#[test]
+fn a_class_body_index_signature_reaches_the_class_body() {
+    let node = last_statement("class C { [k: string]: number }");
+    assert_eq!(node["type"], "ClassDeclaration");
+    let members = node["body"]["body"].as_array().expect("class body");
+    assert_eq!(members.len(), 1, "the index signature is the only member");
+    let member = &members[0];
+    assert_eq!(member["type"], "TSIndexSignature");
+    assert_eq!(member["start"], 42);
+    assert_eq!(member["end"], 61);
+    // acorn-typescript's `parameters` entry spans the whole `k: string`.
+    let parameters = member["parameters"].as_array().expect("parameters");
+    assert_eq!(parameters.len(), 1);
+    assert_eq!(parameters[0]["type"], "Identifier");
+    assert_eq!(parameters[0]["name"], "k");
+    assert_eq!(parameters[0]["start"], 43);
+    assert_eq!(parameters[0]["end"], 52);
+    assert_eq!(
+        parameters[0]["typeAnnotation"]["typeAnnotation"]["type"],
+        "TSStringKeyword"
+    );
+    assert_eq!(
+        member["typeAnnotation"]["typeAnnotation"]["type"],
+        "TSNumberKeyword"
+    );
+}
+
+#[test]
+fn the_controls_are_still_present() {
+    let if_statement = last_statement("if (a) { a; }");
+    assert_eq!(if_statement["type"], "IfStatement");
+
+    let class = last_statement("class C { static { 1; } }");
+    let members = class["body"]["body"].as_array().expect("class body");
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0]["type"], "StaticBlock");
+}


### PR DESCRIPTION
Closes #4195。

## 何が落ちていたか

`parse()` — 公開 export のほう、`compile()` ではありません — が 4 つのノード種を AST から落としていました。3 つの catch-all `_ => None` が、明示アームの名前にないものを全部飲みます。

| kind | 落ちていた場所 |
|---|---|
| `TSImportEqualsDeclaration` | `convert_statement_for_program` |
| `TSExportAssignment` | 同上 |
| `TSNamespaceExportDeclaration` | 同上 |
| `TSIndexSignature`（クラス本体） | `convert_class_element_for_program` / `convert_class_element_for_expr` / `convert_class_element_for_program_as_node` |

official の AST は 4 つとも持っています。**コンパイルせずに rsvelte の AST を読むもの** — `rsvelte_lint`、svelte2tsx、language server、playground — は、そこに無い文・無いメンバを見ていました。

## 修正

隣接する TS 宣言（`TSEnumDeclaration` / `TSTypeAliasDeclaration` / `TSInterfaceDeclaration` / `TSDeclareMethod`）が既に使っている **完全な ESTree オブジェクトを丸ごと持つ** 表現に揃えました。`JsNode` に 4 variant、いずれも `{ start: u32, end: u32, value: Box<Value> }` — 既存の最大 variant より小さいので型のサイズは動きません。

**クラス要素の Value 変換は catch-all を失いました。** 4 つ目のアームを足した時点で `ClassElement` の全 variant を名指ししたので、`_ => None` が `unreachable_patterns` になり、消しました。つまり **oxc に新しい variant が増えたらビルドエラーになります** — 黙って落ちるのではなく。issue が指摘している「catch-all の残余を計算する」作業を、この 1 箇所については型システムに移した形です。

### 落とした回避策が 1 つあります

namespace の本体で `import x = require(…)` に対して立てていた `DebuggerStatement` の身代わり（issue #3681、「typed program にこの variant が無いので」というコメント付き）は、本物のノードが出るようになったので到達不能になりました。消しています。

namespace の非 type 判定（`strip_ts_module_declaration_typed`）は「recurse 後に `EmptyStatement` 以外が残っているか」なので、`DebuggerStatement` でも `TSImportEqualsDeclaration` でも同じく「非 type」と判定されます。**`parse()` がソースに無いノードを報告しなくなる分だけ改善で、判定は動きません。**

## 期待値の出所

**全部 official の `parse()` を `submodules/svelte` から実際に走らせて印刷したもの**です。span・`importKind`・`isExport`・`raw`（`'fs'`、cooked ではなくソースの綴り）・`TSIndexSignature.parameters[0]` が `k: string` 全体を張ること — どれも rsvelte の出力から逆算していません。

## テスト

`crates/rsvelte_core/tests/ts_only_nodes_in_parse_ast_4195.rs` — 6 本。4 種それぞれ + `TSExternalModuleReference` のリテラル + **対照**（`IfStatement` とクラスの `static {}`）。対照が要るのは、全部落とすシリアライザでも「4 つが在る」だけを見るテストは書けないからです。

検出器がユニットテストなのは、`parse()` AST ratchet の母集団が収集コーパスで、**4 つとも担い手がいない**からです（issue の測定: クラス本体の index signature は見つかった 31 個の index signature のうち 0 個、**分母は 104 corpus source のうち 20**）。

## 走らせたもの

`--lib`（`running 1963 tests` / `1962 passed; 0 failed; 1 ignored`）と、名前で読んだ 13 ターゲット: `parser_fixtures` / `compiler_errors` / `ssr` / `css` / `validator` / `print` / `runtime` / `sourcemaps` / `import_export_parser_shapes` / `module_compile_ts_strip` / `module_ts_class_modifier_3538` / 新規 2 本。`cargo fmt --check` と `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` は pre-commit フックで EXIT=0。

## 残り（この PR が直していないもの）

issue が並べて挙げている `TSTypeAliasDeclaration` のプログラム経路、`function` **文**の `params.rest`、関数の `returnType` は**触っていません**。最後の 2 つは `JsNode::FunctionDeclaration` に新しいフィールドが要り、コンパイラ・svelte2tsx・全ルールが共有する型なので、別 PR です。

**そして `-p rsvelte_core` は workspace ではありません。** 最初の測定はそれだけで緑でしたが、`rsvelte_bindings_support/src/napi_raw_parse.rs` の `JsNode` の網羅 match が落ちました（`JsNode` は crate をまたぐ共有型）。捕まえたのは pre-commit の clippy です。`cargo clippy --workspace --all-targets --all-features -- -D warnings` EXIT=0、`-p rsvelte_bindings_support` の 26 本も緑。
