### PR TITLE
perf(client): the source-map resync window is scanned 196k times, so scan it with SIMD

### DIFF
--- a/.changeset/memchr-resync-window.md
+++ b/.changeset/memchr-resync-window.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Scan the source-map resync windows with `memchr` instead of a scalar `position`

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -3569,14 +3569,12 @@ fn copied_spans_for_normalized_code(
         const NEAR_RESYNC_WINDOW: usize = 32;
         let code_tail = &code.as_bytes()[output..];
         let input_tail = &stripped.as_bytes()[input..];
-        let next_input = input_tail
-            .iter()
-            .take(RESYNC_WINDOW)
-            .position(|&byte| byte == output_byte);
-        let next_output = code_tail
-            .iter()
-            .take(RESYNC_WINDOW)
-            .position(|&byte| byte == input_byte);
+        let next_input = memchr::memchr(
+            output_byte,
+            &input_tail[..input_tail.len().min(RESYNC_WINDOW)],
+        );
+        let next_output =
+            memchr::memchr(input_byte, &code_tail[..code_tail.len().min(RESYNC_WINDOW)]);
         let (skip_input, skip_output) = match (next_input, next_output) {
             (Some(left), Some(right)) if left <= right => (left, 0),
             (Some(left), None) => (left, 0),
@@ -3599,15 +3597,13 @@ fn copied_spans_for_normalized_code(
                     best = Some((run, skip_input, skip_output));
                 }
             };
-            for (skip, &byte) in input_tail.iter().take(NEAR_RESYNC_WINDOW).enumerate() {
-                if byte == output_byte {
-                    consider(common_run(code_tail, &input_tail[skip..]), skip, 0);
-                }
+            let near_input = &input_tail[..input_tail.len().min(NEAR_RESYNC_WINDOW)];
+            for skip in memchr::memchr_iter(output_byte, near_input) {
+                consider(common_run(code_tail, &input_tail[skip..]), skip, 0);
             }
-            for (skip, &byte) in code_tail.iter().take(NEAR_RESYNC_WINDOW).enumerate() {
-                if byte == input_byte {
-                    consider(common_run(&code_tail[skip..], input_tail), 0, skip);
-                }
+            let near_output = &code_tail[..code_tail.len().min(NEAR_RESYNC_WINDOW)];
+            for skip in memchr::memchr_iter(input_byte, near_output) {
+                consider(common_run(&code_tail[skip..], input_tail), 0, skip);
             }
             if let Some((_, skip_input, skip_output)) = best {
                 input += skip_input;


### PR DESCRIPTION
`copied_spans_for_normalized_code` aligns the generated script against its
source byte by byte. Instrumented over 2,887 client components it is called
**6.9 times per file** and, within those 20,000 calls, takes the resync branch
**196,071 times** against 240,883 matched runs — the two texts diverge every
~20 bytes, so the alignment spends an order of magnitude more scanning on
re-anchoring than on the runs it is trying to find.

Both resync scans were `iter().take(WINDOW).position(|&b| b == x)`: the 256-byte
primary anchors and the two 32-byte near-anchor sweeps. All four are byte
searches, which is what `memchr` is for, and `memchr` is already a dependency of
this crate. `memchr_iter` also replaces the near-anchor `enumerate()` filter,
which yields the same offsets in the same ascending order, so the candidate set
handed to `consider` is unchanged.

Measured single-threaded over 3,000 corpus components, both arms built from one
tree (hashes differ), 12 ABBA-ordered pairs per target:

| target | mean CPU ratio base/memchr | pairs favouring memchr |
|---|---|---|
| client | 1.0102 | 12/12 |
| client-dev | 1.0099 | 12/12 |

`sink` — the corpus-wide hash of every generated output — is identical on both
arms for both targets, and the source-map gate, `compiler_fixtures`, `css`,
`ssr`, `runtime` and the 1,962 lib tests are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyd6xc1EN5Jt4yNWeiWtuy