### PR TITLE
fix(lsp): a wordPattern that accepts its own ranges, and a codeAction harness that sends the diagnostic it declares

### DIFF
--- a/.changeset/lsp-linked-editing-word-pattern.md
+++ b/.changeset/lsp-linked-editing-word-pattern.md
@@ -1,0 +1,15 @@
+---
+'@rsvelte/language-server': patch
+---
+
+`textDocument/linkedEditingRange` returns a `wordPattern` that accepts its own ranges.
+
+The protocol says the pattern describes valid contents for the ranges returned beside it, and a
+client uses it to decide whether an in-flight edit still applies. rsvelte sent a pattern that
+rejected the contents of the very ranges it accompanied — a tag name containing a `.`, such as
+`Foo.Bar`, failed to match — so a client validating an edit against it would stop applying the
+linked rename partway.
+
+The pattern is now byte-identical to the official server's, which is VS Code's default word
+pattern. The ranges themselves already agreed with official on every measured case; only the
+pattern diverged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,6 +2712,7 @@ version = "0.5.5"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
+ "fancy-regex",
  "lsp-server",
  "lsp-types",
  "oxc_formatter",

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -993,6 +993,80 @@ observed. And a count of zero untracked directories proves nothing on its own: i
 checkout shows *before* a run reaches its first fixture, which is how this was first reported as
 reproducing on one machine and not another.
 
+### Blind spot 27r — `hash=` names two different quantities, and the field saying which is stripped [D]
+
+Every key `diff.mjs` produces carries `hash=<12 hex>`, and whether that digest can be turned back
+into a value depends on which of two branches wrote it.
+
+| branch | what is hashed | preimageable |
+|---|---|---|
+| field (`diff.mjs:98-100`) | `digest(left[key])` — the value itself | yes |
+| element (`diff.mjs:76-83`) | `digest(keys.sort())`, whose members are `item-${digest(value)}` (`:32`) | no — a digest of digests |
+
+Measured both ways on one method. `…/resolveProvider:missing-rsvelte[hash=b5bea41b6c62]` came back in one
+step as `digest(true)`, which is what establishes that official declares `resolveProvider: true`
+and rsvelte omits it. The nine `textDocument/codeAction|:extra-rsvelte[count=1,hash=…]` entries
+return nothing at any depth, so the nine actions behind them can only be had by running both
+servers on the nine fixtures.
+
+The suffix naming the branch does not reach the ratchet: `verify.mjs:462` strips
+`-element` / `-field` deliberately, so that respelling the classifier's labels does not
+staleify every committed entry at once. That is a defensible trade, and it leaves a ratchet
+reader with no explicit statement of which quantity they hold. What survives is `count=`,
+written only on the element branch — so **a key carrying `count=` has an unrecoverable hash and a
+key without one is preimageable**, and that is the entire rule.
+
+`diff.mjs:71-74` states the opposite: "The ratchet key keeps the suffix and drops the bracket,
+so the kind survives and the amount does not." Both halves are inverted against `verify.mjs:462`
+and against every committed key (`:extra-rsvelte[count=1,hash=…]` — no suffix, bracket present).
+**A comment describing what a downstream stage does with a value is checked by nothing that reads
+either file**, and this one is why a table of nine code-action titles was priced as arithmetic
+rather than as a measurement.
+
+**Evidence [D]:** the successful preimage of `b5bea41b6c62` and the structural impossibility for the
+element branch are both read off `diff.mjs`; the stripped suffix from `verify.mjs:462`; the inversion
+from comparing that line and the committed keys against `diff.mjs:71-74`. **Unmeasured:** whether any
+other gate's keys carry the same two-meaning `hash=` — only this gate's were read.
+
+### Blind spot 27s — a manifest records a prediction pointing the opposite way from the measurement beside it [D]
+
+Two `textDocument/codeAction` fixtures in `upstream-fixture-manifest.json` (`code-action-anchor-add`,
+`code-action-anchor-rel`) carry a `native_expected` listing **fewer** titles than `expected`, and a
+`difference_reason` reading "rsvelte does not derive the noreferrer edit from the upstream
+whole-element diagnostic range." That predicts rsvelte omits one of official's actions, which
+would surface as `missing-rsvelte`.
+
+The ratchet records the opposite. Both fixtures hold exactly two entries, both
+`:extra-rsvelte[count=1]`, and no `missing-rsvelte` at all — rsvelte reproduces every one of
+official's actions and adds one. The same holds for all nine codeAction fixtures across both
+phases: 18 entries, every one `extra`, `count=1`.
+
+**`native_expected`, `difference_reason` and `upstream_suite` are read by nothing under
+`scripts/`** (0 hits; positive control: `upstream-fixture-manifest` itself hits `suites.mjs`). So the
+prose is a hypothesis no gate evaluates.
+
+It was **not** true and then overtaken. `git log -S` gives two commits touching those fields, and
+the ratchet at each — including the commit that **introduced** them — already read `extra`, never
+`missing`. The extra action's content did move over that span
+(`hash=6d3d83633239 → e27600e1864d`); its **direction** never did. Read the scope exactly: within
+the window version control can observe, the prediction was never true. It may have been written
+against an uncommitted local measurement, which the history cannot settle.
+
+This is one step past "reason is not attribution". There the prose fails to say *where* a
+divergence is answered; here the prose asserts a *direction*, the direction is false, and the
+field is unread, so nothing can register the contradiction — including the person who later
+fixed the content while leaving the sentence.
+
+The repair is to read the field, not to delete it: a unit whose `native_expected` declares fewer
+titles than `expected` must carry a `missing-rsvelte` entry, which is mechanically checkable.
+Deleting the prose removes the contradiction and also removes whatever would stop the next
+person writing the same prediction.
+
+**Evidence [D]:** the entry counts and directions are read from the committed ratchet at three
+revisions via `git grep <rev>`; the unread-field claim is a grep with a stated positive control.
+**Unmeasured:** what the extra action actually is in each of the nine fixtures — see 27r for why
+that needs a run rather than a preimage — and whether any other manifest field is likewise unread.
+
 ---
 
 ## 1. Compiler output parity — `scripts/compat-corpus/verify.mjs`

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -326,9 +326,14 @@ The real-project population requests hover, definition and completion at every l
 identifier position in the four pinned repositories. Every unit runs its request set twice — once
 on the opened document and once after a deterministic round-trip edit (27b) — and the live official
 server is additionally held to those same upstream snapshots as a run-level precondition (27h). A
