### PR TITLE
fix(ci): a PR's changed files are the three-dot diff, not `git diff BASE HEAD`

### DIFF
--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -88,6 +88,8 @@ concurrency:
 
 permissions:
   contents: read
+  # `Collect the changed files` reads the PR files API for the three-dot list.
+  pull-requests: read
 
 env:
   # The NAPI build is the whole job's bottleneck (~5 min of the ~6 min total):
@@ -126,14 +128,28 @@ jobs:
 
       # Only a `pull_request` has a diff to narrow by. A push, schedule or
       # dispatch writes no list, and the filter then enables every job.
+      #
+      # A PR's own changes are the diff against its MERGE BASE. `git diff BASE
+      # HEAD` is the two-dot one, which for a branch behind `main` also reports
+      # everything `main` gained, with the sign reversed -- and a shallow fetch
+      # cannot compute the merge base to correct it. The files API returns the
+      # three-dot list directly. Measured 2026-09-03: three of 24 open PRs were
+      # opening the 950-job-minute `lsp-corpus` hatch that way, none of them
+      # touching an LSP path (#4211 17 files -> 11, #4218 24 -> 4, #4219 25 -> 5).
       - name: Collect the changed files
         if: github.event_name == 'pull_request'
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          git fetch --no-tags --depth=1 origin "$BASE_SHA" "$HEAD_SHA"
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed-files.txt
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
+            --jq '.[].filename' > changed-files.txt
+          # A pull request always changes at least one file, so an empty list
+          # means the query failed. Left empty it enables every job gate and
+          # CLOSES `lsp-ratchet`, the only output a pull request consults --
+          # failing open everywhere and closed on the one hatch that matters.
+          test -s changed-files.txt
           wc -l < changed-files.txt
 
       - name: Decide which gates the change can reach


### PR DESCRIPTION
`corpus-compat.yml`'s `changes` job narrows every other job by the PR's changed files, and it computed them as

```sh
git fetch --no-tags --depth=1 origin "$BASE_SHA" "$HEAD_SHA"
git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed-files.txt
```

That is the **two-dot** diff, which compares two trees. For a branch that is behind `main` it therefore reports everything `main` gained since the branch's merge base **as if the branch had changed it**, with the sign reversed. The shallow fetch cannot be used to correct this locally: with `--depth=1` there is no common ancestor, so `git merge-base` has nothing to work with.

The consequence is not cosmetic. `lsp-ratchet` is the escape hatch that admits the 950-job-minute `lsp-corpus` gate on a pull request, and it fires on any path under `scripts/compat-lsp/`. `#4206` **added** two files there, so every open PR whose merge base predates it reports them as changed and opens the hatch.

## Measured, on the 24 open PRs (2026-09-03)

Both lists computed per PR from `baseRefOid` / `headRefOid`, and the filter run on each:

| PR | two-dot files | three-dot files | `lsp-ratchet` two-dot → three-dot |
|---|---|---|---|
| #4211 | 17 | 11 | **true → false** |
| #4218 | 24 | 4 | **true → false** |
| #4219 | 25 | 5 | **true → false** |
| #4221 | 9 | 9 | true → true (touches `scripts/compat-lsp/`, correct) |
| #4154 | 19 | 19 | true → true (correct) |
| other 19 | unchanged | unchanged | false → false |

Three of 24 were opening a 950-job-minute gate that none of them can move — ~2,850 job-minutes, against a 20-job / 28,800-job-minute daily ceiling. #4211 is running those 16 shards right now, and it touches only `3_transform/client/**` and two client ratchets.

The two PRs the hatch really applies to are unaffected, which is the control that matters: the fix removes spurious fires without closing the hatch on the PRs it was built for.

## The fix

The PR files API returns exactly the three-dot list and needs no fetch depth:

```sh
gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename' > changed-files.txt
test -s changed-files.txt
```

Verified locally against #4211: the API list is **identical** to `git diff --name-only $(git merge-base BASE HEAD) HEAD` (11 files, sorted diff empty), and the filter then reports `lsp-ratchet=false`.

`test -s` is not decoration. An empty list is the one input where the filter's two defaults disagree — every job gate opens and `lsp-ratchet` **closes** — so a failed query would fail open on every sibling and closed on the only output a pull request consults. A PR always changes at least one file, so an empty file means the query failed and the step must fail with it.

`permissions:` gains `pull-requests: read` for the API call.

## Checked

- The workflow parses (`yaml@2.9.0`), and the `Collect the changed files` step's `run` and `env` are what they look like. Positive control: appending `bad: [unclosed` makes the same parser throw at line 990.
- No behaviour change for `push` / `schedule` / `workflow_dispatch` — the step is still `if: github.event_name == 'pull_request'`, and those events write no list, which the filter reads as "enable everything".
