### PR TITLE
perf(compiler): three scans that rebuild a two-way searcher on every step

### DIFF
--- a/.changeset/memmem-hot-scans.md
+++ b/.changeset/memmem-hot-scans.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Search the three hottest generated-code scans with `memmem` instead of rebuilding a two-way searcher per call

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -373,7 +373,9 @@ fn blank_comments_and_strings(raw: &str) -> String {
 /// - Property names like `foo.$state`
 fn has_rune_text(raw: &str, rune_name: &str) -> bool {
     let mut start = 0;
-    while let Some(pos) = raw[start..].find(rune_name) {
+    // One searcher for the whole walk: `str::find` rebuilds one per iteration.
+    let finder = memchr::memmem::Finder::new(rune_name.as_bytes());
+    while let Some(pos) = finder.find(&raw.as_bytes()[start..]) {
         let abs_pos = start + pos;
 
         // Check character before: must not be `$` or an identifier char

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -2922,10 +2922,13 @@ fn rehome_derived_jsdoc(code: &str) -> String {
     let mut rest = code.as_str();
     const PREFIX: &str = "$.derived(() => /**";
 
-    while let Some(start) = rest.find(PREFIX) {
+    // A 19-byte needle that almost never matches: `str::find` builds a two-way
+    // searcher per call, `memmem` prefilters on a rare byte pair.
+    while let Some(start) = memchr::memmem::find(rest.as_bytes(), PREFIX.as_bytes()) {
         result.push_str(&rest[..start]);
         let comment_start = start + "$.derived(() => ".len();
-        let Some(comment_end) = rest[comment_start + 3..].find("*/") else {
+        let Some(comment_end) = memchr::memmem::find(&rest.as_bytes()[comment_start + 3..], b"*/")
+        else {
             result.push_str(&rest[start..]);
             return result;
         };
@@ -2935,7 +2938,8 @@ fn rehome_derived_jsdoc(code: &str) -> String {
             result.push_str(&rest[start..]);
             return result;
         }
-        let line_start = rest[..start].rfind('\n').map_or(0, |index| index + 1);
+        let line_start =
+            memchr::memrchr(b'\n', &rest.as_bytes()[..start]).map_or(0, |index| index + 1);
         let line = &rest[line_start..start];
         let indent = &line[..line.len() - line.trim_start_matches([' ', '\t']).len()];
         result.push_str("$.derived((");

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -1796,7 +1796,10 @@ pub(super) fn transform_legacy_state_declarations<'a>(
             // inside the for-loop should be skipped - it's a loop variable, not a state variable.
             {
                 let mut search_offset = 0;
-                while let Some(rel_pos) = result[search_offset..].find(&pattern_with_init) {
+                // Hoisted: `str::find` rebuilds a two-way searcher on every step
+                // of this walk, and the needle never changes inside it.
+                let finder = memchr::memmem::Finder::new(pattern_with_init.as_bytes());
+                while let Some(rel_pos) = finder.find(&result.as_bytes()[search_offset..]) {
                     let pos = search_offset + rel_pos;
                     if !at_statement_top_level(&result, pos) {
                         search_offset = pos + pattern_with_init.len();
@@ -1954,7 +1957,10 @@ pub(super) fn transform_legacy_state_declarations<'a>(
             let pattern_no_init = format!("{} {};", keyword, var);
             {
                 let mut search_offset = 0;
-                while let Some(rel_pos) = result[search_offset..].find(&pattern_no_init) {
+                // Hoisted: `str::find` rebuilds a two-way searcher on every step
+                // of this walk, and the needle never changes inside it.
+                let finder = memchr::memmem::Finder::new(pattern_no_init.as_bytes());
+                while let Some(rel_pos) = finder.find(&result.as_bytes()[search_offset..]) {
                     let pos = search_offset + rel_pos;
                     if !at_statement_top_level(&result, pos) {
                         search_offset = pos + pattern_no_init.len();
@@ -2003,7 +2009,10 @@ pub(super) fn transform_legacy_state_declarations<'a>(
             let pattern_no_semi = format!("{} {}", keyword, var);
             {
                 let mut search_offset = 0;
-                while let Some(rel_pos) = result[search_offset..].find(&pattern_no_semi) {
+                // Hoisted: `str::find` rebuilds a two-way searcher on every step
+                // of this walk, and the needle never changes inside it.
+                let finder = memchr::memmem::Finder::new(pattern_no_semi.as_bytes());
+                while let Some(rel_pos) = finder.find(&result.as_bytes()[search_offset..]) {
                     let pos = search_offset + rel_pos;
                     if !at_statement_top_level(&result, pos) {
                         search_offset = pos + pattern_no_semi.len();


### PR DESCRIPTION
Attributing every `core::str::pattern` frame in a 39,233-sample client profile
to its nearest rsvelte caller puts 553 of 8,185 samples (6.8% of a client
compile) in string search, and three callers own a third of that:

| caller | samples | share |
|---|---|---|
| `rehome_derived_jsdoc` | 87 | 1.06% |
| `state_transforms::transform_legacy_state_declarations` | 50 | 0.61% |
| `types::has_rune_text` | 20 | 0.24% |

All three call `str::find` with a `&str` needle, which constructs a `StrSearcher`
— a two-way searcher with its own critical-factorization precompute — on **every
call**, and `StrSearcher::new` is 0.87% of the compile on its own. Two of the
three do it inside a loop whose needle never changes.

`rehome_derived_jsdoc` scans the whole generated script for the 19-byte
`$.derived(() => /**`, a needle that matches in almost no file, so the searcher
setup is most of what it costs; it now uses `memmem::find`, with `memrchr` for
the line start. `transform_legacy_state_declarations` walks three
`while let Some(_) = result[offset..].find(&pattern)` loops per declared
variable, so each hoists one `memmem::Finder`. `has_rune_text` hoists one for the
rune name it is asked about.

A byte-level match cannot land inside a multi-byte sequence, so replacing the
`&str` search with a `&[u8]` one keeps every offset on the same char boundary it
was already on.

Measured single-threaded over 3,000 corpus components, both arms built from one
tree (hashes differ), 12 ABBA-ordered pairs per target:

| target | mean CPU ratio base/new | pairs favouring new |
|---|---|---|
| client | 1.0081 | 12/12 |
| client-dev | 1.0079 | 12/12 |
| server | 1.0029 | 9/12 |

The server moves least because two of the three functions are on the client path
and only `has_rune_text` is shared, which is the direction the attribution
predicts. `sink` — the corpus-wide hash of every generated output — is identical
on both arms for all three targets, and the source-map gate,
`compiler_fixtures`, `css`, `ssr`, `runtime` and the 1,962 lib tests are
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyd6xc1EN5Jt4yNWeiWtuy