-run of one suite alone (`lsp:verify:fixtures`) reports both `NEW` and `stale` against the committed
-ratchet, because that ratchet is the union of all 17 artifacts: the difference is the population,
-not a regression, and such a run **cannot be used to move the ratchet in either direction**.
+run of one suite alone (`lsp:verify:fixtures`) does **not** compare against the whole ratchet:
+`selectKnownForScope` (`ratchet.mjs:114-131`) filters the committed entries to the measured suites,
+repositories and shard, so a `NEW` or `stale` reported within that scope is real rather than a
+population artefact. What a partial run cannot do is **re-baseline**: `verify.mjs` refuses
+`--update-baseline` outright (`:57-60`), and the baseline is merged from the complete
+`CORPUS_SHARDS + 1` = 17 artifacts by `merge-current.mjs`, which rejects any other count
+(`artifacts.mjs:104`). That refusal's own message says "eight corpus artifacts" while the code
+requires sixteen — following it gathers half the set and is refused one layer down.
 
 ### Blind spot 27a — server notifications are discarded [S]
 
@@ -1015,6 +1020,10 @@ staleify every committed entry at once. That is a defensible trade, and it leave
 reader with no explicit statement of which quantity they hold. What survives is `count=`,
 written only on the element branch — so **a key carrying `count=` has an unrecoverable hash and a
 key without one is preimageable**, and that is the entire rule.
+
+Read the ratio before concluding the hash is useless: **1,880 of 23,746 committed keys carry
+`count=`, so 92.1% preimage.** The default should stay "try it"; what the rule buys is knowing
+which 7.9% will not answer, rather than a reason to stop asking.
 
 `diff.mjs:71-74` states the opposite: "The ratchet key keeps the suffix and drops the bracket,
 so the kind survives and the amount does not." Both halves are inverted against `verify.mjs:462`

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -325,7 +325,10 @@ fixture population additionally compares rsvelte with the selected upstream expe
 The real-project population requests hover, definition and completion at every lexically matched
 identifier position in the four pinned repositories. Every unit runs its request set twice — once
 on the opened document and once after a deterministic round-trip edit (27b) — and the live official
-server is additionally held to those same upstream snapshots as a run-level precondition (27h).
+server is additionally held to those same upstream snapshots as a run-level precondition (27h). A
+run of one suite alone (`lsp:verify:fixtures`) reports both `NEW` and `stale` against the committed
+ratchet, because that ratchet is the union of all 17 artifacts: the difference is the population,
+not a regression, and such a run **cannot be used to move the ratchet in either direction**.
 
 ### Blind spot 27a — server notifications are discarded [S]
 
