### PR TITLE
perf(client-dev): the two dev-only whole-source scans, and a name allocated for every identifier

### DIFF
--- a/.changeset/dev-scan-vectorise.md
+++ b/.changeset/dev-scan-vectorise.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Vectorise the two whole-source scans dev-mode prop-mutation validation runs, and stop allocating a name for every identifier the assign-tail scanner rejects

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/assign_dev_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/assign_dev_ast.rs
@@ -393,7 +393,7 @@ struct Site {
     column: usize,
     root: String,
     path: Vec<PathElement>,
-    operator: String,
+    operator: &'static str,
     used: bool,
 }
 
@@ -427,7 +427,6 @@ impl AssignSites {
                     break;
                 }
             }
-            let root = source[start..i].to_string();
             let mut path = Vec::new();
             let mut pos = i;
             let mut malformed = false;
@@ -498,9 +497,9 @@ impl AssignSites {
             sites.push(Site {
                 line,
                 column,
-                root,
+                root: source[start..i].to_string(),
                 path,
-                operator: operator.to_string(),
+                operator,
                 used: false,
             });
             i = pos;
@@ -527,7 +526,7 @@ mod tests {
         let shapes: Vec<_> = sites
             .sites
             .iter()
-            .map(|s| (s.root.as_str(), s.path.len(), s.operator.as_str()))
+            .map(|s| (s.root.as_str(), s.path.len(), s.operator))
             .collect();
         assert_eq!(shapes, vec![("key", 1, "="), ("obj", 1, "??=")]);
         assert_eq!(sites.sites[1].path[0], PathElement::Computed);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -4288,21 +4288,28 @@ fn reactive_statement_ranges(source: &str) -> Vec<(usize, usize)> {
     while i + 1 < bytes.len() {
         match (bytes[i], bytes[i + 1]) {
             (b'/', b'/') => {
-                while i < bytes.len() && bytes[i] != b'\n' {
-                    i += 1;
-                }
+                i = memchr::memchr(b'\n', &bytes[i..]).map_or(bytes.len(), |at| i + at);
             }
             (b'/', b'*') => {
                 i += 2;
-                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                    i += 1;
-                }
+                i = match memchr::memmem::find(&bytes[i..], b"*/") {
+                    Some(at) => i + at,
+                    None => bytes.len().saturating_sub(1),
+                };
                 i += 2;
             }
             (quote @ (b'"' | b'\'' | b'`'), _) => {
                 i += 1;
-                while i < bytes.len() && bytes[i] != quote {
-                    i += if bytes[i] == b'\\' { 2 } else { 1 };
+                while i < bytes.len() {
+                    let Some(at) = memchr::memchr2(quote, b'\\', &bytes[i..]) else {
+                        i = bytes.len();
+                        break;
+                    };
+                    i += at;
+                    if bytes[i] == quote {
+                        break;
+                    }
+                    i += 2;
                 }
                 i += 1;
             }
@@ -4614,6 +4621,29 @@ impl CodeSpans {
         let mut code_from = 0usize;
         let mut i = memchr::memmem::find(bytes, b"<script").unwrap_or(0);
         while i < bytes.len() {
+            // Every state below is looking for one of at most three bytes, so
+            // step over the run in between with SIMD rather than one at a time.
+            let rest = &bytes[i..];
+            let next_interesting = match state {
+                S::Code => match (
+                    memchr::memchr3(b'/', b'\'', b'"', rest),
+                    memchr::memchr(b'`', rest),
+                ) {
+                    (Some(a), Some(b)) => Some(a.min(b)),
+                    (Some(a), None) => Some(a),
+                    (None, b) => b,
+                },
+                S::Line => memchr::memchr(b'\n', rest),
+                S::Block => memchr::memmem::find(rest, b"*/"),
+                S::Single => memchr::memchr2(b'\\', b'\'', rest),
+                S::Double => memchr::memchr2(b'\\', b'"', rest),
+                S::Template => memchr::memchr2(b'\\', b'`', rest),
+            };
+            let skip = next_interesting.unwrap_or(rest.len());
+            if skip > 0 {
+                i += skip;
+                continue;
+            }
             let was_code = state == S::Code;
             let c = bytes[i];
             let next = bytes.get(i + 1).copied();


### PR DESCRIPTION
Sampling `client` and `client-dev` over the same 3,000 corpus components (39,233
and 48,091 stack samples, dev/prod leaf total 1.200 against a measured CPU ratio
of 1.175) leaves only three symbols that appear in the dev profile and are
absent from the prod one:

| symbol | samples | share of a prod client compile |
|---|---|---|
| `PropMutationScan::new` | 135 | 1.65% |
| `assign_dev_ast::collect_assign_edits` | 127 | 1.55% |
| `utils::locate_in_source` | 42 | 0.51% |

`PropMutationScan::new` is `reactive_statement_ranges` plus `CodeSpans::scan`,
and both walk the whole `.svelte` source one byte at a time through a state
machine whose every state is waiting for one of at most three bytes — a line
comment for `\n`, a block comment for `*/`, a string for its closer or a
backslash, code for `/ ' " \``. Each of those is a `memchr` call, so the run
between two interesting bytes is now stepped over with SIMD instead of a byte
per iteration. The state machine itself is untouched: the skip lands *on* the
byte the old loop would have stopped at and falls through to the same arm, so
the spans it produces are the same spans.

`AssignSites::collect` scans every identifier in the script and builds
`source[start..i].to_string()` for each one **before** it knows whether the
identifier is an assignment target — which needs a member path and an assignment
operator after it, so the allocation is discarded for every plain variable
reference in the file. The name is now owned at the push. `Site::operator` was
also a `String` built from one of four `&'static str` literals; it holds the
literal.

Measured single-threaded over 3,000 corpus components, both arms built from one
tree (hashes differ), 12 ABBA-ordered pairs per target:

| target | mean CPU ratio base/new | pairs favouring new |
|---|---|---|
| client-dev | 1.0058 | 12/12 |
| client (control) | 0.9993 | 4/12 |

The prod arm is the negative control: every path touched here is reached only
under `dev`, so it must not move, and it does not. `sink` — the corpus-wide hash
of every generated output — is identical on both arms for both targets, and the
source-map gate, `compiler_fixtures`, `css`, `ssr`, `runtime` and the 1,962 lib
tests are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyd6xc1EN5Jt4yNWeiWtuy