### PR TITLE
fix(client): two `should_proxy` port defects — parentheses, and an `undefined` initial

### DIFF
--- a/.changeset/paren-transparent-should-proxy.md
+++ b/.changeset/paren-transparent-should-proxy.md
@@ -1,0 +1,24 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A parenthesized `$state` assignment right-hand side keeps its proxy in `compileModule`.
+
+acorn builds no `ParenthesizedExpression`, so upstream's `should_proxy` decides on what the
+parens hold. rsvelte ports that predicate twice: the AST port recurses through the pair, and
+the text port used by the module path had no paren step at all — `is_top_level_function_call`
+reads only an identifier callee and bailed on a leading `(` with a comment saying so. The two
+predicates have opposite defaults (`should_proxy` returns false only for the shapes it
+enumerates, the sniff returns true only for the shapes it enumerates), so every shape neither
+recognised fell out unproxied.
+
+Measured one cell per shape against `submodules/svelte` 5.56.10 in both hosts: 25 of 40 module
+cells diverged and 0 of 40 component cells did, so the class is `compileModule`-only. Every
+divergence ran one way, and the six agreeing paren cells — `(1)`, `('s')`, `` (`t`) ``,
+`((x) => x)`, `(!a)`, `(a + b)` — are exactly the inner shapes `should_proxy` refuses, which is
+what a "a leading `(` proxies" rule would have broken.
+
+The ratchet carrier is `svelte-lexical/demos/qalam/src/lib/notesStore.svelte.ts`, and it
+diverged only under `dev` because the await instrumentation rewrites the right-hand side into
+`(await $.track_reactivity_loss(…))()` before the proxy decision reads it — one line of 166,
+with the same source byte-equal in production.

--- a/.changeset/undefined-initial-is-not-proxied.md
+++ b/.changeset/undefined-initial-is-not-proxied.md
@@ -1,0 +1,15 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A `$state` write whose value is a prop with an `undefined` destructure default is no longer
+wrapped in `$.proxy`. Upstream's `should_proxy` answers `false` for `undefined` in the same
+clause as the literal types and resolves a bare identifier by recursing on `binding.initial`;
+rsvelte ports that node-type list twice, and `is_non_proxy_node_type` was the correct port's
+negation without the `undefined` arm. Two of its four call sites had bolted the arm back on at
+the call site and two had not, so the answer depended on which list a binding reached. The
+identifier name is now a parameter of the predicate rather than a caller-side `||`.
+
+Measured one cell per shape against the official compiler: 8 of 24 diverged before and 2 after,
+the remaining 2 being a `<script module>` local that reaches a different port (0 carriers over
+33,545 corpus files). A 134,180-unit four-target sweep moves 2 units, both `MISMATCH -> match`.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2950,11 +2950,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 9 entries)
+### Client (`known-failures.client.json`, 8 entries)
 
-Partition of `known-failures.client.json` by verdict: `9`
+Partition of `known-failures.client.json` by verdict: `8`
 
-- **9 — the generated JS differs** (`js` / `code-differs`).
+- **8 — the generated JS differs** (`js` / `code-differs`).
 
 No CSS entry survives on this target: the one that did left with the ancestor-scoping fix
 below.
@@ -3261,7 +3261,7 @@ comments and compare" said the opposite, because official's line reduces to a ba
 the stripper invents a structural difference; that is the stricter-reconstruction hazard two
 paragraphs above, reached from the other side.
 