@@ -961,6 +964,12 @@ that survives once, because a run was interrupted or aborted between creating it
 `finally`, is never collected again. That is not hypothetical: one checkout carried a `tsgo/` two
 days older than the run that noticed it, while another was clean, and the difference was whether a
 run had ever been killed part-way.
+
+Keying cleanup to *what this run created* rather than to *what this directory should contain* makes
+the leaked set *self-perpetuating*, and that generalizes past this cache. Its size scales with the
+number of **aborted** runs, not with the number of runs — and an aborted run is likeliest exactly
+when someone is changing something, so the moment that produces a survivor is the moment its
+staleness matters most.
 
 A survivor is not inert. `build` (`tsgo_overlay.rs:222-258`) calls `create_dir_all` on the shadow
 directory and **never clears it**, rewriting a shadow per `.svelte` it finds — so a shadow whose

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -1075,9 +1075,54 @@ person writing the same prediction.
 **Evidence [D]:** the entry counts and directions are read from the committed ratchet at three
 revisions via `git grep <rev>`; the unread-field claim is a grep with a stated positive control.
 **Unmeasured:** what the extra action actually is in each of the nine fixtures — see 27r for why
-that needs a run rather than a preimage — and whether any other manifest field is likewise unread.
+that needs a run rather than a preimage. Two more were: `severity` and `diagnostic_source`, in
+the same object — see 27t.
 
 ---
+
+### Blind spot 27t — upstream's own test does not exercise the condition it names, and a faithful transcription inherits the hole [S]
+
+`code_actions.rs:279-284` gates an ignore action on four conditions, one of which is
+`diagnostic.severity != Some(DiagnosticSeverity::ERROR)`. Upstream's counterpart
+(`getQuickfixes.ts:189-197`) opens with `code && …`, and the upstream test that names this
+condition — `getCodeAction.test.ts:89`, `it('if diagnostic is error')` — sends
+`severity: DiagnosticSeverity.Error` and **no `code`**. The first conjunct is already false, so
+`[]` is returned before severity is read. The test passes whatever the severity rule is.
+
+The fixtures suite transcribes that test faithfully, so **the severity guard is exercised by
+nothing here**, and the transcription's own faithfulness is what reproduces the gap: a case that
+sends `severity: error` *with* a code would discriminate, and it does not exist upstream to
+transcribe. This is one level past a grid that holds one of the oracle's properties fixed — there
+the grid's author chose the constant; here the oracle's coverage hole is copied exactly *because*
+the copy is accurate.
+
+It cannot be repaired inside this suite. `suites.mjs:145-148` builds the fixture cases from
+`manifest.behavior_cases` alone, `upstream_fixture_manifest.rs:189` asserts that each suite's
+behavior-case names equal the **multiset** of upstream's `it()` call-site names (` [...]` suffix
+stripped), and `unit_coverage.unported_it_call_sites` is `0` — so there is no unported `it()` to
+attach a case to, a new name breaks the assert, and a second ` [variant]` of an existing name
+breaks it on the count. Reproducing that comparison independently, with the current tree as a
+positive control, gives `EQUAL true` now, `false` for a new name and `false` for an extra
+variant. The assert is working as designed: it is what makes this suite a transcription rather
+than a mixture, and mixing rsvelte-authored cases in would also stop it detecting an unported
+upstream test. The axis therefore needs a case list the multiset assert does not cover.
+
+Two sibling fields of the same manifest object were **declared and read by nothing**:
+`severity` (12 of the 14 codeAction entries declare it; the string does not occur anywhere in
+`scripts/compat-lsp/**/*.mjs`) and `diagnostic_source` (12 declare it; the harness hardcoded
+`source: "svelte"`). Both are read now. Reading `diagnostic_source` is a discriminating case —
+it retires exactly the two `code-action-foreign` entries, with `cases`, `compared`, `skipped` and
+all three oracle-calibration ratios identical across the two arms — while reading `severity`
+moves nothing, for the reason above.
+
+**Evidence [S]:** the condition order is read from `getQuickfixes.ts:189-197` and
+`code_actions.rs:279-284`; the absent `code` from `getCodeAction.test.ts:89`; the closed
+population from `upstream_fixture_manifest.rs:189` plus `unit_coverage.unported_it_call_sites`,
+with the multiset comparison reproduced independently and controlled in both directions. The
+`diagnostic_source` half is **[D]** (−2 entries, 0 new, denominators unmoved). **Unmeasured:**
+whether the severity guard's four conditions agree with upstream's three on any input at all —
+`is_compiler_code` has no upstream counterpart and is tracked separately — and whether the other
+`textDocument/*` methods' manifest params carry further unread fields.
 
 ## 1. Compiler output parity — `scripts/compat-corpus/verify.mjs`
 

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -332,8 +332,9 @@ repositories and shard, so a `NEW` or `stale` reported within that scope is real
 population artefact. What a partial run cannot do is **re-baseline**: `verify.mjs` refuses
 `--update-baseline` outright (`:57-60`), and the baseline is merged from the complete
 `CORPUS_SHARDS + 1` = 17 artifacts by `merge-current.mjs`, which rejects any other count
