### PR TITLE
fix(lint): a `svelte-ignore` id is a compiler warning code, not a rule id

### DIFF
--- a/.changeset/lint-svelte-ignore-id-vocabulary.md
+++ b/.changeset/lint-svelte-ignore-id-vocabulary.md
@@ -1,0 +1,12 @@
+---
+'@rsvelte/lint': patch
+---
+
+`svelte-ignore` no longer suppresses a `svelte/<rule>` plugin id.
+
+Its id vocabulary is the compiler's warning codes; ESLint rule ids belong to
+`eslint-disable*`. rsvelte registered every token, so
+`<!-- svelte-ignore svelte/no-at-html-tags -->` silenced the rule while
+`no-unused-svelte-ignore` still reported the comment as unused — the two halves
+contradicting each other on one line. Measured against eslint-plugin-svelte over
+all four directive x id cells; only this one diverged.

--- a/compatibility/lint-adversarial/no-unused-svelte-ignore/23-plugin-rule-id.svelte
+++ b/compatibility/lint-adversarial/no-unused-svelte-ignore/23-plugin-rule-id.svelte
@@ -1,0 +1,9 @@
+<script>
+	let x = "";
+</script>
+
+<!-- svelte-ignore svelte/no-at-html-tags -->
+{@html x}
+
+<!-- svelte-ignore a11y_missing_attribute svelte/no-at-debug-tags -->
+{@debug x}

--- a/crates/rsvelte_lint/src/suppression.rs
+++ b/crates/rsvelte_lint/src/suppression.rs
@@ -13,7 +13,8 @@
 //! - `eslint-disable [ids]` … `eslint-enable [ids]` — a **block range** (Wave
 //!   2): everything between the two directives (to EOF when never re-enabled).
 //! - `svelte-ignore code` — treated like `disable-next-line` for the listed
-//!   codes.
+//!   codes, which are the compiler's warning codes only: a `svelte/<rule>` id
+//!   is ignored, matching the oracle.
 //!
 //! An empty id list means "all rules" (the `*` token).
 
@@ -113,7 +114,7 @@ impl Suppressions {
                 // (no codes) suppresses NOTHING — Svelte's svelte-ignore needs
                 // explicit codes, and the eslint oracle never lets it disable
                 // `svelte/*` rules. Only add codes when the list is non-empty.
-                s.add_line_no_wildcard(lineno + 1, rest);
+                s.add_line_svelte_ignore(lineno + 1, rest);
             }
             // Upstream re-enables ALL (plugin) suppressions at every `<script>`
             // start tag (`SvelteScriptElement` pushes an enable-all block at the
@@ -159,15 +160,16 @@ impl Suppressions {
         }
     }
 
