### PR TITLE
bench: the typecheck rows type-check with TypeScript 7, not a discontinued preview

### DIFF
--- a/scripts/bench/competitor-oracle/package-lock.json
+++ b/scripts/bench/competitor-oracle/package-lock.json
@@ -7,6 +7,7 @@
       "name": "rsvelte-compiler-competitor-oracle",
       "dependencies": {
         "@mrwaip/svelte-rs": "0.0.0-canary.13.1",
+        "@typescript/native": "npm:typescript@7.0.2",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
         "@verter/wasm": "0.0.1-beta.3",
         "acorn": "8.18.0",
@@ -109,9 +110,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -124,9 +122,6 @@
       "integrity": "sha512-+2J+fIOTPXuKWhClxldWk982qAj1duAt/vcwLZ8/hxxLxHmDcRsoDxCqvNeSIfEH6AuascfnRKlLIZ/jRngQwA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -141,9 +136,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -156,9 +148,6 @@
       "integrity": "sha512-AcD9gkHiLJnnfb6hY9BHEugDn3ZSrzB+Gr/fNEXQ4MpAh+QXIjhaopad4Q4HbrOTLkDY1c6hKCX3VOa29l6nwQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -278,11 +267,47 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
+    "node_modules/@typescript/native": {
+      "name": "typescript",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
     "node_modules/@typescript/native-preview": {
       "version": "7.0.0-dev.20260707.2",
       "resolved": "https://npm.flatt.tech/@typescript/native-preview/-/native-preview-7.0.0-dev.20260707.2.tgz",
       "integrity": "sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsgo": "bin/tsgo"
       },
@@ -411,6 +436,326 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/@verter/wasm": {
       "version": "0.0.1-beta.3",
       "resolved": "https://npm.flatt.tech/@verter/wasm/-/wasm-0.0.1-beta.3.tgz",
@@ -425,6 +770,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/scripts/bench/competitor-oracle/package.json
+++ b/scripts/bench/competitor-oracle/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "dependencies": {
     "@mrwaip/svelte-rs": "0.0.0-canary.13.1",
+    "@typescript/native": "npm:typescript@7.0.2",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "@verter/wasm": "0.0.1-beta.3",
     "acorn": "8.18.0",

--- a/scripts/bench/run-benchmark.mjs
+++ b/scripts/bench/run-benchmark.mjs
@@ -718,8 +718,8 @@ function lintOracleMetadata() {
 }
 
 function ensureLintBenchRunnerBuilt() {
-  if (existsSync(LINT_BENCH_BIN)) return;
-  console.error("  Building lint_benchmark_runner (one-time)...");
+  // Unconditional for the same reason as ensureRsvelteSvelteCheckBuilt.
+  console.error("  Building lint_benchmark_runner...");
   // `--profile=bench` for the same reason the fmt runner uses it: the runner
   // isolates a per-file panic with `catch_unwind`, which needs unwinding.
   const r = spawnSync("cargo", ["build", "--profile=bench", "--bin", "lint_benchmark_runner"], {
@@ -1056,8 +1056,10 @@ function makeSvelteCheckFixture(n) {
 }
 
 function ensureRsvelteSvelteCheckBuilt() {
-  if (existsSync(RSVELTE_SVELTE_CHECK_BIN)) return;
-  console.error("  Building rsvelte svelte_check (one-time)...");
+  // Deliberately unconditional. Skipping the build when the file exists makes
+  // the measured binary a property of whatever was last left in target/, not of
+  // the tree being measured; cargo is a no-op when it is already current.
+  console.error("  Building rsvelte svelte_check...");
   // Stdout from this script becomes the benchmark JSON file — anything
   // cargo prints to its own stdout would corrupt it. Redirect both
   // streams to our stderr so logs still surface in the terminal but

--- a/scripts/bench/run-benchmark.mjs
+++ b/scripts/bench/run-benchmark.mjs
@@ -964,9 +964,17 @@ const JS_SVELTE_CHECK_BIN = join(
   REPO_ROOT,
   "submodules/language-tools/packages/svelte-check/bin/svelte-check",
 );
-const SVELTE_CHECK_TSGO_BIN = join(
+// The TypeScript 7 native compiler both `--tsgo` rows type-check with.
+// `@typescript/native-preview` published its last dated dev build on
+// 2026-07-07 and was superseded by TypeScript 7 stable, which ships the same
+// Go compiler as its own `tsc`; svelte-check's own not-found message names the
+// `@typescript/native@npm:typescript@7` alias as the supported way to install
+// it, and both CLIs resolve that name from the workspace on their own. Pinned
+// exactly in scripts/bench/competitor-oracle for the usual reason: a floating
+// range would move this baseline with no change in this repo.
+const SVELTE_CHECK_TS7_DIR = join(
   REPO_ROOT,
-  "submodules/language-tools/packages/svelte-check/node_modules/.bin/tsgo",
+  "scripts/bench/competitor-oracle/node_modules/@typescript/native",
 );
 const SVELTE_CHECK_RS_BIN = join(
   REPO_ROOT,
@@ -1025,6 +1033,15 @@ function makeSvelteCheckFixture(n) {
     realpathSync(SVELTE_CHECK_RS_TSGO_BIN),
     join(dir, "node_modules", ".bin", "tsgo"),
   );
+  // Both `--tsgo` rows find their compiler here: rsvelte-check walks up from
+  // the workspace for `@typescript/native`, and svelte-check resolves the same
+  // name from the tsconfig's directory. Neither is told where it is, so the
+  // two rows cannot be pointed at different backends by accident.
+  symlinkSync(
+    realpathSync(SVELTE_CHECK_TS7_DIR),
+    join(dir, "node_modules", "@typescript", "native"),
+    "dir",
+  );
   writeFileSync(
     join(dir, "tsconfig.json"),
     JSON.stringify({ compilerOptions: { noEmit: true, skipLibCheck: true }, include: ["src"] }),
@@ -1059,10 +1076,23 @@ function ensureRsvelteSvelteCheckBuilt() {
 }
 
 function ensureSvelteCheckTsgoAvailable() {
-  if (existsSync(SVELTE_CHECK_TSGO_BIN)) return;
-  throw new Error(
-    "svelte-check tsgo backend is missing; run `pnpm --dir submodules/language-tools install --frozen-lockfile`",
-  );
+  const manifest = join(SVELTE_CHECK_TS7_DIR, "package.json");
+  if (!existsSync(manifest)) {
+    throw new Error(
+      "the TypeScript 7 native backend is missing; run `pnpm run report:competitors:install`",
+    );
+  }
+  const { name, version } = JSON.parse(readFileSync(manifest, "utf8"));
+  // Both resolvers accept only these two names at major >= 7, so a pin that
+  // silently resolved to something else would otherwise be found by neither
+  // CLI and reported as "TypeScript 7 is not installed".
+  if (!["typescript", "@typescript/native-preview"].includes(name)) {
+    throw new Error(`@typescript/native resolved to ${name}, which no --tsgo row can use`);
+  }
+  if (Number(version.split(".")[0]) < 7) {
+    throw new Error(`@typescript/native resolved to ${version}; --tsgo requires major >= 7`);
+  }
+  console.error(`  tsgo backend: ${name}@${version}`);
 }
 
 function verifySvelteCheckRsDiagnostics(fixture) {
@@ -1277,7 +1307,9 @@ async function runSvelteCheckTask() {
       "--diagnostic-sources",
       "js,svelte",
     ];
-    const tsgoEnv = { TSGO_BIN: SVELTE_CHECK_TSGO_BIN };
+    // No TSGO_BIN: the override would bypass each CLI's own resolution, and a
+    // flag naming a binary is not evidence that the binary was used.
+    const tsgoEnv = {};
     const cleanTypecheckArtifacts = () => {
       rmSync(join(fixture, ".svelte-check"), { recursive: true, force: true });
       rmSync(join(fixture, "node_modules", ".cache", "svelte-check-rs"), {

--- a/scripts/reports/run-performance.mjs
+++ b/scripts/reports/run-performance.mjs
@@ -677,9 +677,12 @@ const fixtureExcluded = toolResults.excludedFilesCount;
 const svelteCheckVersion = packageVersion(
   "submodules/language-tools/packages/svelte-check/package.json",
 );
-const tsgoVersion = packageVersion(
-  "submodules/language-tools/packages/svelte-check/node_modules/@typescript/native-preview/package.json",
-);
+// TypeScript 7 stable, installed under the `@typescript/native` alias that
+// svelte-check itself prescribes; the manifest inside still names itself
+// `typescript`, which is what both --tsgo resolvers match on.
+const tsgoVersion = `TypeScript ${packageVersion(
+  "scripts/bench/competitor-oracle/node_modules/@typescript/native/package.json",
+)} (native)`;
 const typescriptVersion = packageVersion(
   "submodules/language-tools/packages/svelte-check/node_modules/typescript/package.json",
 );
@@ -836,7 +839,7 @@ const result = {
       `svelte-check@${svelteCheckVersion}`,
       `svelte-check-rs@${svelteCheckRsVersion}`,
       `typescript@${typescriptVersion}`,
-      `@typescript/native-preview@${tsgoVersion}`,
+      `@typescript/native (npm:typescript@${tsgoVersion.replace(/^TypeScript | \(native\)$/g, "")})`,
       `oxvelte@${OXVELTE_VERSION}+${OXVELTE_REV}`,
     ],
     competitorReferences: ["svelte@5.56.4", "svelte@5.56.8"],


### PR DESCRIPTION
`@typescript/native-preview` published its last dated dev build on **2026-07-07** (`7.0.0-dev.20260707.2`); the registry's own `time.modified` agrees. The Go compiler graduated into TypeScript 7, which ships it as its own `tsc` through a per-platform optional dependency — `lib/tsc.js` is a 609-byte launcher that `execve`s the native binary, so both arms below really are the Go implementation.

The report's two `--tsgo` rows were resolving **7.0.0-dev.20260703.1** out of the language-tools submodule's `node_modules`: two months stale, from a package that can never be updated again.

## What changed

- `@typescript/native` = `npm:typescript@7.0.2`, pinned exactly in `scripts/bench/competitor-oracle` — the alias svelte-check's own not-found message prescribes.
- The `TSGO_BIN` override is gone. Both CLIs already resolve that name from the workspace themselves, and an env var naming a binary is a label, not evidence that the binary was used.
- The availability check reads the manifest instead of testing a path: only `typescript` or `@typescript/native-preview` at major >= 7 is a name either resolver accepts, so a pin that resolved to anything else would otherwise surface as "TypeScript 7 is not installed".
- `ensureRsvelteSvelteCheckBuilt` no longer returns early when the binary exists.

## The resolution is pinned from both sides

| fixture carries | rsvelte-check `--tsgo` | js svelte-check `--tsgo` |
|---|---|---|
| a sentinel `@typescript/native` | spawns it **once** | spawns it **once** |
| the real `@typescript/native` | 3 planted errors | the same 3 |
| `@typescript/native-preview` | the same 3 | the same 3 |
| neither | reports TS 7 missing | falls back to the submodule's own copy |

The sentinel is what proves the fixture wins; the "neither" row is what shows the JS side has a `__dirname` fallback at all. Diagnostics are identical across the upgrade — same line, same column, same message.

## It is not a speedup, and the PR does not claim one

Measured with the launch shape held fixed (both arms reached through rsvelte-check's own resolution, nothing told where the compiler is), ABBA-ordered, medians of 4 rounds, behind a quiet gate that reads the actual top of the CPU list:

| | preview 20260703.1 | TypeScript 7.0.2 | ratio |
|---|---|---|---|
| `RAYON_NUM_THREADS=1` | 6,405ms | 6,576ms | 1.027x slower |
| default | 4,887ms | 4,837ms | 0.990x |

Both are inside the run-to-run spread. The value here is leaving a discontinued package, not throughput.

A first attempt at this measurement is **discarded**: it ran while a cargo build held ten cores (the script printed "box now quiet", which was a label rather than a measurement) and it reached the two arms differently — an npm `sh` shim for one, `node <bin>` for the other.

## The unconditional build is a separate defect and it fired immediately

`ensureRsvelteSvelteCheckBuilt` returned early when `target/release/svelte_check` existed, so the row measured whatever that path happened to hold — and on the first run after this change cargo rebuilt `rsvelte_core`, `rsvelte_projection` and `rsvelte_check`, i.e. the published number had been taken from a binary older than the perf work already merged. Every other task reaches its runner through `cargo run`, which rebuilds; this one used the path directly.

Re-measured on the current tree, the single-threaded row moves 6,318ms -> 5,695ms (2.00x -> 2.22x). That is the fresh binary, not the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyd6xc1EN5Jt4yNWeiWtuy