-(`artifacts.mjs:104`). That refusal's own message says "eight corpus artifacts" while the code
-requires sixteen — following it gathers half the set and is refused one layer down.
+(`artifacts.mjs:104`). That refusal's message named "eight corpus artifacts" against a code path
+requiring sixteen, so following it gathered half the set and was refused one layer down; it now
+derives the count from `CORPUS_SHARDS` rather than restating it.
 
 ### Blind spot 27a — server notifications are discarded [S]
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -4546,7 +4546,7 @@ would mean the axis had silently stopped being exercised.
 
 ## LSP differential known failures
 
-`lsp-known-failures.json` contains 23746 entries. Fixture and upstream entries identify one normalized
+`lsp-known-failures.json` contains 23744 entries. Fixture and upstream entries identify one normalized
 structural field for which `rsvelte-language-server` differs from the pinned official
 `svelte-language-server`, or from an upstream expected snapshot. A mismatched scalar key includes
 both value digests; a missing/extra field includes the present-side digest. Unmatched semantic
@@ -4580,13 +4580,13 @@ The ratchet stays on the pending list until it is burned down.
 deletion, a cluster table buys no attribution and would cost a classification pass over every
 remaining key; shrinking the ratchet advances the DoD directly and a taxonomy of it does not.
 
-Partition of `lsp-known-failures.json` by key kind: `21630 + 1776 + 340` — real-world corpus
+Partition of `lsp-known-failures.json` by key kind: `21630 + 1774 + 340` — real-world corpus
 aggregates, per-field divergences against the pinned official server, and per-field divergences
 against an upstream expected snapshot. The three prefixes (`aggregate:corpus/`, `differential:`,
 `expected:`) are disjoint by construction in `merge-current.mjs`, which rejects an artifact
 carrying a key outside its suite's prefix.
 
-Partition of `lsp-known-failures.json` by request phase: `11878 + 11868`
+Partition of `lsp-known-failures.json` by request phase: `11877 + 11867`
 
 Opened-document keys and post-`didChange` keys. The edit phase re-runs the same request set, so the
 two addends differ by exactly the session-level keys, which run once per session rather than once per

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -4546,7 +4546,7 @@ would mean the axis had silently stopped being exercised.
 
 ## LSP differential known failures
 
-`lsp-known-failures.json` contains 23744 entries. Fixture and upstream entries identify one normalized
+`lsp-known-failures.json` contains 23742 entries. Fixture and upstream entries identify one normalized
 structural field for which `rsvelte-language-server` differs from the pinned official
 `svelte-language-server`, or from an upstream expected snapshot. A mismatched scalar key includes
 both value digests; a missing/extra field includes the present-side digest. Unmatched semantic
@@ -4580,13 +4580,13 @@ The ratchet stays on the pending list until it is burned down.
 deletion, a cluster table buys no attribution and would cost a classification pass over every
 remaining key; shrinking the ratchet advances the DoD directly and a taxonomy of it does not.
 
-Partition of `lsp-known-failures.json` by key kind: `21630 + 1774 + 340` — real-world corpus
+Partition of `lsp-known-failures.json` by key kind: `21630 + 1772 + 340` — real-world corpus
 aggregates, per-field divergences against the pinned official server, and per-field divergences
 against an upstream expected snapshot. The three prefixes (`aggregate:corpus/`, `differential:`,
 `expected:`) are disjoint by construction in `merge-current.mjs`, which rejects an artifact
 carrying a key outside its suite's prefix.
 
-Partition of `lsp-known-failures.json` by request phase: `11877 + 11867`
+Partition of `lsp-known-failures.json` by request phase: `11876 + 11866`
 
 Opened-document keys and post-`didChange` keys. The edit phase re-runs the same request set, so the
 two addends differ by exactly the session-level keys, which run once per session rather than once per
@@ -4761,6 +4761,34 @@ positions. `crates/rsvelte_projection/tests/svelte2tsx_await_binding_map.rs` pin
 The third row is not a defect on either side and is the first candidate for
 `deliberate-divergences` in this ratchet — but only once it is pinned by a test, which it is not
 yet.