-    /// Like [`add_line`] but the `*` wildcard is never honoured. Used for
-    /// `svelte-ignore`, which (unlike `eslint-disable`) must NOT suppress every
-    /// rule: a bare `<!-- svelte-ignore -->` (empty → `parse_ids` yields `["*"]`)
-    /// suppresses nothing, and a stray `*` token alongside real codes
-    /// (`<!-- svelte-ignore * foo -->`) is dropped while `foo` is kept.
-    fn add_line_no_wildcard(&mut self, line: u32, rest: &str) {
+    /// Like [`add_line`] but for `svelte-ignore`, whose id vocabulary is the
+    /// compiler's warning codes rather than ESLint rule ids. Two tokens are
+    /// therefore dropped rather than registered: `*`, because a bare
+    /// `<!-- svelte-ignore -->` (empty → `parse_ids` yields `["*"]`) suppresses
+    /// nothing; and any `/`-bearing id, because `svelte/<rule>` names a plugin
+    /// rule the oracle's `svelte-ignore` cannot disable.
+    fn add_line_svelte_ignore(&mut self, line: u32, rest: &str) {
         let entry = self.by_line.entry(line).or_default();
         for id in parse_ids(rest) {
-            if id != ALL {
+            if id != ALL && !id.contains('/') {
                 entry.insert(id);
             }
         }

--- a/crates/rsvelte_lint/tests/svelte_ignore_id_vocabulary.rs
+++ b/crates/rsvelte_lint/tests/svelte_ignore_id_vocabulary.rs
@@ -1,0 +1,125 @@
+//! `svelte-ignore` and `eslint-disable-next-line` do not share an id vocabulary.
+//!
+//! Two axes — the directive (`svelte-ignore` / `eslint-disable-next-line`) and
+//! the id it names (a compiler warning code / a `svelte/<rule>` plugin id) —
+//! give four cells, and each directive suppresses exactly one of them. Two
+//! comment-free controls pin that both rules fire when nothing suppresses them,
+//! so a green cell means "suppressed" rather than "never reported".
+//!
+//! Every expected value below is pasted from
+//! `node scripts/compat-corpus/lint-oracle/run.mjs --rules <the three rules
+//! this file enables>` over these exact sources; none is hand-written. Only
+//! `(ruleId, line, column)` is asserted: `svelte/valid-compile` is on the lint
+//! gate's `EXCLUDE` list and its message text carries a compiler-side
+//! divergence that is not this file's subject.
+
+use std::path::PathBuf;
+
+use rsvelte_core::CompileOptions;
+use rsvelte_lint::{LintConfig, lint_source};
+
+fn config() -> LintConfig {
+    LintConfig::from_json_str(
+        r#"{
+            "extends": ["none"],
+            "rules": {
+                "svelte/no-at-html-tags": "warn",
+                "svelte/valid-compile": "warn",
+                "svelte/no-unused-svelte-ignore": "warn"
+            }
+        }"#,
+    )
+    .unwrap()
+}
+
+/// Findings as `(ruleId, line, 1-based column)` — the oracle's own coordinates.
+fn findings(src: &str) -> Vec<(String, u32, u32)> {
+    let mut out: Vec<(String, u32, u32)> = lint_source(
+        src,
+        &PathBuf::from("test.svelte"),
+        &CompileOptions::default(),
+        &config(),
+    )
+    .into_iter()
+    .filter_map(|d| {
+        let r = d.range?;
+        Some((d.code?, r.start.line, r.start.column + 1))
+    })
+    .collect();
+    out.sort();
+    out
+}
+
+const HTML: &str = "<script>\n\tlet x = \"\";\n</script>\n\n{@html x}\n";
+const IMG: &str = "<img alt=\"photo of a cat\" src=\"a.png\" />\n";
+
+fn html_with(directive: &str) -> String {
+    format!("<script>\n\tlet x = \"\";\n</script>\n\n{directive}\n{{@html x}}\n")
+}
+
+fn img_with(directive: &str) -> String {
+    format!("{directive}\n{IMG}")
+}
+
+#[test]
+fn control_at_html_reports_when_nothing_suppresses_it() {
+    assert_eq!(
+        findings(HTML),
+        vec![("svelte/no-at-html-tags".to_string(), 5, 1)]
+    );
+}
+
+#[test]
+fn control_compiler_warning_reports_when_nothing_suppresses_it() {
+    assert_eq!(
+        findings(IMG),
+        vec![("svelte/valid-compile".to_string(), 1, 1)]
+    );
+}
+
+/// eslint-disable-next-line × plugin rule id — the directive's own vocabulary.
+#[test]
+fn eslint_disable_suppresses_a_plugin_rule() {
+    assert_eq!(
+        findings(&html_with(
+            "<!-- eslint-disable-next-line svelte/no-at-html-tags -->"
+        )),
+        vec![]
+    );
+}
+
+/// svelte-ignore × compiler warning code — the directive's own vocabulary.
+#[test]
+fn svelte_ignore_suppresses_a_compiler_warning_code() {
+    assert_eq!(
+        findings(&img_with("<!-- svelte-ignore a11y_img_redundant_alt -->")),
+        vec![]
+    );
+}
+
+/// svelte-ignore × plugin rule id — the cell this file exists for. The oracle
+/// leaves the rule reporting *and* reports the ignore as unused; both must hold
+/// together, because suppressing while also calling the ignore unused is what
+/// rsvelte did before.
+#[test]
+fn svelte_ignore_does_not_suppress_a_plugin_rule() {
+    assert_eq!(
+        findings(&html_with("<!-- svelte-ignore svelte/no-at-html-tags -->")),
+        vec![
+            ("svelte/no-at-html-tags".to_string(), 6, 1),
+            ("svelte/no-unused-svelte-ignore".to_string(), 5, 20),
+        ]
+    );
+}
+
+/// eslint-disable-next-line × compiler warning code — measured against the
+/// oracle rather than inferred from the three cells above.
+#[test]
+fn eslint_disable_does_not_suppress_a_compiler_warning_code() {
+    assert_eq!(
+        findings(&img_with(
+            "<!-- eslint-disable-next-line a11y_img_redundant_alt -->"
+        )),
+        vec![("svelte/valid-compile".to_string(), 2, 1)]
+    );
+}

--- a/crates/rsvelte_lint/tests/svelte_ignore_id_vocabulary.rs
+++ b/crates/rsvelte_lint/tests/svelte_ignore_id_vocabulary.rs
@@ -12,6 +12,14 @@
 //! `(ruleId, line, column)` is asserted: `svelte/valid-compile` is on the lint
 //! gate's `EXCLUDE` list and its message text carries a compiler-side
 //! divergence that is not this file's subject.
+//!
+//! That exclusion is also why the two compiler-code cells live here and only
+//! here, which was measured rather than assumed: of the ten lint gates, seven
+//! scope themselves with `ruleUniverse()`, whose `EXCLUDE` drops
+//! `svelte/valid-compile`; two drive upstream's `flat/recommended`, which does
+//! not carry that rule; and the last compares `meta.conditions` declarations
+//! rather than findings. So no gate can observe either cell at any corpus size,
+//! and this file is the gate that holds that shape.
 
 use std::path::PathBuf;
 


### PR DESCRIPTION
Closes #4216 (option 1).

`svelte-ignore` and `eslint-disable-next-line` do not share an id vocabulary —
the first names the compiler's warning codes, the second names ESLint rule ids —
and `Suppressions::collect` registered every token from both into one set. A
`/`-bearing id is now dropped from the `svelte-ignore` side.

## The grid, both arms

Two axes, four cells, plus two comment-free controls so that "suppressed" is
distinguishable from "never reported". Every expected value is pasted from
`node scripts/compat-corpus/lint-oracle/run.mjs`; none is hand-written.

| directive | id | oracle | rsvelte before | rsvelte after |
|---|---|---|---|---|
| *(none — control)* | — | `no-at-html-tags` 5:1 | same | same |
| *(none — control)* | — | `valid-compile` 1:1 | same | same |
| `eslint-disable-next-line` | `svelte/no-at-html-tags` | suppressed | suppressed | suppressed |
| `svelte-ignore` | `a11y_img_redundant_alt` | suppressed | suppressed | suppressed |
| `svelte-ignore` | `svelte/no-at-html-tags` | **not suppressed** | **suppressed** | not suppressed |
| `eslint-disable-next-line` | `a11y_img_redundant_alt` | **not suppressed** | not suppressed | not suppressed |

The fourth cell had not been measured by anyone and is not inferred from the
other three: `eslint-disable-next-line <compiler code>` suppresses nothing on
either side, so it needed no work — but that is a measurement, not a deduction
from the diagonal.

Row 5 is the defect, and its shape is worth stating because the gate could only
ever see half of it. rsvelte **suppressed** `no-at-html-tags` *and* reported
`no-unused-svelte-ignore` at 5:20 for the same comment — one line answering
"this ignore silenced something" and "this ignore silenced nothing" at once. The
report key `(ruleId, line, column, message)` agreed with the oracle on the
`no-unused-svelte-ignore` half exactly, so only the missing finding diverged.

## Ablation

Reverting the one-token guard and re-running the six tests:

```
test result: FAILED. 5 passed; 1 failed
---- svelte_ignore_does_not_suppress_a_plugin_rule stdout ----
  left: [("svelte/no-unused-svelte-ignore", 5, 20)]
 right: [("svelte/no-at-html-tags", 6, 1), ("svelte/no-unused-svelte-ignore", 5, 20)]
```

Exactly one cell moves, and it fails for the predicted reason — the rule finding
is gone while the unused-ignore report stays. The other five, controls included,
are unaffected, so the change is scoped to the cell it was written for.

## Gates

`compatibility/lint-adversarial/no-unused-svelte-ignore/23-plugin-rule-id.svelte`
carries the repro, including a mixed comment
(`svelte-ignore a11y_missing_attribute svelte/no-at-debug-tags`) where the
compiler code must survive while the plugin id is dropped. Discriminating: 2
divergences before the fix, 0 after.

```
lint-adversarial            1368 patterns, oracle 5531 / rsvelte 5531,  0 divergences  ✅
lint-adversarial-end        5531 findings compared,                     0 divergences  ✅
lint-adversarial-fix        1361 pattern/rule pairs, 350 / 350 rewrites, 0 divergences ✅
lint-adversarial-fix-all    1367 patterns, 796 / 796 rewrites,          0 divergences  ✅
lint-adversarial-suggest    363 positions, 388 / 388 suggestions,       0 divergences  ✅
cargo test -p rsvelte_lint --lib --tests   365 lib + 55 integration, all pass
```

No ratchet id is added or dropped by this PR.

## What is not covered here, and why

The compiler-code axis (rows 4 and 6) is invisible to every lint gate:
`svelte/valid-compile` is on `lint-universe.mjs`'s `EXCLUDE` list, so those two
cells exist only in `crates/rsvelte_lint/tests/svelte_ignore_id_vocabulary.rs`.
That is the reason the unit test asserts `(ruleId, line, column)` and not the
message — `valid-compile`'s text carries a compiler-side divergence that is not
this PR's subject.

The LSP needs no change: it consumes `rsvelte_lint`, so it inherits the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ayf2LfKqP7yEEtWjunZ7DF
