### PR TITLE
chore(lsp): the mechanism table cited two reports that do not exist

### DIFF
--- a/scripts/compat-lsp/mechanism.mjs
+++ b/scripts/compat-lsp/mechanism.mjs
@@ -29,9 +29,8 @@ export const UNCLASSIFIED = "unclassified";
 export const MECHANISMS = [
   // Architectural: rsvelte proxies tsgo, official bundles `typescript`.
   "ts-lib-copy",
-  // The four renderings a `tsgo --lsp` hover spells differently from `tsc`'s
-  // quick info, each pinned by one probe position in
-  // `upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md`.
+  // One label per rewrite in `TS_RENDER_RULES`: a rendering a `tsgo --lsp`
+  // hover spells differently from `tsc`'s quick info.
   "ts-render-union-order",
   "ts-render-quote-style",
   "ts-render-local-modifier",
@@ -50,7 +49,7 @@ export const MECHANISMS = [
   "ts-render-multiple",
   // Not a rendering difference at all: the same declaration, typed.
   "ts-type-any",
-  // The residual: a hover text none of those four rules explains. It is NOT
+  // The residual: a hover text no rewrite in `TS_RENDER_RULES` explains. It is NOT
   // attributed to tsgo -- the same probe shows `tsc` and `tsgo` agreeing on the
   // shapes this bucket holds, so which side is wrong is unmeasured.
   "ts-render",
@@ -217,10 +216,10 @@ function declarationHead(text) {
   return { kind: "?", name: first.slice(0, 32) };
 }
 
-// The four `tsgo` renderings `upstream_issues/tsgo-lsp-hover-renders-four-
-// things-differently-from-tsc.md` reproduces, each written as the rewrite that
-// makes the two texts equal. The rewrite decides the LABEL only -- it never
-// decides whether the entry diverges -- so it cannot hide a difference.
+// Each `tsgo` rendering that differs from `tsc`'s quick info, written as the
+// rewrite that makes the two texts equal. The rewrite decides the LABEL only --
+// it never decides whether the entry diverges -- so it cannot hide a
+// difference.
 const sortUnions = (text) =>
   text.replace(/(?:"[^"]*"|'[^']*'|[\w.$<>[\]]+)(?:\s*\|\s*(?:"[^"]*"|'[^']*'|[\w.$<>[\]]+))+/g, (run) =>
     run
@@ -339,7 +338,7 @@ function classifyHover(official, rsvelte) {
   }
   if (typeof left !== "string" || typeof right !== "string") return UNCLASSIFIED;
   // Ahead of the head comparison, because `(local function) f()` vs `function
-  // f()` reads as a KIND disagreement and is one of the four renderer rules.
+  // f()` reads as a KIND disagreement and is one of the `TS_RENDER_RULES`.
   // Each rule demands full equality after its rewrite, so a genuinely different
   // symbol cannot match one.
   const rendered = classifyTsRender(left, right);


### PR DESCRIPTION
## What

`scripts/compat-lsp/mechanism.mjs` attributed nine `ts-render*` labels to two `upstream_issues/` reports that were **not in the tree**:

```
upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md   ABSENT
upstream_issues/tsgo-lsp-hover-renders-four-things-differently-from-tsc.md    ABSENT
（positive control）
upstream_issues/tsgo-lsp-completion-item-omits-the-typescript-kind.md         PRESENT
```

> **Correction, recorded after this PR was opened.** The reports were not fabricated — they had been **written and never committed**, and #4265 lands them with both arms' real output. The measurement above was true of the tree and its implied cause was not. What that changes and does not change is at the bottom.

`AGENTS.md` records that *a live but wrong citation never 404s*. This is one step worse: the path 404s and nothing notices, because `lsp-mechanisms-check.mjs` reads only the sidecar. Measured there:

```
ts-render-union-order / quote-style / local-modifier / jsdoc-tag / import-line /
overload-count / declaration-order / multiple / ts-render   → terminal: null (all nine)
142 declared labels, 0 with a terminal
```

So the prose made nine label slots read as attributed while the machine-readable state has no attribution at all.

## Why this still deletes the citations rather than restoring them

Now that the reports exist, the naive repair is to put the paths back. That is the wrong direction and this PR should merge before #4265:

- **A prose path is not an attribution.** `lsp-mechanisms-check.mjs` reads `compatibility/lsp-mechanisms.json` and nothing else, so a citation in a comment cannot make a label attributed no matter which files exist. Restoring the paths restores the same unchecked claim.
- The attribution belongs in the sidecar's `terminal`, where the checker already enforces that the named file exists — machine-readable, and it fails when the target moves.
- Restoring these lines would conflict with #4265 on the same rows.

## The hole that hid it

`check-upstream-issues.mjs` maintains a bijection between the index and the `upstream_issues/` directory. It does not read citations from `scripts/`. **A reference from outside the directory the checker owns is unchecked in both directions** — an absent target is not reported, and neither is an uncommitted report nothing points at. That is the reusable finding, and it is unchanged by the reports turning up.

## The counts

The same comments said "four" in four places. `TS_RENDER_RULES` holds **seven** entries and `MECHANISMS` declares **seven** `ts-render-*` labels. Rather than correct the number, the comments now name `TS_RENDER_RULES` — a count that cannot be written cannot go stale, which is the repair `AGENTS.md` prescribes over promising to re-derive it.

## Scope

**Comments only.** `MECHANISMS` and `TS_RENDER_RULES` are untouched, so no ratchet key can move.

```
git diff -U0 | grep -vE '^[+-]\s*//' | wc -l   →  0
node --check scripts/compat-lsp/mechanism.mjs  →  PASS
grep -n 'four\|upstream_issues' …/mechanism.mjs →  0 lines
```

`scripts/ci/lsp-mechanisms-check.mjs` exits 1 before and after this change, for a reason this PR does not touch: `23742 ratchet entries, 0 with a mechanism set`. The sidecar is only fillable from a complete 17-artifact `lsp-corpus` run.

## What the correction changes

| claim in the original body | status |
|---|---|
| the two paths are absent from the tree | **holds** — measured, with a positive control |
| a citation nothing reads cannot make a label attributed | **holds** — the sidecar is the only reader |
| the nine labels have `terminal: null` | **holds** |
| deleting the citations is the right repair | **holds**, and more so: the target is the sidecar, not prose |
| *implied:* the reports were never written | **wrong** — written, uncommitted, landing in #4265 |

The last row is the one to remember. "Absent from the tree" and "does not exist" are different statements, and I reported the first and let the second be inferred.