+
+### Two `code-action-foreign` entries retired because the request changed, not the server
+
+`suites.mjs` built every `textDocument/codeAction` request's diagnostic with `source: "svelte"`
+hardcoded, while the manifest entry it was built from declares `diagnostic_source: "eslint"` —
+so the fixture transcribing upstream's `it('if no svelte diagnostic')` had never sent a foreign
+source, and neither server was answering the question the case is named for. Reading the field
+retires both of its entries.
+
+This is a **(c) retirement — the input changed** — and not a fix: nothing in
+`rsvelte-language-server` moved. Measured on two arms differing only in `suites.mjs` (same server
+binaries, distinct file hashes, a probe separating them in both directions), the fixtures suite
+goes from 226 divergent fields to 224 with `cases`, `compared`, `skipped` and all three
+oracle-calibration ratios identical, 2 stale entries and **0 new**.
+
+**The axis those entries were observing is not preserved, and cannot be here.** With the source
+corrected both servers decline for the stated reason, so what the pair had actually been
+measuring — whether an ignore action is offered on an **empty document**, the case's `source`
+being `""` — no longer has a carrier. A fixture that preserves it cannot be added: `fixtureCases`
+draws only from `manifest.behavior_cases`, whose names are asserted equal as a multiset to
+upstream's `it()` call sites, with no unported call site to attach one to. #4217 tracks giving
+that axis somewhere to live; it is deliberately not fixed here, because a second case list
+changes this gate's population and needs its own control.
+
+The same object's `severity` was unread too (12 of 14 codeAction entries declare it; the string
+occurred nowhere under `scripts/compat-lsp/`). It is read now and moves nothing, because the
+upstream case that names the condition sends no `code` and is answered before severity is
+reached — see `GATES.md` blind spot 27t, which is why reading it does not make the guard gated.
 
 ### The mechanism of a divergence is carried beside the ratchet, not in its key
 

--- a/compatibility/lsp-known-failures.json
+++ b/compatibility/lsp-known-failures.json
@@ -21801,8 +21801,6 @@
 	"differential:fixtures/html-smoke-hover-uppercase|textDocument/hover|0:2|phase=edit|/:value-mismatch[official=32a8e9510b48,rsvelte=74234e98afe7]",
 	"differential:fixtures/html-smoke-lang|textDocument/completion|0:4|/items:missing-rsvelte[count=131,hash=1f0ad94d5109]",
 	"differential:fixtures/html-smoke-lang|textDocument/completion|0:4|phase=edit|/items:missing-rsvelte[count=131,hash=1f0ad94d5109]",
-	"differential:fixtures/html-smoke-linked|textDocument/linkedEditingRange|0:3|/wordPattern:value-mismatch[official=91181212a1f8,rsvelte=6d141e544799]",
-	"differential:fixtures/html-smoke-linked|textDocument/linkedEditingRange|0:3|phase=edit|/wordPattern:value-mismatch[official=91181212a1f8,rsvelte=6d141e544799]",
 	"differential:fixtures/html-smoke-moustache-completion|textDocument/completion|0:20|/items:extra-rsvelte[count=5,hash=c4371029d568]",
 	"differential:fixtures/html-smoke-moustache-completion|textDocument/completion|0:20|/items:missing-rsvelte[count=5,hash=565537da62b6]",
 	"differential:fixtures/html-smoke-moustache-completion|textDocument/completion|0:20|phase=edit|/items:extra-rsvelte[count=5,hash=c4371029d568]",

--- a/compatibility/lsp-known-failures.json
+++ b/compatibility/lsp-known-failures.json
@@ -21643,8 +21643,6 @@
 	"differential:fixtures/code-action-anchor-add|textDocument/codeAction|phase=edit|:extra-rsvelte[count=1,hash=e27600e1864d]",
 	"differential:fixtures/code-action-anchor-rel|textDocument/codeAction|:extra-rsvelte[count=1,hash=cb4c51ab40a2]",
 	"differential:fixtures/code-action-anchor-rel|textDocument/codeAction|phase=edit|:extra-rsvelte[count=1,hash=cb4c51ab40a2]",
-	"differential:fixtures/code-action-foreign|textDocument/codeAction|:extra-rsvelte[count=1,hash=5befc359d11b]",
-	"differential:fixtures/code-action-foreign|textDocument/codeAction|phase=edit|:extra-rsvelte[count=1,hash=5befc359d11b]",
 	"differential:fixtures/code-action-ignore-indent|textDocument/codeAction|:extra-rsvelte[count=1,hash=f2b9b4ef1625]",
 	"differential:fixtures/code-action-ignore-indent|textDocument/codeAction|phase=edit|:extra-rsvelte[count=1,hash=f2b9b4ef1625]",
 	"differential:fixtures/code-action-ignore-parent|textDocument/codeAction|:extra-rsvelte[count=1,hash=17ebab48bd5c]",

