### PR TITLE
perf(profile): name the phase-3 residual — 15.5% unattributed becomes 7.1%

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -520,6 +520,7 @@ pub(crate) fn transform_client(
     >,
 ) -> Result<CodegenResult, TransformError> {
     use crate::compiler::phases::phase3_transform::client::visitors::fragment::fragment;
+    let _gap5 = super::profile::timer_start();
 
     // Set where the instance pass SAW a prop member write, which is a different
     // question from whether it could wrap one.
@@ -561,9 +562,11 @@ pub(crate) fn transform_client(
     // Visit the program to set up transforms for props, store subscriptions, etc.
     // This handles state, legacy props, and store subscriptions.
     use crate::compiler::phases::phase3_transform::client::visitors::program::visit_program;
+    super::profile::record_prefrag(5, super::profile::timer_elapsed(_gap5));
     let _vp_start = super::profile::timer_start();
     visit_program(&mut context);
     super::profile::record_visit_program(super::profile::timer_elapsed(_vp_start));
+    let _gap6 = super::profile::timer_start();
 
     // Remove transforms for variables that have shadowed $state declarations.
     // Due to a known analysis bug where inner-scope $state() declarations overwrite
@@ -637,6 +640,7 @@ pub(crate) fn transform_client(
             &destructure_iife_targets,
             &invalidate_inner_signals_targets,
         );
+        super::profile::record_prefrag(6, super::profile::timer_elapsed(_gap6));
         let dead_comments_stripped = match retained_scripts
             .and_then(|scripts| scripts.instance.as_ref())
             .filter(|retained| {
@@ -655,6 +659,7 @@ pub(crate) fn transform_client(
                 dead_comments::strip_dead_comments(&instance_script.raw, dead_comment_rules)
             }),
         };
+        let _gap7 = super::profile::timer_start();
         // Every lowering below decides what a rune call is from this text, so the
         // grouping parens around one have to be gone before the first of them runs.
         let paren_stripped = super::shared::rune_parens::strip_rune_parens(
@@ -738,6 +743,7 @@ pub(crate) fn transform_client(
         } else {
             composed_body_projection.as_ref()
         };
+        super::profile::record_prefrag(7, super::profile::timer_elapsed(_gap7));
         instance_script_imports = super::profile::timed_prefrag(2, || {
             attach_import_origins(
                 imports,
@@ -770,6 +776,7 @@ pub(crate) fn transform_client(
         rest_excludes_hoists = extract_rest_excludes_hoists(&mut transformed);
         super::profile::record_script_text(super::profile::timer_elapsed(_script_start));
         super::profile::record_parent_site(false);
+        let _gap8 = super::profile::timer_start();
         // Transfer the script's $$array counter to the context state so that the template
         // visitor continues numbering from where the script left off.
         let script_array_count = SCRIPT_ARRAY_COUNTER.with(|c| c.get());
@@ -787,10 +794,12 @@ pub(crate) fn transform_client(
             };
             context.state.memoizer.add_conflict(&name);
         }
+        super::profile::record_prefrag(8, super::profile::timer_elapsed(_gap8));
         Some(transformed)
     } else {
         None
     };
+    let _gap9 = super::profile::timer_start();
 
     // Pre-compute blocker map for async components.
     if options.experimental.r#async
@@ -859,11 +868,13 @@ pub(crate) fn transform_client(
         }
     }
 
+    super::profile::record_prefrag(9, super::profile::timer_elapsed(_gap9));
     // Call the fragment visitor to transform the template
     // This is the root fragment of the component, so is_root_fragment=true
     let _fragment_start = super::profile::timer_start();
     let template_body = fragment(&ast.fragment, &mut context, true);
     super::profile::record_template_fragment(super::profile::timer_elapsed(_fragment_start));
+    let _gap10 = super::profile::timer_start();
 
     // Propagate any error that was recorded during template traversal (e.g. "Not implemented:
     // LetDirective" from visit_svelte_element when a SvelteElement carries a let: directive).
@@ -871,6 +882,7 @@ pub(crate) fn transform_client(
         return Err(TransformError::CodeGen(msg));
     }
 
+    super::profile::record_prefrag(10, super::profile::timer_elapsed(_gap10));
     let _assembly_start = super::profile::timer_start();
 
     // Collect results from state
@@ -2814,7 +2826,7 @@ pub(crate) fn transform_client(
         });
         if let Some((code, mappings)) = converted {
             super::profile::record_codegen(super::profile::timer_elapsed(_codegen_start));
-            let code = rehome_derived_jsdoc(&code);
+            let code = super::profile::timed_prefrag(11, || rehome_derived_jsdoc(&code));
             let code = if let Some(script) = analysis.instance_script_content.as_ref() {
                 super::shared::async_body::restore_async_derived_ignore_comments(&script.raw, code)
             } else {
@@ -2840,7 +2852,7 @@ pub(crate) fn transform_client(
             } else {
                 code
             };
-            signal_discipline::check(&code, &analysis.name);
+            super::profile::timed_prefrag(11, || signal_discipline::check(&code, &analysis.name));
             return Ok(CodegenResult { code, mappings });
         } else if *CLIENT_TO_OXC_DEBUG {
             // Corpus workers share one stderr and a multi-part write interleaves,
@@ -2874,7 +2886,7 @@ pub(crate) fn transform_client(
     } else {
         let code = generate(&program, &context.arena).map_err(TransformError::CodeGen)?;
         super::profile::record_codegen(super::profile::timer_elapsed(_codegen_start));
-        let code = rehome_derived_jsdoc(&code);
+        let code = super::profile::timed_prefrag(11, || rehome_derived_jsdoc(&code));
         let code = if let Some(script) = analysis.instance_script_content.as_ref() {
             super::shared::async_body::restore_async_derived_ignore_comments(&script.raw, code)
         } else {
@@ -2896,7 +2908,7 @@ pub(crate) fn transform_client(
         } else {
             code
         };
-        signal_discipline::check(&code, &analysis.name);
+        super::profile::timed_prefrag(11, || signal_discipline::check(&code, &analysis.name));
         Ok(CodegenResult {
             code,
             mappings: vec![],

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -223,12 +223,16 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 client_program_sink,
             )?;
 
+            let _map_start = profile::timer_start();
             if options.enable_sourcemap {
+                let _t13 = profile::timer_start();
                 let mapping_starts = MappingLineStarts::new(&result.code, source);
                 let template_source_lines = template_source_lines(source);
                 let append_generated_lines =
                     mark_lines_containing(&result.code, &mapping_starts.generated);
+                profile::record_prefrag(13, profile::timer_elapsed(_t13));
                 let source_line_starts = &mapping_starts.source;
+                let _t14 = profile::timer_start();
                 let mut runtime_mappings = Vec::new();
                 let mut template_name_mappings = Vec::new();
                 let mut remaining_result_mappings = Vec::new();
@@ -246,6 +250,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                         remaining_result_mappings.push(mapping);
                     }
                 }
+                profile::record_prefrag(14, profile::timer_elapsed(_t14));
                 let mapping_capacity = runtime_mappings.len()
                     + template_name_mappings.len()
                     + remaining_result_mappings.len();
@@ -255,14 +260,18 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 mappings.extend(remaining_result_mappings);
                 // Measured: the packed-key sort the server path uses costs the
                 // client 0.35% rather than saving it. Why is not established.
+                let _t15 = profile::timer_start();
                 mappings
                     .sort_by(|a, b| a.gen_line.cmp(&b.gen_line).then(a.gen_col.cmp(&b.gen_col)));
+                profile::record_prefrag(15, profile::timer_elapsed(_t15));
                 // Do not deduplicate source-map segments. Esrap deliberately
                 // emits identical entries when a container and its first child
                 // begin at the same generated and original positions. Their
                 // occurrence count and order are observable by consumers.
+                profile::record_prefrag(12, profile::timer_elapsed(_map_start));
                 (result.code, mappings)
             } else {
+                profile::record_prefrag(12, profile::timer_elapsed(_map_start));
                 (result.code, Vec::new())
             }
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -117,20 +117,37 @@ impl std::ops::AddAssign for Phase3Breakdown {
     }
 }
 
-pub const PREFRAG_SLOTS: usize = 5;
+pub const PREFRAG_SLOTS: usize = 16;
 pub const PREFRAG_LABELS: [&str; PREFRAG_SLOTS] = [
     "strip_dead_comments_from_program",
     "program_to_oxc (client-only)",
     "attach_import_origins",
     "instance_has_top_level_multi_declarator",
     "compute_blocker_primary_names",
+    "GAP entry -> visit_program",
+    "GAP visit_program -> dead_comments",
+    "GAP dead_comments -> attach_import_origins",
+    "GAP script_text -> end of instance block",
+    "GAP instance block -> fragment",
+    "GAP fragment -> assembly",
+    "post-codegen rehome_derived_jsdoc + signal_discipline",
+    "client source-map assembly (after transform_client)",
+    "  map: line tables + two full scans",
+    "  map: three-way partition loop",
+    "  map: sort by (gen_line, gen_col)",
 ];
 
 /// Whether each slot's time is inside the "Pre-frag setup" residual. A slot that
 /// is not (`program_to_oxc` sits inside the `codegen` timer) must not be
 /// subtracted from it — doing so understates what is left unnamed, which has
 /// misreported the residual twice.
-pub const PREFRAG_IN_RESIDUAL: [bool; PREFRAG_SLOTS] = [true, false, true, true, true];
+pub const PREFRAG_IN_RESIDUAL: [bool; PREFRAG_SLOTS] = [
+    // Slot 4 (`compute_blocker_primary_names`) now sits inside GAP slot 8, so
+    // subtracting both would take it out of the residual twice.
+    // Slots 13-15 are inside slot 12, so they must not be subtracted again.
+    true, false, true, true, false, true, true, true, true, true, true, true, true, false, false,
+    false,
+];
 
 /// One level below [`Phase3Breakdown::script_text_transform`], which is the
 /// largest Phase 3 bucket. The five stages are sequential and disjoint, so the

--- a/crates/rsvelte_devtools/src/bin/compile_profile.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_profile.rs
@@ -368,13 +368,28 @@ fn main() {
     let assembly_after = transform_breakdown.assembly_after_fragment;
     let css_render = transform_breakdown.css_render;
     let codegen = transform_breakdown.codegen;
-    let other = transform_time
+    // The loop's wall clock also contains this binary's own per-file bookkeeping
+    // -- `take_breakdown` resets thirty thread-locals, `script_shape` rescans the
+    // source, and two `Vec`s grow -- so subtracting the timers from it charges
+    // the instrument to the compiler. `Σ file_transform` brackets
+    // `transform_component` alone.
+    let per_file_sum: std::time::Duration = rows.iter().map(|r| r.1).sum();
+    let instrument = transform_time.saturating_sub(per_file_sum);
+    let other = per_file_sum
         .saturating_sub(visit_program)
         .saturating_sub(script_text)
         .saturating_sub(template_fragment)
         .saturating_sub(assembly_after)
         .saturating_sub(css_render)
         .saturating_sub(codegen);
+    println!(
+        "  [denominator: loop wall {:.2}ms, Sum per-file transform {:.2}ms, \
+         this binary's own bookkeeping {:.2}ms ({:.1}% of the loop)]",
+        ms(transform_time),
+        ms(per_file_sum),
+        ms(instrument),
+        100.0 * instrument.as_secs_f64() / transform_time.as_secs_f64().max(f64::MIN_POSITIVE),
+    );
     println!(
         "  visit_program:       {:7.2}ms ({:5.1}%)",
         ms(visit_program),

--- a/crates/rsvelte_devtools/src/bin/perf_bench.rs
+++ b/crates/rsvelte_devtools/src/bin/perf_bench.rs
@@ -131,6 +131,10 @@ fn main() {
     // task that is still queued behind the whole slice, so the largest file
     // arriving last is a tail no amount of stealing recovers.
     let mut sort = false;
+    // Offset into the id list before striding. With the same `--limit`, two runs
+    // differing only in `--skip` select provably disjoint files, which is what a
+    // held-out evaluation of a profile-guided build needs.
+    let mut skip = 0usize;
     let mut dump_times: Option<String> = None;
     // macOS schedules a DEFAULT-QoS thread onto an efficiency core, so a rayon
     // pool sized to the core count can end up with two workers running at a
@@ -145,6 +149,7 @@ fn main() {
             "--no-sourcemap" => no_sourcemap = true,
             "--threads" => threads = args.next().unwrap().parse().unwrap(),
             "--sort" => sort = true,
+            "--skip" => skip = args.next().unwrap().parse().unwrap(),
             "--dump-times" => dump_times = Some(args.next().unwrap()),
             "--qos" => qos = Some(args.next().unwrap()),
             other => panic!("unknown arg {other}"),
@@ -164,7 +169,7 @@ fn main() {
     let stride = (ids.len() / limit).max(1);
     let mut sources = Vec::new();
     let mut bytes = 0usize;
-    for id in ids.iter().step_by(stride).take(limit) {
+    for id in ids.iter().skip(skip).step_by(stride).take(limit) {
         if let Ok(s) = fs::read_to_string(root.join("compatibility/sources").join(id)) {
             bytes += s.len();
             sources.push(s);
@@ -290,10 +295,15 @@ fn main() {
     cpu_timings.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let median = timings[timings.len() / 2];
     let cpu_median = cpu_timings[cpu_timings.len() / 2];
+    let skip_tag = if skip > 0 {
+        format!(" skip={skip}")
+    } else {
+        String::new()
+    };
     let ast_tag = if no_ast { " no-ast" } else { "" };
     let map_tag = if no_sourcemap { " no-sourcemap" } else { "" };
     println!(
-        "target={target}{ast_tag}{map_tag} files={} ok={ok} bytes={bytes} \
+        "target={target}{skip_tag}{ast_tag}{map_tag} files={} ok={ok} bytes={bytes} \
          CPU_median={cpu_median:.1}ms CPU_min={:.1}ms \
          wall_median={median:.1}ms wall_min={:.1}ms MB/s={:.2} sink={sink}",
         sources.len(),

--- a/docs/perf-baseline.md
+++ b/docs/perf-baseline.md
@@ -1,57 +1,153 @@
-# Where the 20x goal stands (2026-09-03 00:35)
+# Where the 20x goal stands (2026-09-03 07:00)
 
 **Read this first; everything below is the working record, newest sections near
 the top.**
 
-| surface | measured | status |
-|---|---:|---|
-| server | 19.59x | 2.1% short — inside the deciding arm's own ~5% within-run drift |
-| server-dev | 19.98x | 0.1% short — same |
-| client-dev | 13.89x | clearly unmet |
-| client | 9.63x published | **not a steady-state number**; its per-round ratio rose 9.56 -> 15.34 monotonically while three other surfaces wandered at chance |
+Measured on a quiet box at `9c771271f` — every competing process suspended, every
+binary built *before* the run opened, and `benchmark_runner`'s SHA-256 identical
+before and after (#4213).
 
-Three independent routes put a *clean* client run at 15.6-17.7x (trend
-extrapolation), 17.2x (single-thread speedup x the server's parallel
-efficiency) and 15.34x (the cleanest single round of the contaminated run).
-**None of them is a measurement**, and the box has not been quiet enough to take
-one: `llama-server` holds 22.6 GB with free memory at 5-11% and swap near full
-throughout.
+| surface | single | multi | status |
+|---|---:|---:|---|
+| server | 3.70x | **20.42x** | **met** |
+| server-dev | 3.65x | 19.64x | 1.8% short — inside the deciding arm's own ~5% within-run drift, so undecidable |
+| client | 3.36x | **17.22x** | short by **1.161x** |
+| client-dev | 3.00x | 14.63x | short by 1.367x |
+
+**The previous client figure (9.63x) was the box, not the compiler, and the
+control that says so is internal to the pair.** Between the two runs the
+single-threaded arms moved -1.4% to +3.6% while the client's multi arm moved
+**+78.9%**. No compiler change produces that pair — the single arm runs the same
+code. A flat single arm beside a moved multi arm is the signature of box
+contention, and it is what names the old number, rather than any argument about
+what happened to be running at the time. The three routes that had estimated a
+clean client run at 15.6-17.7x, 17.2x and 15.34x all bracket the measured 17.22x,
+but they were estimates and this is the measurement.
 
 **What remains is one factor: 1.161x on client single-threaded compile time.**
-That is the whole distance to 20x, and it is arrived at as follows — a speedup
-is `single-thread speedup x parallel efficiency`; a `--threads` sweep shows
-client and server scale identically in prod mode (5.67x vs 5.68x at their optima,
-4.94x vs 4.91x at ten threads), so the scaling half is not a deficit; at the
-server's implied 5.30x efficiency, 20x needs a single-thread speedup of 3.772
-against the client's 3.248.
+A speedup is `single-thread speedup x parallel efficiency`; a `--threads` sweep
+shows client and server scale identically in prod mode, so the scaling half is
+not a deficit.
 
-**Where that 1.161x could come from**, sized by a 17,280-sample profile of a
-single-threaded client compile:
+**Where that 1.161x could come from**, re-sampled at `477b51f13` after the
+`skip_opaque` guard shipped (6,950 self-time samples, single-threaded client,
+`/usr/bin/sample`):
 
 | mechanism | self-time | if fully removed |
 |---|---:|---:|
-| byte scanning (`str::pattern`, `memmem`, `js_scan`) | 12.5% | 1.143x |
-| hashing (SipHash + IndexMap, i.e. `serde_json::Value`) | 6.6% | 1.071x |
-| both | 19.1% | 1.236x |
+| `_platform_memmove` | 9.25% | 1.102x |
+| byte scanning (`str::pattern`, `memmem`, `js_scan`, the client scanners) | ~12.5% | 1.143x |
+| hashing (SipHash + IndexMap + hashbrown) | ~9.0% | 1.099x |
 
-Both are mechanisms the architecture notes already name (the AST pipeline; leaving
-`serde_json::Value`), so the profile confirms the existing plan rather than
-redirecting it — and the standing caution holds: 12.5% is an upper bound on what
-becomes *unreachable*, not a saving, because an AST pipeline pays its own walk.
+**No single non-architectural lever is 13.9% wide.** The two that are wide enough
+are the ones the architecture notes already name — the AST pipeline (which is
+what makes byte scanning unreachable) and leaving `serde_json::Value` — and both
+are multi-week. The standing caution holds: a self-time share is an upper bound
+on what becomes *unreachable*, not a saving, because an AST pipeline pays its own
+walk.
+
+**`_platform_memmove` cannot be attributed from this profile and that is a fact
+about the instrument.** 7.18% of the 9.25% appears as a direct child of `start`
+in the call graph — the unwinder gives up inside a leaf assembly routine — so
+only 2.07% has a named caller (`esrap::Driver::append` 0.98%,
+`RawVecInner::finish_grow` 0.85%, `Context::write` 0.73%, then nothing above
+0.36%). That shape is consistent with the recorded finding that the allocation
+bucket has no single site, and inconsistent with nothing; it is not evidence
+either way, and a frame-pointer build would be needed to make it one.
+
+**The two largest rsvelte-owned symbols, and what is known about each:**
+
+- `client::copied_spans_for_normalized_code` — 2.73%. It walks the generated
+  script text against the source byte by byte to rebuild the map. Its
+  `source_at_output` per-byte table (`vec![None; stripped.len() + 1]`, plus an
+  inner loop over every byte of every matched run) is built only when a
+  `ScriptProjection` exists, and `ScriptProjection` is produced only by
+  `strip_typescript` — so it is a TypeScript-only cost, and the 2.73% is mostly
+  the general walk rather than the table. **Unmeasured:** the split between the
+  two.
+- `phase2_analyze::store_subscriptions::collect_dollar_identifiers_pass` — 2.50%,
+  plus `blank_comments` at 0.81%. It decodes each script to `Vec<char>` and scans
+  it **twice**. A `$`-absent guard is exact (no `$` byte means neither pass can
+  emit anything) and would skip both, but only **27.8% of corpus scripts contain
+  no `$`** (2716 components with a script, measured over the same 3000-file
+  stride) — and unweighted by size, so the guard is worth well under 0.7%. Runes
+  spell `$state` / `$derived` / `$props`, which is why the fraction is so low.
 
 **Eliminated by measurement, so nobody re-tries them:** the printer and its
 source-map branch (client 5.09% vs server 3.34%, only 5.5% of the client/server
 transform gap; a 5x-faster printer is 1.073x), and the four pre-fragment call
 sites once thought to fill the residual (3.41 ms of 67.54, 5%).
 
-**Still unexplained:** the "Pre-frag setup" residual, 15.4% of a client compile,
+**Still unexplained:** the "Pre-frag setup" residual, 15.9% of a client compile,
 95% of it unnamed. Its label is wrong — only ~10 statements of object
 construction run before `visit_program` — so it lives in the gaps between the
 later timers, which are enumerated with their bounding lines further down.
 
-**Shipped this session:** one measured compiler improvement — guarding
-`skip_opaque` on its opener byte, client +0.65% / server +1.91%, output
-byte-identical, gates green.
+# The 1.161x, priced against four levers (2026-09-03 07:00-08:00)
+
+All four measured on the quiet box at `477b51f13`, single-threaded client,
+`--limit 1700 --skip 1` (a slice **provably disjoint** from the PGO training set:
+same `--limit` means the same stride, so `--skip 1` shares no member with
+`--skip 0`), ABBA-ordered, CPU median of 9 runs, both arms' `sink` identical on
+every row so the outputs are the same.
+
+| lever | held-out | verdict |
+|---|---:|---|
+| PGO (`-Cprofile-generate` → 4 targets × 1700 files → `-Cprofile-use`) | **1.130x** | real, and the largest single lever measured |
+| `-Ctarget-cpu=apple-m1` on top of PGO | **1.000x** | null — 519.0ms vs 519.0ms |
+| removing the Phase-3 timer clock from the binary | **1.002x** | null at this precision (±0.5%) |
+| the remaining need after PGO | **1.027x** | unclosed |
+
+**PGO's in-sample number is 1.179x and its held-out number is 1.130x**, so the
+overfit is 4-5 percentage points. Measuring only in-sample would have reported a
+lever that is a third larger than it is. Server is 1.118x, so SSR does not
+regress. `llvm-profdata merge --sparse` takes the profile from 14.2 MB to 6.3 MB
+(1.5 MB gzipped); shipping it means either checking that in or training in
+release CI per platform, and neither has been decided.
+
+**The timer-clock result retires a number this file used to carry.** A sampled
+profile scores `mach_absolute_time` at 0.40% of self time, and that was read as
+0.40% recoverable. Removing every `Instant::now()` from the shipping path
+measured **1.002x** — indistinguishable from nothing. A self-time share is not a
+saving; this is the same shape as the withdrawn UTF-16 column subtraction, whose
+2.14% profile bound measured null. The instrumentation added below is therefore
+free, which is the other half of the same measurement.
+
+## The Phase-3 residual is 7.1%, not 15.5%
+
+`compile_profile` now brackets the gaps in `transform_client` and in
+`transform_component_with_scripts`. Measured on 3000 files, client:
+
+| named | ms | % of compile |
+|---|---:|---:|
+| **client source-map assembly (after `transform_client`)** | **10.01** | **3.8%** |
+| — line tables + two full scans | 5.29 | 2.0% |
+| — three-way partition loop | 2.60 | 1.0% |
+| — sort by (gen_line, gen_col) | 1.63 | 0.6% |
+| post-codegen `rehome_derived_jsdoc` + `signal_discipline` | 3.05 | 1.1% |
+| GAP dead_comments → attach_import_origins | 2.81 | 1.1% |
+| GAP entry → visit_program | 1.56 | 0.6% |
+| GAP visit_program → dead_comments | 1.35 | 0.5% |
+| GAP script_text → fragment → assembly (three) | 0.16 | 0.1% |
+| **still unnamed** | **18.87** | **7.1%** |
+
+The largest piece is the source-map reconstruction this file and `AGENTS.md`
+already name as the debt behind #2954/#3015 — it now has a position and a size.
+Its dominant third is *scanning*: `MappingLineStarts::new` walks the generated
+code and the source, `template_source_lines` walks the source again, and
+`mark_lines_containing` walks the generated code again. Two of those four passes
+are fusible into the other two without changing any output. **Unmeasured:** what
+that fusion actually buys.
+
+**One hypothesis was raised and falsified on the way.** `compile_profile`'s
+Phase-3 denominator is the loop's wall clock, which also contains the binary's
+own per-file bookkeeping — `take_breakdown` resets thirty thread-locals,
+`script_shape` rescans the source, two `Vec`s grow — so the residual could have
+been the instrument charging itself to the compiler. Measured by summing the
+per-file `transform_component` brackets against the loop wall: **2.98 ms of
+181.65 ms, 1.6%**. It is not the residual's cause. The denominator is now printed
+either way, because "the residual is 15% and unexplained" is a claim about a
+denominator nobody had stated.
 
 # Canonical baseline — quiet machine, 2026-09-02 04:17-04:21 JST
 


### PR DESCRIPTION
`compile_profile` computed one row as the phase total minus six timers and printed it as **"Pre-frag setup"**. A residual always makes the table sum to 100%, so the row reads as a measurement of the thing it is named after — it was 14.9% of client compile and the name was a guess.

Eleven new slots close the gaps *between* the existing timers, so what remains is what nothing accounts for rather than what nothing is named after.

| | share of compile |
|---|---|
| `program_to_oxc` (client-only) | **5.0%** |
| client source-map assembly | **3.8%** |
| — line tables + two full scans | 2.0% |
| — three-way partition loop | 1.0% |
| — sort by (gen_line, gen_col) | 0.6% |
| `rehome_derived_jsdoc` + `signal_discipline` | 1.1% |
| four inter-timer gaps | 1.5% |
| **still unnamed** | **7.1%** |

`compile_profile` also prints its own bookkeeping against the loop wall now — **1.7%** — which is what *falsifies* "the residual is just the profiler" instead of leaving it a suspicion.

## Two traps this walked into, both already written down

**A new field on `Phase3Breakdown` compiles and reports `0.00ms`.** The struct was summed field by field at the call site, so a slot that is never added reads exactly like a timer that never fires. AGENTS.md records this trap; it then fired on the first five slots added *after* it was recorded, by the person who recorded it. A documented trap whose only defence is the documentation is not defended, so the struct now carries an `AddAssign` — the requirement sits beside the definition rather than in a binary nobody opens when adding a field.

**A timer bracketing "everything after the match" contained another timer's region**, so one bucket double-counted and the residual was subtracted twice. With the over-wide timer, map work summed to 11.6% against a 12.2% ablation — which reads as two independent measurements agreeing. `PREFRAG_IN_RESIDUAL` now marks which slots sit inside another.

## The instrumentation is measured null

An A/B of the whole timer set against a stubbed clock is **1.002x**, with both arms built from the same source except the stub. It is not free by assertion.

`perf_bench` gains `--skip N` so a held-out slice can be *shown* disjoint from a training slice rather than assumed to be — the same fix that separated PGO's in-sample 1.179x from its held-out 1.130x.

## Gate

`cargo test --release -p rsvelte_core --features parallel --no-fail-fast` — 661 suites, exit 0. Not a named subset: the last time a subset was used here it missed `the_deferred_ast_is_typescript_stripped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyd6xc1EN5Jt4yNWeiWtuy