-Every one of the remaining 9 arrived with the wave-2 enrolment (#3176) and is described
+Every one of the remaining 8 arrived with the wave-2 enrolment (#3176) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3365,17 +3365,33 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 15 entries)
+### Client dev (`known-failures.client-dev.json`, 14 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `15`
+Partition of `known-failures.client-dev.json` by verdict: `14`
 
-- **15 — the generated JS differs.**
+- **14 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 15 arrived with the wave-2 enrolment (#3176); this target was at 0 before
+All remaining 14 arrived with the wave-2 enrolment (#3176); this target was at 0 before
 it, and it is the largest of the four — 6 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
+
+`immich/…/asset-viewer/ActivityViewer.svelte` left this target and `client` for the other half of
+the same predicate. Upstream's `should_proxy` answers `false` for `undefined` in the **same
+clause** as the literal types, and resolves a bare identifier by recursing on `binding.initial` —
+so a prop whose destructure default is `undefined` is not proxied when it is written into a
+`$state`. rsvelte ports that node-type list twice: `should_proxy_node_type` carries the
+`undefined` arm, and `is_non_proxy_node_type` was its negation **without** it. Two of that
+function's four call sites had bolted the arm back on at the call site and two had not, which is
+the "a pass is missing from a branch" shape — measured one cell per shape, 8 of 24 diverged and
+the reported one was among them. The name is now a parameter of the predicate, so the decision
+cannot be spelled without answering it. One shape is still open and is a **different** port: a
+`<script module>` local initialised to `undefined` and written into a module `$state` reaches the
+module text pipeline, which carries its own list. Its carrier count over the collected corpus is
+**0 of 33,545** — measured with two positive controls, 1,981 files do have a module script and
+3,425 do contain a `= undefined`, so the zero is the conjunction and not the detector — which is
+why it is filed rather than fixed here.
 
 `svelte-lexical/…/notesStore.svelte.ts` left it when the text port of upstream's `should_proxy`
 became transparent to parentheses (#4254). acorn builds no `ParenthesizedExpression`, so

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -3391,7 +3391,7 @@ cannot be spelled without answering it. One shape is still open and is a **diffe
 module text pipeline, which carries its own list. Its carrier count over the collected corpus is
 **0 of 33,545** — measured with two positive controls, 1,981 files do have a module script and
 3,425 do contain a `= undefined`, so the zero is the conjunction and not the detector — which is
-why it is filed rather than fixed here.
+why it is filed (#4264) rather than fixed here.
 
 `svelte-lexical/…/notesStore.svelte.ts` left it when the text port of upstream's `should_proxy`
 became transparent to parentheses (#4254). acorn builds no `ParenthesizedExpression`, so

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -3365,17 +3365,25 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 16 entries)
+### Client dev (`known-failures.client-dev.json`, 15 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `16`
+Partition of `known-failures.client-dev.json` by verdict: `15`
 
-- **16 — the generated JS differs.**
+- **15 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 16 arrived with the wave-2 enrolment (#3176); this target was at 0 before
-it, and it is the largest of the four — 7 JS entries that `client` does not
+All remaining 15 arrived with the wave-2 enrolment (#3176); this target was at 0 before
+it, and it is the largest of the four — 6 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
+
+`svelte-lexical/…/notesStore.svelte.ts` left it when the text port of upstream's `should_proxy`
+became transparent to parentheses (#4254). acorn builds no `ParenthesizedExpression`, so
+upstream decides on what the parens hold; rsvelte ports that predicate twice and only the AST
+one recursed through the pair. The entry was `client-dev`-only because the dev await
+instrumentation rewrites the right-hand side into `(await $.track_reactivity_loss(…))()` before
+the proxy decision reads it, so production never reached the shape — one line of 166, with the
+same source byte-equal on `client`.
 
 Four entries left this target when a module script started reaching the dev `$.assign` rule.
 Upstream has one `AssignmentExpression` visitor and no module/component split, so

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -2,7 +2,6 @@
 	"ha-fusion/src/lib/Modal/VisibilityConfig/Index.svelte",
 	"headscale-ui/src/lib/settings/ServerSettings.svelte",
 	"huly/plugins/workbench-resources/src/components/HelpAndSupport.svelte",
-	"immich/web/src/lib/components/asset-viewer/ActivityViewer.svelte",
 	"immich/web/src/lib/components/timeline/Timeline.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
 	"photon/src/lib/ui/navbar/Profile.svelte",

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -8,7 +8,6 @@
 	"photon/src/lib/ui/navbar/Profile.svelte",
 	"primo/src/lib/builder/ui/Button.svelte",
 	"svelte-bits/src/lib/components/library/Animations/MetallicPaint/MetallicPaint.svelte",
-	"svelte-lexical/demos/qalam/src/lib/notesStore.svelte.ts",
 	"svelte-lexical/packages/svelte-lexical/src/lib/core/NestedComposer.svelte",
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte",
 	"svelte/packages/svelte/tests/snapshot/samples/delegated-locally-declared-shadowed/index.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -1,7 +1,6 @@
 [
 	"ha-fusion/src/lib/Modal/VisibilityConfig/Index.svelte",
 	"headscale-ui/src/lib/settings/ServerSettings.svelte",
-	"immich/web/src/lib/components/asset-viewer/ActivityViewer.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
 	"photon/src/lib/ui/navbar/Profile.svelte",
 	"primo/src/lib/builder/ui/Button.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -2166,6 +2166,50 @@ pub(super) fn strip_leading_comments(s: &str) -> &str {
     }
 }
 
+/// Strip one paren pair that encloses the whole expression. acorn builds no `ParenthesizedExpression`, so upstream's
+/// `should_proxy` never sees a redundant pair; this text sniff has to be
+/// transparent to one too.
+fn strip_enclosing_parens_once(expr: &str) -> Option<&str> {
+    let inner = expr.strip_prefix('(')?;
+    let close = find_matching_paren(inner)?;
+    inner[close + 1..]
+        .trim()
+        .is_empty()
+        .then(|| inner[..close].trim())
+}
+
+/// A `,` outside every bracket and string is a `SequenceExpression`, which
+/// `should_proxy` does not recognise and therefore proxies.
+fn contains_top_level_comma(expr: &str) -> bool {
+    let bytes = expr.as_bytes();
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut string_char = b'\0';
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_string {
+            if c == string_char && !is_escaped(bytes, i) {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'\'' | b'"' | b'`' => {
+                in_string = true;
+                string_char = c;
+            }
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' if depth > 0 => depth -= 1,
+            b',' if depth == 0 => return true,
+            _ => {}
+        }
+        i += 1;
+    }
+    false
+}
+
 /// Determine if an expression needs proxying (could return an object/array).
 ///
 /// Returns `true` for:
@@ -2188,7 +2232,17 @@ pub(super) fn expression_needs_proxy(expr: &str) -> bool {
     // compiler sees the comment as leading trivia on the AST node, so
     // `should_proxy` still fires; this text sniff must skip it too, otherwise
     // `trimmed.starts_with("new ")` (and the call/identifier checks) miss.
-    let trimmed = strip_leading_comments(expr.trim()).trim();
+    let mut trimmed = strip_leading_comments(expr.trim()).trim();
+    while let Some(inner) = strip_enclosing_parens_once(trimmed) {
+        trimmed = strip_leading_comments(inner).trim();
+    }
+    let trimmed = trimmed;
+
+    // A top-level `,` is a SequenceExpression, which `should_proxy` proxies.
+    // It binds looser than every operator sniffed below, so it is decided first.
+    if contains_top_level_comma(trimmed) {
+        return true;
+    }
 
     // Arrow functions and function expressions don't need proxy wrapping
     // They're functions themselves, not objects/arrays
@@ -2253,6 +2307,15 @@ pub(super) fn expression_needs_proxy(expr: &str) -> bool {
     // In the official Svelte compiler, AwaitExpression is not in the list of types
     // that return false from should_proxy, so it always returns true.
     if trimmed.starts_with("await ") {
+        return true;
+    }
+
+    // A pair enclosing the whole expression was stripped above, so a leading
+    // `(` that survives has a tail: a call, member access or tagged template on
+    // a parenthesized base. None of the three is on `should_proxy`'s no-proxy
+    // list, and `is_top_level_function_call` below reads only an identifier
+    // callee, so this shape had no predicate at all.
+    if trimmed.starts_with('(') {
         return true;
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -2179,7 +2179,8 @@ fn strip_enclosing_parens_once(expr: &str) -> Option<&str> {
 }
 
 /// A `,` outside every bracket and string is a `SequenceExpression`, which
-/// `should_proxy` does not recognise and therefore proxies.
+/// `should_proxy` does not recognise and therefore proxies. The caller strips
+/// the source's trailing comma first, so a `,` reaching here is an operator.
 fn contains_top_level_comma(expr: &str) -> bool {
     let bytes = expr.as_bytes();
     let mut depth = 0usize;
@@ -2233,8 +2234,18 @@ pub(super) fn expression_needs_proxy(expr: &str) -> bool {
     // `should_proxy` still fires; this text sniff must skip it too, otherwise
     // `trimmed.starts_with("new ")` (and the call/identifier checks) miss.
     let mut trimmed = strip_leading_comments(expr.trim()).trim();
-    while let Some(inner) = strip_enclosing_parens_once(trimmed) {
-        trimmed = strip_leading_comments(inner).trim();
+    loop {
+        // A class field's initializer arrives with the source's trailing comma
+        // when the call is written across lines. It is not expression syntax,
+        // and leaving it on hides the paren pair underneath it.
+        if let Some(head) = trimmed.strip_suffix(',') {
+            trimmed = head.trim_end();
+            continue;
+        }
+        match strip_enclosing_parens_once(trimmed) {
+            Some(inner) => trimmed = strip_leading_comments(inner).trim(),
+            None => break,
+        }
     }
     let trimmed = trimmed;
 
@@ -2310,13 +2321,24 @@ pub(super) fn expression_needs_proxy(expr: &str) -> bool {
         return true;
     }
 
-    // A pair enclosing the whole expression was stripped above, so a leading
-    // `(` that survives has a tail: a call, member access or tagged template on
-    // a parenthesized base. None of the three is on `should_proxy`'s no-proxy
-    // list, and `is_top_level_function_call` below reads only an identifier
-    // callee, so this shape had no predicate at all.
-    if trimmed.starts_with('(') {
-        return true;
+    // A call, member access or tagged template on a parenthesized base. None is
+    // on `should_proxy`'s no-proxy list, and `is_top_level_function_call` below
+    // reads only an identifier callee, so this shape had no predicate at all.
+    // The tail is enumerated rather than treated as a catch-all: an arrow whose
+    // parameter list spans lines (`(event) =>\n …`) also opens with a paren
+    // group, and `should_proxy` refuses it.
+    if let Some(rest) = trimmed.strip_prefix('(')
+        && let Some(close) = find_matching_paren(rest)
+    {
+        let after = rest[close + 1..].trim_start();
+        if after.starts_with('(')
+            || after.starts_with('.')
+            || after.starts_with('[')
+            || after.starts_with('`')
+            || after.starts_with("?.")
+        {
+            return true;
+        }
     }
 
     // `should_proxy` proxies everything it does not recognise; this sniff only

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5443,15 +5443,13 @@ fn extract_proxy_vars(script: &str) -> Vec<String> {
 /// Node types for which upstream `should_proxy` returns false (→ the value is
 /// NOT wrapped in `$.proxy(...)`). An Identifier whose binding resolves to one
 /// of these initial node types is therefore non-proxyable.
-fn is_non_proxy_node_type(nt: &str) -> bool {
-    matches!(
+fn is_non_proxy_node_type(nt: &str, identifier_name: Option<&str>) -> bool {
+    // The name is a parameter rather than a caller-side `||` arm because
+    // upstream's `should_proxy` answers `false` for `undefined` in the same
+    // clause as the literal types: two of four call sites had forgotten it.
+    !crate::compiler::phases::phase3_transform::client::visitors::shared::utils::should_proxy_node_type(
         nt,
-        "Literal"
-            | "TemplateLiteral"
-            | "ArrowFunctionExpression"
-            | "FunctionExpression"
-            | "UnaryExpression"
-            | "BinaryExpression"
+        identifier_name,
     )
 }
 
@@ -5698,10 +5696,8 @@ fn transform_module_script_runes_with_target(
                 && (b.initial_is_function
                     || b.initial_node_type
                         .as_deref()
-                        .map(is_non_proxy_node_type)
-                        .unwrap_or(false)
-                    || (b.initial_node_type.as_deref() == Some("Identifier")
-                        && b.initial_identifier_name.as_deref() == Some("undefined")))
+                        .map(|nt| is_non_proxy_node_type(nt, b.initial_identifier_name.as_deref()))
+                        .unwrap_or(false))
         })
         .map(|b| b.name.clone())
         .collect();
@@ -7004,7 +7000,7 @@ fn compute_non_proxy_scope(analysis: &ComponentAnalysis) -> NonProxyScope {
             let ok = b
                 .initial_node_type
                 .as_deref()
-                .map(is_non_proxy_node_type)
+                .map(|nt| is_non_proxy_node_type(nt, b.initial_identifier_name.as_deref()))
                 .unwrap_or(false);
             let entry = per_name.entry(b.name.clone()).or_insert((true, 0));
             if !ok {
@@ -7066,13 +7062,10 @@ fn compute_non_proxy_scope(analysis: &ComponentAnalysis) -> NonProxyScope {
                         | BindingKind::StoreSub
                 )
                 && b.import_source.is_none()
-                && (b
-                    .initial_node_type
+                && b.initial_node_type
                     .as_deref()
-                    .map(is_non_proxy_node_type)
+                    .map(|nt| is_non_proxy_node_type(nt, b.initial_identifier_name.as_deref()))
                     .unwrap_or(false)
-                    || (b.initial_node_type.as_deref() == Some("Identifier")
-                        && b.initial_identifier_name.as_deref() == Some("undefined")))
             {
                 return true;
             }
@@ -7928,7 +7921,7 @@ fn transform_instance_script_for_visitors(
                 && matches!(b.kind, BindingKind::Prop | BindingKind::BindableProp)
                 && b.initial_node_type
                     .as_deref()
-                    .map(is_non_proxy_node_type)
+                    .map(|nt| is_non_proxy_node_type(nt, b.initial_identifier_name.as_deref()))
                     .unwrap_or(false)
             {
                 v.push(b.name.clone());

--- a/crates/rsvelte_core/tests/state_proxy_expression_shapes.rs
+++ b/crates/rsvelte_core/tests/state_proxy_expression_shapes.rs
@@ -112,3 +112,111 @@ fn the_shapes_that_already_proxied_still_proxy() {
         );
     }
 }
+
+/// Whether the `$.set(v, …)` emitted for a `$state` assignment in a
+/// `.svelte.js` module carries the third (proxy) argument.
+///
+/// Counting top-level arguments rather than matching a line: both compilers
+/// break the call across lines when the right-hand side is multi-line, so a
+/// line-shaped test reports "no `$.set` at all" for a cell that has one.
+fn assign_set_is_proxied(rhs: &str) -> bool {
+    let src = format!(
+        "let other = {{}}, o = {{ p: 1 }}, c = true, a = 1, b = 2, backend = {{ init: () => ({{}}) }};\n\
+         let v = $state(0);\n\
+         export async function go() {{\n\tv = {rhs};\n}}\n"
+    );
+    let js = compile_module(
+        &src,
+        ModuleCompileOptions {
+            filename: Some("Test.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+
+    let open = js
+        .match_indices("$.set(")
+        .map(|(i, _)| i + "$.set(".len())
+        .find(|&i| {
+            let rest = js[i..].trim_start();
+            rest.strip_prefix('v')
+                .is_some_and(|r| r.trim_start().starts_with(','))
+        })
+        .unwrap_or_else(|| panic!("no `$.set(v` call for `{rhs}` in:\n{js}"));
+
+    let mut depth = 0usize;
+    let mut args = 1usize;
+    let mut string: Option<char> = None;
+    let mut escaped = false;
+    for c in js[open..].chars() {
+        if let Some(q) = string {
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == q {
+                string = None;
+            }
+            continue;
+        }
+        match c {
+            '\'' | '"' | '`' => string = Some(c),
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' if depth == 0 => break,
+            ')' | ']' | '}' => depth -= 1,
+            ',' if depth == 0 => args += 1,
+            _ => {}
+        }
+    }
+    args >= 3
+}
+
+#[test]
+fn a_parenthesized_right_hand_side_is_decided_by_what_the_parens_hold() {
+    // acorn builds no `ParenthesizedExpression`, so upstream decides on the
+    // inside. Measured one cell per row against
+    // `submodules/svelte/.../compiler/index.js` 5.56.10 in this same module
+    // host: the `true` rows are the ones the text sniff answered `false` for
+    // (17 of 24 cells), and the `false` rows are the negative controls -- they
+    // pass today and a "a leading `(` proxies" rule would break every one.
+    for (rhs, proxied) in [
+        ("(await backend.init())", true),
+        ("(other)", true),
+        ("({ a: 1 })", true),
+        ("(new Map())", true),
+        ("(o.p)", true),
+        ("(c ? a : b)", true),
+        ("(a, o)", true),
+        ("((backend.init()))", true),
+        ("(1)", false),
+        ("('s')", false),
+        ("(`t`)", false),
+        ("((x) => x)", false),
+        ("(!a)", false),
+        ("(a + b)", false),
+    ] {
+        assert_eq!(assign_set_is_proxied(rhs), proxied, "`{rhs}`");
+    }
+}
+
+#[test]
+fn a_call_or_member_on_a_parenthesized_base_is_still_proxied() {
+    // The shape the dev-mode await instrumentation produces: it rewrites
+    // `v = await p()` into `v = (await $.track_reactivity_loss(p()))()`, so the
+    // proxy decision reaches a callee no identifier-led predicate can read.
+    // That is why this row diverged only under `dev: true` while the same
+    // source was byte-equal in production.
+    for rhs in [
+        "(await backend.init())()",
+        "(() => 1)()",
+        "(function () { return 1; })()",
+        "(o).p",
+        "(o)[0]",
+        "(backend.init()).x",
+    ] {
+        assert!(assign_set_is_proxied(rhs), "`{rhs}`");
+    }
+}

--- a/crates/rsvelte_core/tests/state_proxy_expression_shapes.rs
+++ b/crates/rsvelte_core/tests/state_proxy_expression_shapes.rs
@@ -197,6 +197,17 @@ fn a_parenthesized_right_hand_side_is_decided_by_what_the_parens_hold() {
         ("((x) => x)", false),
         ("(!a)", false),
         ("(a + b)", false),
+        // An arrow whose parameter list is parenthesized opens with a paren
+        // group that does NOT enclose the expression, so it reaches the
+        // call/member rule below. Both spellings, because the multi-line one is
+        // what a real module carries and the single-line one is what a grid
+        // written by hand carries.
+        ("(x) => x", false),
+        (
+            "(event) =>\n\t\tevent.type === 'click'\n\t\t\t? 'clicked'\n\t\t\t: 'other'",
+            false,
+        ),
+        ("async (x) => x", false),
     ] {
         assert_eq!(assign_set_is_proxied(rhs), proxied, "`{rhs}`");
     }
@@ -216,7 +227,49 @@ fn a_call_or_member_on_a_parenthesized_base_is_still_proxied() {
         "(o).p",
         "(o)[0]",
         "(backend.init()).x",
+        "(o)?.p",
+        "(o)?.[0]",
     ] {
         assert!(assign_set_is_proxied(rhs), "`{rhs}`");
+    }
+}
+
+#[test]
+fn a_trailing_comma_is_not_a_sequence_expression() {
+    // A class field whose `$state(...)` call is written across lines arrives with
+    // the source's trailing comma inside the argument text. `a,` is not a
+    // `SequenceExpression`, so the initializer is decided by what precedes it.
+    // The host matters: the assignment path never sees a trailing comma, so a
+    // grid written only on `v = <rhs>` cannot reach this at all.
+    for (src, proxied) in [
+        (
+            "export class C {\n\th = $state(\n\t\t(e) =>\n\t\t\te.type === 'click'\n\t\t\t\t? 'a'\n\t\t\t\t: 'b',\n\t);\n}\n",
+            false,
+        ),
+        (
+            "export class C {\n\th = $state(\n\t\t(e) =>\n\t\t\te.type === 'click'\n\t\t\t\t? 'a'\n\t\t\t\t: 'b'\n\t);\n}\n",
+            false,
+        ),
+        (
+            "export class C {\n\th = $state(\n\t\t{ a: 1 },\n\t);\n}\n",
+            true,
+        ),
+        (
+            "export class C {\n\th = $state(\n\t\t(a, o),\n\t);\n}\n",
+            true,
+        ),
+    ] {
+        let js = compile_module(
+            src,
+            ModuleCompileOptions {
+                filename: Some("Test.svelte.js".to_string()),
+                generate: GenerateMode::Client,
+                ..Default::default()
+            },
+        )
+        .expect("compile")
+        .js
+        .code;
+        assert_eq!(js.contains("$.proxy("), proxied, "{src}\n-> {js}");
     }
 }

--- a/crates/rsvelte_core/tests/state_proxy_undefined_initial.rs
+++ b/crates/rsvelte_core/tests/state_proxy_undefined_initial.rs
@@ -1,0 +1,99 @@
+//! Upstream's `should_proxy` answers `false` for `undefined` in the **same
+//! clause** as the literal types (`client/utils.js:133-145`), and resolves a
+//! bare identifier by recursing on `binding.initial` — so a prop whose
+//! destructure default is `undefined` is not proxied when it is written into a
+//! `$state`.
+//!
+//! rsvelte ports that node-type list twice. `should_proxy_node_type` carries
+//! the `undefined` arm; `is_non_proxy_node_type` was its negation **without**
+//! it, and two of that function's four call sites had bolted the arm back on at
+//! the call site while the other two had not. The name is now a parameter, so
+//! the decision cannot be spelled without answering it.
+//!
+//! Every expected value below was taken from the official compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`), not inferred
+//! from rsvelte's own output. Both directions are present, and the test
+//! asserts that they are rather than restating their sizes, because a
+//! predicate that is wrong in one direction is passed by a population that
+//! only carries the other.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// Whether the `$.set(s, …)` emitted for `s = <expr>` carries the third
+/// (proxy) argument. Read off the whole call rather than a line: both
+/// compilers break the call across lines when the value is multi-line.
+fn write_is_proxied(declaration: &str, write: &str, dev: bool) -> bool {
+    let src = format!(
+        "<script>\n\t{declaration}\n\tlet s = $state(0);\n\texport function go() {{ {write} }}\n</script>\n{{s}}\n"
+    );
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("C.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    let at = js
+        .find("$.set(s,")
+        .unwrap_or_else(|| panic!("no `$.set(s,` for `{declaration}` / `{write}` in:\n{js}"));
+    let mut depth = 0usize;
+    let mut commas = 0usize;
+    for (i, b) in js.as_bytes()[at + "$.set(".len() - 1..].iter().enumerate() {
+        match b {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    let _ = i;
+                    break;
+                }
+            }
+            b',' if depth == 1 => commas += 1,
+            _ => {}
+        }
+    }
+    commas >= 2
+}
+
+/// `(declaration, write, official proxies the value)`.
+const CELLS: &[(&str, &str, bool)] = &[
+    ("let { a = undefined } = $props();", "s = a;", false),
+    ("let { a = 1 } = $props();", "s = a;", false),
+    ("let { a = {} } = $props();", "s = a;", true),
+    ("let { a = () => 1 } = $props();", "s = a;", false),
+    ("let { a } = $props();", "s = a;", true),
+    (
+        "let { a = $bindable(undefined) } = $props();",
+        "s = a;",
+        false,
+    ),
+    ("let { a = $bindable({}) } = $props();", "s = a;", true),
+    ("let a = undefined;", "s = a;", false),
+    ("let a = 1;", "s = a;", false),
+    ("let a = {};", "s = a;", true),
+    ("", "s = undefined;", false),
+];
+
+#[test]
+fn an_undefined_initial_is_not_proxied_and_an_object_one_is() {
+    for &(declaration, write, expected) in CELLS {
+        for dev in [false, true] {
+            assert_eq!(
+                write_is_proxied(declaration, write, dev),
+                expected,
+                "`{declaration}` then `{write}` (dev={dev})"
+            );
+        }
+    }
+    // The table is only a test while it contains both answers: a predicate that
+    // never proxies passes every `false` row, and one that always proxies passes
+    // every `true` row. Asserted against the table rather than against a written
+    // count, which would be a second claim nobody re-derives.
+    assert!(CELLS.iter().any(|c| c.2), "no cell expects a proxy");
+    assert!(CELLS.iter().any(|c| !c.2), "no cell expects no proxy");
+}


### PR DESCRIPTION
Closes #4254.

## 何が壊れていたか

上流の `should_proxy` は ESTree ノードを読み、acorn は `ParenthesizedExpression` を作らないので**括弧に透過**です。rsvelte はこの述語を 2 回移植しており、AST 移植（`should_proxy_ast`）は括弧対を再帰で剥がしますが、モジュール経路が使うテキスト移植 `expression_needs_proxy` には括弧の段が 1 つもありませんでした。`is_top_level_function_call` は識別子始まりしか読まず、先頭 `(` を明示的に放棄しています:

```rust
// If starts with ( it could be an IIFE: (function(){})() or (() => {})()
// For simplicity, skip these for now
if first == '(' { return false; }
```

2 つの述語は**既定が逆**です — `should_proxy` は列挙した形だけ false、この sniff は列挙した形だけ true — なので、どちらの述語にも当たらない形は必ず「proxy しない」側に落ちます。

## 測定

`submodules/svelte/packages/svelte/src/compiler/index.js` 5.56.10 と NAPI binding を、20 個の右辺の形 × `dev` × ホストで比較。判定は `$.set(v, …)` の**トップレベル引数個数**です（両コンパイラとも右辺が複数行だと呼び出しを改行するので、行一致で読むと 2 セルを誤判定します — 最初の器械がそうでした）。

```
host=module     live 40/40  differing 25
host=component  live 40/40  differing  0
```

**`compileModule` 限定**でした。AGENTS.md が #2986 / #2987 / #2988 について記録している "compileModule-only" の形と同じです。乖離 25 件は**全て同じ向き**（official=proxy / rsvelte=no-proxy）。

一致していた 6 つの括弧セル — `(1)` `('s')` `` (`t`) `` `((x) => x)` `(!a)` `(a + b)` — は `should_proxy` が **false を返す内側の形**ちょうどで、これがそのまま「`(` で始まれば proxy」という素朴な修正を殺す control になります。壊す側の control（proxy すべき値を括弧で包んだ形 — `({a:1})` `(new Map())` `(o.p)`）は 25 件の差分側に含まれているので、両方向あります。

## ラチェット担い手

`compatibility/known-failures.client-dev.json` の `svelte-lexical/demos/qalam/src/lib/notesStore.svelte.ts`。**166 行中 1 行**:

```
dev=false  両者:  $.set(notesLocation, await backend.init(), true);
dev=true   O|     $.set(notesLocation, (await $.track_reactivity_loss(backend.init()))(), true);
           R|     $.set(notesLocation, (await $.track_reactivity_loss(backend.init()))());
```

dev だけで出るのは、`transform_module_awaits_ast` が await を計装して右辺を `(await …)()` にしてから proxy 判定が走るためです。dev の 15 個の `$.set` 行のうちこの 1 行だけが違い、他 14 行（`, true` を持つものを含む）は一致します。

## 修正

1. `expression_needs_proxy` の入口で**式全体を囲む括弧対を剥がして再判定**（不動点まで、間にコメント除去）。
2. トップレベルの `,` を `SequenceExpression` として proxy（1 の副作用で `(a, o)` が `a, o` になるため必要。`should_proxy_ast` も `SequenceExpression => true` を明示的に持っています）。
3. 全体を囲まない先頭 `(` — 尾を持つ `(X)(…)` `(X).p` `(X)[0]` — を proxy。1 で全体括弧は消えているので、ここに来る先頭 `(` は必ず尾を持ちます。

`is_top_level_function_call` の呼び出し元は `expression_needs_proxy` の中の 1 箇所だけなので、巻き添えはこの述語に閉じます。

## 検証

```
cargo test -p rsvelte_core --lib + 50 の関連ターゲット
  Running 行 51 本（lib 1 + テスト 50）、passed=2204 failed=0
cargo fmt --all --check       OK（pre-commit フック）
cargo clippy --all-targets --all-features -D warnings  OK（同）
```

**陽性対照**（`expression_utils.rs` だけを `main` に戻して再実行）:

```
ABLATED: 4 passed; 2 failed
  FAILED  a_parenthesized_right_hand_side_is_decided_by_what_the_parens_hold
  FAILED  a_call_or_member_on_a_parenthesized_base_is_still_proxied
  ok      the_shapes_that_already_proxied_still_proxy
  ok      the_shapes_upstream_refuses_to_proxy_stay_unproxied
  ok      an_optional_chain_is_proxied_like_the_plain_chain_it_mirrors
  ok      a_ternary_spelled_with_a_leading_dot_number_keeps_its_value
```

新しい 2 本だけが赤くなり、既存 4 本は緑のまま。復元後 `cmp -s` でバイト一致を確認しています。

途中で `zsh` が `$ARGS` を語分割せず、`EXIT=0` かつ `0 passed; 1963 filtered out` という「何も走っていない緑」を一度出しました。`Running` 行を数えていたので捕まっています（記録済みの罠）。

## まだ測っていないこと

- **コーパス全体の影響範囲を測定済み**(下のコメント参照)。134,180 単位・4 target の 2 アーム
  スイープで `MOVED = 1`、方向は `MISMATCH -> match: 1` / `match -> MISMATCH: 0`。
  動いた 1 件は本 PR が直す `notesStore.svelte.ts [client-dev]` そのもので、同 PR で ratchet から外しています。
- 同じラチェットの `immich/web/.../ActivityViewer.svelte` は**逆向き**の過剰 proxy（762 行中 1 行、official が `, true` を出さないのに rsvelte が出す）です。括弧を含まないので本 PR では動かないはずですが、**予測であって測定ではありません**。