--- a/crates/rsvelte_language_server/Cargo.toml
+++ b/crates/rsvelte_language_server/Cargo.toml
@@ -30,6 +30,9 @@ regex = "1.11"
 oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "0389c4010ef8298728f3e47fff8e2a9106d10045" }
 
 [dev-dependencies]
+# Rust's `regex` rejects JS-style escapes inside a character class, which the
+# official server's word pattern uses; only the test needs to evaluate it.
+fancy-regex = { version = "0.19", default-features = false, features = ["std", "perf", "unicode"] }
 url = "2"
 
 [lints]

--- a/crates/rsvelte_language_server/src/html_tags.rs
+++ b/crates/rsvelte_language_server/src/html_tags.rs
@@ -16,6 +16,10 @@ struct TagPair {
     close: ByteRange<usize>,
 }
 
+/// The word pattern the official server sends; the ranges' own contents must match it.
+const WORD_PATTERN: &str =
+    r#"(-?\d*\.\d\w*)|([^\`\~\!\@\#\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\<\>\/\s]+)"#;
+
 /// Linked ranges for the opening and closing name under `offset`.
 #[must_use]
 pub fn linked_ranges(text: &str, offset: usize) -> Option<LinkedEditingRanges> {
@@ -26,9 +30,8 @@ pub fn linked_ranges(text: &str, offset: usize) -> Option<LinkedEditingRanges> {
             range(&index, text, pair.open),
             range(&index, text, pair.close),
         ],
-        // Dots intentionally do not belong here: VS Code uses this pattern to
-        // select the editable word, while `<Foo.Bar>` needs the whole member tag.
-        word_pattern: Some("[-_:A-Za-z0-9$]+".to_string()),
+        // Byte-identical to what the official server sends: VS Code's default word pattern.
+        word_pattern: Some(WORD_PATTERN.to_string()),
     })
 }
 
