### PR TITLE
fix(release): the crate that WRITES the parse envelope needs the same changeset rule as the one that links it

### DIFF
--- a/scripts/release/check-core-consumer-changesets.mjs
+++ b/scripts/release/check-core-consumer-changesets.mjs
@@ -72,6 +72,15 @@ const RULES = [
     requires: ['@rsvelte/svelte-check'],
   },
   {
+    prefix: 'crates/rsvelte_bindings_support/src/',
+    // Only `rsvelte_napi` depends on it, and that ships only as the
+    // `rsvelte.node` cdylib -- so this crate writes the binary parse envelope
+    // that `@rsvelte/vite-plugin-svelte-native` decodes, and reaches no other
+    // artifact. The rule below covers the crate that links it and not the one
+    // that writes it, which is how a decoder can ship ahead of its writer.
+    requires: ['@rsvelte/vite-plugin-svelte-native'],
+  },
+  {
     prefix: 'crates/rsvelte_napi/src/',
     // Ships only as the `rsvelte.node` cdylib inside the vps-native binaries,
     // whose fixed group has no dependency edge to any other artifact. A


### PR DESCRIPTION
`check-core-consumer-changesets.mjs` has a rule for `crates/rsvelte_napi/src/` — the crate that *links* the parse-envelope writer — and none for `crates/rsvelte_bindings_support/src/`, the crate that *writes* it.

`rsvelte_bindings_support` has exactly one dependent (`crates/rsvelte_napi/Cargo.toml:35`) and `rsvelte_napi` ships only as the `rsvelte.node` cdylib inside the `@rsvelte/vite-plugin-svelte-native` fixed group, which has no dependency edge to any other artifact. So the two crates need the identical rule, and only one had it.

The consequence is the shape the `rsvelte_napi` rule's own comment describes: the binary envelope has two ports — `napi_raw_parse.rs` writes it and `apps/npm/vite-plugin-svelte-native/parse-envelope.js` decodes it. A change that adds a tag to both, touching `rsvelte_bindings_support` for the writer, passes this gate with a changeset naming nothing, and **the decoder ships ahead of its writer**.

Found by a teammate adding a `TSModuleBlock` tag to both ports, who named the package by hand.

## Positive control

With the rule in place and a probe file committed under `crates/rsvelte_bindings_support/src/`:

```
Shared-core changes require these packages to be named in a changeset:
  ✓ @rsvelte/vite-plugin-svelte-native  (touched: crates/rsvelte_bindings_support/src/)
```

The `touched:` line names the new prefix, which exists only in this change; without the rule the checker reports `No shared-core source touched`. The probe commit was dropped (`git reset --hard HEAD~1`, tree clean).
