### PR TITLE
perf(profile): split post_passes, which is 6.2% of a dev client compile

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -9306,9 +9306,12 @@ fn transform_instance_script_for_visitors(
     // top-level bindings. They're not in state_vars (to avoid incorrectly transforming
     // top-level references), so neither text-based nor AST-based transforms handle them.
     // This must run regardless of runes mode.
+    let _t = super::profile::timer_start();
     if !shadowed_local_reactive_vars.is_empty() {
         result = transform_shadowed_local_state_vars(&result, &shadowed_local_reactive_vars);
     }
+    super::profile::record_prefrag(16, super::profile::timer_elapsed(_t));
+    let _t = super::profile::timer_start();
 
     // Must run after the runes AST pass: it matches the post-transform `prop()` getter
     // form, which does not exist yet while the per-statement pipeline is still running.
@@ -9324,6 +9327,8 @@ fn transform_instance_script_for_visitors(
             wrap_prop_mutation_validation(&result, &prop_mutation_vars, &analysis.source)
         });
     }
+    super::profile::record_prefrag(17, super::profile::timer_elapsed(_t));
+    let _t = super::profile::timer_start();
 
     // Dev-mode equality / `await` instrumentation for legacy components. Upstream
     // runs one visitor map over both modes; here the runes half rides inside the
@@ -9336,6 +9341,8 @@ fn transform_instance_script_for_visitors(
     {
         result = instrumented;
     }
+    super::profile::record_prefrag(18, super::profile::timer_elapsed(_t));
+    let _t = super::profile::timer_start();
 
     if dev
         && let Some(instrumented) =
@@ -9343,6 +9350,7 @@ fn transform_instance_script_for_visitors(
     {
         result = instrumented;
     }
+    super::profile::record_prefrag(19, super::profile::timer_elapsed(_t));
 
     super::profile::record_st_post_passes(super::profile::timer_elapsed(_stage));
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -117,7 +117,7 @@ impl std::ops::AddAssign for Phase3Breakdown {
     }
 }
 
-pub const PREFRAG_SLOTS: usize = 16;
+pub const PREFRAG_SLOTS: usize = 20;
 pub const PREFRAG_LABELS: [&str; PREFRAG_SLOTS] = [
     "strip_dead_comments_from_program",
     "program_to_oxc (client-only)",
@@ -135,6 +135,10 @@ pub const PREFRAG_LABELS: [&str; PREFRAG_SLOTS] = [
     "  map: line tables + two full scans",
     "  map: three-way partition loop",
     "  map: sort by (gen_line, gen_col)",
+    "  post: shadowed_local_state_vars",
+    "  post: prop_mutation_validation",
+    "  post: legacy dev tail (dev-only)",
+    "  post: assign dev tail (dev-only)",
 ];
 
 /// Whether each slot's time is inside the "Pre-frag setup" residual. A slot that
@@ -145,8 +149,10 @@ pub const PREFRAG_IN_RESIDUAL: [bool; PREFRAG_SLOTS] = [
     // Slot 4 (`compute_blocker_primary_names`) now sits inside GAP slot 8, so
     // subtracting both would take it out of the residual twice.
     // Slots 13-15 are inside slot 12, so they must not be subtracted again.
+    // Slots 16-19 sit inside `script_text_transform`'s `post_passes`, not in the
+    // pre-fragment residual, so they are named here without being subtracted.
     true, false, true, true, false, true, true, true, true, true, true, true, true, false, false,
-    false,
+    false, false, false, false, false,
 ];
 
 /// One level below [`Phase3Breakdown::script_text_transform`], which is the


### PR DESCRIPTION
`post_passes` is the one script-text stage whose dev and prod costs differ by more than a factor of five (19.2ms vs 3.5ms on 3000 files), and it held four sequential passes under one timer. Measured ABBA:

| pass | prod | dev |
|---|---|---|
| `shadowed_local_state_vars` | 3.0ms | 3.7ms |
| `prop_mutation_validation` | 0.05ms | **5.7ms** |
| legacy dev tail | 0.05ms | 0.7ms |
| assign dev tail | 0.05ms | **8.9ms** |

Two things are only visible once they are apart:

- **`prop_mutation_validation` is not written as dev-gated** and reads as shared work; `prop_mutation_vars` is only populated in dev, so it is the second largest dev-only cost in this stage. Someone hunting the dev overhead by grepping for `dev` would not have gone there.
- The three passes that cost anything each run **their own `ast_rewrite::rewrite_batched`** over the settled script text. That is what takes the driver's reparse count from 3629 to 8120 over the same 3889 files, and it is the shape to attack next: upstream pays none of it because it is walking an AST it already has.

### The slots are priced before being added

`record_prefrag` copies the whole `[Duration; PREFRAG_SLOTS]` array in and out of a thread-local, so widening 16 → 20 makes **every existing call** carry more — the "a field is priced on the type, not on the node that sets it" shape. A/B against `main`, both arms built from one tree, six ABBA pairs per target:

| target | 20 slots | 16 slots (main) | ratio | pairs favouring wider | sign p |
|---|---|---|---|---|---|
| client | 590.4ms | 592.6ms | 0.9962x | 1/6 | 1.000 |
| client-dev | 697.3ms | 698.2ms | 0.9987x | 3/6 | 1.000 |

No measurable cost in either direction, and `sink` is identical across all 24 runs.

Gates: `--lib` (1964 tests, `Running unittests src/lib.rs` present), `compiler_fixtures`, `sourcemaps_gate`, `css`, `ssr` — all pass; `cargo fmt --check` and `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyd6xc1EN5Jt4yNWeiWtuy