@@ -152,12 +155,32 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pairs_component_member_tags_without_including_the_dot_in_word_pattern() {
-        let text = "<Foo.Bar><span /></Foo.Bar>";
-        let ranges = linked_ranges(text, 3).unwrap();
+    fn word_pattern_is_byte_identical_to_the_official_server() {
+        let ranges = linked_ranges("<Foo.Bar><span /></Foo.Bar>", 3).unwrap();
         assert_eq!(ranges.ranges.len(), 2);
-        assert_eq!(ranges.word_pattern.as_deref(), Some("[-_:A-Za-z0-9$]+"));
         assert_eq!(ranges.ranges[0].end.character, 8);
+        assert_eq!(ranges.word_pattern.as_deref(), Some(WORD_PATTERN));
+    }
+
+    // The contract: a returned pattern must accept the contents of the returned
+    // ranges. This outlives whatever string the official server settles on.
+    #[test]
+    fn word_pattern_accepts_the_full_contents_of_the_ranges_it_is_sent_with() {
+        for (text, offset, name) in [
+            ("<div></div>", 2, "div"),
+            ("<Foo></Foo>", 2, "Foo"),
+            ("<Foo.Bar><span /></Foo.Bar>", 3, "Foo.Bar"),
+        ] {
+            let ranges = linked_ranges(text, offset).unwrap();
+            let pattern = ranges.word_pattern.as_deref().unwrap();
+            let regex = fancy_regex::Regex::new(pattern).unwrap();
+            let matched = regex.find(name).unwrap().expect("pattern matched nothing");
+            assert_eq!(
+                (matched.start(), matched.end()),
+                (0, name.len()),
+                "{pattern} does not fully accept {name}"
+            );
+        }
     }
 
     #[test]

--- a/scripts/compat-lsp/diff.mjs
+++ b/scripts/compat-lsp/diff.mjs
@@ -70,8 +70,10 @@ function walk(method, left, right, pointer, differences) {
     }
     // `-element` and `-field` name the two mechanisms an unqualified
     // `extra-rsvelte` collapsed: an array that carries one more entry, and an
-    // object the other side has no such key on. The ratchet key keeps the
-    // suffix and drops the bracket, so the kind survives and the amount does not.
+    // object the other side has no such key on. `verify.mjs` strips the suffix
+    // from the ratchet key and keeps the bracket, so `count=` is the only thing
+    // left saying which branch wrote the hash — and this branch's is a digest of
+    // identity keys, which does not preimage back to a value.
     if (missingRsvelte.length) {
       differences.push(
         `${pointer}:missing-rsvelte-element[count=${missingRsvelte.length},hash=${digest(missingRsvelte.sort())}]`,

--- a/scripts/compat-lsp/suites.mjs
+++ b/scripts/compat-lsp/suites.mjs
@@ -8,6 +8,10 @@ export const SUITES = [
   "upstream-testfiles",
   "corpus",
 ];
+// The manifest spells severity the way upstream's tests do; the protocol wants
+// LSP's numbers, and an entry that declares none must send none.
+const DIAGNOSTIC_SEVERITY = { error: 1, warning: 2, information: 3, hint: 4 };
+
 export const CORPUS_REPOS = [
   "bits-ui",
   "flowbite-svelte",
@@ -171,7 +175,8 @@ function fixtureCases(root) {
                 range: entry.params.range,
                 code: entry.params.diagnostic_code,
                 message: "",
-                source: "svelte",
+                source: entry.params.diagnostic_source ?? "svelte",
+                severity: DIAGNOSTIC_SEVERITY[entry.params.severity],
               },
             ],
           },

--- a/scripts/compat-lsp/verify.mjs
+++ b/scripts/compat-lsp/verify.mjs
@@ -21,7 +21,11 @@ import {
   loadCases,
   removeNewServerCaches,
 } from "./suites.mjs";
-import { createCurrentArtifact, recordsFixtureControls } from "./artifacts.mjs";
+import {
+  CORPUS_SHARDS,
+  createCurrentArtifact,
+  recordsFixtureControls,
+} from "./artifacts.mjs";
 import { EDIT_PHASES, OPEN_PHASE, editChanges } from "./edits.mjs";
 import { diffJson } from "./diff.mjs";
 import {
@@ -56,7 +60,7 @@ const UPDATE_POPULATION = args.includes("--update-population");
 const WRITE_CURRENT = argValue("--write-current");
 if (UPDATE)
   throw new Error(
-    "direct --update-baseline is disabled; merge the complete fixture and eight corpus artifacts with merge-current.mjs --update-baseline",
+    `direct --update-baseline is disabled; merge the complete fixture artifact and ${CORPUS_SHARDS} corpus artifacts with merge-current.mjs --update-baseline`,
   );
 const SHOW = Number(argValue("--show") ?? 30);
 // One label per divergence, so the histogram sums to the divergent-field count


### PR DESCRIPTION
Seven commits on the LSP differential gate. Two are server/harness fixes that retire ratchet
entries; the rest record what the gate cannot see.

## Ratchet entries this PR drops (4, declared up front)

```
differential:fixtures/html-smoke-linked|textDocument/linkedEditingRange|0:3|/wordPattern:value-mismatch[official=91181212a1f8,rsvelte=6d141e544799]
differential:fixtures/html-smoke-linked|textDocument/linkedEditingRange|0:3|phase=edit|/wordPattern:value-mismatch[…]
differential:fixtures/code-action-foreign|textDocument/codeAction|:extra-rsvelte[count=1,hash=5befc359d11b]
differential:fixtures/code-action-foreign|textDocument/codeAction|phase=edit|:extra-rsvelte[count=1,hash=5befc359d11b]
```

`lsp-known-failures.json` 23746 → 23742, **4 dropped, 0 added**, measured as a set difference
against `origin/main`.

## 1. The wordPattern did not accept the contents of the ranges it was sent with

`linkedEditingRange` returns ranges plus a `wordPattern` the client uses to validate edits, and
the spec requires the pattern to accept "valid contents for the given ranges". rsvelte's pattern
rejected its own ranges' contents. The ranges themselves were already byte-identical to
official's on all five fixture cells — only the pattern diverged.

Adopted official's pattern byte-for-byte, generated from the oracle's own bytes rather than
transcribed, and verified by reproducing the ratchet's recorded digest `91181212a1f8` from the
committed constant. Two tests pin it: byte-identity with the official server, and the contract
that the pattern matches the full contents of each range it accompanies.

## 2. The codeAction harness dropped two fields the manifest declares

`suites.mjs` built every `textDocument/codeAction` diagnostic with `source: "svelte"` hardcoded
and no `severity`, while 12 of the 14 codeAction manifest entries declare both — the string
`severity` occurred nowhere under `scripts/compat-lsp/`. So the fixture transcribing upstream's
`it('if no svelte diagnostic')` had never sent a foreign source, and neither server was answering
the question the case is named for.

Measured on two arms differing only in that file (same server binaries, distinct file hashes, a
probe separating them in both directions):

| | before | after |
|---|---|---|
| cases / compared / skipped | 154 / 310-324 / 14 | 154 / 310-324 / 14 |
| divergent requests / fields | 153 / 226 | 151 / 224 |
| stale / new | 0 / — | 2 / **0** |
| oracle calibration | 87/92, 13/15, 14/18 | 87/92, 13/15, 14/18 |

**Reading `severity` does not make the severity guard gated**, and that is worth stating because
the fix looks like it would. Upstream's `it('if diagnostic is error')` sends
`severity: DiagnosticSeverity.Error` and no `code`, and `isIgnorableSvelteDiagnostic` tests
`code &&` first — so `[]` is returned before severity is read, and the case passes whatever the
severity rule is. The transcription is faithful; the hole is upstream's.

## 3. What the retirement costs, and where it is tracked

The two `code-action-foreign` entries are a **(c) retirement — the input changed**; nothing in
`rsvelte-language-server` moved. With the source corrected both servers decline for the stated
reason, so what the pair had actually been measuring — an ignore action on an **empty document**
— loses its carrier.

A fixture preserving that axis cannot be added here: `fixtureCases` draws only from
`manifest.behavior_cases`, whose names are asserted equal as a multiset to upstream's `it()` call
sites, with `unported_it_call_sites: 0`. Reproduced independently with the current tree as a
positive control — `EQUAL true` now, `false` for a new name, `false` for an extra ` [variant]`.
#4217 tracks giving that axis somewhere to live; it is deliberately not fixed here, because a
second case list changes this gate's population and needs its own ablation control.

## 4. Gate-coverage rows

- **27r** — `hash=` names two different quantities and the field saying which is stripped from
  the key; 1,880 of 23,746 entries carry `count=`, the rest preimage back to a value.
- **27s** — a manifest records a prediction pointing the opposite way from the measurement beside
  it, in fields nothing reads.
- **27t** — upstream's own test does not exercise the condition it names, and a faithful
  transcription inherits the hole. Classified `[S]`; the `diagnostic_source` half is `[D]`.

Plus corrections to two things I had written wrongly: the partial-run caveat (a one-suite run is
scoped by `selectKnownForScope`, so its NEW/stale within scope is real — what it cannot do is
re-baseline), and an inverted comment in `diff.mjs` about which half of the key survives.

## Verification on this tree

```
node scripts/compat-lsp/verify.mjs --suites fixtures   EXIT=0  no regressions (224), stale 0 / new 0
node scripts/compat-corpus/known-failures-md-check.mjs EXIT=0  50 ratchets match / 33 partitions
node --test scripts/compat-lsp/*.test.mjs              EXIT=0
pnpm run check:attribution-known                       EXIT=0
pnpm run check:attribution-progress                    EXIT=0
pnpm run test:attribution-check                        EXIT=0
pnpm run test:attribution-progress-check               EXIT=0
```

Rebased onto `0258d2411`; all of the above were re-run after the rebase rather than carried over.

## Why this verdict survives `#4211` landing under it, without a re-run

These checks were taken on a tree that does not contain `#4211`, which merges before this PR.
That normally invalidates a measurement, so here is why it does not, as reachability rather than
as "it probably does not matter".

`#4211`'s executable code is three files, all under
`crates/rsvelte_core/src/compiler/phases/3_transform/client/` (`mod.rs`,
`prop_source_reads_ast.rs`, `props_transforms.rs`); everything else it changes is a ratchet, a
changeset, prose, pattern-corpus fixtures, or a test target. So the question is whether any
request this gate issues can reach client codegen.

- `rsvelte_language_server` calls `rsvelte_core::compile` at exactly two sites. `code_lens.rs:20`
  sets `options.generate = GenerateMode::None` on the line above it, so it never enters
  `3_transform/client`. `worker.rs:331` uses the default (client).
- `worker.rs`'s `Job::Compile` has exactly one submitter, `server.rs:790`, which sits inside
  `fn on_get_compiled_code` (opens at `server.rs:764`), dispatched from `"$/getCompiledCode"` at
  `server.rs:724`.
- **This gate issues `$/getCompiledCode` zero times** — 0 occurrences anywhere under
  `scripts/compat-lsp/`, with `textDocument/hover` at 70 as the positive control that the search
  works.
- `textDocument/diagnostic` does not get there either: compiler diagnostics come from phases 1-2,
  and the tsgo half runs on `rsvelte_projection`'s `.svelte.tsx` projection, which never calls
  `rsvelte_core::compile` and reaches only `phases::phase3_transform::shared` (`js_scan`), never
  `client`.

So the three changed files are unreachable from every request this gate makes, and the verdict
recorded here is the same verdict the post-`#4211` tree would produce. Re-running to confirm that
would cost ~950 job-minutes across 16 shards for zero bits.
