### PR TITLE
perf(compiler): the other 1,813 JSON field reads, 1.2-1.5% on every surface

### DIFF
--- a/.changeset/json-field-wide.md
+++ b/.changeset/json-field-wide.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Read every compiler-side JSON AST field by linear scan, a further 1.2-1.5% on each surface

--- a/crates/rsvelte_core/src/ast/js.rs
+++ b/crates/rsvelte_core/src/ast/js.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use super::arena::{IdRange, JsNodeId};
 use super::span::SourceLocation;
 use super::typed_expr::{JsNode, Loc, SourcePosition};
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Wrapper for a typed `JsNode` with lazy JSON cache.
 /// The cache is only populated when `as_json()` is first called (during Phase 2/3),
@@ -673,7 +674,7 @@ impl<'de> Deserialize<'de> for Expression<'_> {
         // must return a deserialize Error here rather than letting
         // `JsNode::from_value` degrade a typeless object to `Null`.
         let is_node = value
-            .get("type")
+            .field("type")
             .and_then(|t| t.as_str())
             .is_some_and(|t| !t.is_empty());
         if !is_node {

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -4,6 +4,7 @@ use serde::ser::{SerializeMap, Serializer};
 use serde_json::Value;
 
 use super::arena::{IdRange, JsNodeId, ParseArena};
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SourcePosition {
@@ -991,10 +992,10 @@ fn opaque_ts_with_comments(value: &Value) -> Value {
                 return;
             };
             let key = obj
-                .get("type")
+                .field("type")
                 .and_then(|v| v.as_str())
-                .zip(obj.get("start").and_then(Value::as_u64))
-                .zip(obj.get("end").and_then(Value::as_u64));
+                .zip(obj.field("start").and_then(Value::as_u64))
+                .zip(obj.field("end").and_then(Value::as_u64));
             if let Some(((node_type, start), end)) = key
                 && let Some((leading, trailing)) =
                     arena.node_comments(node_type, start as u32, end as u32)
@@ -2590,24 +2591,24 @@ fn member_modifiers_from_value(obj: &serde_json::Map<String, Value>) -> TsMember
         readonly: get_bool(obj, "readonly"),
         r#override: get_bool(obj, "override"),
         accessibility: obj
-            .get("accessibility")
+            .field("accessibility")
             .and_then(serde_json::Value::as_str)
             .and_then(TsAccessibility::from_keyword),
     }
 }
 
 fn convert_loc(obj: &serde_json::Map<String, Value>) -> Option<Box<Loc>> {
-    let loc_val = obj.get("loc")?;
+    let loc_val = obj.field("loc")?;
     let loc_obj = loc_val.as_object()?;
-    let start_obj = loc_obj.get("start")?.as_object()?;
-    let end_obj = loc_obj.get("end")?.as_object()?;
+    let start_obj = loc_obj.field("start")?.as_object()?;
+    let end_obj = loc_obj.field("end")?.as_object()?;
 
     Some(Box::new(Loc {
         start: SourcePosition {
             line: get_u32(start_obj, "line"),
             column: get_u32(start_obj, "column"),
             character: start_obj
-                .get("character")
+                .field("character")
                 .and_then(serde_json::Value::as_u64)
                 .and_then(|n| u32::try_from(n).ok()),
         },
@@ -2615,7 +2616,7 @@ fn convert_loc(obj: &serde_json::Map<String, Value>) -> Option<Box<Loc>> {
             line: get_u32(end_obj, "line"),
             column: get_u32(end_obj, "column"),
             character: end_obj
-                .get("character")
+                .field("character")
                 .and_then(serde_json::Value::as_u64)
                 .and_then(|n| u32::try_from(n).ok()),
         },
@@ -2720,7 +2721,7 @@ impl JsNode {
                 // ESTree object. Return before the ordinary typed conversion
                 // removes `loc` and child fields from the owned map.
                 let opaque_type = owned_obj
-                    .get("type")
+                    .field("type")
                     .and_then(Value::as_str)
                     .map(str::to_owned);
                 if matches!(
@@ -2737,11 +2738,11 @@ impl JsNode {
                     )
                 ) {
                     let start = owned_obj
-                        .get("start")
+                        .field("start")
                         .and_then(Value::as_u64)
                         .unwrap_or_default() as u32;
                     let end = owned_obj
-                        .get("end")
+                        .field("end")
                         .and_then(Value::as_u64)
                         .unwrap_or_default() as u32;
                     let value = Box::new(Value::Object(owned_obj));
@@ -2766,7 +2767,7 @@ impl JsNode {
                 }
 
                 let obj = &mut owned_obj;
-                let type_str = obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                let type_str = obj.field("type").and_then(|t| t.as_str()).unwrap_or("");
                 let start = get_u32(obj, "start");
                 let end = get_u32(obj, "end");
                 let loc = convert_loc(obj);
@@ -2778,10 +2779,10 @@ impl JsNode {
                 // read, so the compile path (capture off) pays almost nothing.
                 if type_str != "Program" && crate::ast::arena::comment_capture_active() {
                     let leading = obj
-                        .get("leadingComments")
+                        .field("leadingComments")
                         .and_then(|v| v.as_array().cloned());
                     let trailing = obj
-                        .get("trailingComments")
+                        .field("trailingComments")
                         .and_then(|v| v.as_array().cloned());
                     if leading.is_some() || trailing.is_some() {
                         with_deser_arena(|a| {
@@ -2797,7 +2798,7 @@ impl JsNode {
                         loc,
                         name: get_str(obj, "name"),
                         optional: get_bool(obj, "optional"),
-                        type_annotation: obj.get("typeAnnotation").cloned().map(Box::new),
+                        type_annotation: obj.field("typeAnnotation").cloned().map(Box::new),
                     },
                     "PrivateIdentifier" => Self::PrivateIdentifier {
                         start,
@@ -2806,17 +2807,17 @@ impl JsNode {
                         name: get_str(obj, "name"),
                     },
                     "Literal" => {
-                        let regex = obj.get("regex").and_then(|r| r.as_object()).map(|r| {
+                        let regex = obj.field("regex").and_then(|r| r.as_object()).map(|r| {
                             Box::new(RegexValue {
                                 pattern: get_str(r, "pattern"),
                                 flags: get_str(r, "flags"),
                             })
                         });
-                        let bigint = obj.get("bigint").and_then(|b| b.as_str());
+                        let bigint = obj.field("bigint").and_then(|b| b.as_str());
                         let lit_value = if let Some(digits) = bigint {
                             LiteralValue::BigInt(digits.into())
                         } else {
-                            match obj.get("value") {
+                            match obj.field("value") {
                                 Some(Value::String(s)) => LiteralValue::String(s.as_str().into()),
                                 Some(Value::Number(n)) => {
                                     LiteralValue::Number(n.as_f64().unwrap_or(0.0))
@@ -2904,7 +2905,7 @@ impl JsNode {
                         generator: get_bool(obj, "generator"),
                         r#async: get_bool(obj, "async"),
                         expression: get_bool(obj, "expression"),
-                        type_parameters: obj.get("typeParameters").cloned().map(Box::new),
+                        type_parameters: obj.field("typeParameters").cloned().map(Box::new),
                         type_parameters_after_body: false,
                     },
                     "ClassExpression" => Self::ClassExpression {
@@ -2925,7 +2926,7 @@ impl JsNode {
                         expression: get_bool(obj, "expression"),
                         generator: get_bool(obj, "generator"),
                         r#async: get_bool(obj, "async"),
-                        type_parameters: obj.get("typeParameters").cloned().map(Box::new),
+                        type_parameters: obj.field("typeParameters").cloned().map(Box::new),
                     },
                     "AssignmentExpression" => Self::AssignmentExpression {
                         start,
@@ -2976,11 +2977,11 @@ impl JsNode {
                         quasi: convert_child(obj, "quasi"),
                     },
                     "TemplateElement" => {
-                        let value_obj = obj.get("value").and_then(|v| v.as_object());
+                        let value_obj = obj.field("value").and_then(|v| v.as_object());
                         let tev = TemplateElementValue {
                             raw: value_obj.map(|v| get_str(v, "raw")).unwrap_or_default(),
                             cooked: value_obj.and_then(|v| {
-                                v.get("cooked")
+                                v.field("cooked")
                                     .and_then(|c| c.as_str())
                                     .map(std::convert::Into::into)
                             }),
@@ -3063,14 +3064,14 @@ impl JsNode {
                         end,
                         loc,
                         properties: convert_array(obj, "properties"),
-                        type_annotation: obj.get("typeAnnotation").cloned().map(Box::new),
+                        type_annotation: obj.field("typeAnnotation").cloned().map(Box::new),
                     },
                     "ArrayPattern" => Self::ArrayPattern {
                         start,
                         end,
                         loc,
                         elements: convert_nullable_array(obj, "elements"),
-                        type_annotation: obj.get("typeAnnotation").cloned().map(Box::new),
+                        type_annotation: obj.field("typeAnnotation").cloned().map(Box::new),
                     },
                     "AssignmentPattern" => Self::AssignmentPattern {
                         start,
@@ -3104,10 +3105,10 @@ impl JsNode {
                         source_type: get_str(obj, "sourceType"),
                         metadata: Box::new(ProgramMetadata {
                             leading_comments: obj
-                                .get("leadingComments")
+                                .field("leadingComments")
                                 .and_then(|v| v.as_array().cloned()),
                             trailing_comments: obj
-                                .get("trailingComments")
+                                .field("trailingComments")
                                 .and_then(|v| v.as_array().cloned()),
                             // Reconstructed-from-Value programs carry no analyze-only
                             // svelte-ignore map; comment-bearing nodes in that path keep
@@ -3152,7 +3153,7 @@ impl JsNode {
                         generator: get_bool(obj, "generator"),
                         r#async: get_bool(obj, "async"),
                         expression: get_bool(obj, "expression"),
-                        type_parameters: obj.get("typeParameters").cloned().map(Box::new),
+                        type_parameters: obj.field("typeParameters").cloned().map(Box::new),
                     },
                     "ClassDeclaration" => Self::ClassDeclaration {
                         start,
@@ -3283,7 +3284,7 @@ impl JsNode {
                         specifiers: convert_array(obj, "specifiers"),
                         source: convert_child(obj, "source"),
                         import_kind: obj
-                            .get("importKind")
+                            .field("importKind")
                             .and_then(|v| v.as_str())
                             .map(std::convert::Into::into),
                         attributes: convert_array(obj, "attributes"),
@@ -3295,7 +3296,7 @@ impl JsNode {
                         imported: convert_child(obj, "imported"),
                         local: convert_child(obj, "local"),
                         import_kind: obj
-                            .get("importKind")
+                            .field("importKind")
                             .and_then(|v| v.as_str())
                             .map(std::convert::Into::into),
                     },
@@ -3319,7 +3320,7 @@ impl JsNode {
                         specifiers: convert_array(obj, "specifiers"),
                         source: convert_optional_child(obj, "source"),
                         export_kind: obj
-                            .get("exportKind")
+                            .field("exportKind")
                             .and_then(|v| v.as_str())
                             .map(std::convert::Into::into),
                         attributes: convert_array(obj, "attributes"),
@@ -3331,7 +3332,7 @@ impl JsNode {
                         exported: convert_optional_child(obj, "exported"),
                         source: convert_child(obj, "source"),
                         export_kind: obj
-                            .get("exportKind")
+                            .field("exportKind")
                             .and_then(|v| v.as_str())
                             .map(std::convert::Into::into),
                         attributes: convert_array(obj, "attributes"),
@@ -3342,7 +3343,7 @@ impl JsNode {
                         loc,
                         declaration: convert_child(obj, "declaration"),
                         export_kind: obj
-                            .get("exportKind")
+                            .field("exportKind")
                             .and_then(|v| v.as_str())
                             .map(std::convert::Into::into),
                     },
@@ -3353,7 +3354,7 @@ impl JsNode {
                         local: convert_child(obj, "local"),
                         exported: convert_child(obj, "exported"),
                         export_kind: obj
-                            .get("exportKind")
+                            .field("exportKind")
                             .and_then(|v| v.as_str())
                             .map(std::convert::Into::into),
                     },
@@ -3410,7 +3411,7 @@ impl JsNode {
                         loc,
                         expression: convert_child(obj, "expression"),
                         type_annotation: Box::new(
-                            obj.get("typeAnnotation").cloned().unwrap_or(Value::Null),
+                            obj.field("typeAnnotation").cloned().unwrap_or(Value::Null),
                         ),
                     },
                     "TSSatisfiesExpression" => Self::TSSatisfiesExpression {
@@ -3419,7 +3420,7 @@ impl JsNode {
                         loc,
                         expression: convert_child(obj, "expression"),
                         type_annotation: Box::new(
-                            obj.get("typeAnnotation").cloned().unwrap_or(Value::Null),
+                            obj.field("typeAnnotation").cloned().unwrap_or(Value::Null),
                         ),
                     },
                     "TSNonNullExpression" => Self::TSNonNullExpression {
@@ -3434,7 +3435,7 @@ impl JsNode {
                         loc,
                         expression: convert_child(obj, "expression"),
                         type_annotation: Box::new(
-                            obj.get("typeAnnotation").cloned().unwrap_or(Value::Null),
+                            obj.field("typeAnnotation").cloned().unwrap_or(Value::Null),
                         ),
                     },
                     "TSInstantiationExpression" => Self::TSInstantiationExpression {
@@ -3443,7 +3444,7 @@ impl JsNode {
                         loc,
                         expression: convert_child(obj, "expression"),
                         type_arguments: Box::new(
-                            obj.get("typeArguments").cloned().unwrap_or(Value::Null),
+                            obj.field("typeArguments").cloned().unwrap_or(Value::Null),
                         ),
                     },
                     "Line" | "Block" => Self::Comment {

--- a/crates/rsvelte_core/src/compiler/legacy.rs
+++ b/crates/rsvelte_core/src/compiler/legacy.rs
@@ -31,6 +31,7 @@ use crate::ast::{
     StyleDirective, SvelteComponentElement, SvelteDynamicElement, SvelteElement, TemplateNode,
     Text, TitleElement, TransitionDirective, UseDirective,
 };
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Insert ESTree fields into an existing `Map`, in written order.
 ///
@@ -273,7 +274,7 @@ fn add_binding_locs(value: &mut Value, positions: &Utf8ToUtf16, top_level: bool)
     };
 
     let node_type = object
-        .get("type")
+        .field("type")
         .and_then(Value::as_str)
         .unwrap_or("")
         .to_string();
@@ -289,7 +290,7 @@ fn add_binding_locs(value: &mut Value, positions: &Utf8ToUtf16, top_level: bool)
         "RestElement" => add_binding_child(object, "argument", positions),
         "Property" => {
             if object
-                .get("computed")
+                .field("computed")
                 .and_then(Value::as_bool)
                 .unwrap_or(false)
             {
@@ -315,9 +316,9 @@ fn add_binding_locs(value: &mut Value, positions: &Utf8ToUtf16, top_level: bool)
 
     if !object.contains_key("loc")
         && let Some((start, end)) = object
-            .get("start")
+            .field("start")
             .and_then(Value::as_u64)
-            .zip(object.get("end").and_then(Value::as_u64))
+            .zip(object.field("end").and_then(Value::as_u64))
     {
         let loc = if top_level && node_type == "Identifier" {
             estree_loc_with_character(start as usize, end as usize, positions)
@@ -353,9 +354,9 @@ fn add_loc_to_estree_object(object: &mut Map<String, Value>, positions: &Utf8ToU
         return;
     }
     if let Some((start, end)) = object
-        .get("start")
+        .field("start")
         .and_then(Value::as_u64)
-        .zip(object.get("end").and_then(Value::as_u64))
+        .zip(object.field("end").and_then(Value::as_u64))
     {
         insert_loc_after_end(object, estree_loc(start as usize, end as usize, positions));
     }
@@ -439,9 +440,9 @@ fn add_estree_locs(value: &mut Value, positions: &Utf8ToUtf16) {
             }
 
             let span = object
-                .get("start")
+                .field("start")
                 .and_then(Value::as_u64)
-                .zip(object.get("end").and_then(Value::as_u64));
+                .zip(object.field("end").and_then(Value::as_u64));
             if object.contains_key("type")
                 && !object.contains_key("loc")
                 && let Some((start, end)) = span
@@ -466,17 +467,17 @@ fn add_estree_locs(value: &mut Value, positions: &Utf8ToUtf16) {
 pub fn convert_positions_to_utf16(value: &mut Value, pos_conv: &Utf8ToUtf16) {
     match value {
         Value::Object(map) => {
-            if let Some(Value::Number(n)) = map.get("start")
+            if let Some(Value::Number(n)) = map.field("start")
                 && let Some(pos) = n.as_u64()
             {
                 map.insert("start".to_string(), json!(pos_conv.convert(pos as usize)));
             }
-            if let Some(Value::Number(n)) = map.get("end")
+            if let Some(Value::Number(n)) = map.field("end")
                 && let Some(pos) = n.as_u64()
             {
                 map.insert("end".to_string(), json!(pos_conv.convert(pos as usize)));
             }
-            if let Some(Value::Number(n)) = map.get("character")
+            if let Some(Value::Number(n)) = map.field("character")
                 && let Some(pos) = n.as_u64()
             {
                 map.insert(
@@ -489,7 +490,7 @@ pub fn convert_positions_to_utf16(value: &mut Value, pos_conv: &Utf8ToUtf16) {
             if map.contains_key("line")
                 && map.contains_key("column")
                 && let (Some(Value::Number(line)), Some(Value::Number(col))) =
-                    (map.get("line"), map.get("column"))
+                    (map.field("line"), map.field("column"))
                 && let (Some(line_num), Some(col_num)) = (line.as_u64(), col.as_u64())
             {
                 let new_col = pos_conv.convert_column(line_num as usize, col_num as usize);
@@ -676,7 +677,7 @@ fn convert_css_node(node: &mut Value) {
         map.remove("metadata");
 
         // Convert ComplexSelector to Selector
-        if map.get("type") == Some(&json!("ComplexSelector")) {
+        if map.field("type") == Some(&json!("ComplexSelector")) {
             map.insert("type".to_string(), json!("Selector"));
 
             // Flatten children: extract combinator and selectors from each RelativeSelector
@@ -685,13 +686,13 @@ fn convert_css_node(node: &mut Value) {
                 for rs in relative_selectors {
                     if let Value::Object(rs_map) = rs {
                         // Add combinator if present
-                        if let Some(combinator) = rs_map.get("combinator")
+                        if let Some(combinator) = rs_map.field("combinator")
                             && !combinator.is_null()
                         {
                             new_children.push(combinator.clone());
                         }
                         // Add selectors
-                        if let Some(Value::Array(selectors)) = rs_map.get("selectors") {
+                        if let Some(Value::Array(selectors)) = rs_map.field("selectors") {
                             for selector in selectors {
                                 new_children.push(selector.clone());
                             }
@@ -847,11 +848,11 @@ fn convert_const_tag(const_tag: &ConstTag, positions: &Utf8ToUtf16) -> Value {
     let declaration = declaration_json(&const_tag.declaration, positions);
 
     // Extract the declarator from the VariableDeclaration
-    if let Some(declarations) = declaration.get("declarations").and_then(|d| d.as_array())
+    if let Some(declarations) = declaration.field("declarations").and_then(|d| d.as_array())
         && let Some(first_decl) = declarations.first()
     {
-        let id = first_decl.get("id").cloned().unwrap_or(json!(null));
-        let init = first_decl.get("init").cloned().unwrap_or(json!(null));
+        let id = first_decl.field("id").cloned().unwrap_or(json!(null));
+        let init = first_decl.field("init").cloned().unwrap_or(json!(null));
 
         // Remove typeAnnotation from id
         let mut id = id;
@@ -861,10 +862,13 @@ fn convert_const_tag(const_tag: &ConstTag, positions: &Utf8ToUtf16) -> Value {
 
         // Calculate start position (after 'const ')
         let decl_start = declaration
-            .get("start")
+            .field("start")
             .and_then(|s| s.as_u64())
             .unwrap_or(0);
-        let decl_end = declaration.get("end").and_then(|s| s.as_u64()).unwrap_or(0);
+        let decl_end = declaration
+            .field("end")
+            .and_then(|s| s.as_u64())
+            .unwrap_or(0);
 
         let mut expression = json!({
             "type": "AssignmentExpression",
@@ -1072,7 +1076,7 @@ fn convert_await_block(source: &str, await_block: &AwaitBlock, positions: &Utf8T
     // Get expression end position
     let expression = expression_json(&await_block.expression, positions);
     let expr_end = expression
-        .get("end")
+        .field("end")
         .and_then(|e| e.as_u64())
         .unwrap_or(await_block.start as u64) as usize;
 
@@ -1108,7 +1112,7 @@ fn convert_await_block(source: &str, await_block: &AwaitBlock, positions: &Utf8T
     }
 
     let pending_end = pending_block
-        .get("end")
+        .field("end")
         .and_then(|e| e.as_u64())
         .map(|e| e as usize);
 
@@ -1140,7 +1144,7 @@ fn convert_await_block(source: &str, await_block: &AwaitBlock, positions: &Utf8T
     }
 
     let then_end = then_block
-        .get("end")
+        .field("end")
         .and_then(|e| e.as_u64())
         .map(|e| e as usize);
 
@@ -1393,13 +1397,13 @@ fn convert_svelte_element(
     // Check if tag is a literal string and source doesn't have braces
     let tag_expression = expression_json(&element.tag, positions);
     let tag_start = tag_expression
-        .get("start")
+        .field("start")
         .and_then(|s| s.as_u64())
         .unwrap_or(0) as usize;
     let has_braces = tag_start > 0 && source.as_bytes().get(tag_start - 1) == Some(&b'{');
 
     let tag = if !has_braces {
-        if let Some(value) = tag_expression.get("value").and_then(|v| v.as_str()) {
+        if let Some(value) = tag_expression.field("value").and_then(|v| v.as_str()) {
             json!(value)
         } else {
             tag_expression

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -37,6 +37,7 @@ use crate::ast::typed_expr::{
     alloc_deser_children, alloc_deser_node, child_node_from_value,
 };
 use crate::compiler::phases::phase1_parse::utils::find_matching_bracket;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use crate::compiler::utils::is_escaped;
 use compact_str::CompactString;
 
@@ -2429,13 +2430,13 @@ fn parse_expression_with_typescript<'a>(
 
                 let json_val = expr.as_json();
                 let root_type = json_val
-                    .get("type")
+                    .field("type")
                     .and_then(Value::as_str)
                     .map(str::to_owned);
                 let root_span = json_val
-                    .get("start")
+                    .field("start")
                     .and_then(Value::as_u64)
-                    .zip(json_val.get("end").and_then(Value::as_u64))
+                    .zip(json_val.field("end").and_then(Value::as_u64))
                     .map(|(s, e)| (s as u32, e as u32));
                 let mut ignore_comment_map: Vec<(u32, Vec<CompactString>)> = Vec::new();
                 let mut attacher = CommentAttacher {
@@ -2820,7 +2821,7 @@ fn convert_formal_parameter_with_remap<'a>(
 
     if let Some(obj) = val.as_object_mut() {
         // Fix start position
-        if let Some(start_val) = obj.get("start").and_then(|s| s.as_u64()) {
+        if let Some(start_val) = obj.field("start").and_then(|s| s.as_u64()) {
             // start_val = base_offset - 1 + oxc_start = base_offset + (oxc_start - 1)
             // = base_offset + cleaned_pos
             let cleaned_pos = start_val as usize - base_offset;
@@ -2832,7 +2833,7 @@ fn convert_formal_parameter_with_remap<'a>(
         }
 
         // Fix end position
-        if let Some(end_val) = obj.get("end").and_then(|e| e.as_u64()) {
+        if let Some(end_val) = obj.field("end").and_then(|e| e.as_u64()) {
             let cleaned_pos = end_val as usize - base_offset;
             let original_pos = base_offset + stripped.map_to_original(cleaned_pos);
             obj.set_field(
@@ -2843,11 +2844,11 @@ fn convert_formal_parameter_with_remap<'a>(
 
         // Also fix the "right" field's span if this is an AssignmentPattern
         // (the default value expression span)
-        if obj.get("type").and_then(|t| t.as_str()) == Some("AssignmentPattern")
+        if obj.field("type").and_then(|t| t.as_str()) == Some("AssignmentPattern")
             && let Some(right) = obj.get_mut("right")
             && let Some(right_obj) = right.as_object_mut()
         {
-            if let Some(start_val) = right_obj.get("start").and_then(|s| s.as_u64()) {
+            if let Some(start_val) = right_obj.field("start").and_then(|s| s.as_u64()) {
                 let cleaned_pos = start_val as usize - base_offset;
                 let original_pos = base_offset + stripped.map_to_original(cleaned_pos);
                 right_obj.set_field(
@@ -2855,7 +2856,7 @@ fn convert_formal_parameter_with_remap<'a>(
                     serde_json::Value::Number((original_pos as i64).into()),
                 );
             }
-            if let Some(end_val) = right_obj.get("end").and_then(|e| e.as_u64()) {
+            if let Some(end_val) = right_obj.field("end").and_then(|e| e.as_u64()) {
                 let cleaned_pos = end_val as usize - base_offset;
                 let original_pos = base_offset + stripped.map_to_original(cleaned_pos);
                 right_obj.set_field(
@@ -8888,9 +8889,12 @@ impl CommentAttacher<'_> {
         let Some(obj) = node.as_object() else {
             return;
         };
-        let start = obj.get("start").and_then(|v| v.as_u64()).map(|v| v as u32);
-        let end = obj.get("end").and_then(|v| v.as_u64()).map(|v| v as u32);
-        let node_type = obj.get("type").and_then(|t| t.as_str());
+        let start = obj
+            .field("start")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as u32);
+        let end = obj.field("end").and_then(|v| v.as_u64()).map(|v| v as u32);
+        let node_type = obj.field("type").and_then(|t| t.as_str());
 
         if let Some(start) = start {
             while self
@@ -9051,7 +9055,7 @@ impl CommentAttacher<'_> {
 fn is_estree_node(value: &Value) -> bool {
     value
         .as_object()
-        .and_then(|obj| obj.get("type"))
+        .and_then(|obj| obj.field("type"))
         .is_some_and(|t| t.is_string())
 }
 
@@ -11055,7 +11059,7 @@ fn convert_variable_declarator_for_program(
                     id_obj.set_field("typeAnnotation", ts_value);
                     id_obj.set_field("end", Value::Number((ts_end as i64).into()));
                     if let Some(loc) = create_loc(
-                        id_obj.get("start").and_then(|v| v.as_i64()).unwrap_or(0) as usize,
+                        id_obj.field("start").and_then(|v| v.as_i64()).unwrap_or(0) as usize,
                         ts_end,
                         line_offsets,
                     ) {

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/options.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/options.rs
@@ -25,6 +25,7 @@ use crate::error::{ParseError, ParseResult};
 use serde_json::Value as JsonValue;
 
 use super::super::parser::Parser;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 // Upstream emits one message per code regardless of which check failed.
 const INVALID_TAGNAME: &str = "Tag name must be lowercase and hyphenated";
@@ -234,10 +235,10 @@ fn get_static_value(attr: &crate::ast::template::AttributeNode<'_>) -> Option<St
 /// `get_static_value` reads through (a template literal deliberately is not one).
 fn literal_string(expression: &Expression<'_>) -> Option<String> {
     let json = expression.as_json();
-    if json.get("type") != Some(&JsonValue::String("Literal".to_string())) {
+    if json.field("type") != Some(&JsonValue::String("Literal".to_string())) {
         return None;
     }
-    json.get("value")?.as_str().map(str::to_string)
+    json.field("value")?.as_str().map(str::to_string)
 }
 
 /// Upstream's `get_boolean_value`.
@@ -264,10 +265,10 @@ fn get_boolean_value(attr: &crate::ast::template::AttributeNode<'_>) -> ParseRes
 
 fn literal_bool(expression: &Expression<'_>) -> Option<bool> {
     let json = expression.as_json();
-    if json.get("type") != Some(&JsonValue::String("Literal".to_string())) {
+    if json.field("type") != Some(&JsonValue::String("Literal".to_string())) {
         return None;
     }
-    json.get("value")?.as_bool()
+    json.field("value")?.as_bool()
 }
 
 /// Parse the customElement option.
@@ -308,13 +309,13 @@ fn parse_custom_element_option<'a>(
     };
 
     let json = expression.as_json();
-    let ty = json.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    let ty = json.field("type").and_then(|t| t.as_str()).unwrap_or("");
 
     if ty != "ObjectExpression" {
         // Before Svelte 4 it was necessary to explicitly set customElement to
         // null or else you'd get a warning; upstream still accepts it, and
         // returning `None` keeps the custom-element pipeline off (H-115).
-        if ty == "Literal" && json.get("value") == Some(&JsonValue::Null) {
+        if ty == "Literal" && json.field("value") == Some(&JsonValue::Null) {
             return Ok(None);
         }
         return Err(invalid());
@@ -335,7 +336,7 @@ fn parse_custom_element_object<'a>(
     let mut extend = None;
 
     let empty = Vec::new();
-    let properties = match obj_expr.get("properties") {
+    let properties = match obj_expr.field("properties") {
         Some(JsonValue::Array(properties)) => properties,
         _ => &empty,
     };
@@ -349,13 +350,15 @@ fn parse_custom_element_object<'a>(
             ));
         }
         let key = property_key(prop).unwrap_or_default();
-        let value = prop.get("value");
+        let value = prop.field("value");
 
         match key {
             "tag" => {
                 // Upstream reads `tag[1]?.value`, so anything that is not a
                 // string literal reaches `validate_tag` as a non-string.
-                let tag_value = value.and_then(|v| v.get("value")).and_then(|v| v.as_str());
+                let tag_value = value
+                    .and_then(|v| v.field("value"))
+                    .and_then(|v| v.as_str());
                 validate_tag_name(tag_value, attr)?;
                 tag = tag_value.map(|t| t.to_string().into());
             }
@@ -364,13 +367,16 @@ fn parse_custom_element_object<'a>(
                 // be "open"/"none"; an ObjectExpression (ShadowRootInit) is
                 // passed through verbatim.
                 let value_type = value
-                    .and_then(|v| v.get("type"))
+                    .and_then(|v| v.field("type"))
                     .and_then(|t| t.as_str())
                     .unwrap_or("");
                 if value_type == "ObjectExpression" {
                     shadow_object = value.cloned();
                 } else {
-                    match value.and_then(|v| v.get("value")).and_then(|v| v.as_str()) {
+                    match value
+                        .and_then(|v| v.field("value"))
+                        .and_then(|v| v.as_str())
+                    {
                         Some("open") if value_type == "Literal" => shadow = Some(ShadowMode::Open),
                         Some("none") if value_type == "Literal" => shadow = Some(ShadowMode::None),
                         _ => {
@@ -428,7 +434,8 @@ fn validate_custom_element_props(
         if !is_plain_property(entry) {
             return Err(invalid());
         }
-        let Some(JsonValue::Array(fields)) = entry.get("value").and_then(object_properties) else {
+        let Some(JsonValue::Array(fields)) = entry.field("value").and_then(object_properties)
+        else {
             return Err(invalid());
         };
 
@@ -436,12 +443,12 @@ fn validate_custom_element_props(
             if !is_plain_property(field) {
                 return Err(invalid());
             }
-            let value = field.get("value");
-            if value.and_then(|v| v.get("type")).and_then(|t| t.as_str()) != Some("Literal") {
+            let value = field.field("value");
+            if value.and_then(|v| v.field("type")).and_then(|t| t.as_str()) != Some("Literal") {
                 return Err(invalid());
             }
             let value = value
-                .and_then(|v| v.get("value"))
+                .and_then(|v| v.field("value"))
                 .unwrap_or(&JsonValue::Null);
 
             let ok = match property_key(field).unwrap_or_default() {
@@ -461,26 +468,26 @@ fn validate_custom_element_props(
 
 /// The `properties` array of an `ObjectExpression`, or `None` for anything else.
 fn object_properties(node: &JsonValue) -> Option<&JsonValue> {
-    if node.get("type")?.as_str()? != "ObjectExpression" {
+    if node.field("type")?.as_str()? != "ObjectExpression" {
         return None;
     }
-    node.get("properties")
+    node.field("properties")
 }
 
 /// Upstream's repeated `property.type !== 'Property' || property.computed ||
 /// property.key.type !== 'Identifier'` guard.
 fn is_plain_property(node: &JsonValue) -> bool {
-    node.get("type").and_then(|t| t.as_str()) == Some("Property")
-        && node.get("computed") != Some(&JsonValue::Bool(true))
+    node.field("type").and_then(|t| t.as_str()) == Some("Property")
+        && node.field("computed") != Some(&JsonValue::Bool(true))
         && node
-            .get("key")
-            .and_then(|k| k.get("type"))
+            .field("key")
+            .and_then(|k| k.field("type"))
             .and_then(|t| t.as_str())
             == Some("Identifier")
 }
 
 fn property_key(node: &JsonValue) -> Option<&str> {
-    node.get("key")?.get("name")?.as_str()
+    node.field("key")?.field("name")?.as_str()
 }
 
 /// Upstream's `validate_tag`: a non-string is always invalid, and a falsy tag

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -24,6 +24,7 @@ use crate::error::ParseResult;
 
 use super::super::parser::{Parser, StackEntry, is_js_whitespace};
 use super::super::utils::TrimWs;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 fn leftover_token_offset(content: &str, ts: bool) -> Option<usize> {
     super::super::read::expression::trailing_token_offset(content, ts).filter(|&off| {
@@ -577,11 +578,11 @@ impl<'a> Parser<'a> {
                     .clone();
 
             let id_start = pattern_value
-                .get("start")
+                .field("start")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(seg_off as u64);
             let decl_end = init_value
-                .get("end")
+                .field("end")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(id_start + seg.len() as u64);
 
@@ -2526,12 +2527,12 @@ impl<'a> Parser<'a> {
                         // A comma-separated list parses as a SequenceExpression;
                         // anything else is one argument.
                         let value = expression.as_json();
-                        let expr_type = value.get("type").and_then(|t| t.as_str());
+                        let expr_type = value.field("type").and_then(|t| t.as_str());
 
                         if expr_type == Some("SequenceExpression") {
                             // Extract expressions from sequence
                             if let Some(expressions) =
-                                value.get("expressions").and_then(|e| e.as_array())
+                                value.field("expressions").and_then(|e| e.as_array())
                             {
                                 expressions
                                     .iter()

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/control_flow.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/control_flow.rs
@@ -7,6 +7,7 @@
 
 use super::types::{DomStructure, SiblingCertainty};
 use crate::ast::template::{Attribute, Fragment, TemplateNode};
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use rustc_hash::FxHashMap;
 
 pub fn stylesheet_has_sibling_combinator(stylesheet: &crate::ast::css::StyleSheet) -> bool {
@@ -14,9 +15,9 @@ pub fn stylesheet_has_sibling_combinator(stylesheet: &crate::ast::css::StyleShee
     while let Some(value) = pending.pop() {
         match value {
             serde_json::Value::Object(object) => {
-                if object.get("type").and_then(serde_json::Value::as_str) == Some("Combinator")
+                if object.field("type").and_then(serde_json::Value::as_str) == Some("Combinator")
                     && object
-                        .get("name")
+                        .field("name")
                         .and_then(serde_json::Value::as_str)
                         .is_some_and(|name| matches!(name, "+" | "~"))
                 {
@@ -87,17 +88,17 @@ fn node_ptr(node: &TemplateNode) -> NodePtr {
 /// The snippet a `{@render name(...)}` renders, when the callee is a plain name.
 fn render_tag_callee_name(render_tag: &crate::ast::template::RenderTag) -> Option<String> {
     let expr = render_tag.expression.as_json();
-    let expr = if expr.get("type").and_then(|t| t.as_str()) == Some("ChainExpression") {
-        expr.get("expression").unwrap_or(expr)
+    let expr = if expr.field("type").and_then(|t| t.as_str()) == Some("ChainExpression") {
+        expr.field("expression").unwrap_or(expr)
     } else {
         expr
     };
-    let callee = expr.get("callee")?;
-    if callee.get("type").and_then(|t| t.as_str()) != Some("Identifier") {
+    let callee = expr.field("callee")?;
+    if callee.field("type").and_then(|t| t.as_str()) != Some("Identifier") {
         return None;
     }
     callee
-        .get("name")
+        .field("name")
         .and_then(|n| n.as_str())
         .map(String::from)
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css/analyze.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css/analyze.rs
@@ -8,6 +8,7 @@
 use super::super::types::ComponentAnalysis;
 use super::super::{AnalysisError, errors};
 use crate::ast::css::StyleSheet;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Context passed through CSS analysis, tracking parent rule information.
 struct CssAnalysisState<'a> {
@@ -57,7 +58,7 @@ fn analyze_css_node(
     analysis: &mut ComponentAnalysis,
     state: &CssAnalysisState,
 ) -> Result<(), AnalysisError> {
-    if let Some(node_type) = node.get("type").and_then(|t| t.as_str()) {
+    if let Some(node_type) = node.field("type").and_then(|t| t.as_str()) {
         match node_type {
             "Atrule" => {
                 analyze_atrule(node, analysis, state)?;
@@ -76,7 +77,7 @@ fn analyze_atrule(
     analysis: &mut ComponentAnalysis,
     state: &CssAnalysisState,
 ) -> Result<(), AnalysisError> {
-    let is_keyframes = if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
+    let is_keyframes = if let Some(name) = node.field("name").and_then(|n| n.as_str()) {
         matches!(
             name,
             "keyframes" | "-webkit-keyframes" | "-moz-keyframes" | "-o-keyframes"
@@ -86,32 +87,32 @@ fn analyze_atrule(
     };
 
     if is_keyframes
-        && let Some(prelude) = node.get("prelude").and_then(|p| p.as_str())
+        && let Some(prelude) = node.field("prelude").and_then(|p| p.as_str())
         && !prelude.starts_with("-global-")
     {
         analysis.css.keyframes.push(prelude.to_string());
     } else if is_keyframes
-        && let Some(prelude) = node.get("prelude").and_then(|p| p.as_str())
+        && let Some(prelude) = node.field("prelude").and_then(|p| p.as_str())
         && prelude.starts_with("-global-")
     {
         analysis.css.has_global = true;
     }
 
     // Analyze children (skip validation for keyframes rules)
-    if let Some(block) = node.get("block")
-        && let Some(children) = block.get("children").and_then(|c| c.as_array())
+    if let Some(block) = node.field("block")
+        && let Some(children) = block.field("children").and_then(|c| c.as_array())
     {
         for child in children {
             if is_keyframes {
-                if child.get("type").and_then(|t| t.as_str()) == Some("Rule") {
-                    if let Some(prelude) = child.get("prelude")
+                if child.field("type").and_then(|t| t.as_str()) == Some("Rule") {
+                    if let Some(prelude) = child.field("prelude")
                         && has_global_selector(prelude)
                     {
                         analysis.css.has_global = true;
                     }
-                    if let Some(block) = child.get("block")
+                    if let Some(block) = child.field("block")
                         && let Some(nested_children) =
-                            block.get("children").and_then(|c| c.as_array())
+                            block.field("children").and_then(|c| c.as_array())
                     {
                         for nested_child in nested_children {
                             analyze_css_node(nested_child, analysis, state)?;
@@ -129,8 +130,8 @@ fn analyze_atrule(
 }
 /// Check if a simple selector is a `:global` block selector (without args).
 fn is_global_block_selector(simple_selector: &serde_json::Value) -> bool {
-    simple_selector.get("type").and_then(|t| t.as_str()) == Some("PseudoClassSelector")
-        && simple_selector.get("name").and_then(|n| n.as_str()) == Some("global")
+    simple_selector.field("type").and_then(|t| t.as_str()) == Some("PseudoClassSelector")
+        && simple_selector.field("name").and_then(|n| n.as_str()) == Some("global")
         && !simple_selector
             .as_object()
             .is_some_and(|obj| obj.contains_key("args"))
@@ -147,18 +148,18 @@ fn analyze_rule(
     //     has_global_selectors &&
     //     block has declarations &&
     //     is_unscoped(path) (all ancestor Rules also have global selectors)
-    if let Some(prelude) = node.get("prelude") {
+    if let Some(prelude) = node.field("prelude") {
         let all_selectors_global = is_prelude_fully_global(prelude);
         if all_selectors_global {
             // Check if block has at least one Declaration
             let has_declarations = node
-                .get("block")
-                .and_then(|b| b.get("children"))
+                .field("block")
+                .and_then(|b| b.field("children"))
                 .and_then(|c| c.as_array())
                 .map(|children| {
                     children
                         .iter()
-                        .any(|c| c.get("type").and_then(|t| t.as_str()) == Some("Declaration"))
+                        .any(|c| c.field("type").and_then(|t| t.as_str()) == Some("Declaration"))
                 })
                 .unwrap_or(false);
 
@@ -169,7 +170,7 @@ fn analyze_rule(
                 .parent_rule
                 .map(|parent| {
                     parent
-                        .get("prelude")
+                        .field("prelude")
                         .map(is_prelude_fully_global)
                         .unwrap_or(false)
                 })
@@ -186,10 +187,13 @@ fn analyze_rule(
 
     // === Rule visitor: :global block validation ===
     // This mirrors the official Svelte's Rule visitor in css-analyze.js
-    if let Some(prelude) = node.get("prelude") {
-        if let Some(complex_selectors) = prelude.get("children").and_then(|c| c.as_array()) {
+    if let Some(prelude) = node.field("prelude") {
+        if let Some(complex_selectors) = prelude.field("children").and_then(|c| c.as_array()) {
             for complex_selector in complex_selectors {
-                let children = match complex_selector.get("children").and_then(|c| c.as_array()) {
+                let children = match complex_selector
+                    .field("children")
+                    .and_then(|c| c.as_array())
+                {
                     Some(c) => c,
                     None => continue,
                 };
@@ -197,7 +201,7 @@ fn analyze_rule(
                 let mut local_is_global_block = false;
 
                 for (selector_idx, child) in children.iter().enumerate() {
-                    let selectors = match child.get("selectors").and_then(|s| s.as_array()) {
+                    let selectors = match child.field("selectors").and_then(|s| s.as_array()) {
                         Some(s) => s,
                         None => continue,
                     };
@@ -223,9 +227,9 @@ fn analyze_rule(
                                 local_is_global_block = true;
 
                                 // Check combinator: :global cannot follow a non-space combinator
-                                if let Some(combinator) = child.get("combinator") {
+                                if let Some(combinator) = child.field("combinator") {
                                     let comb_name = combinator
-                                        .get("name")
+                                        .field("name")
                                         .and_then(|n| n.as_str())
                                         .unwrap_or(" ");
                                     if comb_name != " " {
@@ -249,12 +253,12 @@ fn analyze_rule(
 
                                 if is_lone_global {
                                     // Check if the block contains declarations (not just nested rules)
-                                    if let Some(block) = node.get("block")
+                                    if let Some(block) = node.field("block")
                                         && let Some(block_children) =
-                                            block.get("children").and_then(|c| c.as_array())
+                                            block.field("children").and_then(|c| c.as_array())
                                     {
                                         let declaration = block_children.iter().find(|child| {
-                                            child.get("type").and_then(|kind| kind.as_str())
+                                            child.field("type").and_then(|kind| kind.as_str())
                                                 == Some("Declaration")
                                         });
 
@@ -291,12 +295,12 @@ fn analyze_rule(
     }
 
     // === Validate :global(...) selectors (with args) and other selector validations ===
-    if let Some(prelude) = node.get("prelude") {
+    if let Some(prelude) = node.field("prelude") {
         validate_selectors(prelude, state)?;
     }
 
     // === Validate NestingSelector (&) usage ===
-    if let Some(prelude) = node.get("prelude") {
+    if let Some(prelude) = node.field("prelude") {
         validate_nesting_selectors(prelude, state, node, is_global_block)?;
     }
 
@@ -308,17 +312,20 @@ fn analyze_rule(
         source: state.source,
         in_global_block: state.in_global_block || is_global_block,
     };
-    if let Some(block) = node.get("block")
-        && let Some(children) = block.get("children").and_then(|c| c.as_array())
+    if let Some(block) = node.field("block")
+        && let Some(children) = block.field("children").and_then(|c| c.as_array())
     {
         for child in children {
-            if let Some(child_type) = child.get("type").and_then(|t| t.as_str())
+            if let Some(child_type) = child.field("type").and_then(|t| t.as_str())
                 && child_type == "Declaration"
             {
-                let property = child.get("property").and_then(|p| p.as_str()).unwrap_or("");
+                let property = child
+                    .field("property")
+                    .and_then(|p| p.as_str())
+                    .unwrap_or("");
                 let is_custom_property = property.starts_with("--");
 
-                let value = child.get("value");
+                let value = child.field("value");
                 let is_empty = match value {
                     None => true,
                     Some(v) if v.is_null() => true,
@@ -343,20 +350,23 @@ fn validate_nesting_selectors(
     rule: &serde_json::Value,
     is_global_block: bool,
 ) -> Result<(), AnalysisError> {
-    let complex_selectors = match prelude.get("children").and_then(|c| c.as_array()) {
+    let complex_selectors = match prelude.field("children").and_then(|c| c.as_array()) {
         Some(c) => c,
         None => return Ok(()),
     };
 
     for complex_selector in complex_selectors {
-        let children = match complex_selector.get("children").and_then(|c| c.as_array()) {
+        let children = match complex_selector
+            .field("children")
+            .and_then(|c| c.as_array())
+        {
             Some(c) => c,
             None => continue,
         };
 
         for relative_selector in children {
             let selectors = match relative_selector
-                .get("selectors")
+                .field("selectors")
                 .and_then(|s| s.as_array())
             {
                 Some(s) => s,
@@ -364,7 +374,7 @@ fn validate_nesting_selectors(
             };
 
             for selector in selectors {
-                if selector.get("type").and_then(|t| t.as_str()) == Some("NestingSelector") {
+                if selector.field("type").and_then(|t| t.as_str()) == Some("NestingSelector") {
                     validate_single_nesting_selector(
                         selector,
                         state,
@@ -379,8 +389,8 @@ fn validate_nesting_selectors(
                 }
 
                 // Also check inside pseudo-class args for NestingSelector
-                if selector.get("type").and_then(|t| t.as_str()) == Some("PseudoClassSelector") {
-                    if let Some(args) = selector.get("args") {
+                if selector.field("type").and_then(|t| t.as_str()) == Some("PseudoClassSelector") {
+                    if let Some(args) = selector.field("args") {
                         validate_nesting_in_pseudo_args(
                             args,
                             state,
@@ -416,7 +426,7 @@ fn validate_single_nesting_selector(
     if state.parent_rule.is_none() {
         // & at root level - only valid as the first selector inside a lone :global(...)
         // Check: is this rule's prelude a single :global(&) or :global(& ...) ?
-        let complex_selectors = match prelude.get("children").and_then(|c| c.as_array()) {
+        let complex_selectors = match prelude.field("children").and_then(|c| c.as_array()) {
             Some(c) => c,
             None => {
                 return Err(at_node(
@@ -435,7 +445,7 @@ fn validate_single_nesting_selector(
         }
 
         let children = match complex_selectors[0]
-            .get("children")
+            .field("children")
             .and_then(|c| c.as_array())
         {
             Some(c) => c,
@@ -456,7 +466,7 @@ fn validate_single_nesting_selector(
         }
 
         let first_child = &children[0];
-        let selectors = match first_child.get("selectors").and_then(|s| s.as_array()) {
+        let selectors = match first_child.field("selectors").and_then(|s| s.as_array()) {
             Some(s) => s,
             None => {
                 return Err(at_node(
@@ -474,8 +484,8 @@ fn validate_single_nesting_selector(
         }
 
         let first_sel = &selectors[0];
-        if first_sel.get("type").and_then(|t| t.as_str()) != Some("PseudoClassSelector")
-            || first_sel.get("name").and_then(|n| n.as_str()) != Some("global")
+        if first_sel.field("type").and_then(|t| t.as_str()) != Some("PseudoClassSelector")
+            || first_sel.field("name").and_then(|n| n.as_str()) != Some("global")
         {
             return Err(at_node(
                 errors::css_nesting_selector_invalid_placement(),
@@ -484,18 +494,18 @@ fn validate_single_nesting_selector(
         }
 
         // Check that & is the first selector inside :global(...)
-        if let Some(args) = first_sel.get("args") {
-            if let Some(args_children) = args.get("children").and_then(|c| c.as_array()) {
+        if let Some(args) = first_sel.field("args") {
+            if let Some(args_children) = args.field("children").and_then(|c| c.as_array()) {
                 if let Some(first_complex) = args_children.first() {
                     if let Some(first_complex_children) =
-                        first_complex.get("children").and_then(|c| c.as_array())
+                        first_complex.field("children").and_then(|c| c.as_array())
                     {
                         if let Some(first_rel) = first_complex_children.first() {
                             if let Some(rel_sels) =
-                                first_rel.get("selectors").and_then(|s| s.as_array())
+                                first_rel.field("selectors").and_then(|s| s.as_array())
                             {
                                 if let Some(first_inner) = rel_sels.first() {
-                                    if first_inner.get("type").and_then(|t| t.as_str())
+                                    if first_inner.field("type").and_then(|t| t.as_str())
                                         != Some("NestingSelector")
                                     {
                                         return Err(at_node(
@@ -541,19 +551,19 @@ fn validate_single_nesting_selector(
 
 /// Check if a rule is a lone :global block (single :global selector without extra selectors).
 fn is_parent_lone_global_block(rule: &serde_json::Value) -> bool {
-    if let Some(prelude) = rule.get("prelude") {
-        if let Some(complex_selectors) = prelude.get("children").and_then(|c| c.as_array()) {
+    if let Some(prelude) = rule.field("prelude") {
+        if let Some(complex_selectors) = prelude.field("children").and_then(|c| c.as_array()) {
             if complex_selectors.len() != 1 {
                 return false;
             }
             if let Some(children) = complex_selectors[0]
-                .get("children")
+                .field("children")
                 .and_then(|c| c.as_array())
             {
                 if children.len() != 1 {
                     return false;
                 }
-                if let Some(selectors) = children[0].get("selectors").and_then(|s| s.as_array()) {
+                if let Some(selectors) = children[0].field("selectors").and_then(|s| s.as_array()) {
                     if selectors.len() != 1 {
                         return false;
                     }
@@ -579,20 +589,20 @@ fn validate_nesting_in_pseudo_args(
     selectors: &[serde_json::Value],
     is_global_block: bool,
 ) -> Result<(), AnalysisError> {
-    let Some(arg_children) = args.get("children").and_then(|c| c.as_array()) else {
+    let Some(arg_children) = args.field("children").and_then(|c| c.as_array()) else {
         return Ok(());
     };
 
     for complex in arg_children {
-        let Some(complex_children) = complex.get("children").and_then(|c| c.as_array()) else {
+        let Some(complex_children) = complex.field("children").and_then(|c| c.as_array()) else {
             continue;
         };
         for relative in complex_children {
-            let Some(arg_selectors) = relative.get("selectors").and_then(|s| s.as_array()) else {
+            let Some(arg_selectors) = relative.field("selectors").and_then(|s| s.as_array()) else {
                 continue;
             };
             for sel in arg_selectors {
-                match sel.get("type").and_then(|t| t.as_str()) {
+                match sel.field("type").and_then(|t| t.as_str()) {
                     Some("NestingSelector") => validate_single_nesting_selector(
                         sel,
                         state,
@@ -605,7 +615,7 @@ fn validate_nesting_in_pseudo_args(
                         is_global_block,
                     )?,
                     Some("PseudoClassSelector") => {
-                        if let Some(inner) = sel.get("args") {
+                        if let Some(inner) = sel.field("args") {
                             validate_nesting_in_pseudo_args(
                                 inner,
                                 state,
@@ -634,7 +644,7 @@ fn validate_selectors(
     prelude: &serde_json::Value,
     state: &CssAnalysisState,
 ) -> Result<(), AnalysisError> {
-    if let Some(complex_selectors) = prelude.get("children").and_then(|c| c.as_array()) {
+    if let Some(complex_selectors) = prelude.field("children").and_then(|c| c.as_array()) {
         for complex_selector in complex_selectors {
             validate_complex_selector(complex_selector, state)?;
         }
@@ -646,8 +656,8 @@ fn validate_selectors(
 /// passes as the first argument to its `e.*` constructor.
 fn at_node(error: AnalysisError, node: &serde_json::Value) -> AnalysisError {
     match (
-        node.get("start").and_then(|v| v.as_u64()),
-        node.get("end").and_then(|v| v.as_u64()),
+        node.field("start").and_then(|v| v.as_u64()),
+        node.field("end").and_then(|v| v.as_u64()),
     ) {
         (Some(start), Some(end)) => error.at(start as u32, end as u32),
         _ => error,
@@ -658,7 +668,7 @@ fn at_node(error: AnalysisError, node: &serde_json::Value) -> AnalysisError {
 /// is the offset just past the `:` — not the declaration node's own end.
 fn empty_declaration_error(declaration: &serde_json::Value, source: Option<&str>) -> AnalysisError {
     let error = errors::css_empty_declaration();
-    let Some(start) = declaration.get("start").and_then(|v| v.as_u64()) else {
+    let Some(start) = declaration.field("start").and_then(|v| v.as_u64()) else {
         return error;
     };
     let Some(colon) = source
@@ -678,8 +688,8 @@ fn trailing_combinator_error(
 ) -> AnalysisError {
     let error = errors::css_selector_invalid();
     let Some(end) = relative_selector
-        .get("combinator")
-        .and_then(|c| c.get("end"))
+        .field("combinator")
+        .and_then(|c| c.field("end"))
         .and_then(|v| v.as_u64())
     else {
         return error;
@@ -696,7 +706,10 @@ fn validate_complex_selector(
     complex_selector: &serde_json::Value,
     state: &CssAnalysisState,
 ) -> Result<(), AnalysisError> {
-    let children = match complex_selector.get("children").and_then(|c| c.as_array()) {
+    let children = match complex_selector
+        .field("children")
+        .and_then(|c| c.as_array())
+    {
         Some(c) => c,
         None => return Ok(()),
     };
@@ -708,7 +721,10 @@ fn validate_complex_selector(
         let global_relative = &children[idx];
 
         // Check :global block invalid placement (inside a pseudoclass)
-        if let Some(selectors) = global_relative.get("selectors").and_then(|s| s.as_array()) {
+        if let Some(selectors) = global_relative
+            .field("selectors")
+            .and_then(|s| s.as_array())
+        {
             if let Some(first_sel) = selectors.first() {
                 // :global without args inside a pseudoclass is invalid
                 if state.in_pseudoclass
@@ -725,7 +741,9 @@ fn validate_complex_selector(
         }
 
         // Check if :global(...) with args is in the middle of the selector
-        if let Some(selectors) = global_relative.get("selectors").and_then(|s| s.as_array())
+        if let Some(selectors) = global_relative
+            .field("selectors")
+            .and_then(|s| s.as_array())
             && let Some(first_sel) = selectors.first()
             && first_sel
                 .as_object()
@@ -733,7 +751,7 @@ fn validate_complex_selector(
         {
             let is_at_start = children[..idx].iter().all(|child| {
                 child
-                    .get("selectors")
+                    .field("selectors")
                     .and_then(|s| s.as_array())
                     .is_none_or(|s| s.is_empty())
             });
@@ -752,31 +770,33 @@ fn validate_complex_selector(
     // Validate :global(...) selector contents and positioning within each RelativeSelector
     for relative_selector in children.iter() {
         if let Some(selectors) = relative_selector
-            .get("selectors")
+            .field("selectors")
             .and_then(|s| s.as_array())
         {
             for (i, selector) in selectors.iter().enumerate() {
-                if let Some(sel_type) = selector.get("type").and_then(|t| t.as_str())
+                if let Some(sel_type) = selector.field("type").and_then(|t| t.as_str())
                     && sel_type == "PseudoClassSelector"
-                    && let Some(name) = selector.get("name").and_then(|n| n.as_str())
+                    && let Some(name) = selector.field("name").and_then(|n| n.as_str())
                     && name == "global"
                 {
                     // Validate :global(...) selector contents
-                    if let Some(args) = selector.get("args") {
+                    if let Some(args) = selector.field("args") {
                         validate_global_args(args, selector, children.len(), selectors.len())?;
                     }
 
                     // Ensure :global(element) is at first position in compound selector
-                    if let Some(args) = selector.get("args")
-                        && let Some(args_children) = args.get("children").and_then(|c| c.as_array())
+                    if let Some(args) = selector.field("args")
+                        && let Some(args_children) =
+                            args.field("children").and_then(|c| c.as_array())
                         && let Some(first_complex) = args_children.first()
                         && let Some(complex_children) =
-                            first_complex.get("children").and_then(|c| c.as_array())
+                            first_complex.field("children").and_then(|c| c.as_array())
                         && let Some(first_rel) = complex_children.first()
                         && let Some(rel_sels) =
-                            first_rel.get("selectors").and_then(|s| s.as_array())
+                            first_rel.field("selectors").and_then(|s| s.as_array())
                         && let Some(first_inner) = rel_sels.first()
-                        && first_inner.get("type").and_then(|t| t.as_str()) == Some("TypeSelector")
+                        && first_inner.field("type").and_then(|t| t.as_str())
+                            == Some("TypeSelector")
                         && i != 0
                     {
                         return Err(at_node(
@@ -787,7 +807,7 @@ fn validate_complex_selector(
 
                     // Ensure :global(.class) is not followed by a type selector
                     if let Some(next_sel) = selectors.get(i + 1)
-                        && next_sel.get("type").and_then(|t| t.as_str()) == Some("TypeSelector")
+                        && next_sel.field("type").and_then(|t| t.as_str()) == Some("TypeSelector")
                     {
                         return Err(at_node(
                             errors::css_type_selector_invalid_placement(),
@@ -799,8 +819,9 @@ fn validate_complex_selector(
                     if selector
                         .as_object()
                         .is_some_and(|obj| obj.contains_key("args"))
-                        && let Some(args) = selector.get("args")
-                        && let Some(args_children) = args.get("children").and_then(|c| c.as_array())
+                        && let Some(args) = selector.field("args")
+                        && let Some(args_children) =
+                            args.field("children").and_then(|c| c.as_array())
                         && args_children.len() > 1
                         && (children.len() > 1 || selectors.len() > 1)
                     {
@@ -811,18 +832,18 @@ fn validate_complex_selector(
                     validate_global_type_selector_position(selector, selectors)?;
 
                     // Check for :global block inside pseudo-class args
-                    if let Some(args) = selector.get("args") {
+                    if let Some(args) = selector.field("args") {
                         validate_global_block_in_pseudo_args(args)?;
                     }
                 }
 
                 // For other pseudo-classes (:is, :not, :has, :where), validate their args
-                if let Some(sel_type) = selector.get("type").and_then(|t| t.as_str())
+                if let Some(sel_type) = selector.field("type").and_then(|t| t.as_str())
                     && sel_type == "PseudoClassSelector"
-                    && let Some(name) = selector.get("name").and_then(|n| n.as_str())
+                    && let Some(name) = selector.field("name").and_then(|n| n.as_str())
                     && matches!(name, "is" | "not" | "has" | "where")
                 {
-                    if let Some(args) = selector.get("args") {
+                    if let Some(args) = selector.field("args") {
                         let pseudo_state = CssAnalysisState {
                             parent_rule: state.parent_rule,
                             parent_rule_has_parent: state.parent_rule_has_parent,
@@ -843,8 +864,8 @@ fn validate_complex_selector(
         if i == 0
             && !is_nested
             && !state.in_pseudoclass
-            && let Some(combinator) = relative_selector.get("combinator")
-            && combinator.get("type").and_then(|t| t.as_str()) == Some("Combinator")
+            && let Some(combinator) = relative_selector.field("combinator")
+            && combinator.field("type").and_then(|t| t.as_str()) == Some("Combinator")
         {
             return Err(at_node(errors::css_selector_invalid(), combinator));
         }
@@ -852,9 +873,9 @@ fn validate_complex_selector(
 
     // Check for combinator at the end
     if let Some(last) = children.last()
-        && let Some(selectors) = last.get("selectors").and_then(|s| s.as_array())
+        && let Some(selectors) = last.field("selectors").and_then(|s| s.as_array())
         && selectors.is_empty()
-        && last.get("combinator").is_some()
+        && last.field("combinator").is_some()
     {
         return Err(trailing_combinator_error(last, state.source));
     }
@@ -864,11 +885,12 @@ fn validate_complex_selector(
 
 /// Check if :global block (without args) appears inside pseudo-class args.
 fn validate_global_block_in_pseudo_args(args: &serde_json::Value) -> Result<(), AnalysisError> {
-    if let Some(children) = args.get("children").and_then(|c| c.as_array()) {
+    if let Some(children) = args.field("children").and_then(|c| c.as_array()) {
         for complex in children {
-            if let Some(complex_children) = complex.get("children").and_then(|c| c.as_array()) {
+            if let Some(complex_children) = complex.field("children").and_then(|c| c.as_array()) {
                 for relative in complex_children {
-                    if let Some(selectors) = relative.get("selectors").and_then(|s| s.as_array()) {
+                    if let Some(selectors) = relative.field("selectors").and_then(|s| s.as_array())
+                    {
                         for sel in selectors {
                             if is_global_block_selector(sel) {
                                 return Err(at_node(
@@ -889,7 +911,7 @@ fn validate_global_block_in_pseudo_args(args: &serde_json::Value) -> Result<(), 
 /// This mirrors checking `node.metadata.has_global_selectors` in the official compiler,
 /// which is true when ALL complex selectors have `is_global`.
 fn is_prelude_fully_global(prelude: &serde_json::Value) -> bool {
-    if let Some(children) = prelude.get("children").and_then(|c| c.as_array()) {
+    if let Some(children) = prelude.field("children").and_then(|c| c.as_array()) {
         !children.is_empty() && children.iter().all(is_complex_selector_global)
     } else {
         false
@@ -899,7 +921,10 @@ fn is_prelude_fully_global(prelude: &serde_json::Value) -> bool {
 /// Check if a ComplexSelector is fully global.
 /// A ComplexSelector is global when ALL its children (RelativeSelectors) are global or global-like.
 fn is_complex_selector_global(complex_selector: &serde_json::Value) -> bool {
-    if let Some(children) = complex_selector.get("children").and_then(|c| c.as_array()) {
+    if let Some(children) = complex_selector
+        .field("children")
+        .and_then(|c| c.as_array())
+    {
         !children.is_empty()
             && children.iter().all(|rel| {
                 is_relative_selector_global_strict(rel) || is_relative_selector_global_like(rel)
@@ -916,15 +941,15 @@ fn is_complex_selector_global(complex_selector: &serde_json::Value) -> bool {
 ///     are unscoped pseudo-classes or pseudo-elements
 fn is_relative_selector_global_strict(relative_selector: &serde_json::Value) -> bool {
     let selectors = match relative_selector
-        .get("selectors")
+        .field("selectors")
         .and_then(|s| s.as_array())
     {
         Some(s) if !s.is_empty() => s,
         _ => return false,
     };
     let first = &selectors[0];
-    if first.get("type").and_then(|t| t.as_str()) != Some("PseudoClassSelector")
-        || first.get("name").and_then(|n| n.as_str()) != Some("global")
+    if first.field("type").and_then(|t| t.as_str()) != Some("PseudoClassSelector")
+        || first.field("name").and_then(|n| n.as_str()) != Some("global")
     {
         return false;
     }
@@ -932,13 +957,13 @@ fn is_relative_selector_global_strict(relative_selector: &serde_json::Value) -> 
     if !first
         .as_object()
         .is_some_and(|obj| obj.contains_key("args"))
-        || first.get("args").filter(|&a| !a.is_null()).is_none()
+        || first.field("args").filter(|&a| !a.is_null()).is_none()
     {
         return true;
     }
     // Has args: all selectors in this RelativeSelector must be unscoped pseudo-classes or pseudo-elements
     selectors.iter().all(|sel| {
-        let sel_type = sel.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        let sel_type = sel.field("type").and_then(|t| t.as_str()).unwrap_or("");
         if sel_type == "PseudoElementSelector" {
             return true;
         }
@@ -952,7 +977,7 @@ fn is_relative_selector_global_strict(relative_selector: &serde_json::Value) -> 
 /// Check if a RelativeSelector is "global-like" (e.g., :host, :root, ::view-transition-*).
 fn is_relative_selector_global_like(relative_selector: &serde_json::Value) -> bool {
     let selectors = match relative_selector
-        .get("selectors")
+        .field("selectors")
         .and_then(|s| s.as_array())
     {
         Some(s) if !s.is_empty() => s,
@@ -960,8 +985,8 @@ fn is_relative_selector_global_like(relative_selector: &serde_json::Value) -> bo
     };
 
     let first = &selectors[0];
-    let first_type = first.get("type").and_then(|t| t.as_str()).unwrap_or("");
-    let first_name = first.get("name").and_then(|n| n.as_str()).unwrap_or("");
+    let first_type = first.field("type").and_then(|t| t.as_str()).unwrap_or("");
+    let first_name = first.field("name").and_then(|n| n.as_str()).unwrap_or("");
 
     // :host
     if first_type == "PseudoClassSelector" && first_name == "host" {
@@ -984,12 +1009,12 @@ fn is_relative_selector_global_like(relative_selector: &serde_json::Value) -> bo
 
     // :root (but not if it also has :has)
     let has_root = selectors.iter().any(|s| {
-        s.get("type").and_then(|t| t.as_str()) == Some("PseudoClassSelector")
-            && s.get("name").and_then(|n| n.as_str()) == Some("root")
+        s.field("type").and_then(|t| t.as_str()) == Some("PseudoClassSelector")
+            && s.field("name").and_then(|n| n.as_str()) == Some("root")
     });
     let has_has = selectors.iter().any(|s| {
-        s.get("type").and_then(|t| t.as_str()) == Some("PseudoClassSelector")
-            && s.get("name").and_then(|n| n.as_str()) == Some("has")
+        s.field("type").and_then(|t| t.as_str()) == Some("PseudoClassSelector")
+            && s.field("name").and_then(|n| n.as_str()) == Some("has")
     });
     if has_root && !has_has {
         return true;
@@ -1001,25 +1026,28 @@ fn is_relative_selector_global_like(relative_selector: &serde_json::Value) -> bo
 /// Check if a PseudoClassSelector is "unscoped" - meaning it doesn't scope its contents.
 /// Mirrors the official `is_unscoped_pseudo_class` from css/utils.js.
 fn is_unscoped_pseudo_class_selector(selector: &serde_json::Value) -> bool {
-    if selector.get("type").and_then(|t| t.as_str()) != Some("PseudoClassSelector") {
+    if selector.field("type").and_then(|t| t.as_str()) != Some("PseudoClassSelector") {
         return false;
     }
-    let name = selector.get("name").and_then(|n| n.as_str()).unwrap_or("");
+    let name = selector
+        .field("name")
+        .and_then(|n| n.as_str())
+        .unwrap_or("");
 
     // These pseudo-classes scope their contents: :has, :is, :where, :not (with complex args)
     if name == "has" || name == "is" || name == "where" {
         // They can still be unscoped if args is null or all children are global
-        let args = selector.get("args").filter(|a| !a.is_null());
+        let args = selector.field("args").filter(|a| !a.is_null());
         return match args {
             None => true,
             Some(args) => {
                 // All children of args must be global
-                args.get("children")
+                args.field("children")
                     .and_then(|c| c.as_array())
                     .map(|children| {
                         children.iter().all(|complex| {
                             complex
-                                .get("children")
+                                .field("children")
                                 .and_then(|c| c.as_array())
                                 .map(|rels| rels.iter().all(is_relative_selector_global_strict))
                                 .unwrap_or(false)
@@ -1030,16 +1058,16 @@ fn is_unscoped_pseudo_class_selector(selector: &serde_json::Value) -> bool {
         };
     }
     if name == "not" {
-        let args = selector.get("args").filter(|a| !a.is_null());
+        let args = selector.field("args").filter(|a| !a.is_null());
         return match args {
             None => true,
             Some(args) => {
                 let all_simple = args
-                    .get("children")
+                    .field("children")
                     .and_then(|c| c.as_array())
                     .map(|children| {
                         children.iter().all(|c| {
-                            c.get("children")
+                            c.field("children")
                                 .and_then(|cc| cc.as_array())
                                 .map(|rels| rels.len() == 1)
                                 .unwrap_or(false)
@@ -1050,12 +1078,12 @@ fn is_unscoped_pseudo_class_selector(selector: &serde_json::Value) -> bool {
                     return true;
                 }
                 // Check if all children are global
-                args.get("children")
+                args.field("children")
                     .and_then(|c| c.as_array())
                     .map(|children| {
                         children.iter().all(|complex| {
                             complex
-                                .get("children")
+                                .field("children")
                                 .and_then(|c| c.as_array())
                                 .map(|rels| rels.iter().all(is_relative_selector_global_strict))
                                 .unwrap_or(false)
@@ -1073,12 +1101,12 @@ fn is_unscoped_pseudo_class_selector(selector: &serde_json::Value) -> bool {
 /// Check if a RelativeSelector is :global (or :global(...)).
 fn is_global_relative(relative_selector: &serde_json::Value) -> bool {
     if let Some(selectors) = relative_selector
-        .get("selectors")
+        .field("selectors")
         .and_then(|s| s.as_array())
     {
         if let Some(first) = selectors.first() {
-            first.get("type").and_then(|t| t.as_str()) == Some("PseudoClassSelector")
-                && first.get("name").and_then(|n| n.as_str()) == Some("global")
+            first.field("type").and_then(|t| t.as_str()) == Some("PseudoClassSelector")
+                && first.field("name").and_then(|n| n.as_str()) == Some("global")
         } else {
             false
         }
@@ -1088,7 +1116,7 @@ fn is_global_relative(relative_selector: &serde_json::Value) -> bool {
 }
 
 fn has_global_selector(prelude: &serde_json::Value) -> bool {
-    if let Some(children) = prelude.get("children").and_then(|c| c.as_array()) {
+    if let Some(children) = prelude.field("children").and_then(|c| c.as_array()) {
         for child in children {
             if check_selector_for_global(child) {
                 return true;
@@ -1099,13 +1127,13 @@ fn has_global_selector(prelude: &serde_json::Value) -> bool {
 }
 
 fn check_selector_for_global(selector: &serde_json::Value) -> bool {
-    if let Some(children) = selector.get("children").and_then(|c| c.as_array()) {
+    if let Some(children) = selector.field("children").and_then(|c| c.as_array()) {
         for child in children {
-            if let Some(selectors) = child.get("selectors").and_then(|s| s.as_array()) {
+            if let Some(selectors) = child.field("selectors").and_then(|s| s.as_array()) {
                 for sel in selectors {
-                    if let Some(sel_type) = sel.get("type").and_then(|t| t.as_str())
+                    if let Some(sel_type) = sel.field("type").and_then(|t| t.as_str())
                         && sel_type == "PseudoClassSelector"
-                        && let Some(name) = sel.get("name").and_then(|n| n.as_str())
+                        && let Some(name) = sel.field("name").and_then(|n| n.as_str())
                         && name == "global"
                     {
                         return true;
@@ -1124,7 +1152,7 @@ fn validate_global_args(
     num_children: usize,
     num_selectors: usize,
 ) -> Result<(), AnalysisError> {
-    if let Some(arg_children) = args.get("children").and_then(|c| c.as_array()) {
+    if let Some(arg_children) = args.field("children").and_then(|c| c.as_array()) {
         if arg_children.len() > 1 && (num_children > 1 || num_selectors > 1) {
             return Err(at_node(
                 errors::css_global_invalid_selector(),
@@ -1145,16 +1173,16 @@ fn validate_global_type_selector_position(
         .position(|s| std::ptr::eq(s, global_selector))
         .unwrap_or(0);
 
-    if let Some(args) = global_selector.get("args")
-        && let Some(arg_children) = args.get("children").and_then(|c| c.as_array())
+    if let Some(args) = global_selector.field("args")
+        && let Some(arg_children) = args.field("children").and_then(|c| c.as_array())
         && let Some(first_complex) = arg_children.first()
         && let Some(first_relative_children) =
-            first_complex.get("children").and_then(|c| c.as_array())
+            first_complex.field("children").and_then(|c| c.as_array())
         && let Some(first_relative) = first_relative_children.first()
         && let Some(first_relative_selectors) =
-            first_relative.get("selectors").and_then(|s| s.as_array())
+            first_relative.field("selectors").and_then(|s| s.as_array())
         && let Some(first_sel) = first_relative_selectors.first()
-        && first_sel.get("type").and_then(|t| t.as_str()) == Some("TypeSelector")
+        && first_sel.field("type").and_then(|t| t.as_str()) == Some("TypeSelector")
         && global_idx != 0
     {
         return Err(at_node(
@@ -1164,7 +1192,7 @@ fn validate_global_type_selector_position(
     }
 
     if let Some(next_sel) = all_selectors.get(global_idx + 1)
-        && next_sel.get("type").and_then(|t| t.as_str()) == Some("TypeSelector")
+        && next_sel.field("type").and_then(|t| t.as_str()) == Some("TypeSelector")
     {
         return Err(at_node(
             errors::css_type_selector_invalid_placement(),
@@ -1185,16 +1213,16 @@ pub fn extract_css_selector_info(stylesheet: &StyleSheet, analysis: &mut Compone
 }
 
 fn extract_selectors_from_node(node: &serde_json::Value, analysis: &mut ComponentAnalysis) {
-    if let Some(node_type) = node.get("type").and_then(|t| t.as_str()) {
+    if let Some(node_type) = node.field("type").and_then(|t| t.as_str()) {
         match node_type {
             "Rule" => {
                 // Extract selectors from the rule's prelude
-                if let Some(prelude) = node.get("prelude") {
+                if let Some(prelude) = node.field("prelude") {
                     extract_selectors_from_prelude(prelude, analysis);
                 }
                 // Recursively process nested rules
-                if let Some(block) = node.get("block")
-                    && let Some(children) = block.get("children").and_then(|c| c.as_array())
+                if let Some(block) = node.field("block")
+                    && let Some(children) = block.field("children").and_then(|c| c.as_array())
                 {
                     for child in children {
                         extract_selectors_from_node(child, analysis);
@@ -1202,8 +1230,8 @@ fn extract_selectors_from_node(node: &serde_json::Value, analysis: &mut Componen
                 }
             }
             "Atrule" => {
-                if let Some(block) = node.get("block")
-                    && let Some(children) = block.get("children").and_then(|c| c.as_array())
+                if let Some(block) = node.field("block")
+                    && let Some(children) = block.field("children").and_then(|c| c.as_array())
                 {
                     for child in children {
                         extract_selectors_from_node(child, analysis);
@@ -1217,7 +1245,7 @@ fn extract_selectors_from_node(node: &serde_json::Value, analysis: &mut Componen
 
 fn extract_selectors_from_prelude(prelude: &serde_json::Value, analysis: &mut ComponentAnalysis) {
     // prelude is a SelectorList with children (ComplexSelectors)
-    if let Some(complex_selectors) = prelude.get("children").and_then(|c| c.as_array()) {
+    if let Some(complex_selectors) = prelude.field("children").and_then(|c| c.as_array()) {
         for complex_selector in complex_selectors {
             extract_selectors_from_complex(complex_selector, analysis);
         }
@@ -1229,10 +1257,13 @@ fn extract_selectors_from_complex(
     analysis: &mut ComponentAnalysis,
 ) {
     // ComplexSelector has children (RelativeSelectors)
-    if let Some(relative_selectors) = complex_selector.get("children").and_then(|c| c.as_array()) {
+    if let Some(relative_selectors) = complex_selector
+        .field("children")
+        .and_then(|c| c.as_array())
+    {
         for relative_selector in relative_selectors {
             if let Some(selectors) = relative_selector
-                .get("selectors")
+                .field("selectors")
                 .and_then(|s| s.as_array())
             {
                 for sel in selectors {
@@ -1244,10 +1275,10 @@ fn extract_selectors_from_complex(
 }
 
 fn extract_simple_selector(selector: &serde_json::Value, analysis: &mut ComponentAnalysis) {
-    if let Some(sel_type) = selector.get("type").and_then(|t| t.as_str()) {
+    if let Some(sel_type) = selector.field("type").and_then(|t| t.as_str()) {
         match sel_type {
             "TypeSelector" => {
-                if let Some(name) = selector.get("name").and_then(|n| n.as_str()) {
+                if let Some(name) = selector.field("name").and_then(|n| n.as_str()) {
                     if name == "*" {
                         analysis.css.has_universal_selector = true;
                     } else {
@@ -1256,26 +1287,26 @@ fn extract_simple_selector(selector: &serde_json::Value, analysis: &mut Componen
                 }
             }
             "ClassSelector" => {
-                if let Some(name) = selector.get("name").and_then(|n| n.as_str()) {
+                if let Some(name) = selector.field("name").and_then(|n| n.as_str()) {
                     analysis.css.selector_class_names.insert(name.to_string());
                 }
             }
             "IdSelector" => {
-                if let Some(name) = selector.get("name").and_then(|n| n.as_str()) {
+                if let Some(name) = selector.field("name").and_then(|n| n.as_str()) {
                     analysis.css.selector_id_names.insert(name.to_string());
                 }
             }
             "PseudoClassSelector" => {
                 // Process :global() args and other pseudo-classes
-                if let Some(name) = selector.get("name").and_then(|n| n.as_str()) {
+                if let Some(name) = selector.field("name").and_then(|n| n.as_str()) {
                     if name == "global" {
                         // Extract selectors from :global() args
-                        if let Some(args) = selector.get("args") {
+                        if let Some(args) = selector.field("args") {
                             extract_selectors_from_prelude(args, analysis);
                         }
                     } else if name == "is" || name == "where" || name == "not" || name == "has" {
                         // Extract selectors from pseudo-class args
-                        if let Some(args) = selector.get("args") {
+                        if let Some(args) = selector.field("args") {
                             extract_selectors_from_prelude(args, analysis);
                         }
                     }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css/utils.rs
@@ -3,11 +3,12 @@
 //! Provides helper functions for CSS analysis.
 //!
 //! Corresponds to Svelte's `2-analyze/css/utils.js`.
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 /// Returns all parent rules from a rule path; root is last.
 pub fn get_parent_rules<'a>(path: &[&'a serde_json::Value]) -> Vec<&'a serde_json::Value> {
     path.iter()
         .filter(|node| {
-            node.get("type")
+            node.field("type")
                 .and_then(|t| t.as_str())
                 .map(|t| t == "Rule")
                 .unwrap_or(false)
@@ -18,11 +19,11 @@ pub fn get_parent_rules<'a>(path: &[&'a serde_json::Value]) -> Vec<&'a serde_jso
 
 /// True if a relative selector is `:global(...)` or `:global`.
 pub fn is_global(selector: &serde_json::Value) -> bool {
-    if let Some(selectors) = selector.get("selectors").and_then(|s| s.as_array())
+    if let Some(selectors) = selector.field("selectors").and_then(|s| s.as_array())
         && let Some(first) = selectors.first()
-        && let Some(sel_type) = first.get("type").and_then(|t| t.as_str())
+        && let Some(sel_type) = first.field("type").and_then(|t| t.as_str())
         && sel_type == "PseudoClassSelector"
-        && let Some(name) = first.get("name").and_then(|n| n.as_str())
+        && let Some(name) = first.field("name").and_then(|n| n.as_str())
     {
         return name == "global";
     }
@@ -31,9 +32,9 @@ pub fn is_global(selector: &serde_json::Value) -> bool {
 
 /// `true` if is a pseudo class that cannot be or is not scoped.
 pub fn is_unscoped_pseudo_class(selector: &serde_json::Value) -> bool {
-    if let Some(sel_type) = selector.get("type").and_then(|t| t.as_str())
+    if let Some(sel_type) = selector.field("type").and_then(|t| t.as_str())
         && sel_type == "PseudoClassSelector"
-        && let Some(name) = selector.get("name").and_then(|n| n.as_str())
+        && let Some(name) = selector.field("name").and_then(|n| n.as_str())
     {
         // These pseudo-classes can contain scoped selectors
         let scoping_pseudo = matches!(name, "has" | "is" | "where" | "not");
@@ -42,7 +43,7 @@ pub fn is_unscoped_pseudo_class(selector: &serde_json::Value) -> bool {
         }
 
         // Check if args is null (no children to scope)
-        if selector.get("args").is_none() {
+        if selector.field("args").is_none() {
             return true;
         }
     }
@@ -51,17 +52,17 @@ pub fn is_unscoped_pseudo_class(selector: &serde_json::Value) -> bool {
 
 /// True if is `:global(...)` or `:global`, irrespective of scoped pseudo classes.
 pub fn is_outer_global(selector: &serde_json::Value) -> bool {
-    if let Some(selectors) = selector.get("selectors").and_then(|s| s.as_array())
+    if let Some(selectors) = selector.field("selectors").and_then(|s| s.as_array())
         && let Some(first) = selectors.first()
-        && let Some(sel_type) = first.get("type").and_then(|t| t.as_str())
+        && let Some(sel_type) = first.field("type").and_then(|t| t.as_str())
         && sel_type == "PseudoClassSelector"
-        && let Some(name) = first.get("name").and_then(|n| n.as_str())
+        && let Some(name) = first.field("name").and_then(|n| n.as_str())
         && name == "global"
     {
         // Check if all selectors are pseudo classes/elements
         return selectors.iter().all(|s| {
             matches!(
-                s.get("type").and_then(|t| t.as_str()),
+                s.field("type").and_then(|t| t.as_str()),
                 Some("PseudoClassSelector") | Some("PseudoElementSelector")
             )
         });
@@ -107,11 +108,11 @@ pub fn get_possible_values_expr(
 
 pub fn get_possible_values(chunk: &serde_json::Value, is_class: bool) -> Option<Vec<String>> {
     let mut values = Vec::new();
-    let chunk_type = chunk.get("type").and_then(|t| t.as_str());
+    let chunk_type = chunk.field("type").and_then(|t| t.as_str());
 
     // Handle Text nodes
     if let Some("Text") = chunk_type
-        && let Some(data) = chunk.get("data").and_then(|d| d.as_str())
+        && let Some(data) = chunk.field("data").and_then(|d| d.as_str())
     {
         values.push(data.to_string());
         return Some(values);
@@ -119,7 +120,7 @@ pub fn get_possible_values(chunk: &serde_json::Value, is_class: bool) -> Option<
 
     // Handle ExpressionTag nodes
     if let Some("ExpressionTag") = chunk_type
-        && let Some(expression) = chunk.get("expression")
+        && let Some(expression) = chunk.field("expression")
     {
         gather_possible_values(expression, is_class, &mut values, false);
     } else if chunk_type.is_some() {
@@ -151,12 +152,12 @@ fn gather_possible_values(
         return;
     }
 
-    let node_type = node.get("type").and_then(|t| t.as_str());
+    let node_type = node.field("type").and_then(|t| t.as_str());
 
     match node_type {
         Some("Literal") => {
             // Handle string literals
-            if let Some(value) = node.get("value") {
+            if let Some(value) = node.field("value") {
                 let string_value = match value {
                     serde_json::Value::String(s) => s.clone(),
                     serde_json::Value::Number(n) => n.to_string(),
@@ -173,20 +174,20 @@ fn gather_possible_values(
 
         Some("ConditionalExpression") => {
             // Handle ternary: condition ? consequent : alternate
-            if let Some(consequent) = node.get("consequent") {
+            if let Some(consequent) = node.field("consequent") {
                 gather_possible_values(consequent, is_class, values, is_nested);
             }
-            if let Some(alternate) = node.get("alternate") {
+            if let Some(alternate) = node.field("alternate") {
                 gather_possible_values(alternate, is_class, values, is_nested);
             }
         }
 
         Some("LogicalExpression") => {
-            if let Some(operator) = node.get("operator").and_then(|o| o.as_str()) {
+            if let Some(operator) = node.field("operator").and_then(|o| o.as_str()) {
                 if operator == "&&" {
                     // Special case for &&: left side can be included if it's falsy
                     let mut left_values = Vec::new();
-                    if let Some(left) = node.get("left") {
+                    if let Some(left) = node.field("left") {
                         gather_possible_values(left, is_class, &mut left_values, is_nested);
                     }
 
@@ -215,15 +216,15 @@ fn gather_possible_values(
                     }
 
                     // Always add right side values
-                    if let Some(right) = node.get("right") {
+                    if let Some(right) = node.field("right") {
                         gather_possible_values(right, is_class, values, is_nested);
                     }
                 } else {
                     // For || and other operators, add both sides
-                    if let Some(left) = node.get("left") {
+                    if let Some(left) = node.field("left") {
                         gather_possible_values(left, is_class, values, is_nested);
                     }
-                    if let Some(right) = node.get("right") {
+                    if let Some(right) = node.field("right") {
                         gather_possible_values(right, is_class, values, is_nested);
                     }
                 }
@@ -232,7 +233,7 @@ fn gather_possible_values(
 
         Some("ArrayExpression") if is_class => {
             // Arrays are used in class attributes: class={['foo', 'bar']}
-            if let Some(elements) = node.get("elements").and_then(|e| e.as_array()) {
+            if let Some(elements) = node.field("elements").and_then(|e| e.as_array()) {
                 for element in elements {
                     // Skip null/undefined array elements
                     if !element.is_null() {
@@ -244,27 +245,28 @@ fn gather_possible_values(
 
         Some("ObjectExpression") if is_class => {
             // Objects are used in class attributes: class={{ foo: true, bar: false }}
-            if let Some(properties) = node.get("properties").and_then(|p| p.as_array()) {
+            if let Some(properties) = node.field("properties").and_then(|p| p.as_array()) {
                 for property in properties {
-                    if property.get("type").and_then(|t| t.as_str()) == Some("Property") {
+                    if property.field("type").and_then(|t| t.as_str()) == Some("Property") {
                         let is_computed = property
-                            .get("computed")
+                            .field("computed")
                             .and_then(|c| c.as_bool())
                             .unwrap_or(false);
 
                         if !is_computed {
-                            if let Some(key) = property.get("key") {
-                                let key_type = key.get("type").and_then(|t| t.as_str());
+                            if let Some(key) = property.field("key") {
+                                let key_type = key.field("type").and_then(|t| t.as_str());
                                 match key_type {
                                     Some("Identifier") => {
-                                        if let Some(name) = key.get("name").and_then(|n| n.as_str())
+                                        if let Some(name) =
+                                            key.field("name").and_then(|n| n.as_str())
                                         {
                                             values.push(name.to_string());
                                         }
                                     }
                                     Some("Literal") => {
                                         if let Some(value) =
-                                            key.get("value").and_then(|v| v.as_str())
+                                            key.field("value").and_then(|v| v.as_str())
                                         {
                                             values.push(value.to_string());
                                         }
@@ -294,7 +296,7 @@ fn gather_possible_values(
         | Some("TSTypeAssertion") => {
             // TypeScript type assertions don't change the runtime value.
             // Unwrap to the underlying expression.
-            if let Some(expression) = node.get("expression") {
+            if let Some(expression) = node.field("expression") {
                 gather_possible_values(expression, is_class, values, is_nested);
             } else {
                 values.push(UNKNOWN_MARKER.to_string());

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css/warn.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css/warn.rs
@@ -5,6 +5,7 @@
 //! Corresponds to Svelte's `2-analyze/css/css-warn.js`.
 
 use crate::ast::css::StyleSheet;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Warning for an unused CSS selector.
 #[derive(Debug, Clone)]
@@ -33,14 +34,14 @@ fn collect_warnings(stylesheet: &StyleSheet, warnings: &mut Vec<CssWarning>) {
 }
 
 fn collect_node_warnings(node: &serde_json::Value, warnings: &mut Vec<CssWarning>) {
-    if let Some(node_type) = node.get("type").and_then(|t| t.as_str()) {
+    if let Some(node_type) = node.field("type").and_then(|t| t.as_str()) {
         match node_type {
             "Rule" => {
                 collect_rule_warnings(node, warnings);
             }
             "Atrule" => {
-                if let Some(block) = node.get("block")
-                    && let Some(children) = block.get("children").and_then(|c| c.as_array())
+                if let Some(block) = node.field("block")
+                    && let Some(children) = block.field("children").and_then(|c| c.as_array())
                 {
                     for child in children {
                         collect_node_warnings(child, warnings);
@@ -54,12 +55,12 @@ fn collect_node_warnings(node: &serde_json::Value, warnings: &mut Vec<CssWarning
 
 fn collect_rule_warnings(rule: &serde_json::Value, warnings: &mut Vec<CssWarning>) {
     // Check if the rule has unused metadata
-    if let Some(metadata) = rule.get("metadata")
-        && let Some(used) = metadata.get("used").and_then(|u| u.as_bool())
+    if let Some(metadata) = rule.field("metadata")
+        && let Some(used) = metadata.field("used").and_then(|u| u.as_bool())
         && !used
     {
-        let start = rule.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as u32;
-        let end = rule.get("end").and_then(|e| e.as_u64()).unwrap_or(0) as u32;
+        let start = rule.field("start").and_then(|s| s.as_u64()).unwrap_or(0) as u32;
+        let end = rule.field("end").and_then(|e| e.as_u64()).unwrap_or(0) as u32;
 
         warnings.push(CssWarning {
             selector: format!("selector at {}:{}", start, end),
@@ -70,8 +71,8 @@ fn collect_rule_warnings(rule: &serde_json::Value, warnings: &mut Vec<CssWarning
     }
 
     // Recursively check nested rules
-    if let Some(block) = rule.get("block")
-        && let Some(children) = block.get("children").and_then(|c| c.as_array())
+    if let Some(block) = rule.field("block")
+        && let Some(children) = block.field("children").and_then(|c| c.as_array())
     {
         for child in children {
             collect_node_warnings(child, warnings);

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
@@ -8,6 +8,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::types::DomStructure;
 use crate::ast::template::{self, Fragment, TemplateNode};
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Represents the value of an attribute for CSS matching purposes.
 #[derive(Debug, Clone)]
@@ -37,10 +38,10 @@ fn gather_possible_values(
     if *unknown {
         return;
     }
-    let ty = node.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    let ty = node.field("type").and_then(|t| t.as_str()).unwrap_or("");
     match ty {
         "Literal" => {
-            if let Some(v) = node.get("value") {
+            if let Some(v) = node.field("value") {
                 if let Some(s) = v.as_str() {
                     values.push(s.to_string());
                 } else if let Some(b) = v.as_bool() {
@@ -55,20 +56,23 @@ fn gather_possible_values(
             }
         }
         "ConditionalExpression" => {
-            if let Some(cons) = node.get("consequent") {
+            if let Some(cons) = node.field("consequent") {
                 gather_possible_values(cons, is_class, is_nested, values, unknown);
             }
-            if let Some(alt) = node.get("alternate") {
+            if let Some(alt) = node.field("alternate") {
                 gather_possible_values(alt, is_class, is_nested, values, unknown);
             }
         }
         "LogicalExpression" => {
-            let op = node.get("operator").and_then(|o| o.as_str()).unwrap_or("");
+            let op = node
+                .field("operator")
+                .and_then(|o| o.as_str())
+                .unwrap_or("");
             if op == "&&" {
                 // Gather left values into a temp set to detect UNKNOWN
                 let mut left_values = Vec::new();
                 let mut left_unknown = false;
-                if let Some(l) = node.get("left") {
+                if let Some(l) = node.field("left") {
                     gather_possible_values(
                         l,
                         is_class,
@@ -95,20 +99,20 @@ fn gather_possible_values(
                         }
                     }
                 }
-                if let Some(r) = node.get("right") {
+                if let Some(r) = node.field("right") {
                     gather_possible_values(r, is_class, is_nested, values, unknown);
                 }
             } else {
-                if let Some(l) = node.get("left") {
+                if let Some(l) = node.field("left") {
                     gather_possible_values(l, is_class, is_nested, values, unknown);
                 }
-                if let Some(r) = node.get("right") {
+                if let Some(r) = node.field("right") {
                     gather_possible_values(r, is_class, is_nested, values, unknown);
                 }
             }
         }
         "ArrayExpression" if is_class => {
-            if let Some(elements) = node.get("elements").and_then(|e| e.as_array()) {
+            if let Some(elements) = node.field("elements").and_then(|e| e.as_array()) {
                 for entry in elements {
                     if !entry.is_null() {
                         gather_possible_values(entry, is_class, true, values, unknown);
@@ -117,30 +121,33 @@ fn gather_possible_values(
             }
         }
         "ObjectExpression" if is_class => {
-            if let Some(properties) = node.get("properties").and_then(|p| p.as_array()) {
+            if let Some(properties) = node.field("properties").and_then(|p| p.as_array()) {
                 for property in properties {
-                    let prop_ty = property.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    let prop_ty = property
+                        .field("type")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("");
                     if prop_ty != "Property" {
                         *unknown = true;
                         continue;
                     }
                     let computed = property
-                        .get("computed")
+                        .field("computed")
                         .and_then(|c| c.as_bool())
                         .unwrap_or(false);
                     if computed {
                         *unknown = true;
                         continue;
                     }
-                    if let Some(key) = property.get("key") {
-                        let key_ty = key.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    if let Some(key) = property.field("key") {
+                        let key_ty = key.field("type").and_then(|t| t.as_str()).unwrap_or("");
                         if key_ty == "Identifier" {
-                            if let Some(name) = key.get("name").and_then(|n| n.as_str()) {
+                            if let Some(name) = key.field("name").and_then(|n| n.as_str()) {
                                 values.push(name.to_string());
                                 continue;
                             }
                         } else if key_ty == "Literal"
-                            && let Some(v) = key.get("value")
+                            && let Some(v) = key.field("value")
                         {
                             if let Some(s) = v.as_str() {
                                 values.push(s.to_string());
@@ -557,15 +564,15 @@ fn extract_selectors_from_rule(
     parent_selectors: &[CssComplexSelector],
     parent_is_fully_global: bool,
 ) {
-    let node_type = match node.get("type").and_then(|t| t.as_str()) {
+    let node_type = match node.field("type").and_then(|t| t.as_str()) {
         Some(t) => t,
         None => return,
     };
     match node_type {
         "Rule" => {
-            if let Some(metadata) = node.get("metadata")
+            if let Some(metadata) = node.field("metadata")
                 && metadata
-                    .get("is_global_block")
+                    .field("is_global_block")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false)
             {
@@ -573,8 +580,9 @@ fn extract_selectors_from_rule(
             }
             // Parse this rule's own prelude selectors
             let mut own_selectors: Vec<CssComplexSelector> = Vec::new();
-            if let Some(prelude) = node.get("prelude")
-                && let Some(complex_selectors) = prelude.get("children").and_then(|c| c.as_array())
+            if let Some(prelude) = node.field("prelude")
+                && let Some(complex_selectors) =
+                    prelude.field("children").and_then(|c| c.as_array())
             {
                 for cs in complex_selectors {
                     if let Some(parsed) = parse_complex_selector(cs) {
@@ -631,8 +639,8 @@ fn extract_selectors_from_rule(
 
             // Recurse into nested rules with the effective selectors as the new
             // parent_selectors context.
-            if let Some(block) = node.get("block")
-                && let Some(children) = block.get("children").and_then(|c| c.as_array())
+            if let Some(block) = node.field("block")
+                && let Some(children) = block.field("children").and_then(|c| c.as_array())
             {
                 for child in children {
                     extract_selectors_from_rule(child, selectors, &effective, own_is_fully_global);
@@ -645,8 +653,8 @@ fn extract_selectors_from_rule(
             // it, so a step still has to satisfy its parent rule chain; the
             // parser emits an empty relative selector for `0%`, which matches
             // any element, and `from` / `to` stay type selectors that match none.
-            if let Some(block) = node.get("block")
-                && let Some(children) = block.get("children").and_then(|c| c.as_array())
+            if let Some(block) = node.field("block")
+                && let Some(children) = block.field("children").and_then(|c| c.as_array())
             {
                 for child in children {
                     extract_selectors_from_rule(
@@ -821,7 +829,7 @@ fn substitute_explicit_nesting(
 }
 
 fn parse_complex_selector(cs: &serde_json::Value) -> Option<CssComplexSelector> {
-    let children = cs.get("children")?.as_array()?;
+    let children = cs.field("children")?.as_array()?;
     let mut relative_selectors = Vec::new();
     for rel in children {
         if let Some(parsed) = parse_relative_selector(rel) {
@@ -837,23 +845,23 @@ fn parse_complex_selector(cs: &serde_json::Value) -> Option<CssComplexSelector> 
 }
 
 fn parse_relative_selector(rel: &serde_json::Value) -> Option<CssRelativeSelector> {
-    let combinator = rel.get("combinator").and_then(|c| {
+    let combinator = rel.field("combinator").and_then(|c| {
         if c.is_null() {
             None
         } else {
-            c.get("name")
+            c.field("name")
                 .and_then(|n| n.as_str())
                 .map(|s| s.to_string())
         }
     });
 
     let is_global = rel
-        .get("metadata")
-        .and_then(|m| m.get("is_global"))
+        .field("metadata")
+        .and_then(|m| m.field("is_global"))
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    let selectors_json = rel.get("selectors")?.as_array()?;
+    let selectors_json = rel.field("selectors")?.as_array()?;
 
     // Compute `is_global_like` the way upstream's css-analyze.js RelativeSelector
     // visitor does (the parser does not store this metadata in the JSON AST):
@@ -861,8 +869,8 @@ fn parse_relative_selector(rel: &serde_json::Value) -> Option<CssRelativeSelecto
     //    `:host` or a `::view-transition*` pseudo-element, or
     // 2. any selector is `:root` and none is `:has`.
     let is_global_like = rel
-        .get("metadata")
-        .and_then(|m| m.get("is_global_like"))
+        .field("metadata")
+        .and_then(|m| m.field("is_global_like"))
         .and_then(|v| v.as_bool())
         .unwrap_or_else(|| compute_is_global_like(selectors_json));
     let mut selectors = Vec::new();
@@ -884,13 +892,13 @@ fn parse_relative_selector(rel: &serde_json::Value) -> Option<CssRelativeSelecto
 /// `is_global_like` computation (lines 156-181).
 fn compute_is_global_like(selectors_json: &[serde_json::Value]) -> bool {
     let ty = |s: &serde_json::Value| {
-        s.get("type")
+        s.field("type")
             .and_then(|t| t.as_str())
             .unwrap_or("")
             .to_string()
     };
     let name = |s: &serde_json::Value| {
-        s.get("name")
+        s.field("name")
             .and_then(|n| n.as_str())
             .unwrap_or("")
             .to_string()
@@ -931,36 +939,36 @@ fn compute_is_global_like(selectors_json: &[serde_json::Value]) -> bool {
 }
 
 fn parse_simple_selector(sel: &serde_json::Value) -> Option<CssSimpleSelector> {
-    let sel_type = sel.get("type")?.as_str()?;
+    let sel_type = sel.field("type")?.as_str()?;
     match sel_type {
         "TypeSelector" => {
-            let name = sel.get("name")?.as_str()?.to_string();
+            let name = sel.field("name")?.as_str()?.to_string();
             Some(CssSimpleSelector::Type(name))
         }
         "ClassSelector" => {
-            let name = sel.get("name")?.as_str()?.to_string();
+            let name = sel.field("name")?.as_str()?.to_string();
             Some(CssSimpleSelector::Class(decode_css_escape(&name)))
         }
         "IdSelector" => {
-            let name = sel.get("name")?.as_str()?.to_string();
+            let name = sel.field("name")?.as_str()?.to_string();
             Some(CssSimpleSelector::Id(decode_css_escape(&name)))
         }
         "AttributeSelector" => {
             let name = sel
-                .get("name")
+                .field("name")
                 .and_then(|n| n.as_str())
                 .unwrap_or("")
                 .to_string();
             let matcher = sel
-                .get("matcher")
+                .field("matcher")
                 .and_then(|m| if m.is_null() { None } else { m.as_str() })
                 .map(|s| s.to_string());
             let value = sel
-                .get("value")
+                .field("value")
                 .and_then(|v| if v.is_null() { None } else { v.as_str() })
                 .map(|s| s.to_string());
             let flags = sel
-                .get("flags")
+                .field("flags")
                 .and_then(|f| if f.is_null() { None } else { f.as_str() })
                 .map(|s| s.to_string());
             Some(CssSimpleSelector::Attribute {
@@ -971,12 +979,12 @@ fn parse_simple_selector(sel: &serde_json::Value) -> Option<CssSimpleSelector> {
             })
         }
         "PseudoClassSelector" => {
-            let name = sel.get("name")?.as_str()?.to_string();
-            let args = sel.get("args").and_then(|args| {
+            let name = sel.field("name")?.as_str()?.to_string();
+            let args = sel.field("args").and_then(|args| {
                 if args.is_null() {
                     return None;
                 }
-                let children = args.get("children")?.as_array()?;
+                let children = args.field("children")?.as_array()?;
                 let mut complex_selectors = Vec::new();
                 for cs in children {
                     if let Some(parsed) = parse_complex_selector(cs) {
@@ -1388,15 +1396,15 @@ fn has_sibling_combinator(selector: &CssComplexSelector) -> bool {
 fn get_render_tag_callee_name(render_tag: &template::RenderTag) -> Option<String> {
     // Use JSON-based approach to avoid arena dependency
     let expr_json = render_tag.expression.as_json();
-    let expr = if expr_json.get("type").and_then(|t| t.as_str()) == Some("ChainExpression") {
-        expr_json.get("expression").unwrap_or(expr_json)
+    let expr = if expr_json.field("type").and_then(|t| t.as_str()) == Some("ChainExpression") {
+        expr_json.field("expression").unwrap_or(expr_json)
     } else {
         expr_json
     };
-    let callee = expr.get("callee")?;
-    if callee.get("type").and_then(|t| t.as_str()) == Some("Identifier") {
+    let callee = expr.field("callee")?;
+    if callee.field("type").and_then(|t| t.as_str()) == Some("Identifier") {
         callee
-            .get("name")
+            .field("name")
             .and_then(|n| n.as_str())
             .map(String::from)
     } else {
@@ -3295,9 +3303,9 @@ fn component_snippet_resolution(attributes: &[template::Attribute]) -> (bool, Ve
             template::Attribute::Attribute(a) => {
                 if let template::AttributeValue::Expression(expr_tag) = &a.value {
                     let json = expr_tag.expression.as_json();
-                    match json.get("type").and_then(|t| t.as_str()) {
+                    match json.field("type").and_then(|t| t.as_str()) {
                         Some("Identifier") => {
-                            if let Some(n) = json.get("name").and_then(|n| n.as_str()) {
+                            if let Some(n) = json.field("name").and_then(|n| n.as_str()) {
                                 names.push(n.to_string());
                             }
                         }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -48,6 +48,7 @@ use crate::ast::arena::ParseArena;
 use crate::ast::template::Root;
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::CompileOptions;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Analyze a parsed Svelte component.
 ///
@@ -183,8 +184,8 @@ pub(crate) fn analyze_prepared_component_with_retained(
         // 49-53: `remove_typescript_nodes(customElementOptions.extend)`).
         let extend = ce_opts.extend.as_ref().and_then(|expr| {
             let json = expr.as_json();
-            let start = json.get("start")?.as_u64()? as usize;
-            let end = json.get("end")?.as_u64()? as usize;
+            let start = json.field("start")?.as_u64()? as usize;
+            let end = json.field("end")?.as_u64()? as usize;
             let text = source.get(start..end)?.to_string();
             let is_ts = |script: &Option<Box<crate::ast::Script>>| {
                 script.as_ref().is_some_and(|s| {
@@ -212,8 +213,8 @@ pub(crate) fn analyze_prepared_component_with_retained(
         // upstream passes the AST through to `create_custom_element`
         // (transform-client.js line 641: `shadow_root_init = ce.shadow`).
         let shadow_object_source = ce_opts.shadow_object.as_ref().and_then(|obj| {
-            let start = obj.get("start")?.as_u64()? as usize;
-            let end = obj.get("end")?.as_u64()? as usize;
+            let start = obj.field("start")?.as_u64()? as usize;
+            let end = obj.field("end")?.as_u64()? as usize;
             Some(source.get(start..end)?.to_string())
         });
         analysis.custom_element = Some(types::CustomElementConfig {
@@ -1274,8 +1275,8 @@ fn blob_span(node: &serde_json::Value) -> (u32, u32) {
 /// `Identifier` is terminal because every JSON walker's `Identifier` arm
 /// recorded the name and stopped, never descending into a nested annotation.
 fn for_each_blob_identifier(blob: &serde_json::Value, f: &mut impl FnMut(&str, (u32, u32))) {
-    if blob.get("type").and_then(|t| t.as_str()) == Some("Identifier") {
-        if let Some(name) = blob.get("name").and_then(|n| n.as_str()) {
+    if blob.field("type").and_then(|t| t.as_str()) == Some("Identifier") {
+        if let Some(name) = blob.field("name").and_then(|n| n.as_str()) {
             f(name, blob_span(blob));
         }
         return;
@@ -5109,55 +5110,55 @@ fn extract_all_identifiers_from_expr(expr: &serde_json::Value, ids: &mut Vec<Str
         Some(o) => o,
         None => return,
     };
-    let expr_type = match obj.get("type").and_then(|t| t.as_str()) {
+    let expr_type = match obj.field("type").and_then(|t| t.as_str()) {
         Some(t) => t,
         None => return,
     };
     match expr_type {
         "Identifier" => {
-            if let Some(name) = obj.get("name").and_then(|n| n.as_str())
+            if let Some(name) = obj.field("name").and_then(|n| n.as_str())
                 && !ids.iter().any(|i| i == name)
             {
                 ids.push(name.to_string());
             }
         }
         "MemberExpression" => {
-            if let Some(object) = obj.get("object") {
+            if let Some(object) = obj.field("object") {
                 extract_all_identifiers_from_expr(object, ids);
             }
             // Only extract computed property identifiers (e.g., [index] in arr[index])
-            if obj.get("computed").and_then(|c| c.as_bool()) == Some(true)
-                && let Some(property) = obj.get("property")
+            if obj.field("computed").and_then(|c| c.as_bool()) == Some(true)
+                && let Some(property) = obj.field("property")
             {
                 extract_all_identifiers_from_expr(property, ids);
             }
         }
         "CallExpression" => {
-            if let Some(callee) = obj.get("callee") {
+            if let Some(callee) = obj.field("callee") {
                 extract_all_identifiers_from_expr(callee, ids);
             }
-            if let Some(args) = obj.get("arguments").and_then(|a| a.as_array()) {
+            if let Some(args) = obj.field("arguments").and_then(|a| a.as_array()) {
                 for arg in args {
                     extract_all_identifiers_from_expr(arg, ids);
                 }
             }
         }
         "BinaryExpression" | "LogicalExpression" => {
-            if let Some(left) = obj.get("left") {
+            if let Some(left) = obj.field("left") {
                 extract_all_identifiers_from_expr(left, ids);
             }
-            if let Some(right) = obj.get("right") {
+            if let Some(right) = obj.field("right") {
                 extract_all_identifiers_from_expr(right, ids);
             }
         }
         "ConditionalExpression" => {
-            if let Some(test) = obj.get("test") {
+            if let Some(test) = obj.field("test") {
                 extract_all_identifiers_from_expr(test, ids);
             }
-            if let Some(consequent) = obj.get("consequent") {
+            if let Some(consequent) = obj.field("consequent") {
                 extract_all_identifiers_from_expr(consequent, ids);
             }
-            if let Some(alternate) = obj.get("alternate") {
+            if let Some(alternate) = obj.field("alternate") {
                 extract_all_identifiers_from_expr(alternate, ids);
             }
         }
@@ -5281,34 +5282,34 @@ fn build_keypath_parts(expr: &serde_json::Value, parts: &mut Vec<String>) {
         Some(o) => o,
         None => return,
     };
-    let expr_type = match obj.get("type").and_then(|t| t.as_str()) {
+    let expr_type = match obj.field("type").and_then(|t| t.as_str()) {
         Some(t) => t,
         None => return,
     };
     match expr_type {
         "Identifier" => {
-            if let Some(name) = obj.get("name").and_then(|n| n.as_str()) {
+            if let Some(name) = obj.field("name").and_then(|n| n.as_str()) {
                 parts.push(name.to_string());
             }
         }
         "MemberExpression" => {
             // Walk the object part
-            if let Some(object) = obj.get("object") {
+            if let Some(object) = obj.field("object") {
                 build_keypath_parts(object, parts);
             }
             // Handle the property part
             let computed = obj
-                .get("computed")
+                .field("computed")
                 .and_then(|c| c.as_bool())
                 .unwrap_or(false);
             if computed {
                 // Computed property: arr[idx] → push "[idx]"
-                if let Some(property) = obj.get("property") {
+                if let Some(property) = obj.field("property") {
                     let prop_str = build_binding_keypath(property);
                     parts.push(format!("[{}]", prop_str));
                 }
-            } else if let Some(property) = obj.get("property")
-                && let Some(name) = property.get("name").and_then(|n| n.as_str())
+            } else if let Some(property) = obj.field("property")
+                && let Some(name) = property.field("name").and_then(|n| n.as_str())
             {
                 // Static property: obj.prop → push "prop"
                 parts.push(name.to_string());
@@ -6510,7 +6511,7 @@ fn collect_identifier_names_in_json(
     use serde_json::Value;
     match value {
         Value::Object(obj) => {
-            let node_type = obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            let node_type = obj.field("type").and_then(|t| t.as_str()).unwrap_or("");
 
             // TypeScript type-space nodes (`TSTypeAnnotation`, `TSTypeReference`,
             // …) never contain value references — their identifiers live in type
@@ -6525,7 +6526,7 @@ fn collect_identifier_names_in_json(
 
             // If this is an Identifier node, collect its name.
             if node_type == "Identifier"
-                && let Some(Value::String(name)) = obj.get("name")
+                && let Some(Value::String(name)) = obj.field("name")
             {
                 out.insert(name.clone());
             }
@@ -6541,11 +6542,11 @@ fn collect_identifier_names_in_json(
                     "MemberExpression" => {
                         // For non-computed member expressions, the property is a name slot, not a ref
                         k == "property"
-                            && obj.get("computed").and_then(|c| c.as_bool()) != Some(true)
+                            && obj.field("computed").and_then(|c| c.as_bool()) != Some(true)
                     }
                     "Property" | "MethodDefinition" | "PropertyDefinition" => {
                         // Non-computed object/class property keys are name slots, not refs
-                        k == "key" && obj.get("computed").and_then(|c| c.as_bool()) != Some(true)
+                        k == "key" && obj.field("computed").and_then(|c| c.as_bool()) != Some(true)
                     }
                     "FunctionDeclaration"
                     | "FunctionExpression"

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/pattern_ids.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/pattern_ids.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 
 use crate::ast::arena::ParseArena;
 use crate::ast::typed_expr::JsNode;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Collect bound identifier names from a destructuring pattern (typed).
 ///
@@ -56,27 +57,27 @@ pub(crate) fn collect_pattern_identifiers(
 /// a `serde_json::Value` (template expressions where no `ParseArena` is
 /// threaded). Enumeration order and duplicate handling match the typed walker.
 pub(crate) fn collect_pattern_identifiers_json(node: &Value, names: &mut Vec<String>) {
-    match node.get("type").and_then(|t| t.as_str()) {
+    match node.field("type").and_then(|t| t.as_str()) {
         Some("Identifier") => {
-            if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
+            if let Some(name) = node.field("name").and_then(|n| n.as_str()) {
                 names.push(name.to_string());
             }
         }
         Some("ObjectPattern" | "ObjectExpression") => {
-            if let Some(props) = node.get("properties").and_then(|p| p.as_array()) {
+            if let Some(props) = node.field("properties").and_then(|p| p.as_array()) {
                 for prop in props {
-                    if prop.get("type").and_then(|t| t.as_str()) == Some("RestElement") {
-                        if let Some(arg) = prop.get("argument") {
+                    if prop.field("type").and_then(|t| t.as_str()) == Some("RestElement") {
+                        if let Some(arg) = prop.field("argument") {
                             collect_pattern_identifiers_json(arg, names);
                         }
-                    } else if let Some(value) = prop.get("value") {
+                    } else if let Some(value) = prop.field("value") {
                         collect_pattern_identifiers_json(value, names);
                     }
                 }
             }
         }
         Some("ArrayPattern" | "ArrayExpression") => {
-            if let Some(elements) = node.get("elements").and_then(|e| e.as_array()) {
+            if let Some(elements) = node.field("elements").and_then(|e| e.as_array()) {
                 for elem in elements {
                     if !elem.is_null() {
                         collect_pattern_identifiers_json(elem, names);
@@ -85,12 +86,12 @@ pub(crate) fn collect_pattern_identifiers_json(node: &Value, names: &mut Vec<Str
             }
         }
         Some("AssignmentPattern") => {
-            if let Some(left) = node.get("left") {
+            if let Some(left) = node.field("left") {
                 collect_pattern_identifiers_json(left, names);
             }
         }
         Some("RestElement" | "SpreadElement") => {
-            if let Some(arg) = node.get("argument") {
+            if let Some(arg) = node.field("argument") {
                 collect_pattern_identifiers_json(arg, names);
             }
         }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/await_expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/await_expression.rs
@@ -7,6 +7,7 @@
 use super::{JsPathEntry, VisitorContext};
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::AnalysisError;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use serde_json::Value;
 
 /// Returns true when the JS path between the current node and the enclosing
@@ -106,19 +107,19 @@ fn is_last_evaluated_expression_js(js_path: &[JsPathEntry], node: &Value) -> boo
 
     for entry in js_path.iter().rev() {
         let parent = entry.as_value();
-        let parent_type = parent.get("type").and_then(|t| t.as_str());
+        let parent_type = parent.field("type").and_then(|t| t.as_str());
 
         if parent_type == Some("ConstTag") {
             return false;
         }
 
-        if parent.get("metadata").is_some() {
+        if parent.field("metadata").is_some() {
             return true;
         }
 
         match parent_type {
             Some("ArrayExpression") => {
-                if let Some(Value::Array(elements)) = parent.get("elements")
+                if let Some(Value::Array(elements)) = parent.field("elements")
                     && !is_same_node(elements.last(), current)
                 {
                     return false;
@@ -126,13 +127,13 @@ fn is_last_evaluated_expression_js(js_path: &[JsPathEntry], node: &Value) -> boo
             }
 
             Some("AssignmentExpression") | Some("BinaryExpression") | Some("LogicalExpression") => {
-                if is_same_node(parent.get("left"), current) {
+                if is_same_node(parent.field("left"), current) {
                     return false;
                 }
             }
 
             Some("CallExpression") | Some("NewExpression") => {
-                if let Some(Value::Array(args)) = parent.get("arguments")
+                if let Some(Value::Array(args)) = parent.field("arguments")
                     && !is_same_node(args.last(), current)
                 {
                     return false;
@@ -140,24 +141,24 @@ fn is_last_evaluated_expression_js(js_path: &[JsPathEntry], node: &Value) -> boo
             }
 
             Some("ConditionalExpression") => {
-                if is_same_node(parent.get("test"), current) {
+                if is_same_node(parent.field("test"), current) {
                     return false;
                 }
             }
 
             Some("MemberExpression") => {
                 if parent
-                    .get("computed")
+                    .field("computed")
                     .and_then(|c| c.as_bool())
                     .unwrap_or(false)
-                    && is_same_node(parent.get("object"), current)
+                    && is_same_node(parent.field("object"), current)
                 {
                     return false;
                 }
             }
 
             Some("ObjectExpression") => {
-                if let Some(Value::Array(props)) = parent.get("properties")
+                if let Some(Value::Array(props)) = parent.field("properties")
                     && !is_same_node(props.last(), current)
                 {
                     return false;
@@ -165,13 +166,13 @@ fn is_last_evaluated_expression_js(js_path: &[JsPathEntry], node: &Value) -> boo
             }
 
             Some("Property") => {
-                if is_same_node(parent.get("key"), current) {
+                if is_same_node(parent.field("key"), current) {
                     return false;
                 }
             }
 
             Some("SequenceExpression") => {
-                if let Some(Value::Array(exprs)) = parent.get("expressions")
+                if let Some(Value::Array(exprs)) = parent.field("expressions")
                     && !is_same_node(exprs.last(), current)
                 {
                     return false;
@@ -179,8 +180,8 @@ fn is_last_evaluated_expression_js(js_path: &[JsPathEntry], node: &Value) -> boo
             }
 
             Some("TaggedTemplateExpression") => {
-                if let Some(quasi) = parent.get("quasi")
-                    && let Some(Value::Array(exprs)) = quasi.get("expressions")
+                if let Some(quasi) = parent.field("quasi")
+                    && let Some(Value::Array(exprs)) = quasi.field("expressions")
                     && !is_same_node(exprs.last(), current)
                 {
                     return false;
@@ -188,7 +189,7 @@ fn is_last_evaluated_expression_js(js_path: &[JsPathEntry], node: &Value) -> boo
             }
 
             Some("TemplateLiteral") => {
-                if let Some(Value::Array(exprs)) = parent.get("expressions")
+                if let Some(Value::Array(exprs)) = parent.field("expressions")
                     && !is_same_node(exprs.last(), current)
                 {
                     return false;
@@ -214,10 +215,10 @@ fn is_last_evaluated_expression_js(js_path: &[JsPathEntry], node: &Value) -> boo
 fn is_same_node(a: Option<&Value>, b: &Value) -> bool {
     match a {
         Some(a_val) => {
-            let a_start = a_val.get("start").and_then(|s| s.as_u64());
-            let b_start = b.get("start").and_then(|s| s.as_u64());
-            let a_end = a_val.get("end").and_then(|s| s.as_u64());
-            let b_end = b.get("end").and_then(|s| s.as_u64());
+            let a_start = a_val.field("start").and_then(|s| s.as_u64());
+            let b_start = b.field("start").and_then(|s| s.as_u64());
+            let a_end = a_val.field("end").and_then(|s| s.as_u64());
+            let b_end = b.field("end").and_then(|s| s.as_u64());
             a_start.is_some() && a_start == b_start && a_end == b_end
         }
         None => false,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
@@ -13,6 +13,7 @@ use crate::compiler::phases::phase2_analyze::binding_properties::{
     BINDING_PROPERTIES, all_binding_names, get_valid_bindings,
 };
 use crate::compiler::phases::phase2_analyze::errors;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 /// Visit a bind directive with explicit element context.
 ///
 /// This is called from regular_element visitor when we have direct access to the element.
@@ -815,18 +816,18 @@ fn get_object_name_via_json(node: &JsNode) -> Option<String> {
 }
 
 fn get_object_name_from_json(v: &serde_json::Value) -> Option<String> {
-    let node_type = v.get("type")?.as_str()?;
+    let node_type = v.field("type")?.as_str()?;
     match node_type {
-        "Identifier" => v.get("name").and_then(|n| n.as_str()).map(String::from),
+        "Identifier" => v.field("name").and_then(|n| n.as_str()).map(String::from),
         "MemberExpression" => {
-            let obj = v.get("object")?;
+            let obj = v.field("object")?;
             get_object_name_from_json(obj)
         }
         "TSAsExpression"
         | "TSSatisfiesExpression"
         | "TSNonNullExpression"
         | "TSTypeAssertion"
-        | "TSInstantiationExpression" => get_object_name_from_json(v.get("expression")?),
+        | "TSInstantiationExpression" => get_object_name_from_json(v.field("expression")?),
         _ => None,
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/call_expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/call_expression.rs
@@ -8,6 +8,7 @@ use super::super::errors;
 use super::VisitorContext;
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::AnalysisError;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use serde_json::Value;
 
 /// Get the rune name from a CallExpression node, if it is a rune call.
@@ -19,11 +20,11 @@ use serde_json::Value;
 /// * `node` - The CallExpression node
 /// * `context` - The visitor context
 fn get_rune(node: &Value, context: &VisitorContext) -> Option<String> {
-    if node.get("type").and_then(|t| t.as_str()) != Some("CallExpression") {
+    if node.field("type").and_then(|t| t.as_str()) != Some("CallExpression") {
         return None;
     }
 
-    let callee = node.get("callee")?;
+    let callee = node.field("callee")?;
     let keypath = get_global_keypath(callee, context)?;
 
     if super::shared::function::is_rune(&keypath) {
@@ -48,28 +49,31 @@ fn get_global_keypath(node: &Value, context: &VisitorContext) -> Option<String> 
     let mut joined = String::new();
 
     // Handle MemberExpression chain
-    while n.get("type").and_then(|t| t.as_str()) == Some("MemberExpression") {
+    while n.field("type").and_then(|t| t.as_str()) == Some("MemberExpression") {
         // Must not be computed
-        if n.get("computed").and_then(|c| c.as_bool()).unwrap_or(false) {
+        if n.field("computed")
+            .and_then(|c| c.as_bool())
+            .unwrap_or(false)
+        {
             return None;
         }
 
         // Property must be an Identifier
-        let property = n.get("property")?;
-        if property.get("type").and_then(|t| t.as_str()) != Some("Identifier") {
+        let property = n.field("property")?;
+        if property.field("type").and_then(|t| t.as_str()) != Some("Identifier") {
             return None;
         }
 
-        let prop_name = property.get("name").and_then(|n| n.as_str())?;
+        let prop_name = property.field("name").and_then(|n| n.as_str())?;
         joined = format!(".{}{}", prop_name, joined);
 
-        n = n.get("object")?;
+        n = n.field("object")?;
     }
 
     // Handle CallExpression (for patterns like `$inspect().with`)
-    if n.get("type").and_then(|t| t.as_str()) == Some("CallExpression") {
-        let callee = n.get("callee")?;
-        if callee.get("type").and_then(|t| t.as_str()) != Some("Identifier") {
+    if n.field("type").and_then(|t| t.as_str()) == Some("CallExpression") {
+        let callee = n.field("callee")?;
+        if callee.field("type").and_then(|t| t.as_str()) != Some("Identifier") {
             return None;
         }
         joined = format!("(){}", joined);
@@ -77,11 +81,11 @@ fn get_global_keypath(node: &Value, context: &VisitorContext) -> Option<String> 
     }
 
     // Must be an Identifier at the base
-    if n.get("type").and_then(|t| t.as_str()) != Some("Identifier") {
+    if n.field("type").and_then(|t| t.as_str()) != Some("Identifier") {
         return None;
     }
 
-    let name = n.get("name").and_then(|n| n.as_str())?;
+    let name = n.field("name").and_then(|n| n.as_str())?;
 
     // Check if it's a binding (if so, it's not a rune/global)
     // This matches the official Svelte compiler's get_global_keypath in scope.js (L1408-1409):
@@ -205,7 +209,7 @@ fn is_bindable_valid_placement(context: &VisitorContext) -> bool {
         return get_rune_node(init_node, context).as_deref() == Some("$props");
     }
 
-    if let Some(init) = var_declarator.as_value().get("init") {
+    if let Some(init) = var_declarator.as_value().field("init") {
         let rune = get_rune(init, context);
         return rune.as_deref() == Some("$props");
     }
@@ -390,8 +394,8 @@ fn is_props_id_valid_placement(context: &VisitorContext) -> bool {
         ) {
             return false;
         }
-    } else if let Some(id) = parent.as_value().get("id") {
-        let id_type = id.get("type").and_then(|t| t.as_str());
+    } else if let Some(id) = parent.as_value().field("id") {
+        let id_type = id.field("type").and_then(|t| t.as_str());
         if id_type != Some("Identifier") {
             return false;
         }
@@ -527,7 +531,7 @@ fn is_class_property_assignment_at_constructor_root(
     context: &VisitorContext,
 ) -> bool {
     // Check assignment operator is '='
-    if node.get("operator").and_then(|o| o.as_str()) != Some("=") {
+    if node.field("operator").and_then(|o| o.as_str()) != Some("=") {
         return false;
     }
 
@@ -550,29 +554,33 @@ fn is_class_property_assignment_at_constructor_root(
     // Check left side: MemberExpression with 'this' object.
     // If left is null (private field expression not handled by parser), we still
     // accept the placement since we confirmed we're in a constructor.
-    let left = match node.get("left") {
+    let left = match node.field("left") {
         Some(l) if !l.is_null() => l,
         _ => return true, // Accept: we're in constructor, left is null (private field)
     };
 
-    let left_type = left.get("type").and_then(|t| t.as_str());
+    let left_type = left.field("type").and_then(|t| t.as_str());
     if left_type != Some("MemberExpression") {
         return false;
     }
 
-    let object = left.get("object");
-    if object.and_then(|o| o.get("type")).and_then(|t| t.as_str()) != Some("ThisExpression") {
+    let object = left.field("object");
+    if object
+        .and_then(|o| o.field("type"))
+        .and_then(|t| t.as_str())
+        != Some("ThisExpression")
+    {
         return false;
     }
 
     // Check property type: must be (Identifier && !computed) || PrivateIdentifier || Literal
     // This mirrors the official Svelte compiler's is_class_property_assignment_at_constructor_root
     let computed = left
-        .get("computed")
+        .field("computed")
         .and_then(|c| c.as_bool())
         .unwrap_or(false);
-    if let Some(property) = left.get("property") {
-        let prop_type = property.get("type").and_then(|t| t.as_str());
+    if let Some(property) = left.field("property") {
+        let prop_type = property.field("type").and_then(|t| t.as_str());
         match prop_type {
             Some("Identifier") if !computed => true,
             Some("PrivateIdentifier") => true,
@@ -664,11 +672,11 @@ fn is_inspect_trace_valid_placement(context: &VisitorContext) -> bool {
     // distinct AST nodes have distinct `start` offsets within a single parse.
     if let Some(body) = grandparent
         .as_value()
-        .get("body")
+        .field("body")
         .and_then(|b| b.as_array())
         && let Some(first) = body.first()
     {
-        let first_start = first.get("start").and_then(|s| s.as_u64());
+        let first_start = first.field("start").and_then(|s| s.as_u64());
         let parent_start = parent.get_field_u64("start");
         return first_start.is_some() && first_start == parent_start;
     }
@@ -801,8 +809,8 @@ pub(crate) fn validate_rune_call(
             if let Some(parent) = get_parent(context, 1)
                 && let Some(id_name) = parent
                     .as_value()
-                    .get("id")
-                    .and_then(|id| id.get("name"))
+                    .field("id")
+                    .and_then(|id| id.field("name"))
                     .and_then(|n| n.as_str())
             {
                 context.analysis.props_id = Some(id_name.to_string());

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/class_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/class_body.rs
@@ -13,6 +13,7 @@ use super::super::types::StateField;
 use super::VisitorContext;
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::AnalysisError;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Visit a class body.
 ///
@@ -31,7 +32,7 @@ fn visit_impl(
     context: &mut VisitorContext,
 ) -> Result<(), AnalysisError> {
     // Get the class body array
-    let body = match node.get("body").and_then(|b| b.as_array()) {
+    let body = match node.field("body").and_then(|b| b.as_array()) {
         Some(b) => b,
         None => return Ok(()),
     };
@@ -48,8 +49,8 @@ fn visit_impl(
 
     /// Helper function to get a node's `(start, end)` source range
     fn span(node: &Value) -> Option<(u32, u32)> {
-        let start = node.get("start")?.as_u64()? as u32;
-        let end = node.get("end")?.as_u64()? as u32;
+        let start = node.field("start")?.as_u64()? as u32;
+        let end = node.field("end")?.as_u64()? as u32;
         Some((start, end))
     }
 
@@ -64,18 +65,18 @@ fn visit_impl(
 
     /// Helper function to get the name from a key (Identifier, PrivateIdentifier, or Literal)
     fn get_name(key: &Value) -> Option<String> {
-        match key.get("type").and_then(|t| t.as_str()) {
-            Some("Literal") => key.get("value").and_then(|v| {
+        match key.field("type").and_then(|t| t.as_str()) {
+            Some("Literal") => key.field("value").and_then(|v| {
                 v.as_str()
                     .map(|s| s.to_string())
                     .or_else(|| v.as_i64().map(|n| n.to_string()))
             }),
             Some("PrivateIdentifier") => key
-                .get("name")
+                .field("name")
                 .and_then(|n| n.as_str())
                 .map(|n| format!("#{}", n)),
             Some("Identifier") => key
-                .get("name")
+                .field("name")
                 .and_then(|n| n.as_str())
                 .map(|s| s.to_string()),
             _ => None,
@@ -84,30 +85,30 @@ fn visit_impl(
 
     /// Helper function to check if a value is a rune call and return the rune name
     fn get_rune(value: &Value) -> Option<String> {
-        if value.get("type").and_then(|t| t.as_str()) != Some("CallExpression") {
+        if value.field("type").and_then(|t| t.as_str()) != Some("CallExpression") {
             return None;
         }
 
-        let callee = value.get("callee")?;
+        let callee = value.field("callee")?;
 
         // Handle direct rune calls ($state, $derived, etc.)
-        if callee.get("type").and_then(|t| t.as_str()) == Some("Identifier") {
-            let name = callee.get("name").and_then(|n| n.as_str())?;
+        if callee.field("type").and_then(|t| t.as_str()) == Some("Identifier") {
+            let name = callee.field("name").and_then(|n| n.as_str())?;
             if is_state_creation_rune(name) {
                 return Some(name.to_string());
             }
         }
 
         // Handle member expression runes ($state.raw, $derived.by)
-        if callee.get("type").and_then(|t| t.as_str()) == Some("MemberExpression") {
-            let object = callee.get("object")?;
-            let property = callee.get("property")?;
+        if callee.field("type").and_then(|t| t.as_str()) == Some("MemberExpression") {
+            let object = callee.field("object")?;
+            let property = callee.field("property")?;
 
-            if object.get("type").and_then(|t| t.as_str()) == Some("Identifier")
-                && property.get("type").and_then(|t| t.as_str()) == Some("Identifier")
+            if object.field("type").and_then(|t| t.as_str()) == Some("Identifier")
+                && property.field("type").and_then(|t| t.as_str()) == Some("Identifier")
             {
-                let obj_name = object.get("name").and_then(|n| n.as_str())?;
-                let prop_name = property.get("name").and_then(|n| n.as_str())?;
+                let obj_name = object.field("name").and_then(|n| n.as_str())?;
+                let prop_name = property.field("name").and_then(|n| n.as_str())?;
                 let full_name = format!("{}.{}", obj_name, prop_name);
 
                 if is_state_creation_rune(&full_name) {
@@ -170,24 +171,24 @@ fn visit_impl(
 
     // Process property definitions and methods
     for child in body {
-        let child_type = child.get("type").and_then(|t| t.as_str());
+        let child_type = child.field("type").and_then(|t| t.as_str());
 
         // Handle PropertyDefinition
         if child_type == Some("PropertyDefinition") {
             let computed = child
-                .get("computed")
+                .field("computed")
                 .and_then(|c| c.as_bool())
                 .unwrap_or(false);
             let is_static = child
-                .get("static")
+                .field("static")
                 .and_then(|s| s.as_bool())
                 .unwrap_or(false);
 
             if !computed
                 && !is_static
-                && let Some(key) = child.get("key")
+                && let Some(key) = child.field("key")
             {
-                let value = child.get("value");
+                let value = child.field("value");
                 handle_field(child, key, value, &mut state_fields, &mut fields, false)?;
 
                 // Track the field for duplicate detection
@@ -213,7 +214,7 @@ fn visit_impl(
         // Handle MethodDefinition
         if child_type == Some("MethodDefinition") {
             let kind = child
-                .get("kind")
+                .field("kind")
                 .and_then(|k| k.as_str())
                 .unwrap_or("method");
 
@@ -221,16 +222,16 @@ fn visit_impl(
                 constructor = Some(child);
             } else {
                 let computed = child
-                    .get("computed")
+                    .field("computed")
                     .and_then(|c| c.as_bool())
                     .unwrap_or(false);
 
                 if !computed
-                    && let Some(key) = child.get("key")
+                    && let Some(key) = child.field("key")
                     && let Some(name) = get_name(key)
                 {
                     let is_static = child
-                        .get("static")
+                        .field("static")
                         .and_then(|s| s.as_bool())
                         .unwrap_or(false);
                     let field_key = if is_static {
@@ -275,59 +276,59 @@ fn visit_impl(
 
     // Process constructor assignments (this.x = $state(...))
     if let Some(constructor_node) = constructor
-        && let Some(value) = constructor_node.get("value")
-        && let Some(body) = value.get("body")
-        && let Some(body_array) = body.get("body").and_then(|b| b.as_array())
+        && let Some(value) = constructor_node.field("value")
+        && let Some(body) = value.field("body")
+        && let Some(body_array) = body.field("body").and_then(|b| b.as_array())
     {
         for statement in body_array {
             // Must be ExpressionStatement
-            if statement.get("type").and_then(|t| t.as_str()) != Some("ExpressionStatement") {
+            if statement.field("type").and_then(|t| t.as_str()) != Some("ExpressionStatement") {
                 continue;
             }
 
             // Must be AssignmentExpression
-            let expr = match statement.get("expression") {
+            let expr = match statement.field("expression") {
                 Some(e) => e,
                 None => continue,
             };
 
-            if expr.get("type").and_then(|t| t.as_str()) != Some("AssignmentExpression") {
+            if expr.field("type").and_then(|t| t.as_str()) != Some("AssignmentExpression") {
                 continue;
             }
 
             // Left side must be MemberExpression with ThisExpression
-            let left = match expr.get("left") {
+            let left = match expr.field("left") {
                 Some(l) => l,
                 None => continue,
             };
 
-            if left.get("type").and_then(|t| t.as_str()) != Some("MemberExpression") {
+            if left.field("type").and_then(|t| t.as_str()) != Some("MemberExpression") {
                 continue;
             }
 
-            let object = match left.get("object") {
+            let object = match left.field("object") {
                 Some(o) => o,
                 None => continue,
             };
 
-            if object.get("type").and_then(|t| t.as_str()) != Some("ThisExpression") {
+            if object.field("type").and_then(|t| t.as_str()) != Some("ThisExpression") {
                 continue;
             }
 
             // Skip computed properties with non-literal keys
             let computed = left
-                .get("computed")
+                .field("computed")
                 .and_then(|c| c.as_bool())
                 .unwrap_or(false);
             if computed
-                && let Some(property) = left.get("property")
-                && property.get("type").and_then(|t| t.as_str()) != Some("Literal")
+                && let Some(property) = left.field("property")
+                && property.field("type").and_then(|t| t.as_str()) != Some("Literal")
             {
                 continue;
             }
 
             // Handle the assignment
-            if let (Some(property), Some(right)) = (left.get("property"), expr.get("right")) {
+            if let (Some(property), Some(right)) = (left.field("property"), expr.field("right")) {
                 handle_field(
                     expr,
                     property,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/declaration_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/declaration_tag.rs
@@ -21,6 +21,7 @@ use super::{FragmentOwnerType, VisitorContext};
 use crate::ast::template::DeclarationTag;
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::scope::BindingKind;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Visit a declaration tag.
 ///
@@ -129,11 +130,11 @@ pub fn visit(tag: &mut DeclarationTag, context: &mut VisitorContext) -> Result<(
     // reactive binding referenced at the "top level" of an initializer warns.
     if context.analysis.runes && !context.is_ignored("state_referenced_locally") {
         let decl_json = tag.declaration.as_json();
-        if let Some(decls) = decl_json.get("declarations").and_then(|d| d.as_array()) {
+        if let Some(decls) = decl_json.field("declarations").and_then(|d| d.as_array()) {
             // Collect first to drop the borrow on `tag` before mutating `context`.
             let inits: Vec<serde_json::Value> = decls
                 .iter()
-                .filter_map(|d| d.get("init"))
+                .filter_map(|d| d.field("init"))
                 .filter(|i| !i.is_null())
                 .cloned()
                 .collect();
@@ -153,9 +154,9 @@ pub fn visit(tag: &mut DeclarationTag, context: &mut VisitorContext) -> Result<(
 /// branch of the main `Identifier` visitor.
 fn warn_local_state_reads(node: &serde_json::Value, context: &mut VisitorContext) {
     use serde_json::Value;
-    match node.get("type").and_then(|t| t.as_str()) {
+    match node.field("type").and_then(|t| t.as_str()) {
         Some("Identifier") => {
-            let Some(name) = node.get("name").and_then(|n| n.as_str()) else {
+            let Some(name) = node.field("name").and_then(|n| n.as_str()) else {
                 return;
             };
             let eligible = context
@@ -172,8 +173,11 @@ fn warn_local_state_reads(node: &serde_json::Value, context: &mut VisitorContext
                     )
                 });
             if eligible {
-                let start = node.get("start").and_then(|v| v.as_u64()).map(|v| v as u32);
-                let end = node.get("end").and_then(|v| v.as_u64()).map(|v| v as u32);
+                let start = node
+                    .field("start")
+                    .and_then(|v| v.as_u64())
+                    .map(|v| v as u32);
+                let end = node.field("end").and_then(|v| v.as_u64()).map(|v| v as u32);
                 context
                     .analysis
                     .warnings
@@ -187,13 +191,13 @@ fn warn_local_state_reads(node: &serde_json::Value, context: &mut VisitorContext
         | Some("FunctionExpression")
         | Some("FunctionDeclaration") => {}
         Some("CallExpression") => {
-            if let Some(callee) = node.get("callee") {
+            if let Some(callee) = node.field("callee") {
                 warn_local_state_reads(callee, context);
             }
             // `$state(…)` / `$derived(…)` arguments become closures, so reads
             // there are reactive — skip them.
             if !callee_is_state_rune(node)
-                && let Some(args) = node.get("arguments").and_then(|a| a.as_array())
+                && let Some(args) = node.field("arguments").and_then(|a| a.as_array())
             {
                 for arg in args {
                     warn_local_state_reads(arg, context);
@@ -202,7 +206,7 @@ fn warn_local_state_reads(node: &serde_json::Value, context: &mut VisitorContext
         }
         // The assignment target is a write, not a read; only walk the value.
         Some("AssignmentExpression") => {
-            if let Some(right) = node.get("right") {
+            if let Some(right) = node.field("right") {
                 warn_local_state_reads(right, context);
             }
         }
@@ -230,18 +234,18 @@ fn warn_local_state_reads(node: &serde_json::Value, context: &mut VisitorContext
 /// (or `.raw` / `.frozen` / `.by`) rune — whose arguments are treated as
 /// closures for the purposes of `state_referenced_locally`.
 fn callee_is_state_rune(call: &serde_json::Value) -> bool {
-    let Some(callee) = call.get("callee") else {
+    let Some(callee) = call.field("callee") else {
         return false;
     };
-    match callee.get("type").and_then(|t| t.as_str()) {
+    match callee.field("type").and_then(|t| t.as_str()) {
         Some("Identifier") => matches!(
-            callee.get("name").and_then(|n| n.as_str()),
+            callee.field("name").and_then(|n| n.as_str()),
             Some("$state" | "$derived")
         ),
         Some("MemberExpression") => matches!(
             callee
-                .get("object")
-                .and_then(|o| o.get("name"))
+                .field("object")
+                .and_then(|o| o.field("name"))
                 .and_then(|n| n.as_str()),
             Some("$state" | "$derived")
         ),

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
@@ -11,6 +11,7 @@ use super::shared::utils::{
 };
 use super::{EachBlockContext, VisitorContext};
 use crate::ast::template::{EachBlock, TemplateNode};
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Visit an each block.
 ///
@@ -303,10 +304,10 @@ fn walk_pattern_defaults_typed(
 /// in each block destructuring patterns where we need reference counts but must
 /// not affect the component's context requirements.
 fn walk_expression_refs_only(node: &serde_json::Value, context: &mut VisitorContext) {
-    let node_type = node.get("type").and_then(|t| t.as_str());
+    let node_type = node.field("type").and_then(|t| t.as_str());
     match node_type {
         Some("Identifier") => {
-            if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
+            if let Some(name) = node.field("name").and_then(|n| n.as_str()) {
                 // Try to find binding and add a reference
                 if let Some(binding_idx) = context
                     .analysis
@@ -315,9 +316,9 @@ fn walk_expression_refs_only(node: &serde_json::Value, context: &mut VisitorCont
                     .or_else(|| context.analysis.root.find_binding_any_scope(name))
                 {
                     let (start, end) = node
-                        .get("start")
+                        .field("start")
                         .and_then(|s| s.as_u64())
-                        .zip(node.get("end").and_then(|e| e.as_u64()))
+                        .zip(node.field("end").and_then(|e| e.as_u64()))
                         .unwrap_or((0, 0));
                     context.analysis.root.bindings[binding_idx].add_reference(
                         start as u32,
@@ -347,11 +348,11 @@ fn walk_expression_children_refs_only(node: &serde_json::Value, context: &mut Vi
             }
             if let Some(arr) = value.as_array() {
                 for item in arr {
-                    if item.get("type").is_some() {
+                    if item.field("type").is_some() {
                         walk_expression_refs_only(item, context);
                     }
                 }
-            } else if value.get("type").is_some() {
+            } else if value.field("type").is_some() {
                 walk_expression_refs_only(value, context);
             }
         }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/expression_statement.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/expression_statement.rs
@@ -9,6 +9,7 @@ use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::{
     AnalysisError, BindingKind, DeclarationKind, warnings,
 };
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use serde_json::Value;
 
 /// Visit an expression statement (typed JsNode path).
@@ -29,7 +30,7 @@ pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), An
                 expr_node.end().unwrap_or_default(),
             );
             let value = node.to_value();
-            if let Some(expr_val) = value.get("expression") {
+            if let Some(expr_val) = value.field("expression") {
                 check_legacy_component_creation(expr_val, span, context);
             }
         }
@@ -44,17 +45,17 @@ fn check_legacy_component_creation(
     span: (u32, u32),
     context: &mut VisitorContext,
 ) {
-    if expression.get("type").and_then(|t| t.as_str()) != Some("NewExpression") {
+    if expression.field("type").and_then(|t| t.as_str()) != Some("NewExpression") {
         return;
     }
 
-    let Some(callee) = expression.get("callee") else {
+    let Some(callee) = expression.field("callee") else {
         return;
     };
-    if callee.get("type").and_then(|t| t.as_str()) != Some("Identifier") {
+    if callee.field("type").and_then(|t| t.as_str()) != Some("Identifier") {
         return;
     }
-    let Some(args_array) = expression.get("arguments").and_then(|a| a.as_array()) else {
+    let Some(args_array) = expression.field("arguments").and_then(|a| a.as_array()) else {
         return;
     };
     if args_array.len() != 1 {
@@ -63,22 +64,22 @@ fn check_legacy_component_creation(
     let Some(arg) = args_array.first() else {
         return;
     };
-    if arg.get("type").and_then(|t| t.as_str()) != Some("ObjectExpression") {
+    if arg.field("type").and_then(|t| t.as_str()) != Some("ObjectExpression") {
         return;
     }
 
     let has_target_property = arg
-        .get("properties")
+        .field("properties")
         .and_then(|p| p.as_array())
         .map(|props| {
             props.iter().any(|p| {
-                p.get("type").and_then(|t| t.as_str()) == Some("Property")
-                    && p.get("key")
-                        .and_then(|k| k.get("type"))
+                p.field("type").and_then(|t| t.as_str()) == Some("Property")
+                    && p.field("key")
+                        .and_then(|k| k.field("type"))
                         .and_then(|t| t.as_str())
                         == Some("Identifier")
-                    && p.get("key")
-                        .and_then(|k| k.get("name"))
+                    && p.field("key")
+                        .and_then(|k| k.field("name"))
                         .and_then(|n| n.as_str())
                         == Some("target")
             })
@@ -88,7 +89,7 @@ fn check_legacy_component_creation(
     if !has_target_property {
         return;
     }
-    let Some(callee_name) = callee.get("name").and_then(|n| n.as_str()) else {
+    let Some(callee_name) = callee.field("name").and_then(|n| n.as_str()) else {
         return;
     };
     let Some(&binding_idx) = context.analysis.root.all_scopes
@@ -109,21 +110,22 @@ fn check_legacy_component_creation(
         && let Ok(initial_json) = serde_json::from_str::<Value>(initial_str)
     {
         let is_svelte_import = initial_json
-            .get("source")
-            .and_then(|s| s.get("value"))
+            .field("source")
+            .and_then(|s| s.field("value"))
             .and_then(|v| v.as_str())
             .is_some_and(|src| src.ends_with(".svelte"));
 
         if is_svelte_import {
             let is_default_import = initial_json
-                .get("specifiers")
+                .field("specifiers")
                 .and_then(|s| s.as_array())
                 .is_some_and(|specs| {
                     specs.iter().any(|spec| {
-                        spec.get("type").and_then(|t| t.as_str()) == Some("ImportDefaultSpecifier")
+                        spec.field("type").and_then(|t| t.as_str())
+                            == Some("ImportDefaultSpecifier")
                             && spec
-                                .get("local")
-                                .and_then(|l| l.get("name"))
+                                .field("local")
+                                .and_then(|l| l.field("name"))
                                 .and_then(|n| n.as_str())
                                 == Some(callee_name)
                     })

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/identifier.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/identifier.rs
@@ -10,6 +10,7 @@ use super::shared::function::is_rune;
 use super::shared::utils::is_reference_for_identifier_typed;
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::{AnalysisError, BindingKind, errors, warnings};
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Visit an identifier (typed JsNode path).
 ///
@@ -174,8 +175,8 @@ fn visit_identifier_inner(
         }
         // For value entries, use JSON path
         ancestor
-            .get("label")
-            .and_then(|l| l.get("name"))
+            .field("label")
+            .and_then(|l| l.field("name"))
             .and_then(|n| n.as_str())
             == Some("$")
     });
@@ -468,16 +469,16 @@ fn check_callee_is_state_rune(
     }
 
     // Fall back to value-based access
-    if let Some(callee) = call_entry.get("callee") {
-        let is_direct = callee.get("name").and_then(|n| n.as_str()) == Some("$state");
-        let is_member = callee.get("type").and_then(|t| t.as_str()) == Some("MemberExpression")
+    if let Some(callee) = call_entry.field("callee") {
+        let is_direct = callee.field("name").and_then(|n| n.as_str()) == Some("$state");
+        let is_member = callee.field("type").and_then(|t| t.as_str()) == Some("MemberExpression")
             && callee
-                .get("object")
-                .and_then(|o| o.get("name").and_then(|n| n.as_str()))
+                .field("object")
+                .and_then(|o| o.field("name").and_then(|n| n.as_str()))
                 == Some("$state")
             && callee
-                .get("property")
-                .and_then(|p| p.get("name").and_then(|n| n.as_str()))
+                .field("property")
+                .and_then(|p| p.field("name").and_then(|n| n.as_str()))
                 == Some("raw");
         return is_direct || is_member;
     }
@@ -535,8 +536,8 @@ fn validate_rune_usage(
         } else {
             // Fall back to value-based access for property name
             parent
-                .get("property")
-                .and_then(|p| p.get("name"))
+                .field("property")
+                .and_then(|p| p.field("name"))
                 .and_then(|n| n.as_str())
         };
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -83,6 +83,7 @@ use super::AnalysisError;
 use super::types::{ComponentAnalysis, CssDomElement};
 use crate::ast::arena::ParseArena;
 use crate::ast::template::{Root, TemplateNode};
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Information about the current EachBlock context for animate: validation.
 #[derive(Debug, Clone)]
@@ -204,7 +205,7 @@ impl JsPathEntry {
                 let js_node = unsafe { &**node };
                 Some(js_node.type_str())
             }
-            _ => self.as_value().get("type").and_then(|t| t.as_str()),
+            _ => self.as_value().field("type").and_then(|t| t.as_str()),
         }
     }
 
@@ -273,7 +274,7 @@ impl JsPathEntry {
             _ => self
                 .as_value()
                 .get(field)
-                .and_then(|v| v.get("start"))
+                .and_then(|v| v.field("start"))
                 .and_then(|s| s.as_u64())
                 .map(|n| n as u32),
         }
@@ -296,7 +297,7 @@ impl JsPathEntry {
             _ => self
                 .as_value()
                 .get(field)
-                .and_then(|v| v.get("end"))
+                .and_then(|v| v.field("end"))
                 .and_then(|e| e.as_u64())
                 .map(|n| n as u32),
         }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
@@ -8,6 +8,7 @@ use crate::ast::js::Expression;
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::AnalysisError;
 use crate::compiler::phases::phase2_analyze::utils::extract_svelte_ignore;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Visit a JavaScript script content from an Expression.
 ///
@@ -45,7 +46,7 @@ pub fn visit_script_expr(
                 if let Some(comments) = metadata.leading_comments.as_ref()
                     && let Some(text) = comments
                         .last()
-                        .and_then(|c| c.get("value"))
+                        .and_then(|c| c.field("value"))
                         .and_then(|v| v.as_str())
                 {
                     let ignores = extract_svelte_ignore(text, context.analysis.runes);

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/fragment.rs
@@ -10,6 +10,7 @@ use super::super::super::utils::{check_graph_for_cycles, extract_svelte_ignore_w
 use super::super::super::warnings;
 use super::super::VisitorContext;
 use crate::ast::template::{ConstTag, Fragment, TemplateNode};
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Insertion-ordered identifier set: the JS original uses a `Set`, and the order
 /// decides which `{@const}` cycle a diagnostic reports.
@@ -194,18 +195,19 @@ fn check_const_tag_cycles(nodes: &[TemplateNode]) -> Result<(), AnalysisError> {
             // 2. An AssignmentExpression (what the Rust parser currently produces):
             //    { type: "AssignmentExpression", left, right }
 
-            let decl_type = decl_json.get("type").and_then(|t| t.as_str());
+            let decl_type = decl_json.field("type").and_then(|t| t.as_str());
             let (bindings, deps) = if decl_type == Some("VariableDeclaration") {
                 // VariableDeclaration structure
-                if let Some(declarations) = decl_json.get("declarations").and_then(|d| d.as_array())
+                if let Some(declarations) =
+                    decl_json.field("declarations").and_then(|d| d.as_array())
                     && let Some(declaration) = declarations.first()
                 {
-                    let bindings = if let Some(id) = declaration.get("id") {
+                    let bindings = if let Some(id) = declaration.field("id") {
                         extract_pattern_identifiers(id)
                     } else {
                         Vec::new()
                     };
-                    let deps = if let Some(init) = declaration.get("init") {
+                    let deps = if let Some(init) = declaration.field("init") {
                         extract_expression_identifiers(init)
                     } else {
                         IdentifierSet::default()
@@ -216,12 +218,12 @@ fn check_const_tag_cycles(nodes: &[TemplateNode]) -> Result<(), AnalysisError> {
                 }
             } else if decl_type == Some("AssignmentExpression") {
                 // AssignmentExpression structure
-                let bindings = if let Some(left) = decl_json.get("left") {
+                let bindings = if let Some(left) = decl_json.field("left") {
                     extract_pattern_identifiers(left)
                 } else {
                     Vec::new()
                 };
-                let deps = if let Some(right) = decl_json.get("right") {
+                let deps = if let Some(right) = decl_json.field("right") {
                     extract_expression_identifiers(right)
                 } else {
                     IdentifierSet::default()
@@ -285,14 +287,14 @@ fn check_const_tag_cycles(nodes: &[TemplateNode]) -> Result<(), AnalysisError> {
 fn extract_pattern_identifiers(pattern: &serde_json::Value) -> Vec<String> {
     let mut names = Vec::new();
 
-    match pattern.get("type").and_then(|t| t.as_str()) {
+    match pattern.field("type").and_then(|t| t.as_str()) {
         Some("Identifier") => {
-            if let Some(name) = pattern.get("name").and_then(|n| n.as_str()) {
+            if let Some(name) = pattern.field("name").and_then(|n| n.as_str()) {
                 names.push(name.to_string());
             }
         }
         Some("ArrayPattern") => {
-            if let Some(elements) = pattern.get("elements").and_then(|e| e.as_array()) {
+            if let Some(elements) = pattern.field("elements").and_then(|e| e.as_array()) {
                 for element in elements {
                     if !element.is_null() {
                         names.extend(extract_pattern_identifiers(element));
@@ -301,21 +303,21 @@ fn extract_pattern_identifiers(pattern: &serde_json::Value) -> Vec<String> {
             }
         }
         Some("ObjectPattern") => {
-            if let Some(properties) = pattern.get("properties").and_then(|p| p.as_array()) {
+            if let Some(properties) = pattern.field("properties").and_then(|p| p.as_array()) {
                 for property in properties {
-                    if let Some(value) = property.get("value") {
+                    if let Some(value) = property.field("value") {
                         names.extend(extract_pattern_identifiers(value));
                     }
                 }
             }
         }
         Some("AssignmentPattern") => {
-            if let Some(left) = pattern.get("left") {
+            if let Some(left) = pattern.field("left") {
                 names.extend(extract_pattern_identifiers(left));
             }
         }
         Some("RestElement") => {
-            if let Some(argument) = pattern.get("argument") {
+            if let Some(argument) = pattern.field("argument") {
                 names.extend(extract_pattern_identifiers(argument));
             }
         }
@@ -337,24 +339,24 @@ fn extract_expression_identifiers(expression: &serde_json::Value) -> IdentifierS
 /// (ArrowFunctionExpression, FunctionExpression, FunctionDeclaration)
 /// because those create new scopes where local declarations shadow outer names.
 fn collect_expression_identifiers(expression: &serde_json::Value, identifiers: &mut IdentifierSet) {
-    if let Some(expr_type) = expression.get("type").and_then(|t| t.as_str()) {
+    if let Some(expr_type) = expression.field("type").and_then(|t| t.as_str()) {
         match expr_type {
             "Identifier" => {
-                if let Some(name) = expression.get("name").and_then(|n| n.as_str()) {
+                if let Some(name) = expression.field("name").and_then(|n| n.as_str()) {
                     identifiers.insert(name.to_string());
                 }
             }
             "MemberExpression" => {
                 // Only collect from the object, not the property (unless computed)
-                if let Some(object) = expression.get("object") {
+                if let Some(object) = expression.field("object") {
                     collect_expression_identifiers(object, identifiers);
                 }
                 // If computed, also collect from property
                 if expression
-                    .get("computed")
+                    .field("computed")
                     .and_then(|c| c.as_bool())
                     .unwrap_or(false)
-                    && let Some(property) = expression.get("property")
+                    && let Some(property) = expression.field("property")
                 {
                     collect_expression_identifiers(property, identifiers);
                 }
@@ -372,24 +374,24 @@ fn collect_expression_identifiers(expression: &serde_json::Value, identifiers: &
             "Property" => {
                 // For computed keys like `[expr]`, collect from the key expression
                 if expression
-                    .get("computed")
+                    .field("computed")
                     .and_then(|c| c.as_bool())
                     .unwrap_or(false)
-                    && let Some(key) = expression.get("key")
+                    && let Some(key) = expression.field("key")
                 {
                     collect_expression_identifiers(key, identifiers);
                 }
                 // Always collect from value
-                if let Some(value) = expression.get("value") {
+                if let Some(value) = expression.field("value") {
                     collect_expression_identifiers(value, identifiers);
                 }
             }
             // Handle AssignmentPattern: collect from both left (pattern) and right (default value)
             "AssignmentPattern" => {
-                if let Some(left) = expression.get("left") {
+                if let Some(left) = expression.field("left") {
                     collect_expression_identifiers(left, identifiers);
                 }
-                if let Some(right) = expression.get("right") {
+                if let Some(right) = expression.field("right") {
                     collect_expression_identifiers(right, identifiers);
                 }
             }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -9,6 +9,7 @@ use crate::ast::typed_expr::{JsNode, LiteralValue};
 use crate::compiler::phases::phase3_transform::server::evaluate::{
     EvalScope, EvalValue, Evaluation, evaluate_binding_initial,
 };
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -38,7 +39,7 @@ struct AnalysisEvalScope<'a> {
 impl EvalScope for AnalysisEvalScope<'_> {
     fn evaluate_identifier(&self, node: &serde_json::Value, name: &str, depth: u8) -> Evaluation {
         let by_position = node
-            .get("start")
+            .field("start")
             .and_then(serde_json::Value::as_u64)
             .and_then(|start| {
                 self.analysis.root.bindings.iter().find(|binding| {
@@ -1133,7 +1134,7 @@ pub fn validate_assignment_node(
 
         if let Some(ref field_name) = name
             && let Some(field) = context.state_fields.get(field_name)
-            && field.node.get("type").and_then(|t| t.as_str()) == Some("AssignmentExpression")
+            && field.node.field("type").and_then(|t| t.as_str()) == Some("AssignmentExpression")
         {
             let mut i = context.js_path.len();
             while i > 0 {
@@ -1154,7 +1155,7 @@ pub fn validate_assignment_node(
                         let node_start = argument.start();
                         let field_start = field
                             .node
-                            .get("start")
+                            .field("start")
                             .and_then(|s| s.as_u64())
                             .map(|n| n as u32);
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
@@ -14,6 +14,7 @@ use crate::ast::js::Expression;
 use crate::ast::template::{ExpressionMetadata, SnippetBlock, TemplateNode};
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::AnalysisError;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Visit a snippet block.
 pub fn visit<'a, 'b: 'a>(
@@ -673,11 +674,11 @@ fn check_hoistable(
         };
         let json = declaration.as_json();
         if let Some(obj) = json.as_object()
-            && obj.get("type").and_then(|t| t.as_str()) == Some("VariableDeclaration")
-            && let Some(decls) = obj.get("declarations").and_then(|d| d.as_array())
+            && obj.field("type").and_then(|t| t.as_str()) == Some("VariableDeclaration")
+            && let Some(decls) = obj.field("declarations").and_then(|d| d.as_array())
         {
             for d in decls {
-                if let Some(id) = d.get("id")
+                if let Some(id) = d.field("id")
                     && let Some(names) = extract_pattern_names(id)
                 {
                     for n in names {
@@ -913,11 +914,11 @@ fn check_hoistable(
             TemplateNode::ConstTag(tag) => {
                 let json = tag.declaration.as_json();
                 if let Some(obj) = json.as_object()
-                    && obj.get("type").and_then(|t| t.as_str()) == Some("VariableDeclaration")
-                    && let Some(decls) = obj.get("declarations").and_then(|d| d.as_array())
+                    && obj.field("type").and_then(|t| t.as_str()) == Some("VariableDeclaration")
+                    && let Some(decls) = obj.field("declarations").and_then(|d| d.as_array())
                 {
                     for d in decls {
-                        if let Some(init) = d.get("init")
+                        if let Some(init) = d.field("init")
                             && !init.is_null()
                             && !expression_only_uses_params(init, param_names, context)
                         {
@@ -949,11 +950,11 @@ fn check_hoistable(
             TemplateNode::DeclarationTag(tag) => {
                 let json = tag.declaration.as_json();
                 if let Some(obj) = json.as_object()
-                    && obj.get("type").and_then(|t| t.as_str()) == Some("VariableDeclaration")
-                    && let Some(decls) = obj.get("declarations").and_then(|d| d.as_array())
+                    && obj.field("type").and_then(|t| t.as_str()) == Some("VariableDeclaration")
+                    && let Some(decls) = obj.field("declarations").and_then(|d| d.as_array())
                 {
                     for d in decls {
-                        if let Some(init) = d.get("init")
+                        if let Some(init) = d.field("init")
                             && !init.is_null()
                             && !expression_only_uses_params(init, param_names, context)
                         {
@@ -1145,36 +1146,37 @@ fn extract_all_param_names(param: &Expression) -> Vec<String> {
 /// Extract all names from a pattern (Identifier, ObjectPattern, ArrayPattern) - JSON version.
 fn extract_pattern_names(val: &serde_json::Value) -> Option<Vec<String>> {
     if let serde_json::Value::Object(obj) = val {
-        let expr_type = obj.get("type").and_then(|v| v.as_str())?;
+        let expr_type = obj.field("type").and_then(|v| v.as_str())?;
 
         match expr_type {
             "Identifier" => {
-                let name = obj.get("name").and_then(|v| v.as_str())?.to_string();
+                let name = obj.field("name").and_then(|v| v.as_str())?.to_string();
                 Some(vec![name])
             }
             "ObjectPattern" => {
                 let mut names = Vec::new();
-                if let Some(props) = obj.get("properties").and_then(|p| p.as_array()) {
+                if let Some(props) = obj.field("properties").and_then(|p| p.as_array()) {
                     for prop in props {
                         if let Some(prop_obj) = prop.as_object() {
-                            if prop_obj.get("type").and_then(|v| v.as_str()) == Some("Property") {
-                                if let Some(value) = prop_obj.get("value") {
-                                    let actual_value = if value.get("type").and_then(|v| v.as_str())
-                                        == Some("AssignmentPattern")
-                                    {
-                                        value.get("left")
-                                    } else {
-                                        Some(value)
-                                    };
+                            if prop_obj.field("type").and_then(|v| v.as_str()) == Some("Property") {
+                                if let Some(value) = prop_obj.field("value") {
+                                    let actual_value =
+                                        if value.field("type").and_then(|v| v.as_str())
+                                            == Some("AssignmentPattern")
+                                        {
+                                            value.field("left")
+                                        } else {
+                                            Some(value)
+                                        };
                                     if let Some(v) = actual_value
                                         && let Some(inner_names) = extract_pattern_names(v)
                                     {
                                         names.extend(inner_names);
                                     }
                                 }
-                            } else if prop_obj.get("type").and_then(|v| v.as_str())
+                            } else if prop_obj.field("type").and_then(|v| v.as_str())
                                 == Some("RestElement")
-                                && let Some(arg) = prop_obj.get("argument")
+                                && let Some(arg) = prop_obj.field("argument")
                                 && let Some(inner_names) = extract_pattern_names(arg)
                             {
                                 names.extend(inner_names);
@@ -1186,7 +1188,7 @@ fn extract_pattern_names(val: &serde_json::Value) -> Option<Vec<String>> {
             }
             "ArrayPattern" => {
                 let mut names = Vec::new();
-                if let Some(elements) = obj.get("elements").and_then(|e| e.as_array()) {
+                if let Some(elements) = obj.field("elements").and_then(|e| e.as_array()) {
                     for elem in elements {
                         if !elem.is_null()
                             && let Some(inner_names) = extract_pattern_names(elem)
@@ -1198,13 +1200,13 @@ fn extract_pattern_names(val: &serde_json::Value) -> Option<Vec<String>> {
                 Some(names)
             }
             "AssignmentPattern" => {
-                if let Some(left) = obj.get("left") {
+                if let Some(left) = obj.field("left") {
                     return extract_pattern_names(left);
                 }
                 None
             }
             "RestElement" => {
-                if let Some(arg) = obj.get("argument") {
+                if let Some(arg) = obj.field("argument") {
                     return extract_pattern_names(arg);
                 }
                 None
@@ -1343,12 +1345,12 @@ fn collect_local_bindings(val: &serde_json::Value, out: &mut FxHashSet<String>) 
             }
         }
         serde_json::Value::Object(o) => {
-            let ty = o.get("type").and_then(|t| t.as_str());
+            let ty = o.field("type").and_then(|t| t.as_str());
             match ty {
                 Some("VariableDeclarator")
                 | Some("FunctionDeclaration")
                 | Some("ClassDeclaration") => {
-                    if let Some(id) = o.get("id")
+                    if let Some(id) = o.field("id")
                         && let Some(names) = extract_pattern_names(id)
                     {
                         for n in names {
@@ -1363,7 +1365,7 @@ fn collect_local_bindings(val: &serde_json::Value, out: &mut FxHashSet<String>) 
                 Some("FunctionDeclaration")
                     | Some("FunctionExpression")
                     | Some("ArrowFunctionExpression")
-            ) && let Some(params) = o.get("params").and_then(|p| p.as_array())
+            ) && let Some(params) = o.field("params").and_then(|p| p.as_array())
             {
                 for p in params {
                     if let Some(names) = extract_pattern_names(p) {
@@ -1374,7 +1376,7 @@ fn collect_local_bindings(val: &serde_json::Value, out: &mut FxHashSet<String>) 
                 }
             }
             if ty == Some("CatchClause")
-                && let Some(param) = o.get("param")
+                && let Some(param) = o.field("param")
                 && let Some(names) = extract_pattern_names(param)
             {
                 for n in names {
@@ -1399,19 +1401,21 @@ fn refs_hoistable(
 ) -> bool {
     match val {
         serde_json::Value::Array(a) => a.iter().all(|v| refs_hoistable(v, params, context)),
-        serde_json::Value::Object(o) => match o.get("type").and_then(|t| t.as_str()) {
+        serde_json::Value::Object(o) => match o.field("type").and_then(|t| t.as_str()) {
             Some("Identifier") => o
-                .get("name")
+                .field("name")
                 .and_then(|n| n.as_str())
                 .is_none_or(|n| is_identifier_hoistable(n, params, context)),
             Some("MemberExpression") => {
-                if let Some(obj) = o.get("object")
+                if let Some(obj) = o.field("object")
                     && !refs_hoistable(obj, params, context)
                 {
                     return false;
                 }
-                if o.get("computed").and_then(|c| c.as_bool()).unwrap_or(false)
-                    && let Some(prop) = o.get("property")
+                if o.field("computed")
+                    .and_then(|c| c.as_bool())
+                    .unwrap_or(false)
+                    && let Some(prop) = o.field("property")
                     && !refs_hoistable(prop, params, context)
                 {
                     return false;
@@ -1419,13 +1423,15 @@ fn refs_hoistable(
                 true
             }
             Some("Property") => {
-                if o.get("computed").and_then(|c| c.as_bool()).unwrap_or(false)
-                    && let Some(key) = o.get("key")
+                if o.field("computed")
+                    .and_then(|c| c.as_bool())
+                    .unwrap_or(false)
+                    && let Some(key) = o.field("key")
                     && !refs_hoistable(key, params, context)
                 {
                     return false;
                 }
-                o.get("value")
+                o.field("value")
                     .is_none_or(|v| refs_hoistable(v, params, context))
             }
             _ => o
@@ -1457,11 +1463,11 @@ fn expression_only_uses_params(
     context: &VisitorContext,
 ) -> bool {
     if let serde_json::Value::Object(obj) = val {
-        let expr_type = obj.get("type").and_then(|v| v.as_str());
+        let expr_type = obj.field("type").and_then(|v| v.as_str());
 
         match expr_type {
             Some("Identifier") => {
-                if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
+                if let Some(name) = obj.field("name").and_then(|v| v.as_str()) {
                     return is_identifier_hoistable(name, param_names, context);
                 }
                 true
@@ -1474,12 +1480,12 @@ fn expression_only_uses_params(
             | Some("NullLiteral") => true,
 
             Some("CallExpression") | Some("NewExpression") => {
-                if let Some(callee) = obj.get("callee")
+                if let Some(callee) = obj.field("callee")
                     && !expression_only_uses_params(callee, param_names, context)
                 {
                     return false;
                 }
-                if let Some(args) = obj.get("arguments").and_then(|a| a.as_array()) {
+                if let Some(args) = obj.field("arguments").and_then(|a| a.as_array()) {
                     for arg in args {
                         if !expression_only_uses_params(arg, param_names, context) {
                             return false;
@@ -1490,20 +1496,20 @@ fn expression_only_uses_params(
             }
 
             Some("ChainExpression") => obj
-                .get("expression")
+                .field("expression")
                 .is_none_or(|e| expression_only_uses_params(e, param_names, context)),
 
             Some("MemberExpression") => {
-                if let Some(object) = obj.get("object")
+                if let Some(object) = obj.field("object")
                     && !expression_only_uses_params(object, param_names, context)
                 {
                     return false;
                 }
                 if obj
-                    .get("computed")
+                    .field("computed")
                     .and_then(|c| c.as_bool())
                     .unwrap_or(false)
-                    && let Some(prop) = obj.get("property")
+                    && let Some(prop) = obj.field("property")
                     && !expression_only_uses_params(prop, param_names, context)
                 {
                     return false;
@@ -1512,12 +1518,12 @@ fn expression_only_uses_params(
             }
 
             Some("BinaryExpression") | Some("LogicalExpression") => {
-                if let Some(left) = obj.get("left")
+                if let Some(left) = obj.field("left")
                     && !expression_only_uses_params(left, param_names, context)
                 {
                     return false;
                 }
-                if let Some(right) = obj.get("right")
+                if let Some(right) = obj.field("right")
                     && !expression_only_uses_params(right, param_names, context)
                 {
                     return false;
@@ -1537,7 +1543,7 @@ fn expression_only_uses_params(
             }
 
             Some("TemplateLiteral") => {
-                if let Some(exprs) = obj.get("expressions").and_then(|e| e.as_array()) {
+                if let Some(exprs) = obj.field("expressions").and_then(|e| e.as_array()) {
                     for e in exprs {
                         if !expression_only_uses_params(e, param_names, context) {
                             return false;
@@ -1548,7 +1554,7 @@ fn expression_only_uses_params(
             }
 
             Some("ArrayExpression") => {
-                if let Some(elements) = obj.get("elements").and_then(|e| e.as_array()) {
+                if let Some(elements) = obj.field("elements").and_then(|e| e.as_array()) {
                     for elem in elements {
                         if !elem.is_null()
                             && !expression_only_uses_params(elem, param_names, context)
@@ -1561,19 +1567,19 @@ fn expression_only_uses_params(
             }
 
             Some("ObjectExpression") => {
-                if let Some(props) = obj.get("properties").and_then(|p| p.as_array()) {
+                if let Some(props) = obj.field("properties").and_then(|p| p.as_array()) {
                     for prop in props {
                         if let Some(prop_obj) = prop.as_object() {
                             if prop_obj
-                                .get("computed")
+                                .field("computed")
                                 .and_then(|c| c.as_bool())
                                 .unwrap_or(false)
-                                && let Some(key) = prop_obj.get("key")
+                                && let Some(key) = prop_obj.field("key")
                                 && !expression_only_uses_params(key, param_names, context)
                             {
                                 return false;
                             }
-                            if let Some(value) = prop_obj.get("value")
+                            if let Some(value) = prop_obj.field("value")
                                 && !expression_only_uses_params(value, param_names, context)
                             {
                                 return false;
@@ -1585,26 +1591,26 @@ fn expression_only_uses_params(
             }
 
             Some("SpreadElement") => {
-                if let Some(arg) = obj.get("argument") {
+                if let Some(arg) = obj.field("argument") {
                     return expression_only_uses_params(arg, param_names, context);
                 }
                 true
             }
 
             Some("UnaryExpression") | Some("UpdateExpression") => {
-                if let Some(arg) = obj.get("argument") {
+                if let Some(arg) = obj.field("argument") {
                     return expression_only_uses_params(arg, param_names, context);
                 }
                 true
             }
 
             Some("AssignmentExpression") => {
-                if let Some(left) = obj.get("left")
+                if let Some(left) = obj.field("left")
                     && !expression_only_uses_params(left, param_names, context)
                 {
                     return false;
                 }
-                if let Some(right) = obj.get("right")
+                if let Some(right) = obj.field("right")
                     && !expression_only_uses_params(right, param_names, context)
                 {
                     return false;
@@ -1613,7 +1619,7 @@ fn expression_only_uses_params(
             }
 
             Some("SequenceExpression") => {
-                if let Some(exprs) = obj.get("expressions").and_then(|e| e.as_array()) {
+                if let Some(exprs) = obj.field("expressions").and_then(|e| e.as_array()) {
                     for e in exprs {
                         if !expression_only_uses_params(e, param_names, context) {
                             return false;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
@@ -11,6 +11,7 @@ use super::shared::utils;
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::BindingKind;
 use crate::compiler::phases::phase2_analyze::scope::is_known_defined_global_call;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 /// Collect svelte-ignore codes from the parent VariableDeclaration's or
 /// ExportNamedDeclaration's leading comments.
 fn collect_ignore_codes_from_parent(context: &VisitorContext) -> Vec<String> {
@@ -53,10 +54,10 @@ fn collect_ignore_codes_from_parent(context: &VisitorContext) -> Vec<String> {
                 // where `script_ignore_comments` is empty).
                 if codes.len() == before
                     && node.as_js_node().is_none()
-                    && let Some(comments) = node.get("leadingComments").and_then(|c| c.as_array())
+                    && let Some(comments) = node.field("leadingComments").and_then(|c| c.as_array())
                 {
                     for comment in comments {
-                        if let Some(value) = comment.get("value").and_then(|v| v.as_str()) {
+                        if let Some(value) = comment.field("value").and_then(|v| v.as_str()) {
                             let extracted =
                                 crate::compiler::phases::phase2_analyze::utils::extract_svelte_ignore(
                                     value,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_wrap.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_wrap.rs
@@ -34,6 +34,7 @@ use serde_json::Value;
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase3_transform::server::evaluate as server_evaluate;
 use crate::compiler::phases::phase3_transform::server::evaluate::EvalCtx;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 pub(super) const CONSOLE_METHODS: &[&str] = &[
     "debug",
@@ -77,7 +78,7 @@ pub(super) fn args_need_wrap(args: &[Value], analysis: &ComponentAnalysis) -> bo
     }
     with_eval_ctx(analysis, None, |ctx| {
         args.iter().any(|arg| {
-            arg.get("type").and_then(|t| t.as_str()) == Some("SpreadElement")
+            arg.field("type").and_then(|t| t.as_str()) == Some("SpreadElement")
                 || ctx.evaluate_estree(arg, 0).has_unknown()
         })
     })

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -126,6 +126,7 @@ use crate::compiler::phases::phase2_analyze::scope::{BindingKind, DeclarationKin
 use crate::compiler::phases::phase2_analyze::types::{CopiedSourceChunk, ScriptProjection};
 
 // Import new visitor system types
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use types::{ComponentClientTransformState, ComponentContext, TransformOptions, TransformResult};
 
 // Cached regular expression for $$props replacement
@@ -2550,32 +2551,32 @@ pub(crate) fn transform_client(
         let ce_props: Vec<(String, serde_json::Map<String, serde_json::Value>)> = ce
             .props
             .as_ref()
-            .and_then(|p| p.get("properties"))
+            .and_then(|p| p.field("properties"))
             .and_then(|p| p.as_array())
             .map(|props| {
                 props
                     .iter()
                     .filter_map(|prop| {
-                        let key = prop.get("key")?;
+                        let key = prop.field("key")?;
                         let name = key
-                            .get("name")
+                            .field("name")
                             .and_then(|n| n.as_str())
-                            .or_else(|| key.get("value").and_then(|v| v.as_str()))?
+                            .or_else(|| key.field("value").and_then(|v| v.as_str()))?
                             .to_string();
                         let mut def = serde_json::Map::new();
                         if let Some(value_props) = prop
-                            .get("value")
-                            .and_then(|v| v.get("properties"))
+                            .field("value")
+                            .and_then(|v| v.field("properties"))
                             .and_then(|p| p.as_array())
                         {
                             for vp in value_props {
-                                let vkey = vp.get("key").and_then(|k| {
-                                    k.get("name")
+                                let vkey = vp.field("key").and_then(|k| {
+                                    k.field("name")
                                         .and_then(|n| n.as_str())
-                                        .or_else(|| k.get("value").and_then(|v| v.as_str()))
+                                        .or_else(|| k.field("value").and_then(|v| v.as_str()))
                                 });
                                 if let (Some(vkey), Some(vval)) =
-                                    (vkey, vp.get("value").and_then(|v| v.get("value")))
+                                    (vkey, vp.field("value").and_then(|v| v.field("value")))
                                 {
                                     def.insert(vkey.to_string(), vval.clone());
                                 }
@@ -2597,7 +2598,7 @@ pub(crate) fn transform_client(
                     .unwrap_or_else(|| name.clone());
 
                 let mut prop_type = prop_def
-                    .get("type")
+                    .field("type")
                     .and_then(|t| t.as_str())
                     .map(|s| s.to_string());
                 // If no explicit type and the binding's initial value is a boolean
@@ -2611,11 +2612,11 @@ pub(crate) fn transform_client(
                 }
 
                 let mut value_props: Vec<super::js_ast::nodes::JsObjectMember> = Vec::new();
-                if let Some(attribute) = prop_def.get("attribute").and_then(|a| a.as_str()) {
+                if let Some(attribute) = prop_def.field("attribute").and_then(|a| a.as_str()) {
                     value_props.push(b::prop(&context.arena, "attribute", b::string(attribute)));
                 }
                 if prop_def
-                    .get("reflect")
+                    .field("reflect")
                     .and_then(|r| r.as_bool())
                     .unwrap_or(false)
                 {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
@@ -14,6 +14,7 @@ use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::
     build_render_statement_with_memoizer, expression_has_await,
 };
 use crate::compiler::phases::phase3_transform::js_ast::nodes::{JsArrowBody, JsExpr};
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use crate::compiler::phases::phase3_transform::utils::locate_in_source;
 #[cfg(test)]
 use crate::compiler::utils::can_delegate_event;
@@ -519,13 +520,13 @@ pub(super) fn expression_has_side_effects(expr: &crate::ast::js::Expression) -> 
 }
 
 fn json_has_side_effects(value: &serde_json::Value) -> bool {
-    if let Some(node_type) = value.get("type").and_then(|t| t.as_str()) {
+    if let Some(node_type) = value.field("type").and_then(|t| t.as_str()) {
         match node_type {
             "CallExpression" | "NewExpression" | "AssignmentExpression" | "UpdateExpression" => {
                 return true;
             }
             "SequenceExpression" => {
-                if let Some(serde_json::Value::Array(exprs)) = value.get("expressions") {
+                if let Some(serde_json::Value::Array(exprs)) = value.field("expressions") {
                     return exprs.iter().any(json_has_side_effects);
                 }
             }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
@@ -55,6 +55,7 @@ use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::
 use crate::compiler::phases::phase3_transform::js_ast::arena::JsArena;
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Transform an AwaitBlock node into client-side JavaScript.
 ///
@@ -494,9 +495,9 @@ fn extract_identifiers(expr: &Expression) -> Vec<String> {
 fn extract_identifiers_recursive(expr: &Expression, identifiers: &mut Vec<String>) {
     let val = expr.as_json();
     if let serde_json::Value::Object(obj) = val {
-        match obj.get("type").and_then(|v| v.as_str()) {
+        match obj.field("type").and_then(|v| v.as_str()) {
             Some("Identifier") => {
-                if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
+                if let Some(name) = obj.field("name").and_then(|v| v.as_str()) {
                     let trimmed = name.trim();
                     // Check if this "identifier" is actually a destructuring pattern string
                     if trimmed.starts_with('{') || trimmed.starts_with('[') {
@@ -507,14 +508,14 @@ fn extract_identifiers_recursive(expr: &Expression, identifiers: &mut Vec<String
                 }
             }
             Some("ObjectPattern") => {
-                if let Some(props) = obj.get("properties").and_then(|p| p.as_array()) {
+                if let Some(props) = obj.field("properties").and_then(|p| p.as_array()) {
                     for prop in props {
                         // Check if this is a RestElement inside the properties
-                        if let Some(prop_type) = prop.get("type").and_then(|t| t.as_str())
+                        if let Some(prop_type) = prop.field("type").and_then(|t| t.as_str())
                             && prop_type == "RestElement"
                         {
                             // Extract from the argument of RestElement
-                            if let Some(arg) = prop.get("argument") {
+                            if let Some(arg) = prop.field("argument") {
                                 extract_identifiers_recursive(
                                     &Expression::from_json(arg.clone()),
                                     identifiers,
@@ -524,12 +525,12 @@ fn extract_identifiers_recursive(expr: &Expression, identifiers: &mut Vec<String
                         }
 
                         // Regular Property
-                        if let Some(value) = prop.get("value") {
+                        if let Some(value) = prop.field("value") {
                             extract_identifiers_recursive(
                                 &Expression::from_json(value.clone()),
                                 identifiers,
                             );
-                        } else if let Some(key) = prop.get("key") {
+                        } else if let Some(key) = prop.field("key") {
                             // Shorthand property
                             extract_identifiers_recursive(
                                 &Expression::from_json(key.clone()),
@@ -540,7 +541,7 @@ fn extract_identifiers_recursive(expr: &Expression, identifiers: &mut Vec<String
                 }
             }
             Some("ArrayPattern") => {
-                if let Some(elems) = obj.get("elements").and_then(|e| e.as_array()) {
+                if let Some(elems) = obj.field("elements").and_then(|e| e.as_array()) {
                     for elem in elems {
                         if !elem.is_null() {
                             extract_identifiers_recursive(
@@ -552,12 +553,12 @@ fn extract_identifiers_recursive(expr: &Expression, identifiers: &mut Vec<String
                 }
             }
             Some("RestElement") => {
-                if let Some(arg) = obj.get("argument") {
+                if let Some(arg) = obj.field("argument") {
                     extract_identifiers_recursive(&Expression::from_json(arg.clone()), identifiers);
                 }
             }
             Some("AssignmentPattern") => {
-                if let Some(left) = obj.get("left") {
+                if let Some(left) = obj.field("left") {
                     extract_identifiers_recursive(
                         &Expression::from_json(left.clone()),
                         identifiers,
@@ -714,9 +715,9 @@ fn convert_value_to_pattern_with_context(
     context: &mut ComponentContext,
 ) -> JsPattern {
     if let serde_json::Value::Object(obj) = val {
-        match obj.get("type").and_then(|v| v.as_str()) {
+        match obj.field("type").and_then(|v| v.as_str()) {
             Some("Identifier") => {
-                if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
+                if let Some(name) = obj.field("name").and_then(|v| v.as_str()) {
                     let trimmed = name.trim();
                     if trimmed.starts_with('{') || trimmed.starts_with('[') {
                         return parse_pattern_string(trimmed, &context.arena);
@@ -725,7 +726,7 @@ fn convert_value_to_pattern_with_context(
                 }
             }
             Some("AssignmentPattern") => {
-                if let (Some(left), Some(right)) = (obj.get("left"), obj.get("right")) {
+                if let (Some(left), Some(right)) = (obj.field("left"), obj.field("right")) {
                     let left_pattern = convert_value_to_pattern_with_context(left, context);
                     let right_expr = convert_value_to_js_expr_simple(right, &context.arena);
                     return JsPattern::Assignment(JsAssignmentPattern {
@@ -735,39 +736,39 @@ fn convert_value_to_pattern_with_context(
                 }
             }
             Some("ObjectPattern") => {
-                if let Some(props) = obj.get("properties").and_then(|p| p.as_array()) {
+                if let Some(props) = obj.field("properties").and_then(|p| p.as_array()) {
                     let properties = props
                         .iter()
                         .filter_map(|prop| {
                             let prop_obj = prop.as_object()?;
-                            let prop_type = prop_obj.get("type").and_then(|t| t.as_str())?;
+                            let prop_type = prop_obj.field("type").and_then(|t| t.as_str())?;
 
                             if prop_type == "RestElement" {
-                                if let Some(arg) = prop_obj.get("argument") {
+                                if let Some(arg) = prop_obj.field("argument") {
                                     let inner = convert_value_to_pattern_with_context(arg, context);
                                     return Some(JsObjectPatternProperty::Rest(Box::new(inner)));
                                 }
                                 return None;
                             }
 
-                            let key_val = prop_obj.get("key")?;
+                            let key_val = prop_obj.field("key")?;
                             let key = key_val.as_object()?;
-                            let value = prop_obj.get("value")?;
+                            let value = prop_obj.field("value")?;
 
                             let shorthand = prop_obj
-                                .get("shorthand")
+                                .field("shorthand")
                                 .and_then(|s| s.as_bool())
                                 .unwrap_or(false);
 
                             let computed = prop_obj
-                                .get("computed")
+                                .field("computed")
                                 .and_then(|c| c.as_bool())
                                 .unwrap_or(false);
 
                             let value_pattern =
                                 convert_value_to_pattern_with_context(value, context);
 
-                            let key_type = key.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                            let key_type = key.field("type").and_then(|t| t.as_str()).unwrap_or("");
                             let property_key = if computed {
                                 // Computed key: use convert_expression to apply reactive transforms
                                 // This converts num++ to $.update(num) and num to $.get(num) etc.
@@ -776,20 +777,21 @@ fn convert_value_to_pattern_with_context(
                                 let converted = apply_transforms_to_expression(&converted, context);
                                 JsPropertyKey::Computed(context.arena.alloc_expr(converted))
                             } else if key_type == "Literal" {
-                                if let Some(n) = key.get("value").and_then(|v| v.as_f64()) {
+                                if let Some(n) = key.field("value").and_then(|v| v.as_f64()) {
                                     JsPropertyKey::Literal(JsLiteral::Number(n))
-                                } else if let Some(s) = key.get("value").and_then(|v| v.as_str()) {
+                                } else if let Some(s) = key.field("value").and_then(|v| v.as_str())
+                                {
                                     JsPropertyKey::Literal(JsLiteral::String(s.into()))
                                 } else {
                                     let raw =
-                                        key.get("raw").and_then(|r| r.as_str()).unwrap_or("0");
+                                        key.field("raw").and_then(|r| r.as_str()).unwrap_or("0");
                                     JsPropertyKey::Literal(JsLiteral::String(raw.into()))
                                 }
-                            } else if let Some(name) = key.get("name").and_then(|v| v.as_str()) {
+                            } else if let Some(name) = key.field("name").and_then(|v| v.as_str()) {
                                 JsPropertyKey::Identifier(name.into())
-                            } else if let Some(s) = key.get("value").and_then(|v| v.as_str()) {
+                            } else if let Some(s) = key.field("value").and_then(|v| v.as_str()) {
                                 JsPropertyKey::Literal(JsLiteral::String(s.into()))
-                            } else if let Some(n) = key.get("value").and_then(|v| v.as_f64()) {
+                            } else if let Some(n) = key.field("value").and_then(|v| v.as_f64()) {
                                 JsPropertyKey::Literal(JsLiteral::Number(n))
                             } else {
                                 JsPropertyKey::Identifier("unknown".into())
@@ -808,7 +810,7 @@ fn convert_value_to_pattern_with_context(
                 }
             }
             Some("ArrayPattern") => {
-                if let Some(elems) = obj.get("elements").and_then(|e| e.as_array()) {
+                if let Some(elems) = obj.field("elements").and_then(|e| e.as_array()) {
                     let elements = elems
                         .iter()
                         .map(|elem| {
@@ -824,7 +826,7 @@ fn convert_value_to_pattern_with_context(
                 }
             }
             Some("RestElement") => {
-                if let Some(arg) = obj.get("argument") {
+                if let Some(arg) = obj.field("argument") {
                     let inner = convert_value_to_pattern_with_context(arg, context);
                     return JsPattern::Rest(Box::new(inner));
                 }
@@ -842,9 +844,9 @@ fn convert_value_to_pattern_with_context(
 /// AssignmentPattern, and RestElement.
 fn convert_value_to_pattern(val: &serde_json::Value, arena: &JsArena) -> JsPattern {
     if let serde_json::Value::Object(obj) = val {
-        match obj.get("type").and_then(|v| v.as_str()) {
+        match obj.field("type").and_then(|v| v.as_str()) {
             Some("Identifier") => {
-                if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
+                if let Some(name) = obj.field("name").and_then(|v| v.as_str()) {
                     let trimmed = name.trim();
                     // Check if this "identifier" is actually a destructuring pattern string
                     if trimmed.starts_with('{') || trimmed.starts_with('[') {
@@ -855,7 +857,7 @@ fn convert_value_to_pattern(val: &serde_json::Value, arena: &JsArena) -> JsPatte
             }
             Some("AssignmentPattern") => {
                 // Default value pattern: `a = 3` or `{ x } = {}`
-                if let (Some(left), Some(right)) = (obj.get("left"), obj.get("right")) {
+                if let (Some(left), Some(right)) = (obj.field("left"), obj.field("right")) {
                     let left_pattern = convert_value_to_pattern(left, arena);
                     let right_expr = convert_value_to_js_expr_simple(right, arena);
                     return JsPattern::Assignment(JsAssignmentPattern {
@@ -865,16 +867,16 @@ fn convert_value_to_pattern(val: &serde_json::Value, arena: &JsArena) -> JsPatte
                 }
             }
             Some("ObjectPattern") => {
-                if let Some(props) = obj.get("properties").and_then(|p| p.as_array()) {
+                if let Some(props) = obj.field("properties").and_then(|p| p.as_array()) {
                     let properties = props
                         .iter()
                         .filter_map(|prop| {
                             let prop_obj = prop.as_object()?;
-                            let prop_type = prop_obj.get("type").and_then(|t| t.as_str())?;
+                            let prop_type = prop_obj.field("type").and_then(|t| t.as_str())?;
 
                             // Handle RestElement inside ObjectPattern
                             if prop_type == "RestElement" {
-                                if let Some(arg) = prop_obj.get("argument") {
+                                if let Some(arg) = prop_obj.field("argument") {
                                     let inner = convert_value_to_pattern(arg, arena);
                                     return Some(JsObjectPatternProperty::Rest(Box::new(inner)));
                                 }
@@ -882,24 +884,24 @@ fn convert_value_to_pattern(val: &serde_json::Value, arena: &JsArena) -> JsPatte
                             }
 
                             // Handle regular Property
-                            let key_val = prop_obj.get("key")?;
+                            let key_val = prop_obj.field("key")?;
                             let key = key_val.as_object()?;
-                            let value = prop_obj.get("value")?;
+                            let value = prop_obj.field("value")?;
 
                             let shorthand = prop_obj
-                                .get("shorthand")
+                                .field("shorthand")
                                 .and_then(|s| s.as_bool())
                                 .unwrap_or(false);
 
                             let computed = prop_obj
-                                .get("computed")
+                                .field("computed")
                                 .and_then(|c| c.as_bool())
                                 .unwrap_or(false);
 
                             let value_pattern = convert_value_to_pattern(value, arena);
 
                             // Determine property key
-                            let key_type = key.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                            let key_type = key.field("type").and_then(|t| t.as_str()).unwrap_or("");
                             let property_key = if computed {
                                 // Computed key: [expr]
                                 JsPropertyKey::Computed(
@@ -909,21 +911,22 @@ fn convert_value_to_pattern(val: &serde_json::Value, arena: &JsArena) -> JsPatte
                                 )
                             } else if key_type == "Literal" {
                                 // Literal key (number or string)
-                                if let Some(n) = key.get("value").and_then(|v| v.as_f64()) {
+                                if let Some(n) = key.field("value").and_then(|v| v.as_f64()) {
                                     JsPropertyKey::Literal(JsLiteral::Number(n))
-                                } else if let Some(s) = key.get("value").and_then(|v| v.as_str()) {
+                                } else if let Some(s) = key.field("value").and_then(|v| v.as_str())
+                                {
                                     JsPropertyKey::Literal(JsLiteral::String(s.into()))
                                 } else {
                                     let raw =
-                                        key.get("raw").and_then(|r| r.as_str()).unwrap_or("0");
+                                        key.field("raw").and_then(|r| r.as_str()).unwrap_or("0");
                                     JsPropertyKey::Literal(JsLiteral::String(raw.into()))
                                 }
-                            } else if let Some(name) = key.get("name").and_then(|v| v.as_str()) {
+                            } else if let Some(name) = key.field("name").and_then(|v| v.as_str()) {
                                 JsPropertyKey::Identifier(name.into())
-                            } else if let Some(s) = key.get("value").and_then(|v| v.as_str()) {
+                            } else if let Some(s) = key.field("value").and_then(|v| v.as_str()) {
                                 // String literal key
                                 JsPropertyKey::Literal(JsLiteral::String(s.into()))
-                            } else if let Some(n) = key.get("value").and_then(|v| v.as_f64()) {
+                            } else if let Some(n) = key.field("value").and_then(|v| v.as_f64()) {
                                 // Numeric literal key
                                 JsPropertyKey::Literal(JsLiteral::Number(n))
                             } else {
@@ -943,7 +946,7 @@ fn convert_value_to_pattern(val: &serde_json::Value, arena: &JsArena) -> JsPatte
                 }
             }
             Some("ArrayPattern") => {
-                if let Some(elems) = obj.get("elements").and_then(|e| e.as_array()) {
+                if let Some(elems) = obj.field("elements").and_then(|e| e.as_array()) {
                     let elements = elems
                         .iter()
                         .map(|elem| {
@@ -959,7 +962,7 @@ fn convert_value_to_pattern(val: &serde_json::Value, arena: &JsArena) -> JsPatte
                 }
             }
             Some("RestElement") => {
-                if let Some(arg) = obj.get("argument") {
+                if let Some(arg) = obj.field("argument") {
                     let inner = convert_value_to_pattern(arg, arena);
                     return JsPattern::Rest(Box::new(inner));
                 }
@@ -975,18 +978,18 @@ fn convert_value_to_pattern(val: &serde_json::Value, arena: &JsArena) -> JsPatte
 fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> JsExpr {
     match val {
         serde_json::Value::Object(obj) => {
-            let node_type = obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            let node_type = obj.field("type").and_then(|t| t.as_str()).unwrap_or("");
             match node_type {
                 "Identifier" => {
                     let name = obj
-                        .get("name")
+                        .field("name")
                         .and_then(|v| v.as_str())
                         .unwrap_or("undefined");
                     JsExpr::Identifier(name.into())
                 }
                 "Literal" => {
-                    if let Some(raw) = obj.get("raw").and_then(|r| r.as_str()) {
-                        let value = obj.get("value");
+                    if let Some(raw) = obj.field("raw").and_then(|r| r.as_str()) {
+                        let value = obj.field("value");
                         if let Some(n) = value.and_then(|v| v.as_f64()) {
                             JsExpr::Literal(JsLiteral::Number(n))
                         } else if let Some(s) = value.and_then(|v| v.as_str()) {
@@ -998,11 +1001,11 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                         } else {
                             JsExpr::Raw(raw.into())
                         }
-                    } else if let Some(n) = obj.get("value").and_then(|v| v.as_f64()) {
+                    } else if let Some(n) = obj.field("value").and_then(|v| v.as_f64()) {
                         JsExpr::Literal(JsLiteral::Number(n))
-                    } else if let Some(s) = obj.get("value").and_then(|v| v.as_str()) {
+                    } else if let Some(s) = obj.field("value").and_then(|v| v.as_str()) {
                         JsExpr::Literal(JsLiteral::String(s.into()))
-                    } else if let Some(b) = obj.get("value").and_then(|v| v.as_bool()) {
+                    } else if let Some(b) = obj.field("value").and_then(|v| v.as_bool()) {
                         JsExpr::Literal(JsLiteral::Boolean(b))
                     } else {
                         JsExpr::Literal(JsLiteral::Null)
@@ -1011,12 +1014,12 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                 "TemplateLiteral" => {
                     // Convert template literal
                     let quasis_arr = obj
-                        .get("quasis")
+                        .field("quasis")
                         .and_then(|q| q.as_array())
                         .cloned()
                         .unwrap_or_default();
                     let expressions_arr = obj
-                        .get("expressions")
+                        .field("expressions")
                         .and_then(|e| e.as_array())
                         .cloned()
                         .unwrap_or_default();
@@ -1026,13 +1029,13 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                         .enumerate()
                         .map(|(i, quasi)| {
                             let raw = quasi
-                                .get("value")
-                                .and_then(|v| v.get("raw"))
+                                .field("value")
+                                .and_then(|v| v.field("raw"))
                                 .and_then(|r| r.as_str())
                                 .unwrap_or("");
                             let cooked = quasi
-                                .get("value")
-                                .and_then(|v| v.get("cooked"))
+                                .field("value")
+                                .and_then(|v| v.field("cooked"))
                                 .and_then(|c| c.as_str())
                                 .unwrap_or(raw);
                             JsTemplateElement {
@@ -1055,14 +1058,17 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                 }
                 "BinaryExpression" => {
                     let left = obj
-                        .get("left")
+                        .field("left")
                         .map(|v| convert_value_to_js_expr_simple(v, arena))
                         .unwrap_or(JsExpr::Literal(JsLiteral::Number(0.0)));
                     let right = obj
-                        .get("right")
+                        .field("right")
                         .map(|v| convert_value_to_js_expr_simple(v, arena))
                         .unwrap_or(JsExpr::Literal(JsLiteral::Number(0.0)));
-                    let op_str = obj.get("operator").and_then(|o| o.as_str()).unwrap_or("+");
+                    let op_str = obj
+                        .field("operator")
+                        .and_then(|o| o.as_str())
+                        .unwrap_or("+");
                     let operator = str_to_binary_op(op_str);
                     JsExpr::Binary(JsBinaryExpression {
                         operator,
@@ -1072,16 +1078,16 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                 }
                 "MemberExpression" => {
                     let object = obj
-                        .get("object")
+                        .field("object")
                         .map(|v| convert_value_to_js_expr_simple(v, arena))
                         .unwrap_or(JsExpr::Identifier("undefined".into()));
-                    let prop_val = obj.get("property");
+                    let prop_val = obj.field("property");
                     let computed = obj
-                        .get("computed")
+                        .field("computed")
                         .and_then(|c| c.as_bool())
                         .unwrap_or(false);
                     let optional = obj
-                        .get("optional")
+                        .field("optional")
                         .and_then(|o| o.as_bool())
                         .unwrap_or(false);
                     let property = if computed {
@@ -1095,7 +1101,7 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                     } else {
                         let prop_name = prop_val
                             .and_then(|v| v.as_object())
-                            .and_then(|o| o.get("name"))
+                            .and_then(|o| o.field("name"))
                             .and_then(|n| n.as_str())
                             .unwrap_or("undefined");
                         JsMemberProperty::Identifier(prop_name.into())
@@ -1109,11 +1115,11 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                 }
                 "CallExpression" => {
                     let callee = obj
-                        .get("callee")
+                        .field("callee")
                         .map(|v| convert_value_to_js_expr_simple(v, arena))
                         .unwrap_or(JsExpr::Identifier("undefined".into()));
                     let args = obj
-                        .get("arguments")
+                        .field("arguments")
                         .and_then(|a| a.as_array())
                         .map(|arr| {
                             arr.iter()
@@ -1122,7 +1128,7 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                         })
                         .unwrap_or_default();
                     let optional = obj
-                        .get("optional")
+                        .field("optional")
                         .and_then(|o| o.as_bool())
                         .unwrap_or(false);
                     JsExpr::Call(JsCallExpression {
@@ -1133,16 +1139,22 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                 }
                 "UpdateExpression" => {
                     let argument = obj
-                        .get("argument")
+                        .field("argument")
                         .map(|v| convert_value_to_js_expr_simple(v, arena))
                         .unwrap_or(JsExpr::Identifier("undefined".into()));
-                    let op_str = obj.get("operator").and_then(|o| o.as_str()).unwrap_or("++");
+                    let op_str = obj
+                        .field("operator")
+                        .and_then(|o| o.as_str())
+                        .unwrap_or("++");
                     let operator = if op_str == "--" {
                         JsUpdateOp::Decrement
                     } else {
                         JsUpdateOp::Increment
                     };
-                    let prefix = obj.get("prefix").and_then(|p| p.as_bool()).unwrap_or(false);
+                    let prefix = obj
+                        .field("prefix")
+                        .and_then(|p| p.as_bool())
+                        .unwrap_or(false);
                     JsExpr::Update(JsUpdateExpression {
                         operator,
                         argument: arena.alloc_expr(argument),
@@ -1151,7 +1163,7 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                 }
                 "ObjectExpression" => {
                     let props = obj
-                        .get("properties")
+                        .field("properties")
                         .and_then(|p| p.as_array())
                         .cloned()
                         .unwrap_or_default();
@@ -1159,30 +1171,30 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                         .iter()
                         .filter_map(|p| {
                             let p_obj = p.as_object()?;
-                            let key_val = p_obj.get("key")?;
+                            let key_val = p_obj.field("key")?;
                             let key_obj = key_val.as_object()?;
-                            let val = p_obj.get("value")?;
+                            let val = p_obj.field("value")?;
                             let computed = p_obj
-                                .get("computed")
+                                .field("computed")
                                 .and_then(|c| c.as_bool())
                                 .unwrap_or(false);
                             let shorthand = p_obj
-                                .get("shorthand")
+                                .field("shorthand")
                                 .and_then(|s| s.as_bool())
                                 .unwrap_or(false);
 
-                            let key = if computed {
-                                JsPropertyKey::Computed(
-                                    arena.alloc_expr(convert_value_to_js_expr_simple(
-                                        key_val, arena,
-                                    )),
-                                )
-                            } else if let Some(name) = key_obj.get("name").and_then(|n| n.as_str())
-                            {
-                                JsPropertyKey::Identifier(name.into())
-                            } else {
-                                JsPropertyKey::Identifier("unknown".into())
-                            };
+                            let key =
+                                if computed {
+                                    JsPropertyKey::Computed(arena.alloc_expr(
+                                        convert_value_to_js_expr_simple(key_val, arena),
+                                    ))
+                                } else if let Some(name) =
+                                    key_obj.field("name").and_then(|n| n.as_str())
+                                {
+                                    JsPropertyKey::Identifier(name.into())
+                                } else {
+                                    JsPropertyKey::Identifier("unknown".into())
+                                };
 
                             Some(JsObjectMember::Property(JsProperty {
                                 key,
@@ -1201,7 +1213,7 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                 }
                 "ArrayExpression" => {
                     let elems = obj
-                        .get("elements")
+                        .field("elements")
                         .and_then(|e| e.as_array())
                         .cloned()
                         .unwrap_or_default();
@@ -1219,12 +1231,18 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                 }
                 "UnaryExpression" => {
                     let argument = obj
-                        .get("argument")
+                        .field("argument")
                         .map(|v| convert_value_to_js_expr_simple(v, arena))
                         .unwrap_or(JsExpr::Literal(JsLiteral::Number(0.0)));
-                    let op_str = obj.get("operator").and_then(|o| o.as_str()).unwrap_or("-");
+                    let op_str = obj
+                        .field("operator")
+                        .and_then(|o| o.as_str())
+                        .unwrap_or("-");
                     let operator = str_to_unary_op(op_str);
-                    let prefix = obj.get("prefix").and_then(|p| p.as_bool()).unwrap_or(true);
+                    let prefix = obj
+                        .field("prefix")
+                        .and_then(|p| p.as_bool())
+                        .unwrap_or(true);
                     JsExpr::Unary(JsUnaryExpression {
                         operator,
                         argument: arena.alloc_expr(argument),
@@ -1233,15 +1251,15 @@ fn convert_value_to_js_expr_simple(val: &serde_json::Value, arena: &JsArena) -> 
                 }
                 "ConditionalExpression" => {
                     let test = obj
-                        .get("test")
+                        .field("test")
                         .map(|v| convert_value_to_js_expr_simple(v, arena))
                         .unwrap_or(JsExpr::Literal(JsLiteral::Boolean(false)));
                     let consequent = obj
-                        .get("consequent")
+                        .field("consequent")
                         .map(|v| convert_value_to_js_expr_simple(v, arena))
                         .unwrap_or(JsExpr::Identifier("undefined".into()));
                     let alternate = obj
-                        .get("alternate")
+                        .field("alternate")
                         .map(|v| convert_value_to_js_expr_simple(v, arena))
                         .unwrap_or(JsExpr::Identifier("undefined".into()));
                     JsExpr::Conditional(JsConditionalExpression {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -23,6 +23,7 @@ use crate::compiler::phases::phase3_transform::js_ast::JsArena;
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
 use crate::compiler::phases::phase3_transform::js_ast::to_oxc::SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 // Note: We implement bind_this directly here rather than using shared/utils
 // to avoid complex borrow checker issues with the context
@@ -963,31 +964,31 @@ fn build_group_keypath_parts(expr: &serde_json::Value, parts: &mut Vec<String>) 
         Some(o) => o,
         None => return,
     };
-    let expr_type = match obj.get("type").and_then(|t| t.as_str()) {
+    let expr_type = match obj.field("type").and_then(|t| t.as_str()) {
         Some(t) => t,
         None => return,
     };
     match expr_type {
         "Identifier" => {
-            if let Some(name) = obj.get("name").and_then(|n| n.as_str()) {
+            if let Some(name) = obj.field("name").and_then(|n| n.as_str()) {
                 parts.push(name.to_string());
             }
         }
         "MemberExpression" => {
-            if let Some(object) = obj.get("object") {
+            if let Some(object) = obj.field("object") {
                 build_group_keypath_parts(object, parts);
             }
             let computed = obj
-                .get("computed")
+                .field("computed")
                 .and_then(|c| c.as_bool())
                 .unwrap_or(false);
             if computed {
-                if let Some(property) = obj.get("property") {
+                if let Some(property) = obj.field("property") {
                     let prop_str = build_group_binding_keypath(property);
                     parts.push(format!("[{}]", prop_str));
                 }
-            } else if let Some(property) = obj.get("property")
-                && let Some(name) = property.get("name").and_then(|n| n.as_str())
+            } else if let Some(property) = obj.field("property")
+                && let Some(name) = property.field("name").and_then(|n| n.as_str())
             {
                 parts.push(name.to_string());
             }
@@ -1205,7 +1206,7 @@ fn expression_json_is_member(val: &serde_json::Value) -> bool {
         Some(o) => o,
         None => return false,
     };
-    let expr_type = match obj.get("type").and_then(|t| t.as_str()) {
+    let expr_type = match obj.field("type").and_then(|t| t.as_str()) {
         Some(t) => t,
         None => return false,
     };
@@ -1213,7 +1214,7 @@ fn expression_json_is_member(val: &serde_json::Value) -> bool {
         "MemberExpression" => true,
         "CallExpression" => {
             // For call expressions, check the callee
-            if let Some(callee) = obj.get("callee") {
+            if let Some(callee) = obj.field("callee") {
                 expression_json_is_member(callee)
             } else {
                 false
@@ -2579,10 +2580,10 @@ fn analyze_each_binding_expression(
 fn extract_member_path(
     obj: &serde_json::Map<String, serde_json::Value>,
 ) -> Option<(String, String)> {
-    let object = obj.get("object")?.as_object()?;
-    let property = obj.get("property")?.as_object()?;
+    let object = obj.field("object")?.as_object()?;
+    let property = obj.field("property")?.as_object()?;
     let computed = obj
-        .get("computed")
+        .field("computed")
         .and_then(|c| c.as_bool())
         .unwrap_or(false);
 
@@ -2592,13 +2593,13 @@ fn extract_member_path(
         let prop_str = format_json_expr(&prop_val);
         format!("[{}]", prop_str)
     } else {
-        property.get("name").and_then(|n| n.as_str())?.to_string()
+        property.field("name").and_then(|n| n.as_str())?.to_string()
     };
 
-    let object_type = object.get("type").and_then(|t| t.as_str())?;
+    let object_type = object.field("type").and_then(|t| t.as_str())?;
 
     if object_type == "Identifier" {
-        let root_name = object.get("name").and_then(|n| n.as_str())?;
+        let root_name = object.field("name").and_then(|n| n.as_str())?;
         Some((root_name.to_string(), prop_name))
     } else if object_type == "MemberExpression" {
         let (root, parent_path) = extract_member_path(object)?;
@@ -2616,17 +2617,17 @@ fn extract_member_path(
 fn format_json_expr(val: &serde_json::Value) -> String {
     match val {
         serde_json::Value::Object(obj) => {
-            let expr_type = obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            let expr_type = obj.field("type").and_then(|t| t.as_str()).unwrap_or("");
             match expr_type {
                 "Identifier" => obj
-                    .get("name")
+                    .field("name")
                     .and_then(|n| n.as_str())
                     .unwrap_or("?")
                     .to_string(),
                 "Literal" | "NumericLiteral" => {
-                    if let Some(raw) = obj.get("raw").and_then(|r| r.as_str()) {
+                    if let Some(raw) = obj.field("raw").and_then(|r| r.as_str()) {
                         raw.to_string()
-                    } else if let Some(v) = obj.get("value") {
+                    } else if let Some(v) = obj.field("value") {
                         match v {
                             serde_json::Value::Number(n) => n.to_string(),
                             serde_json::Value::String(s) => format!("'{}'", s),
@@ -2823,10 +2824,10 @@ fn collect_ast_identifiers(expr: &Expression) -> Vec<String> {
 fn collect_ast_identifiers_recursive(val: &serde_json::Value, names: &mut Vec<String>) {
     match val {
         serde_json::Value::Object(obj) => {
-            let node_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            let node_type = obj.field("type").and_then(|v| v.as_str()).unwrap_or("");
             match node_type {
                 "Identifier" => {
-                    if let Some(name) = obj.get("name").and_then(|v| v.as_str())
+                    if let Some(name) = obj.field("name").and_then(|v| v.as_str())
                         && !names.contains(&name.to_string())
                     {
                         names.push(name.to_string());
@@ -2966,13 +2967,13 @@ pub fn emit_validate_binding(
 /// Extract the root identifier name from a JSON expression.
 fn extract_root_identifier_span_from_json(val: &serde_json::Value) -> Option<(String, u32, u32)> {
     let obj = val.as_object()?;
-    match obj.get("type")?.as_str()? {
+    match obj.field("type")?.as_str()? {
         "Identifier" => Some((
-            obj.get("name")?.as_str()?.to_string(),
-            u32::try_from(obj.get("start")?.as_u64()?).ok()?,
-            u32::try_from(obj.get("end")?.as_u64()?).ok()?,
+            obj.field("name")?.as_str()?.to_string(),
+            u32::try_from(obj.field("start")?.as_u64()?).ok()?,
+            u32::try_from(obj.field("end")?.as_u64()?).ok()?,
         )),
-        "MemberExpression" => extract_root_identifier_span_from_json(obj.get("object")?),
+        "MemberExpression" => extract_root_identifier_span_from_json(obj.field("object")?),
         _ => None,
     }
 }
@@ -3085,31 +3086,31 @@ fn build_ast_member_path_recursive(
         Some(o) => o,
         None => return true,
     };
-    match obj.get("type").and_then(|t| t.as_str()) {
+    match obj.field("type").and_then(|t| t.as_str()) {
         Some("MemberExpression") => {
             // Recurse into object first
-            if let Some(object) = obj.get("object")
+            if let Some(object) = obj.field("object")
                 && !build_ast_member_path_recursive(object, path, read_computed)
             {
                 return false;
             }
             // Add current property
             let computed = obj
-                .get("computed")
+                .field("computed")
                 .and_then(|c| c.as_bool())
                 .unwrap_or(false);
-            let Some(property) = obj.get("property") else {
+            let Some(property) = obj.field("property") else {
                 return true;
             };
             let Some(prop_obj) = property.as_object() else {
                 return true;
             };
-            let Some(prop_type) = prop_obj.get("type").and_then(|t| t.as_str()) else {
+            let Some(prop_type) = prop_obj.field("type").and_then(|t| t.as_str()) else {
                 return true;
             };
             match prop_type {
                 "Identifier" => {
-                    if let Some(name) = prop_obj.get("name").and_then(|n| n.as_str()) {
+                    if let Some(name) = prop_obj.field("name").and_then(|n| n.as_str()) {
                         if computed {
                             path.push(read_computed(name));
                         } else {
@@ -3119,7 +3120,7 @@ fn build_ast_member_path_recursive(
                     true
                 }
                 "Literal" => {
-                    if let Some(value) = prop_obj.get("value") {
+                    if let Some(value) = prop_obj.field("value") {
                         if let Some(s) = value.as_str() {
                             path.push(b::string(s));
                         } else if let Some(n) = value.as_f64() {
@@ -3132,7 +3133,7 @@ fn build_ast_member_path_recursive(
             }
         }
         Some("Identifier") => {
-            if let Some(name) = obj.get("name").and_then(|n| n.as_str()) {
+            if let Some(name) = obj.field("name").and_then(|n| n.as_str()) {
                 path.push(b::string(name));
             }
             true

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/const_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/const_tag.rs
@@ -17,6 +17,7 @@ use crate::compiler::phases::phase3_transform::client::visitors::shared::declara
 use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::build_expression;
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Visit a const tag.
 ///
@@ -354,23 +355,23 @@ fn extract_identifiers_from_pattern(pattern: &serde_json::Value) -> Vec<String> 
 }
 
 fn collect_identifiers(pattern: &serde_json::Value, out: &mut Vec<String>) {
-    let pat_type = pattern.get("type").and_then(|v| v.as_str());
+    let pat_type = pattern.field("type").and_then(|v| v.as_str());
     match pat_type {
         Some("Identifier") => {
-            if let Some(name) = pattern.get("name").and_then(|v| v.as_str()) {
+            if let Some(name) = pattern.field("name").and_then(|v| v.as_str()) {
                 out.push(name.to_string());
             }
         }
         // Handle both ObjectPattern (official AST) and ObjectExpression (our parser's AST)
         Some("ObjectPattern") | Some("ObjectExpression") => {
-            if let Some(properties) = pattern.get("properties").and_then(|v| v.as_array()) {
+            if let Some(properties) = pattern.field("properties").and_then(|v| v.as_array()) {
                 for prop in properties {
-                    let prop_type = prop.get("type").and_then(|v| v.as_str());
+                    let prop_type = prop.field("type").and_then(|v| v.as_str());
                     if prop_type == Some("RestElement") || prop_type == Some("SpreadElement") {
-                        if let Some(arg) = prop.get("argument") {
+                        if let Some(arg) = prop.field("argument") {
                             collect_identifiers(arg, out);
                         }
-                    } else if let Some(value) = prop.get("value") {
+                    } else if let Some(value) = prop.field("value") {
                         collect_identifiers(value, out);
                     }
                 }
@@ -378,7 +379,7 @@ fn collect_identifiers(pattern: &serde_json::Value, out: &mut Vec<String>) {
         }
         // Handle both ArrayPattern (official AST) and ArrayExpression (our parser's AST)
         Some("ArrayPattern") | Some("ArrayExpression") => {
-            if let Some(elements) = pattern.get("elements").and_then(|v| v.as_array()) {
+            if let Some(elements) = pattern.field("elements").and_then(|v| v.as_array()) {
                 for elem in elements {
                     if !elem.is_null() {
                         collect_identifiers(elem, out);
@@ -387,12 +388,12 @@ fn collect_identifiers(pattern: &serde_json::Value, out: &mut Vec<String>) {
             }
         }
         Some("RestElement") | Some("SpreadElement") => {
-            if let Some(arg) = pattern.get("argument") {
+            if let Some(arg) = pattern.field("argument") {
                 collect_identifiers(arg, out);
             }
         }
         Some("AssignmentPattern") | Some("AssignmentExpression") => {
-            if let Some(left) = pattern.get("left") {
+            if let Some(left) = pattern.field("left") {
                 collect_identifiers(left, out);
             }
         }
@@ -402,37 +403,37 @@ fn collect_identifiers(pattern: &serde_json::Value, out: &mut Vec<String>) {
 
 /// Render a pattern JSON as a string for raw output fallback.
 fn render_pattern_as_string(pattern: &serde_json::Value) -> String {
-    let pat_type = pattern.get("type").and_then(|v| v.as_str());
+    let pat_type = pattern.field("type").and_then(|v| v.as_str());
     match pat_type {
         Some("Identifier") => pattern
-            .get("name")
+            .field("name")
             .and_then(|v| v.as_str())
             .unwrap_or("_")
             .to_string(),
         Some("ObjectPattern") | Some("ObjectExpression") => {
             let props: Vec<String> = pattern
-                .get("properties")
+                .field("properties")
                 .and_then(|v| v.as_array())
                 .map(|props| {
                     props
                         .iter()
                         .map(|prop| {
-                            let prop_type = prop.get("type").and_then(|v| v.as_str());
+                            let prop_type = prop.field("type").and_then(|v| v.as_str());
                             if prop_type == Some("RestElement") {
                                 let arg = prop
-                                    .get("argument")
+                                    .field("argument")
                                     .map(render_pattern_as_string)
                                     .unwrap_or_default();
                                 format!("...{}", arg)
                             } else {
                                 let key = prop
-                                    .get("key")
-                                    .and_then(|k| k.get("name"))
+                                    .field("key")
+                                    .and_then(|k| k.field("name"))
                                     .and_then(|n| n.as_str())
                                     .unwrap_or("_");
-                                let value = prop.get("value").map(render_pattern_as_string);
+                                let value = prop.field("value").map(render_pattern_as_string);
                                 let shorthand = prop
-                                    .get("shorthand")
+                                    .field("shorthand")
                                     .and_then(|s| s.as_bool())
                                     .unwrap_or(false);
                                 if shorthand || value.as_deref() == Some(key) {
@@ -451,7 +452,7 @@ fn render_pattern_as_string(pattern: &serde_json::Value) -> String {
         }
         Some("ArrayPattern") | Some("ArrayExpression") => {
             let elems: Vec<String> = pattern
-                .get("elements")
+                .field("elements")
                 .and_then(|v| v.as_array())
                 .map(|elems| {
                     elems
@@ -470,7 +471,7 @@ fn render_pattern_as_string(pattern: &serde_json::Value) -> String {
         }
         Some("RestElement") => {
             let arg = pattern
-                .get("argument")
+                .field("argument")
                 .map(render_pattern_as_string)
                 .unwrap_or_default();
             format!("...{}", arg)
@@ -478,7 +479,7 @@ fn render_pattern_as_string(pattern: &serde_json::Value) -> String {
         Some("AssignmentPattern") => {
             // We don't render defaults in the const destructuring pattern
             pattern
-                .get("left")
+                .field("left")
                 .map(render_pattern_as_string)
                 .unwrap_or_default()
         }
@@ -501,9 +502,9 @@ fn extract_refs_from_json_expr(expr: &crate::ast::js::Expression) -> Vec<String>
 fn collect_json_identifiers(value: &serde_json::Value, out: &mut Vec<String>) {
     match value {
         serde_json::Value::Object(obj) => {
-            if let Some(typ) = obj.get("type").and_then(|t| t.as_str()) {
+            if let Some(typ) = obj.field("type").and_then(|t| t.as_str()) {
                 if typ == "Identifier" {
-                    if let Some(name) = obj.get("name").and_then(|n| n.as_str())
+                    if let Some(name) = obj.field("name").and_then(|n| n.as_str())
                         && !out.contains(&name.to_string())
                     {
                         out.push(name.to_string());
@@ -935,24 +936,24 @@ fn parse_variable_declaration<'a>(expr: &Expression<'a>) -> Option<ParsedDeclara
     {
         let json_value = expr.as_json();
         let obj = json_value.as_object()?;
-        let expr_type = obj.get("type")?.as_str()?;
+        let expr_type = obj.field("type")?.as_str()?;
 
         match expr_type {
             "VariableDeclaration" => {
-                let declarations = obj.get("declarations")?.as_array()?;
+                let declarations = obj.field("declarations")?.as_array()?;
                 if declarations.is_empty() {
                     return None;
                 }
 
                 let first_decl = declarations[0].as_object()?;
-                let id = first_decl.get("id")?;
-                let init = first_decl.get("init")?;
+                let id = first_decl.field("id")?;
+                let init = first_decl.field("init")?;
 
                 let id_obj = id.as_object()?;
-                let id_type = id_obj.get("type")?.as_str()?;
+                let id_type = id_obj.field("type")?.as_str()?;
 
                 if id_type == "Identifier" {
-                    let name = id_obj.get("name")?.as_str()?.to_string();
+                    let name = id_obj.field("name")?.as_str()?.to_string();
                     let init_expr = Expression::from_json(init.clone());
                     Some(ParsedDeclaration {
                         id_name: name,
@@ -973,14 +974,14 @@ fn parse_variable_declaration<'a>(expr: &Expression<'a>) -> Option<ParsedDeclara
             }
             "AssignmentExpression" => {
                 // Our Rust parser format: { type: "AssignmentExpression", left: id, right: init }
-                let left = obj.get("left")?;
-                let right = obj.get("right")?;
+                let left = obj.field("left")?;
+                let right = obj.field("right")?;
 
                 let left_obj = left.as_object()?;
-                let left_type = left_obj.get("type")?.as_str()?;
+                let left_type = left_obj.field("type")?.as_str()?;
 
                 if left_type == "Identifier" {
-                    let name = left_obj.get("name")?.as_str()?.to_string();
+                    let name = left_obj.field("name")?.as_str()?.to_string();
                     let init_expr = Expression::from_json(right.clone());
                     Some(ParsedDeclaration {
                         id_name: name,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
@@ -19,6 +19,7 @@
 use crate::ast::template::DeclarationTag;
 use crate::compiler::phases::phase3_transform::client::types::*;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::{JsExpr, JsStatement};
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use crate::compiler::utils::is_escaped;
 
 /// Visit a declaration tag.
@@ -57,10 +58,10 @@ pub fn declaration_tag(node: &DeclarationTag, context: &mut ComponentContext) {
     // `build_expression`'s transform tracker.
     {
         let decl_json = node.declaration.as_json();
-        if let Some(decls) = decl_json.get("declarations").and_then(|d| d.as_array()) {
+        if let Some(decls) = decl_json.field("declarations").and_then(|d| d.as_array()) {
             let mut refs: Vec<String> = Vec::new();
             for d in decls {
-                if let Some(init) = d.get("init").filter(|i| !i.is_null()) {
+                if let Some(init) = d.field("init").filter(|i| !i.is_null()) {
                     collect_init_identifiers(init, &mut refs);
                 }
             }
@@ -221,7 +222,7 @@ fn try_emit_async_declaration(
     context: &mut ComponentContext,
 ) -> Option<()> {
     let decl_json = node.declaration.as_json();
-    let decls = decl_json.get("declarations")?.as_array()?;
+    let decls = decl_json.field("declarations")?.as_array()?;
     // Only single-declarator tags are async-lowered here; genuine
     // multi-declarator (`{let a = …, b = …}`) tags fall back to the sync /
     // rejoin path. Destructuring patterns (`{const { x, y } = …}`) ARE handled
@@ -230,8 +231,8 @@ fn try_emit_async_declaration(
         return None;
     }
     let d = decls[0].as_object()?;
-    let id = d.get("id")?;
-    let id_type = id.get("type")?.as_str()?;
+    let id = d.field("id")?;
+    let id_type = id.field("type")?.as_str()?;
     let is_pattern = matches!(
         id_type,
         "ObjectPattern" | "ObjectExpression" | "ArrayPattern" | "ArrayExpression"
@@ -239,7 +240,7 @@ fn try_emit_async_declaration(
     if id_type != "Identifier" && !is_pattern {
         return None;
     }
-    let init = d.get("init").filter(|i| !i.is_null())?;
+    let init = d.field("init").filter(|i| !i.is_null())?;
 
     // Identifiers referenced by the initializer, for async-blocker lookup.
     let mut init_refs: Vec<String> = Vec::new();
@@ -291,9 +292,9 @@ fn try_emit_async_declaration(
         }
         let src = &context.state.analysis.source;
         let lhs_pattern = id
-            .get("start")
+            .field("start")
             .and_then(|v| v.as_u64())
-            .zip(id.get("end").and_then(|v| v.as_u64()))
+            .zip(id.field("end").and_then(|v| v.as_u64()))
             .and_then(|(st, en)| {
                 let (st, en) = (st as usize, en as usize);
                 if st < en && en <= src.len() {
@@ -314,7 +315,7 @@ fn try_emit_async_declaration(
         return Some(());
     }
 
-    let name = id.get("name")?.as_str()?;
+    let name = id.field("name")?.as_str()?;
     super::const_tag::add_const_declaration(
         context,
         name,
@@ -362,8 +363,8 @@ fn find_top_level_assignment_eq(s: &str) -> Option<usize> {
 fn collect_init_identifiers(value: &serde_json::Value, out: &mut Vec<String>) {
     match value {
         serde_json::Value::Object(map) => {
-            if map.get("type").and_then(|t| t.as_str()) == Some("Identifier")
-                && let Some(n) = map.get("name").and_then(|n| n.as_str())
+            if map.field("type").and_then(|t| t.as_str()) == Some("Identifier")
+                && let Some(n) = map.field("name").and_then(|n| n.as_str())
             {
                 let n = n.to_string();
                 if !out.contains(&n) {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
@@ -52,6 +52,7 @@ use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
 use crate::compiler::phases::phase3_transform::shared::js_scan::find_code;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use crate::compiler::phases::phase3_transform::shared::template::escape_js_string;
 use rustc_hash::FxHashMap;
 use std::cell::Cell;
@@ -799,9 +800,9 @@ fn get_object_name(expr: &Expression) -> Option<String> {
     // TODO: migrate to JsNode pattern matching
     let val = expr.as_json();
     if let serde_json::Value::Object(obj) = val {
-        match obj.get("type").and_then(|v| v.as_str()) {
+        match obj.field("type").and_then(|v| v.as_str()) {
             Some("MemberExpression") => {
-                if let Some(object) = obj.get("object") {
+                if let Some(object) = obj.field("object") {
                     get_object_name(&Expression::from_json(object.clone()))
                 } else {
                     None
@@ -809,7 +810,7 @@ fn get_object_name(expr: &Expression) -> Option<String> {
             }
             // Handle LogicalExpression like `$items ?? []` by recursing into the left operand
             Some("LogicalExpression") | Some("BinaryExpression") => {
-                if let Some(left) = obj.get("left") {
+                if let Some(left) = obj.field("left") {
                     get_object_name(&Expression::from_json(left.clone()))
                 } else {
                     None
@@ -890,17 +891,17 @@ fn collect_pattern_names(
     obj: &serde_json::Map<String, serde_json::Value>,
     names: &mut Vec<compact_str::CompactString>,
 ) {
-    match obj.get("type").and_then(|v| v.as_str()) {
+    match obj.field("type").and_then(|v| v.as_str()) {
         Some("Identifier") => {
-            if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
+            if let Some(name) = obj.field("name").and_then(|v| v.as_str()) {
                 names.push(name.into());
             }
         }
         Some("ObjectPattern") => {
-            if let Some(props) = obj.get("properties").and_then(|p| p.as_array()) {
+            if let Some(props) = obj.field("properties").and_then(|p| p.as_array()) {
                 for prop in props {
                     if let Some(prop_obj) = prop.as_object()
-                        && let Some(value) = prop_obj.get("value").and_then(|v| v.as_object())
+                        && let Some(value) = prop_obj.field("value").and_then(|v| v.as_object())
                     {
                         collect_pattern_names(value, names);
                     }
@@ -908,7 +909,7 @@ fn collect_pattern_names(
             }
         }
         Some("ArrayPattern") => {
-            if let Some(elements) = obj.get("elements").and_then(|e| e.as_array()) {
+            if let Some(elements) = obj.field("elements").and_then(|e| e.as_array()) {
                 for elem in elements {
                     if let Some(elem_obj) = elem.as_object() {
                         collect_pattern_names(elem_obj, names);
@@ -917,12 +918,12 @@ fn collect_pattern_names(
             }
         }
         Some("AssignmentPattern") => {
-            if let Some(left) = obj.get("left").and_then(|l| l.as_object()) {
+            if let Some(left) = obj.field("left").and_then(|l| l.as_object()) {
                 collect_pattern_names(left, names);
             }
         }
         Some("RestElement") => {
-            if let Some(arg) = obj.get("argument").and_then(|a| a.as_object()) {
+            if let Some(arg) = obj.field("argument").and_then(|a| a.as_object()) {
                 collect_pattern_names(arg, names);
             }
         }
@@ -1386,10 +1387,10 @@ fn _extract_destructured_paths(
     has_default_value: bool,
     context: &mut ComponentContext,
 ) {
-    match param.get("type").and_then(|v| v.as_str()) {
+    match param.field("type").and_then(|v| v.as_str()) {
         Some("Identifier") => {
             let name = param
-                .get("name")
+                .field("name")
                 .and_then(|n| n.as_str())
                 .unwrap_or("$$unknown");
             paths.push(DestructuredPath {
@@ -1403,10 +1404,10 @@ fn _extract_destructured_paths(
             });
         }
         Some("ObjectPattern") => {
-            if let Some(props) = param.get("properties").and_then(|p| p.as_array()) {
+            if let Some(props) = param.field("properties").and_then(|p| p.as_array()) {
                 for prop in props {
                     if let Some(prop_obj) = prop.as_object() {
-                        let prop_type = prop_obj.get("type").and_then(|v| v.as_str());
+                        let prop_type = prop_obj.field("type").and_then(|v| v.as_str());
 
                         if prop_type == Some("RestElement") {
                             // RestElement in ObjectPattern: ...rest
@@ -1414,24 +1415,26 @@ fn _extract_destructured_paths(
                             let mut excluded_keys: Vec<String> = Vec::new();
                             for p in props {
                                 if let Some(p_obj) = p.as_object()
-                                    && p_obj.get("type").and_then(|t| t.as_str())
+                                    && p_obj.field("type").and_then(|t| t.as_str())
                                         == Some("Property")
-                                    && let Some(key) = p_obj.get("key").and_then(|k| k.as_object())
+                                    && let Some(key) =
+                                        p_obj.field("key").and_then(|k| k.as_object())
                                 {
-                                    let key_type = key.get("type").and_then(|t| t.as_str());
+                                    let key_type = key.field("type").and_then(|t| t.as_str());
                                     let computed = p_obj
-                                        .get("computed")
+                                        .field("computed")
                                         .and_then(|c| c.as_bool())
                                         .unwrap_or(false);
 
                                     if key_type == Some("Identifier")
                                         && !computed
-                                        && let Some(name) = key.get("name").and_then(|n| n.as_str())
+                                        && let Some(name) =
+                                            key.field("name").and_then(|n| n.as_str())
                                     {
                                         excluded_keys.push(format!("'{}'", escape_js_string(name)));
                                     } else if key_type == Some("Literal") {
                                         // Match official compiler: b.literal(String(p.key.value))
-                                        if let Some(val) = key.get("value") {
+                                        if let Some(val) = key.field("value") {
                                             let val_str = match val {
                                                 serde_json::Value::String(s) => s.clone(),
                                                 serde_json::Value::Number(n) => {
@@ -1473,12 +1476,13 @@ fn _extract_destructured_paths(
                                 excluded_keys.join(", ")
                             );
 
-                            if let Some(arg) = prop_obj.get("argument").and_then(|a| a.as_object())
+                            if let Some(arg) =
+                                prop_obj.field("argument").and_then(|a| a.as_object())
                             {
-                                let arg_type = arg.get("type").and_then(|t| t.as_str());
+                                let arg_type = arg.field("type").and_then(|t| t.as_str());
                                 if arg_type == Some("Identifier") {
                                     let name = arg
-                                        .get("name")
+                                        .field("name")
                                         .and_then(|n| n.as_str())
                                         .unwrap_or("$$unknown");
                                     paths.push(DestructuredPath {
@@ -1503,15 +1507,15 @@ fn _extract_destructured_paths(
                                 }
                             }
                         } else if prop_type == Some("Property") {
-                            let key = prop_obj.get("key").and_then(|k| k.as_object());
-                            let value = prop_obj.get("value");
+                            let key = prop_obj.field("key").and_then(|k| k.as_object());
+                            let value = prop_obj.field("value");
                             let computed = prop_obj
-                                .get("computed")
+                                .field("computed")
                                 .and_then(|c| c.as_bool())
                                 .unwrap_or(false);
 
                             if let (Some(key_obj), Some(value)) = (key, value) {
-                                let key_type = key_obj.get("type").and_then(|t| t.as_str());
+                                let key_type = key_obj.field("type").and_then(|t| t.as_str());
 
                                 // Build the property access expression (read) and
                                 // update expression (write LHS) separately.
@@ -1540,7 +1544,7 @@ fn _extract_destructured_paths(
                                     )
                                 } else {
                                     let key_name = key_obj
-                                        .get("name")
+                                        .field("name")
                                         .and_then(|n| n.as_str())
                                         .unwrap_or("unknown");
                                     (
@@ -1578,7 +1582,7 @@ fn _extract_destructured_paths(
         Some("ArrayPattern") => {
             // For ArrayPattern, create an intermediate declaration to convert
             // iterables to arrays. This matches the official compiler.
-            let elements = match param.get("elements").and_then(|e| e.as_array()) {
+            let elements = match param.field("elements").and_then(|e| e.as_array()) {
                 Some(e) => e,
                 None => return,
             };
@@ -1590,7 +1594,7 @@ fn _extract_destructured_paths(
             let last_is_rest = elements
                 .last()
                 .and_then(|e| e.as_object())
-                .and_then(|o| o.get("type").and_then(|t| t.as_str()))
+                .and_then(|o| o.field("type").and_then(|t| t.as_str()))
                 == Some("RestElement");
 
             // Build the $.to_array() call expression
@@ -1612,7 +1616,7 @@ fn _extract_destructured_paths(
                 }
 
                 if let Some(elem_obj) = elem.as_object() {
-                    let elem_type = elem_obj.get("type").and_then(|v| v.as_str());
+                    let elem_type = elem_obj.field("type").and_then(|v| v.as_str());
 
                     if elem_type == Some("RestElement") {
                         // RestElement read expression: $.get($$array).slice(i)
@@ -1622,11 +1626,11 @@ fn _extract_destructured_paths(
                         let rest_expression = format!("$.get({}).slice({})", array_id, i);
                         let rest_update_expression = format!("{}.slice({})", array_id, i);
 
-                        if let Some(arg) = elem_obj.get("argument").and_then(|a| a.as_object()) {
-                            let arg_type = arg.get("type").and_then(|t| t.as_str());
+                        if let Some(arg) = elem_obj.field("argument").and_then(|a| a.as_object()) {
+                            let arg_type = arg.field("type").and_then(|t| t.as_str());
                             if arg_type == Some("Identifier") {
                                 let name = arg
-                                    .get("name")
+                                    .field("name")
                                     .and_then(|n| n.as_str())
                                     .unwrap_or("$$unknown");
                                 paths.push(DestructuredPath {
@@ -1673,13 +1677,13 @@ fn _extract_destructured_paths(
         }
         Some("AssignmentPattern") => {
             // Default value pattern: { a = default } or [a = default]
-            if let Some(left) = param.get("left").and_then(|l| l.as_object()) {
-                let left_type = left.get("type").and_then(|t| t.as_str());
-                let default_val = param.get("right").cloned();
+            if let Some(left) = param.field("left").and_then(|l| l.as_object()) {
+                let left_type = left.field("type").and_then(|t| t.as_str());
+                let default_val = param.field("right").cloned();
 
                 if left_type == Some("Identifier") {
                     let name = left
-                        .get("name")
+                        .field("name")
                         .and_then(|n| n.as_str())
                         .unwrap_or("$$unknown");
                     paths.push(DestructuredPath {
@@ -1719,18 +1723,18 @@ fn _extract_destructured_paths(
 
 /// Format a JSON key expression for use in computed property access.
 fn format_json_expr_for_key(key_obj: &serde_json::Map<String, serde_json::Value>) -> String {
-    let key_type = key_obj.get("type").and_then(|t| t.as_str());
+    let key_type = key_obj.field("type").and_then(|t| t.as_str());
 
     match key_type {
         Some("Identifier") => key_obj
-            .get("name")
+            .field("name")
             .and_then(|n| n.as_str())
             .unwrap_or("unknown")
             .to_string(),
         Some("Literal") => {
-            if let Some(raw) = key_obj.get("raw").and_then(|r| r.as_str()) {
+            if let Some(raw) = key_obj.field("raw").and_then(|r| r.as_str()) {
                 raw.to_string()
-            } else if let Some(val) = key_obj.get("value") {
+            } else if let Some(val) = key_obj.field("value") {
                 match val {
                     serde_json::Value::Number(n) => n.to_string(),
                     serde_json::Value::String(s) => format!("'{}'", s),
@@ -1741,9 +1745,9 @@ fn format_json_expr_for_key(key_obj: &serde_json::Map<String, serde_json::Value>
             }
         }
         Some("CallExpression") => {
-            let callee = key_obj.get("callee");
+            let callee = key_obj.field("callee");
             let args = key_obj
-                .get("arguments")
+                .field("arguments")
                 .and_then(|a| a.as_array())
                 .cloned()
                 .unwrap_or_default();
@@ -1774,10 +1778,10 @@ fn format_json_expr_for_key(key_obj: &serde_json::Map<String, serde_json::Value>
             format!("{}({})", callee_str, args_str.join(", "))
         }
         Some("MemberExpression") => {
-            let object = key_obj.get("object").and_then(|o| o.as_object());
-            let property = key_obj.get("property").and_then(|p| p.as_object());
+            let object = key_obj.field("object").and_then(|o| o.as_object());
+            let property = key_obj.field("property").and_then(|p| p.as_object());
             let computed = key_obj
-                .get("computed")
+                .field("computed")
                 .and_then(|c| c.as_bool())
                 .unwrap_or(false);
 
@@ -1791,10 +1795,10 @@ fn format_json_expr_for_key(key_obj: &serde_json::Map<String, serde_json::Value>
             }
         }
         Some("BinaryExpression") => {
-            let left = key_obj.get("left").and_then(|l| l.as_object());
-            let right = key_obj.get("right").and_then(|r| r.as_object());
+            let left = key_obj.field("left").and_then(|l| l.as_object());
+            let right = key_obj.field("right").and_then(|r| r.as_object());
             let operator = key_obj
-                .get("operator")
+                .field("operator")
                 .and_then(|o| o.as_str())
                 .unwrap_or("+");
 
@@ -1804,13 +1808,13 @@ fn format_json_expr_for_key(key_obj: &serde_json::Map<String, serde_json::Value>
             format!("{} {} {}", left_str, operator, right_str)
         }
         Some("UnaryExpression") => {
-            let argument = key_obj.get("argument").and_then(|a| a.as_object());
+            let argument = key_obj.field("argument").and_then(|a| a.as_object());
             let operator = key_obj
-                .get("operator")
+                .field("operator")
                 .and_then(|o| o.as_str())
                 .unwrap_or("-");
             let prefix = key_obj
-                .get("prefix")
+                .field("prefix")
                 .and_then(|p| p.as_bool())
                 .unwrap_or(true);
 
@@ -1823,9 +1827,9 @@ fn format_json_expr_for_key(key_obj: &serde_json::Map<String, serde_json::Value>
             }
         }
         Some("ConditionalExpression") => {
-            let test = key_obj.get("test").and_then(|t| t.as_object());
-            let consequent = key_obj.get("consequent").and_then(|c| c.as_object());
-            let alternate = key_obj.get("alternate").and_then(|a| a.as_object());
+            let test = key_obj.field("test").and_then(|t| t.as_object());
+            let consequent = key_obj.field("consequent").and_then(|c| c.as_object());
+            let alternate = key_obj.field("alternate").and_then(|a| a.as_object());
 
             let test_str = test.map_or("unknown".to_string(), format_json_expr_for_key);
             let cons_str = consequent.map_or("unknown".to_string(), format_json_expr_for_key);
@@ -1836,12 +1840,12 @@ fn format_json_expr_for_key(key_obj: &serde_json::Map<String, serde_json::Value>
         Some("TemplateLiteral") => {
             // Simple template literal support
             let quasis = key_obj
-                .get("quasis")
+                .field("quasis")
                 .and_then(|q| q.as_array())
                 .cloned()
                 .unwrap_or_default();
             let expressions = key_obj
-                .get("expressions")
+                .field("expressions")
                 .and_then(|e| e.as_array())
                 .cloned()
                 .unwrap_or_default();
@@ -1850,9 +1854,9 @@ fn format_json_expr_for_key(key_obj: &serde_json::Map<String, serde_json::Value>
             for (i, quasi) in quasis.iter().enumerate() {
                 if let Some(raw) = quasi
                     .as_object()
-                    .and_then(|q| q.get("value"))
+                    .and_then(|q| q.field("value"))
                     .and_then(|v| v.as_object())
-                    .and_then(|v| v.get("raw"))
+                    .and_then(|v| v.field("raw"))
                     .and_then(|r| r.as_str())
                 {
                     result.push_str(raw);
@@ -1890,13 +1894,13 @@ fn build_fallback_expression(
                 );
             format!("$.fallback({}, {})", expression, default_str)
         } else if let Some(obj) = default_val.as_object()
-            && obj.get("type").and_then(|t| t.as_str()) == Some("CallExpression")
+            && obj.field("type").and_then(|t| t.as_str()) == Some("CallExpression")
             && obj
-                .get("arguments")
+                .field("arguments")
                 .and_then(|a| a.as_array())
                 .is_some_and(|a| a.is_empty())
-            && let Some(callee) = obj.get("callee").and_then(|c| c.as_object())
-            && callee.get("type").and_then(|t| t.as_str()) == Some("Identifier")
+            && let Some(callee) = obj.field("callee").and_then(|c| c.as_object())
+            && callee.field("type").and_then(|t| t.as_str()) == Some("Identifier")
         {
             let callee_expr = convert_expression(
                 &Expression::from_json(serde_json::Value::Object(callee.clone())),
@@ -1939,7 +1943,7 @@ fn is_simple_default(value: &serde_json::Value) -> bool {
         None => return true,
     };
 
-    let expr_type = match obj.get("type").and_then(|t| t.as_str()) {
+    let expr_type = match obj.field("type").and_then(|t| t.as_str()) {
         Some(t) => t,
         None => return true,
     };
@@ -1947,15 +1951,21 @@ fn is_simple_default(value: &serde_json::Value) -> bool {
     match expr_type {
         "Literal" | "Identifier" | "ArrowFunctionExpression" | "FunctionExpression" => true,
         "ConditionalExpression" => {
-            obj.get("test").map(is_simple_default).unwrap_or(true)
-                && obj.get("consequent").map(is_simple_default).unwrap_or(true)
-                && obj.get("alternate").map(is_simple_default).unwrap_or(true)
+            obj.field("test").map(is_simple_default).unwrap_or(true)
+                && obj
+                    .field("consequent")
+                    .map(is_simple_default)
+                    .unwrap_or(true)
+                && obj
+                    .field("alternate")
+                    .map(is_simple_default)
+                    .unwrap_or(true)
         }
         "BinaryExpression" | "LogicalExpression" => {
-            obj.get("left").map(is_simple_default).unwrap_or(true)
-                && obj.get("right").map(is_simple_default).unwrap_or(true)
+            obj.field("left").map(is_simple_default).unwrap_or(true)
+                && obj.field("right").map(is_simple_default).unwrap_or(true)
         }
-        "UnaryExpression" => obj.get("argument").map(is_simple_default).unwrap_or(true),
+        "UnaryExpression" => obj.field("argument").map(is_simple_default).unwrap_or(true),
         _ => false,
     }
 }
@@ -2053,21 +2063,21 @@ fn collect_pattern_identifiers(expr: &Expression, out: &mut Vec<String>) {
 
 fn collect_pattern_identifiers_value(val: &serde_json::Value, out: &mut Vec<String>) {
     if let serde_json::Value::Object(obj) = val {
-        match obj.get("type").and_then(|t| t.as_str()) {
+        match obj.field("type").and_then(|t| t.as_str()) {
             Some("Identifier") => {
-                if let Some(name) = obj.get("name").and_then(|n| n.as_str()) {
+                if let Some(name) = obj.field("name").and_then(|n| n.as_str()) {
                     out.push(name.to_string());
                 }
             }
             Some("ObjectPattern") => {
-                if let Some(props) = obj.get("properties").and_then(|p| p.as_array()) {
+                if let Some(props) = obj.field("properties").and_then(|p| p.as_array()) {
                     for prop in props {
                         if let Some(po) = prop.as_object() {
-                            if po.get("type").and_then(|t| t.as_str()) == Some("RestElement") {
-                                if let Some(arg) = po.get("argument") {
+                            if po.field("type").and_then(|t| t.as_str()) == Some("RestElement") {
+                                if let Some(arg) = po.field("argument") {
                                     collect_pattern_identifiers_value(arg, out);
                                 }
-                            } else if let Some(value) = po.get("value") {
+                            } else if let Some(value) = po.field("value") {
                                 collect_pattern_identifiers_value(value, out);
                             }
                         }
@@ -2075,7 +2085,7 @@ fn collect_pattern_identifiers_value(val: &serde_json::Value, out: &mut Vec<Stri
                 }
             }
             Some("ArrayPattern") => {
-                if let Some(elems) = obj.get("elements").and_then(|e| e.as_array()) {
+                if let Some(elems) = obj.field("elements").and_then(|e| e.as_array()) {
                     for elem in elems {
                         if !elem.is_null() {
                             collect_pattern_identifiers_value(elem, out);
@@ -2084,12 +2094,12 @@ fn collect_pattern_identifiers_value(val: &serde_json::Value, out: &mut Vec<Stri
                 }
             }
             Some("AssignmentPattern") => {
-                if let Some(left) = obj.get("left") {
+                if let Some(left) = obj.field("left") {
                     collect_pattern_identifiers_value(left, out);
                 }
             }
             Some("RestElement") => {
-                if let Some(arg) = obj.get("argument") {
+                if let Some(arg) = obj.field("argument") {
                     collect_pattern_identifiers_value(arg, out);
                 }
             }
@@ -2110,9 +2120,9 @@ fn json_value_references_identifier(val: &serde_json::Value, name: &str) -> bool
     match val {
         serde_json::Value::Object(obj) => {
             // Check if this node is an Identifier with the matching name
-            if let Some(serde_json::Value::String(node_type)) = obj.get("type")
+            if let Some(serde_json::Value::String(node_type)) = obj.field("type")
                 && node_type == "Identifier"
-                && let Some(serde_json::Value::String(id_name)) = obj.get("name")
+                && let Some(serde_json::Value::String(id_name)) = obj.field("name")
                 && id_name == name
             {
                 return true;
@@ -2173,14 +2183,16 @@ fn literal_property_key(
     key: &serde_json::Map<String, serde_json::Value>,
 ) -> Option<crate::compiler::phases::phase3_transform::js_ast::JsLiteral> {
     use crate::compiler::phases::phase3_transform::js_ast::JsLiteral;
-    match key.get("value") {
-        Some(serde_json::Value::String(s)) => Some(match key.get("raw").and_then(|r| r.as_str()) {
-            Some(raw) if !raw.is_empty() => JsLiteral::RawString {
-                value: s.as_str().into(),
-                raw: raw.into(),
-            },
-            _ => JsLiteral::String(s.as_str().into()),
-        }),
+    match key.field("value") {
+        Some(serde_json::Value::String(s)) => {
+            Some(match key.field("raw").and_then(|r| r.as_str()) {
+                Some(raw) if !raw.is_empty() => JsLiteral::RawString {
+                    value: s.as_str().into(),
+                    raw: raw.into(),
+                },
+                _ => JsLiteral::String(s.as_str().into()),
+            })
+        }
         Some(serde_json::Value::Number(n)) => Some(JsLiteral::Number(n.as_f64()?)),
         _ => None,
     }
@@ -2194,21 +2206,21 @@ fn convert_context_pattern(
     use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::apply_transforms_to_expression_with_shadowed;
     let val = expr.as_json();
     if let serde_json::Value::Object(obj) = val {
-        match obj.get("type").and_then(|v| v.as_str()) {
+        match obj.field("type").and_then(|v| v.as_str()) {
             Some("Identifier") => {
-                if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
+                if let Some(name) = obj.field("name").and_then(|v| v.as_str()) {
                     return JsPattern::Identifier(name.into());
                 }
             }
             Some("ObjectPattern") => {
-                if let Some(props) = obj.get("properties").and_then(|p| p.as_array()) {
+                if let Some(props) = obj.field("properties").and_then(|p| p.as_array()) {
                     let mut properties = Vec::with_capacity(props.len());
                     for prop in props {
                         let Some(prop_obj) = prop.as_object() else {
                             continue;
                         };
-                        if prop_obj.get("type").and_then(|t| t.as_str()) == Some("RestElement") {
-                            if let Some(arg) = prop_obj.get("argument") {
+                        if prop_obj.field("type").and_then(|t| t.as_str()) == Some("RestElement") {
+                            if let Some(arg) = prop_obj.field("argument") {
                                 let inner = convert_context_pattern(
                                     context,
                                     &Expression::from_json(arg.clone()),
@@ -2218,12 +2230,13 @@ fn convert_context_pattern(
                             }
                             continue;
                         }
-                        let (Some(key), Some(value)) = (prop_obj.get("key"), prop_obj.get("value"))
+                        let (Some(key), Some(value)) =
+                            (prop_obj.field("key"), prop_obj.field("value"))
                         else {
                             continue;
                         };
                         let computed = prop_obj
-                            .get("computed")
+                            .field("computed")
                             .and_then(|c| c.as_bool())
                             .unwrap_or(false);
                         if computed {
@@ -2248,8 +2261,9 @@ fn convert_context_pattern(
                             });
                         } else {
                             let key_obj = key.as_object();
-                            let key_name =
-                                key_obj.and_then(|k| k.get("name")).and_then(|n| n.as_str());
+                            let key_name = key_obj
+                                .and_then(|k| k.field("name"))
+                                .and_then(|n| n.as_str());
                             // A literal key that is not a valid identifier
                             // (`{ 'a-b': z }`) carries no `name`; dropping the
                             // property left its value binding unbound in the
@@ -2274,7 +2288,7 @@ fn convert_context_pattern(
                             };
                             let shorthand = key_name.is_some()
                                 && prop_obj
-                                    .get("shorthand")
+                                    .field("shorthand")
                                     .and_then(|s| s.as_bool())
                                     .unwrap_or(false);
                             properties.push(JsObjectPatternProperty::Property {
@@ -2289,7 +2303,7 @@ fn convert_context_pattern(
                 }
             }
             Some("ArrayPattern") => {
-                if let Some(elems) = obj.get("elements").and_then(|e| e.as_array()) {
+                if let Some(elems) = obj.field("elements").and_then(|e| e.as_array()) {
                     let mut elements = Vec::with_capacity(elems.len());
                     for elem in elems {
                         if elem.is_null() {
@@ -2306,7 +2320,7 @@ fn convert_context_pattern(
                 }
             }
             Some("RestElement") => {
-                if let Some(arg) = obj.get("argument") {
+                if let Some(arg) = obj.field("argument") {
                     let inner = convert_context_pattern(
                         context,
                         &Expression::from_json(arg.clone()),
@@ -2316,7 +2330,7 @@ fn convert_context_pattern(
                 }
             }
             Some("AssignmentPattern") => {
-                if let Some(left) = obj.get("left") {
+                if let Some(left) = obj.field("left") {
                     let left_pattern = convert_context_pattern(
                         context,
                         &Expression::from_json(left.clone()),
@@ -2326,7 +2340,7 @@ fn convert_context_pattern(
                     // `key_state`, so `[first = 0]` keys on the defaulted value.
                     // The default expression itself is visited (prop/state reads
                     // rewritten; the context names stay shadowed).
-                    if let Some(right) = obj.get("right") {
+                    if let Some(right) = obj.field("right") {
                         let right_js =
                             convert_expression(&Expression::from_json(right.clone()), context);
                         let right_js = apply_transforms_to_expression_with_shadowed(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -17,6 +17,7 @@ use crate::compiler::phases::phase3_transform::client::types::{
 };
 use crate::compiler::phases::phase3_transform::js_ast::ExprId;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use compact_str::CompactString;
 use serde_json::Value;
 use std::fmt::Write as _;
@@ -29,7 +30,7 @@ use std::fmt::Write as _;
 fn json_has_await_expression(value: &Value) -> bool {
     match value {
         Value::Object(obj) => {
-            let node_type = obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            let node_type = obj.field("type").and_then(|t| t.as_str()).unwrap_or("");
             if node_type == "AwaitExpression" {
                 return true;
             }
@@ -57,17 +58,21 @@ fn json_has_await_expression(value: &Value) -> bool {
 fn json_is_simple_expression(value: &Value) -> bool {
     match value {
         Value::Object(obj) => {
-            let node_type = obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            let node_type = obj.field("type").and_then(|t| t.as_str()).unwrap_or("");
             match node_type {
                 "Literal" | "Identifier" | "ArrowFunctionExpression" | "FunctionExpression" => true,
                 "ConditionalExpression" => {
-                    obj.get("test").is_some_and(json_is_simple_expression)
-                        && obj.get("consequent").is_some_and(json_is_simple_expression)
-                        && obj.get("alternate").is_some_and(json_is_simple_expression)
+                    obj.field("test").is_some_and(json_is_simple_expression)
+                        && obj
+                            .field("consequent")
+                            .is_some_and(json_is_simple_expression)
+                        && obj
+                            .field("alternate")
+                            .is_some_and(json_is_simple_expression)
                 }
                 "BinaryExpression" | "LogicalExpression" => {
-                    obj.get("left").is_some_and(json_is_simple_expression)
-                        && obj.get("right").is_some_and(json_is_simple_expression)
+                    obj.field("left").is_some_and(json_is_simple_expression)
+                        && obj.field("right").is_some_and(json_is_simple_expression)
                 }
                 _ => false,
             }
@@ -103,11 +108,11 @@ fn build_fallback_expr(
     // Case 2: AwaitExpression with simple argument
     let right_type = right_json
         .as_object()
-        .and_then(|o| o.get("type"))
+        .and_then(|o| o.field("type"))
         .and_then(|t| t.as_str())
         .unwrap_or("");
     if right_type == "AwaitExpression"
-        && let Some(argument) = right_json.as_object().and_then(|o| o.get("argument"))
+        && let Some(argument) = right_json.as_object().and_then(|o| o.field("argument"))
         && json_is_simple_expression(argument)
     {
         let arg_converted = convert_json_value(argument, context);
@@ -1692,7 +1697,7 @@ fn convert_json_value(value: &Value, context: &mut ComponentContext) -> JsExpr {
         Value::Object(obj) => {
             // Get the ESTree node type
             let node_type = obj
-                .get("type")
+                .field("type")
                 .and_then(|t| t.as_str())
                 .unwrap_or("Unknown");
 
@@ -1701,7 +1706,9 @@ fn convert_json_value(value: &Value, context: &mut ComponentContext) -> JsExpr {
                 "PrivateIdentifier" => JsExpr::Identifier(
                     format!(
                         "#{}",
-                        obj.get("name").and_then(|name| name.as_str()).unwrap_or("")
+                        obj.field("name")
+                            .and_then(|name| name.as_str())
+                            .unwrap_or("")
                     )
                     .into(),
                 ),
@@ -1734,28 +1741,31 @@ fn convert_json_value(value: &Value, context: &mut ComponentContext) -> JsExpr {
                     // converted source/options as sub-expressions emitted lazily
                     // by codegen (was: eager generate_expr + Raw stringification).
                     let source_expr = obj
-                        .get("source")
+                        .field("source")
                         .map(|source| convert_json_value(source, context))
                         .unwrap_or(JsExpr::Raw("".into()));
                     let source = context.arena.alloc_expr(source_expr);
-                    let options = obj.get("options").filter(|v| !v.is_null()).map(|options| {
-                        let options_expr = convert_json_value(options, context);
-                        context.arena.alloc_expr(options_expr)
-                    });
+                    let options = obj
+                        .field("options")
+                        .filter(|v| !v.is_null())
+                        .map(|options| {
+                            let options_expr = convert_json_value(options, context);
+                            context.arena.alloc_expr(options_expr)
+                        });
                     JsExpr::ImportExpression { source, options }
                 }
                 "MetaProperty" => {
                     // ESTree MetaProperty: meta.property (e.g., import.meta, new.target)
                     let meta = obj
-                        .get("meta")
+                        .field("meta")
                         .and_then(|m| m.as_object())
-                        .and_then(|m| m.get("name"))
+                        .and_then(|m| m.field("name"))
                         .and_then(|n| n.as_str())
                         .unwrap_or("import");
                     let property = obj
-                        .get("property")
+                        .field("property")
                         .and_then(|p| p.as_object())
-                        .and_then(|p| p.get("name"))
+                        .and_then(|p| p.field("name"))
                         .and_then(|n| n.as_str())
                         .unwrap_or("meta");
                     JsExpr::MetaProperty(meta.into(), property.into())
@@ -1805,7 +1815,7 @@ fn convert_identifier(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let name = obj
-        .get("name")
+        .field("name")
         .and_then(|n| n.as_str())
         .unwrap_or("unknown")
         .to_string();
@@ -1865,14 +1875,14 @@ fn convert_literal(
     obj: &serde_json::Map<String, Value>,
     _context: &mut ComponentContext,
 ) -> JsExpr {
-    let value = obj.get("value");
+    let value = obj.field("value");
 
     match value {
         Some(Value::String(s)) => {
             // esrap writes `node.raw` whenever it is set, so quote style AND
             // escape spelling come from the source; the printer's escape set is
             // not esrap's, and cooking here loses `\t`, `\x41`, …
-            if let Some(Value::String(raw)) = obj.get("raw")
+            if let Some(Value::String(raw)) = obj.field("raw")
                 && !raw.is_empty()
             {
                 return JsExpr::Literal(JsLiteral::RawString {
@@ -1887,14 +1897,14 @@ fn convert_literal(
         Some(Value::Null) | None => JsExpr::Literal(JsLiteral::Null),
         _ => {
             // Check for regex
-            if let Some(regex_obj) = obj.get("regex").and_then(|r| r.as_object()) {
+            if let Some(regex_obj) = obj.field("regex").and_then(|r| r.as_object()) {
                 let pattern = regex_obj
-                    .get("pattern")
+                    .field("pattern")
                     .and_then(|p| p.as_str())
                     .unwrap_or("")
                     .to_string();
                 let flags = regex_obj
-                    .get("flags")
+                    .field("flags")
                     .and_then(|f| f.as_str())
                     .unwrap_or("")
                     .to_string();
@@ -1914,7 +1924,7 @@ fn convert_literal(
 fn convert_json_chain_boundary(value: &Value, context: &mut ComponentContext) -> ExprId {
     let is_chain = value
         .as_object()
-        .and_then(|obj| obj.get("type"))
+        .and_then(|obj| obj.field("type"))
         .and_then(Value::as_str)
         == Some("ChainExpression");
     let mut converted = convert_json_value(value, context);
@@ -1943,20 +1953,20 @@ fn convert_member_expression(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let computed = obj
-        .get("computed")
+        .field("computed")
         .and_then(|c| c.as_bool())
         .unwrap_or(false);
 
     let optional = obj
-        .get("optional")
+        .field("optional")
         .and_then(|o| o.as_bool())
         .unwrap_or(false);
 
     // Handle private state field access: this.#foo -> this.#foo.v (in constructor) or $.get(this.#foo)
     // Reference: MemberExpression.js in official Svelte compiler
-    if let Some(prop_obj) = obj.get("property").and_then(|p| p.as_object())
-        && let Some("PrivateIdentifier") = prop_obj.get("type").and_then(|t| t.as_str())
-        && let Some(prop_name) = prop_obj.get("name").and_then(|n| n.as_str())
+    if let Some(prop_obj) = obj.field("property").and_then(|p| p.as_object())
+        && let Some("PrivateIdentifier") = prop_obj.field("type").and_then(|t| t.as_str())
+        && let Some(prop_name) = prop_obj.field("name").and_then(|n| n.as_str())
     {
         let mut field_name = String::with_capacity(1 + prop_name.len());
         field_name.push('#');
@@ -1971,7 +1981,7 @@ fn convert_member_expression(
         if let Some((field_type, in_constructor)) = field_info {
             // Build the base member expression (this.#foo)
             let object = obj
-                .get("object")
+                .field("object")
                 .map(|o| {
                     let __tmp = convert_json_value(o, context);
                     context.arena.alloc_expr(__tmp)
@@ -2028,13 +2038,13 @@ fn convert_member_expression(
     // 3. Must NOT be computed (i.e., `others.bar`, not `others[bar]`)
     // 4. Must NOT be a direct assignment LHS (e.g., `others.bar = x` stays as-is)
     // 5. Property name must NOT be in the binding's exclude_props list
-    if let Some(object_obj) = obj.get("object").and_then(|o| o.as_object())
-        && let Some("Identifier") = object_obj.get("type").and_then(|t| t.as_str())
-        && let Some(obj_name) = object_obj.get("name").and_then(|n| n.as_str())
+    if let Some(object_obj) = obj.field("object").and_then(|o| o.as_object())
+        && let Some("Identifier") = object_obj.field("type").and_then(|t| t.as_str())
+        && let Some(obj_name) = object_obj.field("name").and_then(|n| n.as_str())
         && let Some(prop_name) = obj
-            .get("property")
+            .field("property")
             .and_then(|p| p.as_object())
-            .and_then(|p| p.get("name"))
+            .and_then(|p| p.field("name"))
             .and_then(|n| n.as_str())
         && super::shared::utils::rest_prop_member_reads_props(
             context, computed, obj_name, prop_name,
@@ -2052,7 +2062,7 @@ fn convert_member_expression(
     }
 
     let object = {
-        obj.get("object")
+        obj.field("object")
             .map(|o| convert_json_chain_boundary(o, context))
             .unwrap_or_else(|| {
                 context
@@ -2062,7 +2072,7 @@ fn convert_member_expression(
     };
 
     let property = if computed {
-        obj.get("property")
+        obj.field("property")
             .map(|p| {
                 JsMemberProperty::Expression({
                     let __tmp = convert_json_value(p, context);
@@ -2072,15 +2082,15 @@ fn convert_member_expression(
             .unwrap_or(JsMemberProperty::Identifier("unknown".into()))
     } else {
         // Check if property is a PrivateIdentifier
-        if let Some(prop_obj) = obj.get("property").and_then(|p| p.as_object())
-            && let Some("PrivateIdentifier") = prop_obj.get("type").and_then(|t| t.as_str())
-            && let Some(prop_name) = prop_obj.get("name").and_then(|n| n.as_str())
+        if let Some(prop_obj) = obj.field("property").and_then(|p| p.as_object())
+            && let Some("PrivateIdentifier") = prop_obj.field("type").and_then(|t| t.as_str())
+            && let Some(prop_name) = prop_obj.field("name").and_then(|n| n.as_str())
         {
             JsMemberProperty::PrivateIdentifier(prop_name.into())
         } else {
-            obj.get("property")
+            obj.field("property")
                 .and_then(|p| p.as_object())
-                .and_then(|p| p.get("name"))
+                .and_then(|p| p.field("name"))
                 .and_then(|n| n.as_str())
                 .map(|n| JsMemberProperty::Identifier(n.into()))
                 .unwrap_or(JsMemberProperty::Identifier("unknown".into()))
@@ -2114,7 +2124,7 @@ fn convert_call_expression(
     // Reference: CallExpression.js lines 91-115 in the official Svelte compiler
     let empty_args: Vec<Value> = Vec::new();
     let raw_args = obj
-        .get("arguments")
+        .field("arguments")
         .and_then(|a| a.as_array())
         .unwrap_or(&empty_args);
     let console_method = if context.state.options.dev {
@@ -2129,7 +2139,7 @@ fn convert_call_expression(
     };
     if let Some(method) = console_method {
         let callee = obj
-            .get("callee")
+            .field("callee")
             .map(|c| convert_json_chain_boundary(c, context))
             .unwrap_or_else(|| {
                 context
@@ -2137,7 +2147,7 @@ fn convert_call_expression(
                     .alloc_expr(JsExpr::Identifier("unknown".into()))
             });
         let args: Vec<JsExpr> = obj
-            .get("arguments")
+            .field("arguments")
             .and_then(|a| a.as_array())
             .map(|args| {
                 args.iter()
@@ -2149,7 +2159,7 @@ fn convert_call_expression(
     }
 
     let callee = obj
-        .get("callee")
+        .field("callee")
         .map(|c| convert_json_chain_boundary(c, context))
         .unwrap_or_else(|| {
             context
@@ -2158,7 +2168,7 @@ fn convert_call_expression(
         });
 
     let arguments = obj
-        .get("arguments")
+        .field("arguments")
         .and_then(|a| a.as_array())
         .map(|args| {
             args.iter()
@@ -2168,7 +2178,7 @@ fn convert_call_expression(
         .unwrap_or_default();
 
     let optional = obj
-        .get("optional")
+        .field("optional")
         .and_then(|o| o.as_bool())
         .unwrap_or(false);
 
@@ -2182,19 +2192,21 @@ fn convert_call_expression(
 /// Extract console method name from a CallExpression JSON node.
 /// Returns Some("log") for `console.log(...)`, etc.
 fn get_console_method_name(obj: &serde_json::Map<String, Value>) -> Option<String> {
-    let callee = obj.get("callee")?.as_object()?;
-    if callee.get("type")?.as_str()? != "MemberExpression" {
+    let callee = obj.field("callee")?.as_object()?;
+    if callee.field("type")?.as_str()? != "MemberExpression" {
         return None;
     }
-    let object = callee.get("object")?.as_object()?;
-    if object.get("type")?.as_str()? != "Identifier" || object.get("name")?.as_str()? != "console" {
+    let object = callee.field("object")?.as_object()?;
+    if object.field("type")?.as_str()? != "Identifier"
+        || object.field("name")?.as_str()? != "console"
+    {
         return None;
     }
-    let property = callee.get("property")?.as_object()?;
-    if property.get("type")?.as_str()? != "Identifier" {
+    let property = callee.field("property")?.as_object()?;
+    if property.field("type")?.as_str()? != "Identifier" {
         return None;
     }
-    Some(property.get("name")?.as_str()?.to_string())
+    Some(property.field("name")?.as_str()?.to_string())
 }
 
 /// The console method a typed callee names, when upstream's dev branch applies:
@@ -2281,33 +2293,33 @@ fn get_rune_from_call(
     obj: &serde_json::Map<String, Value>,
     context: &ComponentContext,
 ) -> Option<String> {
-    let callee = obj.get("callee")?;
+    let callee = obj.field("callee")?;
     let callee_obj = callee.as_object()?;
-    let callee_type = callee_obj.get("type")?.as_str()?;
+    let callee_type = callee_obj.field("type")?.as_str()?;
 
     let rune_name = match callee_type {
         "Identifier" => {
             // Simple rune like $state, $derived, $effect, $inspect
-            callee_obj.get("name")?.as_str()?.to_string()
+            callee_obj.field("name")?.as_str()?.to_string()
         }
         "MemberExpression" => {
             // Could be either:
             // 1. Rune with method like $state.raw(), $derived.by()
             // 2. Rune call chain like $inspect().with()
 
-            let object = callee_obj.get("object")?.as_object()?;
-            let property = callee_obj.get("property")?.as_object()?;
-            let property_name = property.get("name")?.as_str()?;
-            let object_type = object.get("type")?.as_str()?;
+            let object = callee_obj.field("object")?.as_object()?;
+            let property = callee_obj.field("property")?.as_object()?;
+            let property_name = property.field("name")?.as_str()?;
+            let object_type = object.field("type")?.as_str()?;
 
             if object_type == "CallExpression" {
                 // This might be $inspect().with() pattern
                 // The object is a CallExpression, so check if it's a rune call
-                let inner_callee = object.get("callee")?.as_object()?;
-                let inner_callee_type = inner_callee.get("type")?.as_str()?;
+                let inner_callee = object.field("callee")?.as_object()?;
+                let inner_callee_type = inner_callee.field("type")?.as_str()?;
 
                 if inner_callee_type == "Identifier" {
-                    let inner_name = inner_callee.get("name")?.as_str()?;
+                    let inner_name = inner_callee.field("name")?.as_str()?;
                     // Produce "$inspect().with" style keypath
                     let keypath = format!("{}().{}", inner_name, property_name);
                     if RUNES.contains(&keypath.as_str()) {
@@ -2321,7 +2333,7 @@ fn get_rune_from_call(
                 return None;
             } else if object_type == "Identifier" {
                 // Standard rune with method like $state.raw
-                let object_name = object.get("name")?.as_str()?;
+                let object_name = object.field("name")?.as_str()?;
                 format!("{}.{}", object_name, property_name)
             } else {
                 return None;
@@ -2362,7 +2374,7 @@ fn should_proxy_json(value: &Value) -> bool {
         None => return false,
     };
 
-    let node_type = match obj.get("type").and_then(|t| t.as_str()) {
+    let node_type = match obj.field("type").and_then(|t| t.as_str()) {
         Some(t) => t,
         None => return true, // Unknown type, assume proxy needed
     };
@@ -2379,7 +2391,7 @@ fn should_proxy_json(value: &Value) -> bool {
         // Identifiers might need proxy (could reference objects/arrays),
         // EXCEPT for `undefined` which is a primitive
         "Identifier" => {
-            if let Some(name) = obj.get("name").and_then(|n| n.as_str()) {
+            if let Some(name) = obj.field("name").and_then(|n| n.as_str()) {
                 // undefined doesn't need proxy, everything else does
                 name != "undefined"
             } else {
@@ -2399,7 +2411,7 @@ fn should_proxy_json(value: &Value) -> bool {
 fn is_state_rune_call(value: &Value, context: &ComponentContext) -> bool {
     value
         .as_object()
-        .filter(|obj| obj.get("type").and_then(|t| t.as_str()) == Some("CallExpression"))
+        .filter(|obj| obj.field("type").and_then(|t| t.as_str()) == Some("CallExpression"))
         .and_then(|obj| get_rune_from_call(obj, context))
         .is_some_and(|rune| is_named_declarator_rune(&rune))
 }
@@ -2475,7 +2487,7 @@ fn transform_rune_call(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let arguments = obj
-        .get("arguments")
+        .field("arguments")
         .and_then(|a| a.as_array())
         .cloned()
         .unwrap_or_default();
@@ -2808,12 +2820,12 @@ fn transform_rune_call(
             } else {
                 // $inspect().with - need to get args from the inner $inspect() call
                 // and the callback from the outer .with() call
-                let callee = obj.get("callee").and_then(|c| c.as_object());
+                let callee = obj.field("callee").and_then(|c| c.as_object());
                 if let Some(callee_obj) = callee {
-                    let inner_call = callee_obj.get("object").and_then(|o| o.as_object());
+                    let inner_call = callee_obj.field("object").and_then(|o| o.as_object());
                     if let Some(inner) = inner_call {
                         let inner_args = inner
-                            .get("arguments")
+                            .field("arguments")
                             .and_then(|a| a.as_array())
                             .map(|arr| {
                                 arr.iter()
@@ -2887,7 +2899,7 @@ fn transform_rune_call(
         _ => {
             // Unknown rune - pass through as regular call
             let callee = obj
-                .get("callee")
+                .field("callee")
                 .map(|c| {
                     let __tmp = convert_json_value(c, context);
                     context.arena.alloc_expr(__tmp)
@@ -2917,7 +2929,10 @@ fn convert_binary_expression(
     obj: &serde_json::Map<String, Value>,
     context: &mut ComponentContext,
 ) -> JsExpr {
-    let operator_str = obj.get("operator").and_then(|o| o.as_str()).unwrap_or("+");
+    let operator_str = obj
+        .field("operator")
+        .and_then(|o| o.as_str())
+        .unwrap_or("+");
 
     // In dev mode, transform equality operators:
     // === / !== -> $.strict_equals()
@@ -2930,12 +2945,12 @@ fn convert_binary_expression(
             || operator_str == "!=")
     {
         let left = obj
-            .get("left")
+            .field("left")
             .map(|l| convert_json_value(l, context))
             .unwrap_or(JsExpr::Literal(JsLiteral::Null));
 
         let right = obj
-            .get("right")
+            .field("right")
             .map(|r| convert_json_value(r, context))
             .unwrap_or(JsExpr::Literal(JsLiteral::Null));
 
@@ -2987,7 +3002,7 @@ fn convert_binary_expression(
     };
 
     let left = obj
-        .get("left")
+        .field("left")
         .map(|l| {
             let __tmp = convert_json_value(l, context);
             context.arena.alloc_expr(__tmp)
@@ -2995,7 +3010,7 @@ fn convert_binary_expression(
         .unwrap_or_else(|| context.arena.alloc_expr(JsExpr::Literal(JsLiteral::Null)));
 
     let right = obj
-        .get("right")
+        .field("right")
         .map(|r| {
             let __tmp = convert_json_value(r, context);
             context.arena.alloc_expr(__tmp)
@@ -3014,7 +3029,10 @@ fn convert_unary_expression(
     obj: &serde_json::Map<String, Value>,
     context: &mut ComponentContext,
 ) -> JsExpr {
-    let operator_str = obj.get("operator").and_then(|o| o.as_str()).unwrap_or("!");
+    let operator_str = obj
+        .field("operator")
+        .and_then(|o| o.as_str())
+        .unwrap_or("!");
 
     let operator = match operator_str {
         "-" => JsUnaryOp::Minus,
@@ -3028,14 +3046,17 @@ fn convert_unary_expression(
     };
 
     let argument = obj
-        .get("argument")
+        .field("argument")
         .map(|a| {
             let __tmp = convert_json_value(a, context);
             context.arena.alloc_expr(__tmp)
         })
         .unwrap_or_else(|| context.arena.alloc_expr(JsExpr::Literal(JsLiteral::Null)));
 
-    let prefix = obj.get("prefix").and_then(|p| p.as_bool()).unwrap_or(true);
+    let prefix = obj
+        .field("prefix")
+        .and_then(|p| p.as_bool())
+        .unwrap_or(true);
 
     JsExpr::Unary(JsUnaryExpression {
         operator,
@@ -3049,7 +3070,10 @@ fn convert_logical_expression(
     obj: &serde_json::Map<String, Value>,
     context: &mut ComponentContext,
 ) -> JsExpr {
-    let operator_str = obj.get("operator").and_then(|o| o.as_str()).unwrap_or("&&");
+    let operator_str = obj
+        .field("operator")
+        .and_then(|o| o.as_str())
+        .unwrap_or("&&");
 
     let operator = match operator_str {
         "&&" => JsLogicalOp::And,
@@ -3059,7 +3083,7 @@ fn convert_logical_expression(
     };
 
     let left = obj
-        .get("left")
+        .field("left")
         .map(|l| {
             let __tmp = convert_json_value(l, context);
             context.arena.alloc_expr(__tmp)
@@ -3067,7 +3091,7 @@ fn convert_logical_expression(
         .unwrap_or_else(|| context.arena.alloc_expr(JsExpr::Literal(JsLiteral::Null)));
 
     let right = obj
-        .get("right")
+        .field("right")
         .map(|r| {
             let __tmp = convert_json_value(r, context);
             context.arena.alloc_expr(__tmp)
@@ -3087,7 +3111,7 @@ fn convert_conditional_expression(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let test = obj
-        .get("test")
+        .field("test")
         .map(|t| {
             let __tmp = convert_json_value(t, context);
             context.arena.alloc_expr(__tmp)
@@ -3095,7 +3119,7 @@ fn convert_conditional_expression(
         .unwrap_or_else(|| context.arena.alloc_expr(JsExpr::Literal(JsLiteral::Null)));
 
     let consequent = obj
-        .get("consequent")
+        .field("consequent")
         .map(|c| {
             let __tmp = convert_json_value(c, context);
             context.arena.alloc_expr(__tmp)
@@ -3103,7 +3127,7 @@ fn convert_conditional_expression(
         .unwrap_or_else(|| context.arena.alloc_expr(JsExpr::Literal(JsLiteral::Null)));
 
     let alternate = obj
-        .get("alternate")
+        .field("alternate")
         .map(|a| {
             let __tmp = convert_json_value(a, context);
             context.arena.alloc_expr(__tmp)
@@ -3123,7 +3147,7 @@ fn convert_array_expression(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let elements = obj
-        .get("elements")
+        .field("elements")
         .and_then(|e| e.as_array())
         .map(|elems| {
             elems
@@ -3148,20 +3172,20 @@ fn convert_object_expression(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let properties = obj
-        .get("properties")
+        .field("properties")
         .and_then(|p| p.as_array())
         .map(|props| {
             props
                 .iter()
                 .filter_map(|prop| {
                     let prop_obj = prop.as_object()?;
-                    let prop_type = prop_obj.get("type")?.as_str()?;
+                    let prop_type = prop_obj.field("type")?.as_str()?;
 
                     match prop_type {
                         "Property" => {
                             let key = convert_property_key(prop_obj, context);
                             let value = prop_obj
-                                .get("value")
+                                .field("value")
                                 .map(|v| {
                                     let __tmp = convert_json_value(v, context);
                                     context.arena.alloc_expr(__tmp)
@@ -3171,16 +3195,16 @@ fn convert_object_expression(
                                 });
 
                             let computed = prop_obj
-                                .get("computed")
+                                .field("computed")
                                 .and_then(|c| c.as_bool())
                                 .unwrap_or(false);
 
                             let shorthand = prop_obj
-                                .get("shorthand")
+                                .field("shorthand")
                                 .and_then(|s| s.as_bool())
                                 .unwrap_or(false);
 
-                            let kind = match prop_obj.get("kind")?.as_str()? {
+                            let kind = match prop_obj.field("kind")?.as_str()? {
                                 "init" => JsPropertyKind::Init,
                                 "get" => JsPropertyKind::Get,
                                 "set" => JsPropertyKind::Set,
@@ -3188,7 +3212,7 @@ fn convert_object_expression(
                             };
 
                             let method = prop_obj
-                                .get("method")
+                                .field("method")
                                 .and_then(|v| v.as_bool())
                                 .unwrap_or(false);
 
@@ -3203,7 +3227,7 @@ fn convert_object_expression(
                         }
                         "SpreadElement" => {
                             let argument = prop_obj
-                                .get("argument")
+                                .field("argument")
                                 .map(|a| {
                                     let __tmp = convert_json_value(a, context);
                                     context.arena.alloc_expr(__tmp)
@@ -3229,9 +3253,9 @@ fn convert_property_key(
     obj: &serde_json::Map<String, Value>,
     context: &mut ComponentContext,
 ) -> JsPropertyKey {
-    let key = obj.get("key");
+    let key = obj.field("key");
     let computed = obj
-        .get("computed")
+        .field("computed")
         .and_then(|c| c.as_bool())
         .unwrap_or(false);
 
@@ -3243,12 +3267,12 @@ fn convert_property_key(
     }
 
     if let Some(key_obj) = key.and_then(|k| k.as_object()) {
-        if let Some("Identifier") = key_obj.get("type").and_then(|t| t.as_str())
-            && let Some(name) = key_obj.get("name").and_then(|n| n.as_str())
+        if let Some("Identifier") = key_obj.field("type").and_then(|t| t.as_str())
+            && let Some(name) = key_obj.field("name").and_then(|n| n.as_str())
         {
             return JsPropertyKey::Identifier(name.into());
         }
-        if let Some("Literal") = key_obj.get("type").and_then(|t| t.as_str()) {
+        if let Some("Literal") = key_obj.field("type").and_then(|t| t.as_str()) {
             return JsPropertyKey::Literal(convert_literal(key_obj, context).into());
         }
     }
@@ -3261,7 +3285,7 @@ fn convert_property_key(
 /// when entering arrow/function expression bodies.
 fn extract_param_names_from_json(obj: &serde_json::Map<String, Value>) -> Vec<String> {
     let mut names = Vec::new();
-    if let Some(params) = obj.get("params").and_then(|p| p.as_array()) {
+    if let Some(params) = obj.field("params").and_then(|p| p.as_array()) {
         for param in params {
             collect_param_names(param, &mut names);
         }
@@ -3272,29 +3296,33 @@ fn extract_param_names_from_json(obj: &serde_json::Map<String, Value>) -> Vec<St
 /// Recursively collect identifier names from a parameter pattern.
 fn collect_param_names(value: &Value, names: &mut Vec<String>) {
     if let Some(obj) = value.as_object() {
-        match obj.get("type").and_then(|t| t.as_str()).unwrap_or("") {
+        match obj.field("type").and_then(|t| t.as_str()).unwrap_or("") {
             "Identifier" => {
-                if let Some(name) = obj.get("name").and_then(|n| n.as_str()) {
+                if let Some(name) = obj.field("name").and_then(|n| n.as_str()) {
                     names.push(name.to_string());
                 }
             }
             "AssignmentPattern" => {
-                if let Some(left) = obj.get("left") {
+                if let Some(left) = obj.field("left") {
                     collect_param_names(left, names);
                 }
             }
             "ObjectPattern" => {
-                if let Some(props) = obj.get("properties").and_then(|p| p.as_array()) {
+                if let Some(props) = obj.field("properties").and_then(|p| p.as_array()) {
                     for prop in props {
                         if let Some(prop_obj) = prop.as_object() {
-                            match prop_obj.get("type").and_then(|t| t.as_str()).unwrap_or("") {
+                            match prop_obj
+                                .field("type")
+                                .and_then(|t| t.as_str())
+                                .unwrap_or("")
+                            {
                                 "Property" => {
-                                    if let Some(val) = prop_obj.get("value") {
+                                    if let Some(val) = prop_obj.field("value") {
                                         collect_param_names(val, names);
                                     }
                                 }
                                 "RestElement" => {
-                                    if let Some(arg) = prop_obj.get("argument") {
+                                    if let Some(arg) = prop_obj.field("argument") {
                                         collect_param_names(arg, names);
                                     }
                                 }
@@ -3305,7 +3333,7 @@ fn collect_param_names(value: &Value, names: &mut Vec<String>) {
                 }
             }
             "ArrayPattern" => {
-                if let Some(elements) = obj.get("elements").and_then(|e| e.as_array()) {
+                if let Some(elements) = obj.field("elements").and_then(|e| e.as_array()) {
                     for el in elements {
                         if !el.is_null() {
                             collect_param_names(el, names);
@@ -3314,7 +3342,7 @@ fn collect_param_names(value: &Value, names: &mut Vec<String>) {
                 }
             }
             "RestElement" => {
-                if let Some(arg) = obj.get("argument") {
+                if let Some(arg) = obj.field("argument") {
                     collect_param_names(arg, names);
                 }
             }
@@ -3330,7 +3358,10 @@ fn convert_arrow_function(
 ) -> JsExpr {
     let params = convert_params(obj, context);
 
-    let is_async = obj.get("async").and_then(|a| a.as_bool()).unwrap_or(false);
+    let is_async = obj
+        .field("async")
+        .and_then(|a| a.as_bool())
+        .unwrap_or(false);
 
     // Save transforms and remove any for parameter names that shadow outer variables.
     // For example, in `createRawSnippet((count) => { ... })`, the `count` parameter
@@ -3350,24 +3381,24 @@ fn convert_arrow_function(
     // when processing assignments inside the arrow body.
     context.state.push_local_scope();
 
-    let body = if let Some(body_obj) = obj.get("body").and_then(|b| b.as_object()) {
-        if body_obj.get("type").and_then(|t| t.as_str()) == Some("BlockStatement") {
+    let body = if let Some(body_obj) = obj.field("body").and_then(|b| b.as_object()) {
+        if body_obj.field("type").and_then(|t| t.as_str()) == Some("BlockStatement") {
             JsArrowBody::Block(convert_block_statement(body_obj, context))
         } else {
             let body_is_assignment = matches!(
-                body_obj.get("type").and_then(|t| t.as_str()),
+                body_obj.field("type").and_then(|t| t.as_str()),
                 Some("AssignmentExpression")
             );
-            let is_exempt_arrow = obj
-                .get("start")
-                .and_then(|v| v.as_u64())
-                .is_some_and(|start| {
-                    context
-                        .state
-                        .analysis
-                        .assign_exempt_arrow_starts
-                        .contains(&(start as u32))
-                });
+            let is_exempt_arrow =
+                obj.field("start")
+                    .and_then(|v| v.as_u64())
+                    .is_some_and(|start| {
+                        context
+                            .state
+                            .analysis
+                            .assign_exempt_arrow_starts
+                            .contains(&(start as u32))
+                    });
             let saved_level = context.state.event_handler_arrow_body_level;
             context.state.event_handler_arrow_body_level =
                 u32::from(is_exempt_arrow && body_is_assignment);
@@ -3401,9 +3432,9 @@ fn convert_function_expression(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let id: Option<CompactString> = obj
-        .get("id")
+        .field("id")
         .and_then(|i| i.as_object())
-        .and_then(|i| i.get("name"))
+        .and_then(|i| i.field("name"))
         .and_then(|n| n.as_str())
         .map(|n| n.into());
 
@@ -3424,7 +3455,7 @@ fn convert_function_expression(
     context.state.push_local_scope();
 
     let body = obj
-        .get("body")
+        .field("body")
         .and_then(|b| b.as_object())
         .map(|b| convert_block_statement(b, context))
         .unwrap_or_default();
@@ -3437,10 +3468,13 @@ fn convert_function_expression(
     context.state.transform_deep_read = saved_transform_deep_read;
     context.state.shadowed_prop_names = saved_shadowed;
 
-    let is_async = obj.get("async").and_then(|a| a.as_bool()).unwrap_or(false);
+    let is_async = obj
+        .field("async")
+        .and_then(|a| a.as_bool())
+        .unwrap_or(false);
 
     let is_generator = obj
-        .get("generator")
+        .field("generator")
         .and_then(|g| g.as_bool())
         .unwrap_or(false);
 
@@ -3461,22 +3495,22 @@ fn convert_class_expression(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let id: Option<CompactString> = obj
-        .get("id")
+        .field("id")
         .and_then(|i| i.as_object())
-        .and_then(|i| i.get("name"))
+        .and_then(|i| i.field("name"))
         .and_then(|n| n.as_str())
         .map(|n| n.into());
 
-    let super_class = obj.get("superClass").filter(|v| !v.is_null()).map(|sc| {
+    let super_class = obj.field("superClass").filter(|v| !v.is_null()).map(|sc| {
         let expr = convert_json_value(sc, context);
         context.arena.alloc_expr(expr)
     });
 
     let mut members = Vec::new();
     if let Some(body_arr) = obj
-        .get("body")
+        .field("body")
         .and_then(|b| b.as_object())
-        .and_then(|b| b.get("body"))
+        .and_then(|b| b.field("body"))
         .and_then(|b| b.as_array())
     {
         for m in body_arr {
@@ -3508,7 +3542,7 @@ fn class_declaration_nodes_are_supported(value: &Value) -> bool {
     match value {
         Value::Array(values) => values.iter().all(class_declaration_nodes_are_supported),
         Value::Object(obj) => {
-            if let Some(node_type) = obj.get("type").and_then(|node_type| node_type.as_str())
+            if let Some(node_type) = obj.field("type").and_then(|node_type| node_type.as_str())
                 && !matches!(
                     node_type,
                     "Identifier"
@@ -3586,23 +3620,30 @@ fn class_declaration_nodes_are_supported(value: &Value) -> bool {
 /// / `StaticBlock`) into a `JsClassMember`.
 fn convert_class_member(member: &Value, context: &mut ComponentContext) -> Option<JsClassMember> {
     let obj = member.as_object()?;
-    let member_type = obj.get("type").and_then(|t| t.as_str())?;
+    let member_type = obj.field("type").and_then(|t| t.as_str())?;
     let computed = obj
-        .get("computed")
+        .field("computed")
         .and_then(|c| c.as_bool())
         .unwrap_or(false);
-    let is_static = obj.get("static").and_then(|s| s.as_bool()).unwrap_or(false);
+    let is_static = obj
+        .field("static")
+        .and_then(|s| s.as_bool())
+        .unwrap_or(false);
 
     match member_type {
         "MethodDefinition" => {
-            let key = convert_class_member_key(obj.get("key")?, computed, context);
-            let kind = match obj.get("kind").and_then(|k| k.as_str()).unwrap_or("method") {
+            let key = convert_class_member_key(obj.field("key")?, computed, context);
+            let kind = match obj
+                .field("kind")
+                .and_then(|k| k.as_str())
+                .unwrap_or("method")
+            {
                 "constructor" => JsMethodKind::Constructor,
                 "get" => JsMethodKind::Get,
                 "set" => JsMethodKind::Set,
                 _ => JsMethodKind::Method,
             };
-            let value_obj = obj.get("value").and_then(|v| v.as_object())?;
+            let value_obj = obj.field("value").and_then(|v| v.as_object())?;
             let func = match convert_function_expression(value_obj, context) {
                 JsExpr::Function(f) => f,
                 _ => return None,
@@ -3616,8 +3657,8 @@ fn convert_class_member(member: &Value, context: &mut ComponentContext) -> Optio
             }))
         }
         "PropertyDefinition" => {
-            let key = convert_class_member_key(obj.get("key")?, computed, context);
-            let value = obj.get("value").filter(|v| !v.is_null()).map(|v| {
+            let key = convert_class_member_key(obj.field("key")?, computed, context);
+            let value = obj.field("value").filter(|v| !v.is_null()).map(|v| {
                 let expr = convert_json_value(v, context);
                 context.arena.alloc_expr(expr)
             });
@@ -3642,13 +3683,13 @@ fn convert_class_member_key(
     context: &mut ComponentContext,
 ) -> JsPropertyKey {
     if !computed && let Some(obj) = key_val.as_object() {
-        match obj.get("type").and_then(|t| t.as_str()).unwrap_or("") {
+        match obj.field("type").and_then(|t| t.as_str()).unwrap_or("") {
             "Identifier" => {
-                let name = obj.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                let name = obj.field("name").and_then(|n| n.as_str()).unwrap_or("");
                 return JsPropertyKey::Identifier(name.into());
             }
             "PrivateIdentifier" => {
-                let name = obj.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                let name = obj.field("name").and_then(|n| n.as_str()).unwrap_or("");
                 return JsPropertyKey::Identifier(format!("#{name}").into());
             }
             "Literal" => {
@@ -3668,7 +3709,7 @@ fn convert_params(
     obj: &serde_json::Map<String, Value>,
     context: &mut ComponentContext,
 ) -> Vec<JsPattern> {
-    obj.get("params")
+    obj.field("params")
         .and_then(|p| p.as_array())
         .map(|params| {
             params
@@ -3682,18 +3723,18 @@ fn convert_params(
 /// Convert a JSON parameter value to a JsPattern, handling all ESTree pattern types.
 pub fn convert_param_pattern(value: &Value, context: &mut ComponentContext) -> Option<JsPattern> {
     let obj = value.as_object()?;
-    let param_type = obj.get("type").and_then(|t| t.as_str())?;
+    let param_type = obj.field("type").and_then(|t| t.as_str())?;
     match param_type {
         "Identifier" => {
-            let name = obj.get("name").and_then(|n| n.as_str())?;
+            let name = obj.field("name").and_then(|n| n.as_str())?;
             Some(JsPattern::Identifier(name.into()))
         }
         "AssignmentPattern" => {
             let left = obj
-                .get("left")
+                .field("left")
                 .and_then(|l| convert_param_pattern(l, context))?;
             let right = obj
-                .get("right")
+                .field("right")
                 .map(|r| {
                     let expr = convert_json_value(r, context);
                     // Apply transforms so reactive identifiers in default values get their getter calls
@@ -3707,7 +3748,7 @@ pub fn convert_param_pattern(value: &Value, context: &mut ComponentContext) -> O
         }
         "RestElement" => {
             let argument = obj
-                .get("argument")
+                .field("argument")
                 .and_then(|a| convert_param_pattern(a, context))?;
             Some(JsPattern::Rest(Box::new(argument)))
         }
@@ -3715,29 +3756,29 @@ pub fn convert_param_pattern(value: &Value, context: &mut ComponentContext) -> O
         // for destructuring in @const tags)
         "ObjectPattern" | "ObjectExpression" => {
             let properties = obj
-                .get("properties")
+                .field("properties")
                 .and_then(|p| p.as_array())
                 .map(|props| {
                     props
                         .iter()
                         .filter_map(|prop| {
                             let prop_obj = prop.as_object()?;
-                            let prop_type = prop_obj.get("type").and_then(|t| t.as_str())?;
+                            let prop_type = prop_obj.field("type").and_then(|t| t.as_str())?;
                             if prop_type == "RestElement" || prop_type == "SpreadElement" {
                                 let arg = prop_obj
-                                    .get("argument")
+                                    .field("argument")
                                     .and_then(|a| convert_param_pattern(a, context))?;
                                 Some(JsObjectPatternProperty::Rest(Box::new(arg)))
                             } else {
-                                let key_val = prop_obj.get("key").and_then(|k| k.as_object())?;
+                                let key_val = prop_obj.field("key").and_then(|k| k.as_object())?;
                                 let key_type =
-                                    key_val.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                                    key_val.field("type").and_then(|t| t.as_str()).unwrap_or("");
 
                                 // Handle Identifier keys, Literal keys, and computed keys
                                 let (key, fallback_name) = if key_type == "Literal" {
                                     // Literal key: { 'the-area': area } or { 2: sum }
                                     {
-                                        let val = key_val.get("value")?;
+                                        let val = key_val.field("value")?;
                                         if let Some(s) = val.as_str() {
                                             (
                                                 JsPropertyKey::Literal(JsLiteral::String(
@@ -3757,7 +3798,7 @@ pub fn convert_param_pattern(value: &Value, context: &mut ComponentContext) -> O
                                     }
                                 } else if key_type == "Identifier" {
                                     // Identifier key: { x } or { x: y }
-                                    let name = key_val.get("name").and_then(|n| n.as_str())?;
+                                    let name = key_val.field("name").and_then(|n| n.as_str())?;
                                     (
                                         JsPropertyKey::Identifier(name.into()),
                                         Some(name.to_string()),
@@ -3775,7 +3816,7 @@ pub fn convert_param_pattern(value: &Value, context: &mut ComponentContext) -> O
                                 };
 
                                 let value_pat = prop_obj
-                                    .get("value")
+                                    .field("value")
                                     .and_then(|v| convert_param_pattern(v, context))
                                     .or_else(|| {
                                         fallback_name
@@ -3783,11 +3824,11 @@ pub fn convert_param_pattern(value: &Value, context: &mut ComponentContext) -> O
                                             .map(|n| JsPattern::Identifier(n.clone().into()))
                                     })?;
                                 let shorthand = prop_obj
-                                    .get("shorthand")
+                                    .field("shorthand")
                                     .and_then(|s| s.as_bool())
                                     .unwrap_or(false);
                                 let computed = prop_obj
-                                    .get("computed")
+                                    .field("computed")
                                     .and_then(|c| c.as_bool())
                                     .unwrap_or(false);
                                 Some(JsObjectPatternProperty::Property {
@@ -3806,7 +3847,7 @@ pub fn convert_param_pattern(value: &Value, context: &mut ComponentContext) -> O
         // Handle both ArrayPattern (official AST) and ArrayExpression (our parser's AST)
         "ArrayPattern" | "ArrayExpression" => {
             let elements = obj
-                .get("elements")
+                .field("elements")
                 .and_then(|e| e.as_array())
                 .map(|elems| {
                     elems
@@ -3824,7 +3865,7 @@ pub fn convert_param_pattern(value: &Value, context: &mut ComponentContext) -> O
             Some(JsPattern::Array(JsArrayPattern { elements }))
         }
         _ => obj
-            .get("name")
+            .field("name")
             .and_then(|n| n.as_str())
             .map(|n| JsPattern::Identifier(n.into())),
     }
@@ -3936,7 +3977,7 @@ fn convert_block_statement(
     let saved_shadowed = context.state.shadowed_prop_names.clone();
 
     let body = obj
-        .get("body")
+        .field("body")
         .and_then(|b| b.as_array())
         .map(|stmts| {
             let mut body: Vec<JsStatement> = Vec::with_capacity(stmts.len());
@@ -3944,12 +3985,12 @@ fn convert_block_statement(
             for stmt in stmts {
                 let stmt_start = stmt
                     .as_object()
-                    .and_then(|o| o.get("start"))
+                    .and_then(|o| o.field("start"))
                     .and_then(|s| s.as_u64())
                     .map(|s| s as usize);
                 let stmt_end = stmt
                     .as_object()
-                    .and_then(|o| o.get("end"))
+                    .and_then(|o| o.field("end"))
                     .and_then(|e| e.as_u64())
                     .map(|e| e as usize);
                 if let Some(start) = stmt_start {
@@ -3982,19 +4023,19 @@ fn convert_block_statement(
 /// rewrite those names as `$$props.name`.
 fn register_block_decl_names_json(stmt: &Value, context: &mut ComponentContext) {
     let Some(obj) = stmt.as_object() else { return };
-    if obj.get("type").and_then(|t| t.as_str()) != Some("VariableDeclaration") {
+    if obj.field("type").and_then(|t| t.as_str()) != Some("VariableDeclaration") {
         return;
     }
-    let Some(decls) = obj.get("declarations").and_then(|d| d.as_array()) else {
+    let Some(decls) = obj.field("declarations").and_then(|d| d.as_array()) else {
         return;
     };
     for decl in decls {
         if let Some(name) = decl
             .as_object()
-            .and_then(|d| d.get("id"))
+            .and_then(|d| d.field("id"))
             .and_then(|id| id.as_object())
-            .filter(|o| o.get("type").and_then(|t| t.as_str()) == Some("Identifier"))
-            .and_then(|o| o.get("name").and_then(|n| n.as_str()))
+            .filter(|o| o.field("type").and_then(|t| t.as_str()) == Some("Identifier"))
+            .and_then(|o| o.field("name").and_then(|n| n.as_str()))
         {
             context.state.shadowed_prop_names.insert(name.to_string());
         }
@@ -4124,22 +4165,23 @@ fn push_own_line_comment_raws(
 /// non-destructuring outer assignment's right-hand side).
 fn convert_expression_statement_child(expr_json: &Value, context: &mut ComponentContext) -> JsExpr {
     if let Some(obj) = expr_json.as_object()
-        && obj.get("type").and_then(|t| t.as_str()) == Some("AssignmentExpression")
-        && let Some(left_val) = obj.get("left")
+        && obj.field("type").and_then(|t| t.as_str()) == Some("AssignmentExpression")
+        && let Some(left_val) = obj.field("left")
         && matches!(
             left_val
                 .as_object()
-                .and_then(|o| o.get("type"))
+                .and_then(|o| o.field("type"))
                 .and_then(|t| t.as_str()),
             Some("ArrayPattern" | "ObjectPattern" | "RestElement")
         )
-        && let Some(result) = try_destructure_assignment(left_val, obj.get("right"), context, true)
+        && let Some(result) =
+            try_destructure_assignment(left_val, obj.field("right"), context, true)
     {
         return result;
     }
     if expr_json
         .as_object()
-        .and_then(|obj| obj.get("type"))
+        .and_then(|obj| obj.field("type"))
         .and_then(|t| t.as_str())
         == Some("AssignmentExpression")
     {
@@ -4153,38 +4195,38 @@ fn convert_expression_statement_child(expr_json: &Value, context: &mut Component
 /// Convert a statement node to JsStatement.
 fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsStatement> {
     let obj = stmt.as_object()?;
-    let stmt_type = obj.get("type").and_then(|t| t.as_str())?;
+    let stmt_type = obj.field("type").and_then(|t| t.as_str())?;
 
     match stmt_type {
         "ExpressionStatement" => {
             let expr = obj
-                .get("expression")
+                .field("expression")
                 .map(|e| convert_expression_statement_child(e, context))?;
             Some(JsStatement::Expression(JsExpressionStatement {
                 expression: context.arena.alloc_expr(expr),
                 comment_anchor: obj
-                    .get("start")
+                    .field("start")
                     .and_then(|start| start.as_u64())
                     .map(|start| start as u32),
             }))
         }
         "VariableDeclaration" => {
-            let kind = obj.get("kind").and_then(|k| k.as_str()).unwrap_or("let");
+            let kind = obj.field("kind").and_then(|k| k.as_str()).unwrap_or("let");
             let declarations = obj
-                .get("declarations")
+                .field("declarations")
                 .and_then(|d| d.as_array())
                 .map(|decls| {
                     decls
                         .iter()
                         .filter_map(|decl| {
                             let decl_obj = decl.as_object()?;
-                            let id_val = decl_obj.get("id")?;
+                            let id_val = decl_obj.field("id")?;
                             let pattern = convert_param_pattern(id_val, context)?;
 
                             // Register the init expression's node type for should_proxy() lookups.
                             // This enables scope-aware identifier tracing for local variables.
                             if !context.state.local_var_init_types.is_empty()
-                                && let Some(init_json) = decl_obj.get("init")
+                                && let Some(init_json) = decl_obj.field("init")
                                 && let Some(t) = unwrap_ts_expression_type(init_json)
                                 && let JsPattern::Identifier(ref name) = pattern
                             {
@@ -4195,7 +4237,7 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
 
                             // In ESTree, `init: null` means no initializer (e.g., `let x;`).
                             // We must filter out JSON null so we don't generate `let x = null;`.
-                            let init = decl_obj.get("init").filter(|i| !i.is_null()).map(|i| {
+                            let init = decl_obj.field("init").filter(|i| !i.is_null()).map(|i| {
                                 let saved_state_declarator_name =
                                     context.state.state_declarator_name.take();
                                 if let JsPattern::Identifier(ref name) = pattern
@@ -4230,7 +4272,7 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
             // Filter out JSON null: `{ "argument": null }` means `return;` (no value),
             // not `return null;`. Without this filter, convert_json_value(Null) produces
             // a null literal, turning bare `return;` into `return null;`.
-            let argument = obj.get("argument").filter(|a| !a.is_null()).map(|a| {
+            let argument = obj.field("argument").filter(|a| !a.is_null()).map(|a| {
                 let __tmp = convert_json_value(a, context);
                 context.arena.alloc_expr(__tmp)
             });
@@ -4242,7 +4284,7 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
         }
         "IfStatement" => {
             let test = obj
-                .get("test")
+                .field("test")
                 .map(|t| {
                     let __tmp = convert_json_value(t, context);
                     context.arena.alloc_expr(__tmp)
@@ -4253,12 +4295,12 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
                         .alloc_expr(JsExpr::Literal(JsLiteral::Boolean(false)))
                 });
             let consequent = obj
-                .get("consequent")
+                .field("consequent")
                 .and_then(|c| convert_statement(c, context))
                 .map(|s| context.arena.alloc_stmt(s))
                 .unwrap_or_else(|| context.arena.alloc_stmt(JsStatement::Empty));
             let alternate = obj
-                .get("alternate")
+                .field("alternate")
                 .and_then(|a| convert_statement(a, context))
                 .map(|s| context.arena.alloc_stmt(s));
             Some(JsStatement::If(JsIfStatement {
@@ -4270,35 +4312,35 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
         "EmptyStatement" => Some(JsStatement::Empty),
         "ThrowStatement" => {
             let argument = obj
-                .get("argument")
+                .field("argument")
                 .map(|a| convert_json_value(a, context))
                 .unwrap_or(JsExpr::Literal(JsLiteral::Null));
             Some(JsStatement::Throw(context.arena.alloc_expr(argument)))
         }
         "TryStatement" => {
             let block = obj
-                .get("block")
+                .field("block")
                 .and_then(|b| b.as_object())
                 .map(|b| convert_block_statement(b, context))
                 .unwrap_or_else(JsBlockStatement::new);
-            let handler = obj.get("handler").and_then(|h| {
+            let handler = obj.field("handler").and_then(|h| {
                 let h_obj = h.as_object()?;
                 // Route the catch parameter through the full pattern converter so
                 // destructuring catch params (`catch ({ message }) {}`) are
                 // preserved, not just bare identifiers (H-112).
                 let param = h_obj
-                    .get("param")
+                    .field("param")
                     .filter(|p| !p.is_null())
                     .and_then(|p| convert_param_pattern(p, context));
                 // A catch parameter binds like a function parameter, so it shadows
                 // the same transforms one does — for the body only.
                 let mut names: Vec<String> = Vec::new();
-                if let Some(param_val) = h_obj.get("param").filter(|p| !p.is_null()) {
+                if let Some(param_val) = h_obj.field("param").filter(|p| !p.is_null()) {
                     collect_param_names(param_val, &mut names);
                 }
                 let restore = enter_shadowed_names(&names, context);
                 let body = h_obj
-                    .get("body")
+                    .field("body")
                     .and_then(|b| b.as_object())
                     .map(|b| convert_block_statement(b, context))
                     .unwrap_or_else(JsBlockStatement::new);
@@ -4306,7 +4348,7 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
                 Some(JsCatchClause { param, body })
             });
             let finalizer = obj
-                .get("finalizer")
+                .field("finalizer")
                 .and_then(|f| f.as_object())
                 .map(|f| convert_block_statement(f, context));
             Some(JsStatement::Try(JsTryStatement {
@@ -4321,24 +4363,24 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
             // This prevents `x++` in `for (let x = 0; x < 10; x++)` from being
             // transformed to `$.update(x)` when `x` shadows an outer state variable.
             let mut init_var_names: Vec<String> = Vec::new();
-            if let Some(init_val) = obj.get("init")
+            if let Some(init_val) = obj.field("init")
                 && let Some(init_obj) = init_val.as_object()
-                && init_obj.get("type").and_then(|t| t.as_str()) == Some("VariableDeclaration")
+                && init_obj.field("type").and_then(|t| t.as_str()) == Some("VariableDeclaration")
             {
                 let kind = init_obj
-                    .get("kind")
+                    .field("kind")
                     .and_then(|k| k.as_str())
                     .unwrap_or("var");
                 // Only let/const create block scope; var is hoisted
                 if (kind == "let" || kind == "const")
-                    && let Some(decls) = init_obj.get("declarations").and_then(|d| d.as_array())
+                    && let Some(decls) = init_obj.field("declarations").and_then(|d| d.as_array())
                 {
                     for decl in decls {
                         if let Some(id) = decl
                             .as_object()
-                            .and_then(|d| d.get("id"))
+                            .and_then(|d| d.field("id"))
                             .and_then(|id| id.as_object())
-                            && let Some(name) = id.get("name").and_then(|n| n.as_str())
+                            && let Some(name) = id.field("name").and_then(|n| n.as_str())
                         {
                             init_var_names.push(name.to_string());
                         }
@@ -4346,22 +4388,25 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
                 }
             }
 
-            let init = obj.get("init").and_then(|i| {
+            let init = obj.field("init").and_then(|i| {
                 let i_obj = i.as_object()?;
-                let i_type = i_obj.get("type").and_then(|t| t.as_str())?;
+                let i_type = i_obj.field("type").and_then(|t| t.as_str())?;
                 if i_type == "VariableDeclaration" {
-                    let kind = i_obj.get("kind").and_then(|k| k.as_str()).unwrap_or("let");
+                    let kind = i_obj
+                        .field("kind")
+                        .and_then(|k| k.as_str())
+                        .unwrap_or("let");
                     let declarations = i_obj
-                        .get("declarations")
+                        .field("declarations")
                         .and_then(|d| d.as_array())
                         .map(|decls| {
                             decls
                                 .iter()
                                 .filter_map(|decl| {
                                     let decl_obj = decl.as_object()?;
-                                    let id_val = decl_obj.get("id")?;
+                                    let id_val = decl_obj.field("id")?;
                                     let pattern = convert_param_pattern(id_val, context)?;
-                                    let init_val = decl_obj.get("init").map(|iv| {
+                                    let init_val = decl_obj.field("init").map(|iv| {
                                         let __tmp = convert_json_value(iv, context);
                                         context.arena.alloc_expr(__tmp)
                                     });
@@ -4401,16 +4446,16 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
                 None
             };
 
-            let test = obj.get("test").filter(|t| !t.is_null()).map(|t| {
+            let test = obj.field("test").filter(|t| !t.is_null()).map(|t| {
                 let __tmp = convert_json_value(t, context);
                 context.arena.alloc_expr(__tmp)
             });
-            let update = obj.get("update").filter(|u| !u.is_null()).map(|u| {
+            let update = obj.field("update").filter(|u| !u.is_null()).map(|u| {
                 let __tmp = convert_json_value(u, context);
                 context.arena.alloc_expr(__tmp)
             });
             let body = obj
-                .get("body")
+                .field("body")
                 .and_then(|b| convert_statement(b, context))
                 .map(|s| context.arena.alloc_stmt(s))
                 .unwrap_or_else(|| context.arena.alloc_stmt(JsStatement::Empty));
@@ -4432,33 +4477,36 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
 
             // Collect variable names declared in `left` to avoid transforming them
             let mut left_var_names: Vec<String> = Vec::new();
-            if let Some(left_obj) = obj.get("left").and_then(|l| l.as_object())
-                && left_obj.get("type").and_then(|t| t.as_str()) == Some("VariableDeclaration")
-                && let Some(decls) = left_obj.get("declarations").and_then(|d| d.as_array())
+            if let Some(left_obj) = obj.field("left").and_then(|l| l.as_object())
+                && left_obj.field("type").and_then(|t| t.as_str()) == Some("VariableDeclaration")
+                && let Some(decls) = left_obj.field("declarations").and_then(|d| d.as_array())
             {
                 for decl in decls {
-                    if let Some(id_val) = decl.as_object().and_then(|d| d.get("id")) {
+                    if let Some(id_val) = decl.as_object().and_then(|d| d.field("id")) {
                         collect_param_names(id_val, &mut left_var_names);
                     }
                 }
             }
 
-            let left = obj.get("left").and_then(|l| {
+            let left = obj.field("left").and_then(|l| {
                 let l_obj = l.as_object()?;
-                let l_type = l_obj.get("type").and_then(|t| t.as_str())?;
+                let l_type = l_obj.field("type").and_then(|t| t.as_str())?;
                 if l_type == "VariableDeclaration" {
-                    let kind = l_obj.get("kind").and_then(|k| k.as_str()).unwrap_or("let");
+                    let kind = l_obj
+                        .field("kind")
+                        .and_then(|k| k.as_str())
+                        .unwrap_or("let");
                     let declarations = l_obj
-                        .get("declarations")
+                        .field("declarations")
                         .and_then(|d| d.as_array())
                         .map(|decls| {
                             decls
                                 .iter()
                                 .filter_map(|decl| {
                                     let decl_obj = decl.as_object()?;
-                                    let id_val = decl_obj.get("id")?;
+                                    let id_val = decl_obj.field("id")?;
                                     let pattern = convert_param_pattern(id_val, context)?;
-                                    let init_val = decl_obj.get("init").map(|iv| {
+                                    let init_val = decl_obj.field("init").map(|iv| {
                                         let __tmp = convert_json_value(iv, context);
                                         context.arena.alloc_expr(__tmp)
                                     });
@@ -4485,7 +4533,7 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
             })?;
 
             let right = obj
-                .get("right")
+                .field("right")
                 .map(|r| {
                     let __tmp = convert_json_value(r, context);
                     context.arena.alloc_expr(__tmp)
@@ -4499,14 +4547,17 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
             let restore = enter_shadowed_names(&left_var_names, context);
 
             let body = obj
-                .get("body")
+                .field("body")
                 .and_then(|b| convert_statement(b, context))
                 .map(|s| context.arena.alloc_stmt(s))
                 .unwrap_or_else(|| context.arena.alloc_stmt(JsStatement::Empty));
 
             leave_shadowed_names(restore, context);
 
-            let is_await = obj.get("await").and_then(|a| a.as_bool()).unwrap_or(false);
+            let is_await = obj
+                .field("await")
+                .and_then(|a| a.as_bool())
+                .unwrap_or(false);
             // `for...in` and `for...of` share `JsForOfStatement`; the `is_for_in`
             // flag drives codegen to emit ` in ` vs ` of ` (H-110). `for await`
             // only applies to `for...of`.
@@ -4520,7 +4571,7 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
         }
         "WhileStatement" => {
             let test = obj
-                .get("test")
+                .field("test")
                 .map(|t| {
                     let __tmp = convert_json_value(t, context);
                     context.arena.alloc_expr(__tmp)
@@ -4531,7 +4582,7 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
                         .alloc_expr(JsExpr::Literal(JsLiteral::Boolean(true)))
                 });
             let body = obj
-                .get("body")
+                .field("body")
                 .and_then(|b| convert_statement(b, context))
                 .map(|s| context.arena.alloc_stmt(s))
                 .unwrap_or_else(|| context.arena.alloc_stmt(JsStatement::Empty));
@@ -4539,7 +4590,7 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
         }
         "DoWhileStatement" => {
             let test = obj
-                .get("test")
+                .field("test")
                 .map(|t| {
                     let __tmp = convert_json_value(t, context);
                     context.arena.alloc_expr(__tmp)
@@ -4550,7 +4601,7 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
                         .alloc_expr(JsExpr::Literal(JsLiteral::Boolean(true)))
                 });
             let body = obj
-                .get("body")
+                .field("body")
                 .and_then(|b| convert_statement(b, context))
                 .map(|s| context.arena.alloc_stmt(s))
                 .unwrap_or_else(|| context.arena.alloc_stmt(JsStatement::Empty));
@@ -4561,11 +4612,11 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
             // `break label;` / `continue label;` references a label that no
             // longer exists (ReferenceError at runtime). H-111.
             let label = obj
-                .get("label")
-                .and_then(|l| l.get("name"))
+                .field("label")
+                .and_then(|l| l.field("name"))
                 .and_then(|n| n.as_str())?;
             let body = obj
-                .get("body")
+                .field("body")
                 .and_then(|b| convert_statement(b, context))?;
             let body_id = context.arena.alloc_stmt(body);
             Some(JsStatement::Labeled(JsLabeledStatement {
@@ -4575,18 +4626,18 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
         }
         "BreakStatement" => {
             let label = obj
-                .get("label")
+                .field("label")
                 .and_then(|l| l.as_object())
-                .and_then(|l| l.get("name"))
+                .and_then(|l| l.field("name"))
                 .and_then(|n| n.as_str())
                 .map(CompactString::from);
             Some(JsStatement::Break(label))
         }
         "ContinueStatement" => {
             let label = obj
-                .get("label")
+                .field("label")
                 .and_then(|l| l.as_object())
-                .and_then(|l| l.get("name"))
+                .and_then(|l| l.field("name"))
                 .and_then(|n| n.as_str())
                 .map(CompactString::from);
             Some(JsStatement::Continue(label))
@@ -4596,23 +4647,23 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
             // flattening dropped the discriminant and merged every case body,
             // destroying the `case` matching. H-109.
             let discriminant = {
-                let d = obj.get("discriminant")?;
+                let d = obj.field("discriminant")?;
                 let expr = convert_json_value(d, context);
                 context.arena.alloc_expr(expr)
             };
             let mut cases = Vec::new();
-            if let Some(cs) = obj.get("cases").and_then(|c| c.as_array()) {
+            if let Some(cs) = obj.field("cases").and_then(|c| c.as_array()) {
                 for case in cs {
                     let Some(case_obj) = case.as_object() else {
                         continue;
                     };
                     // `test` is `null` for the `default:` clause.
-                    let test = case_obj.get("test").filter(|t| !t.is_null()).map(|t| {
+                    let test = case_obj.field("test").filter(|t| !t.is_null()).map(|t| {
                         let expr = convert_json_value(t, context);
                         context.arena.alloc_expr(expr)
                     });
                     let mut consequent = Vec::new();
-                    if let Some(stmts) = case_obj.get("consequent").and_then(|c| c.as_array()) {
+                    if let Some(stmts) = case_obj.field("consequent").and_then(|c| c.as_array()) {
                         for s in stmts {
                             if let Some(converted) = convert_statement(s, context) {
                                 consequent.push(converted);
@@ -4629,9 +4680,9 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
         }
         "FunctionDeclaration" => {
             let id: Option<CompactString> = obj
-                .get("id")
+                .field("id")
                 .and_then(|i| i.as_object())
-                .and_then(|i| i.get("name"))
+                .and_then(|i| i.field("name"))
                 .and_then(|n| n.as_str())
                 .map(|n| n.into());
 
@@ -4652,7 +4703,7 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
             context.state.push_local_scope();
 
             let body = obj
-                .get("body")
+                .field("body")
                 .and_then(|b| b.as_object())
                 .map(|b| convert_block_statement(b, context))
                 .unwrap_or_default();
@@ -4665,9 +4716,12 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
             context.state.transform_deep_read = saved_transform_deep_read;
             context.state.shadowed_prop_names = saved_shadowed;
 
-            let is_async = obj.get("async").and_then(|a| a.as_bool()).unwrap_or(false);
+            let is_async = obj
+                .field("async")
+                .and_then(|a| a.as_bool())
+                .unwrap_or(false);
             let is_generator = obj
-                .get("generator")
+                .field("generator")
                 .and_then(|g| g.as_bool())
                 .unwrap_or(false);
 
@@ -4680,8 +4734,8 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
             }))
         }
         "ClassDeclaration" => {
-            let start = obj.get("start")?.as_u64()? as usize;
-            let end = obj.get("end")?.as_u64()? as usize;
+            let start = obj.field("start")?.as_u64()? as usize;
+            let end = obj.field("end")?.as_u64()? as usize;
             let source: CompactString = context.state.analysis.source.get(start..end)?.into();
             if !class_declaration_has_structured_fallback(stmt, &source) {
                 return Some(JsStatement::Raw(source));
@@ -4714,16 +4768,19 @@ fn convert_assignment_expression(
     // Taken here so a nested assignment converted while this one is in flight
     // does not inherit it.
     let is_statement = std::mem::take(&mut context.state.assignment_is_statement);
-    let operator_str = obj.get("operator").and_then(|o| o.as_str()).unwrap_or("=");
+    let operator_str = obj
+        .field("operator")
+        .and_then(|o| o.as_str())
+        .unwrap_or("=");
 
     // Check if the LHS is a destructuring pattern (ArrayPattern or ObjectPattern).
     // If so, we need to decompose it into individual assignments and potentially
     // wrap in an IIFE with $.to_array() calls.
     // This corresponds to visit_assignment_expression in shared/assignments.js.
-    if let Some(left_val) = obj.get("left") {
+    if let Some(left_val) = obj.field("left") {
         let left_type = left_val
             .as_object()
-            .and_then(|o| o.get("type"))
+            .and_then(|o| o.field("type"))
             .and_then(|t| t.as_str())
             .unwrap_or("");
 
@@ -4735,7 +4792,7 @@ fn convert_assignment_expression(
         // state.
         if matches!(left_type, "ArrayPattern" | "ObjectPattern" | "RestElement")
             && let Some(result) =
-                try_destructure_assignment(left_val, obj.get("right"), context, false)
+                try_destructure_assignment(left_val, obj.field("right"), context, false)
         {
             return result;
         }
@@ -4764,18 +4821,18 @@ fn convert_assignment_expression(
     // Check if the LHS is a MemberExpression with a direct Identifier object (e.g., props.a)
     // If so, we set the flag to prevent rest_prop → $$props transformation
     let is_direct_member_assignment = if let Some(left_obj) =
-        obj.get("left").and_then(|l| l.as_object())
-        && let Some("MemberExpression") = left_obj.get("type").and_then(|t| t.as_str())
+        obj.field("left").and_then(|l| l.as_object())
+        && let Some("MemberExpression") = left_obj.field("type").and_then(|t| t.as_str())
     {
         // Check if the computed flag is false (non-computed property access)
         let computed = left_obj
-            .get("computed")
+            .field("computed")
             .and_then(|c| c.as_bool())
             .unwrap_or(false);
         if !computed {
             // Check if the object is directly an Identifier (not a nested MemberExpression)
-            if let Some(object_obj) = left_obj.get("object").and_then(|o| o.as_object())
-                && let Some("Identifier") = object_obj.get("type").and_then(|t| t.as_str())
+            if let Some(object_obj) = left_obj.field("object").and_then(|o| o.as_object())
+                && let Some("Identifier") = object_obj.field("type").and_then(|t| t.as_str())
             {
                 true
             } else {
@@ -4795,7 +4852,7 @@ fn convert_assignment_expression(
     }
 
     let left = obj
-        .get("left")
+        .field("left")
         .map(|l| {
             let __tmp = convert_json_value(l, context);
             context.arena.alloc_expr(__tmp)
@@ -4806,7 +4863,7 @@ fn convert_assignment_expression(
     context.state.in_direct_assignment_lhs = saved_flag;
 
     let right = obj
-        .get("right")
+        .field("right")
         .map(|r| {
             let __tmp = convert_json_value(r, context);
             context.arena.alloc_expr(__tmp)
@@ -4814,14 +4871,16 @@ fn convert_assignment_expression(
         .unwrap_or_else(|| context.arena.alloc_expr(JsExpr::Literal(JsLiteral::Null)));
 
     // Pre-compute the proxy decision for the RHS
-    let should_proxy_rhs = Some(should_proxy_value(obj.get("right"), context));
+    let should_proxy_rhs = Some(should_proxy_value(obj.field("right"), context));
 
     // Extract the root identifier from the ORIGINAL JSON (before conversion/transforms)
     // This is necessary because convert_json_value applies read transforms that turn
     // `rows` into `rows()`, making it impossible to identify the root identifier later.
-    let original_root_name = obj.get("left").and_then(extract_root_identifier_from_json);
+    let original_root_name = obj
+        .field("left")
+        .and_then(extract_root_identifier_from_json);
     let original_root_start = obj
-        .get("left")
+        .field("left")
         .and_then(extract_root_identifier_start_from_json);
 
     // Mirror the official EachBlock `assign`/`mutate` transforms (EachBlock.js
@@ -4855,7 +4914,7 @@ fn convert_assignment_expression(
             "ownership_invalid_mutation",
             &context.state.analysis.source,
         ) {
-        check_ownership_validation(obj.get("left"), context)
+        check_ownership_validation(obj.field("left"), context)
     } else {
         None
     };
@@ -4894,8 +4953,8 @@ fn convert_assignment_expression(
     let result = preserve_each_mutation_sequence(
         result,
         original_root_name.as_deref(),
-        obj.get("left")
-            .and_then(|left| left.get("type"))
+        obj.field("left")
+            .and_then(|left| left.field("type"))
             .and_then(|node_type| node_type.as_str())
             == Some("MemberExpression"),
         context,
@@ -4922,11 +4981,11 @@ fn convert_assignment_expression(
 /// Check if a JSON AST node has a `svelte-ignore` leading comment with the given code.
 /// This checks the `leadingComments` array for comments containing `svelte-ignore <code>`.
 pub(crate) fn is_svelte_ignored(obj: &serde_json::Map<String, Value>, code: &str) -> bool {
-    if let Some(Value::Array(comments)) = obj.get("leadingComments") {
+    if let Some(Value::Array(comments)) = obj.field("leadingComments") {
         for comment in comments {
             if let Some(value) = comment
                 .as_object()
-                .and_then(|c| c.get("value"))
+                .and_then(|c| c.field("value"))
                 .and_then(|v| v.as_str())
                 && comment_has_svelte_ignore(value, code)
             {
@@ -4952,7 +5011,7 @@ pub(crate) fn is_svelte_ignored_with_source(
     // Also check the source code directly before the node's start position
     // This handles comments inside template expressions (arrow bodies) that
     // aren't attached as leadingComments by our parser
-    if let Some(start) = obj.get("start").and_then(|s| s.as_u64()) {
+    if let Some(start) = obj.field("start").and_then(|s| s.as_u64()) {
         return is_svelte_ignored_before_offset(start as usize, code, source);
     }
     false
@@ -5037,7 +5096,7 @@ pub(crate) fn check_ownership_validation(
     let left_obj = left_val.as_object()?;
 
     // Only validate member expressions
-    if left_obj.get("type")?.as_str()? != "MemberExpression" {
+    if left_obj.field("type")?.as_str()? != "MemberExpression" {
         return None;
     }
 
@@ -5148,9 +5207,9 @@ pub(crate) fn ownership_alias_literal(prop_alias: Option<String>) -> JsExpr {
 /// Get the start position of the root identifier in a member expression chain.
 fn get_root_start_position(val: &Value) -> Option<u32> {
     let obj = val.as_object()?;
-    match obj.get("type")?.as_str()? {
-        "Identifier" => obj.get("start")?.as_u64().map(|n| n as u32),
-        "MemberExpression" => get_root_start_position(obj.get("object")?),
+    match obj.field("type")?.as_str()? {
+        "Identifier" => obj.field("start")?.as_u64().map(|n| n as u32),
+        "MemberExpression" => get_root_start_position(obj.field("object")?),
         _ => None,
     }
 }
@@ -5158,9 +5217,9 @@ fn get_root_start_position(val: &Value) -> Option<u32> {
 /// Get the root identifier name from a JSON member expression chain.
 fn get_root_identifier_from_member_json(val: &Value) -> Option<String> {
     let obj = val.as_object()?;
-    match obj.get("type")?.as_str()? {
-        "Identifier" => obj.get("name")?.as_str().map(|s| s.to_string()),
-        "MemberExpression" => get_root_identifier_from_member_json(obj.get("object")?),
+    match obj.field("type")?.as_str()? {
+        "Identifier" => obj.field("name")?.as_str().map(|s| s.to_string()),
+        "MemberExpression" => get_root_identifier_from_member_json(obj.field("object")?),
         _ => None,
     }
 }
@@ -5176,18 +5235,21 @@ fn build_member_path_from_json(val: &Value, context: &ComponentContext) -> Optio
     let mut current = val;
 
     while let Some(obj) = current.as_object() {
-        match obj.get("type").and_then(|t| t.as_str()) {
+        match obj.field("type").and_then(|t| t.as_str()) {
             Some("MemberExpression") => {
-                let property = obj.get("property");
+                let property = obj.field("property");
                 let computed = obj
-                    .get("computed")
+                    .field("computed")
                     .and_then(|c| c.as_bool())
                     .unwrap_or(false);
 
                 if let Some(prop_obj) = property.and_then(|p| p.as_object()) {
-                    let prop_type = prop_obj.get("type").and_then(|t| t.as_str());
+                    let prop_type = prop_obj.field("type").and_then(|t| t.as_str());
                     if prop_type == Some("Identifier") {
-                        let name = prop_obj.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                        let name = prop_obj
+                            .field("name")
+                            .and_then(|n| n.as_str())
+                            .unwrap_or("");
                         if computed {
                             // Check if there's a transform for this identifier
                             if let Some(transform) = context.state.transform.get(name) {
@@ -5207,7 +5269,7 @@ fn build_member_path_from_json(val: &Value, context: &ComponentContext) -> Optio
                         }
                     } else if prop_type == Some("Literal") {
                         // Literal property (e.g., obj[0])
-                        if let Some(val) = prop_obj.get("value") {
+                        if let Some(val) = prop_obj.field("value") {
                             if let Some(n) = val.as_f64() {
                                 path.push(b::literal_number(n));
                             } else if let Some(s) = val.as_str() {
@@ -5219,13 +5281,13 @@ fn build_member_path_from_json(val: &Value, context: &ComponentContext) -> Optio
                     }
                 }
 
-                current = match obj.get("object") {
+                current = match obj.field("object") {
                     Some(o) => o,
                     None => break,
                 };
             }
             Some("Identifier") => {
-                let name = obj.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                let name = obj.field("name").and_then(|n| n.as_str()).unwrap_or("");
                 path.push(b::string(name));
                 break;
             }
@@ -5626,14 +5688,14 @@ fn is_known_primitive_json(value: Option<&Value>) -> bool {
         // and a function value is not UNKNOWN either.
         "CallExpression" => {
             let no_spread = value
-                .get("arguments")
+                .field("arguments")
                 .and_then(|a| a.as_array())
                 .is_some_and(|args| {
                     args.iter()
-                        .all(|a| a.get("type").and_then(|t| t.as_str()) != Some("SpreadElement"))
+                        .all(|a| a.field("type").and_then(|t| t.as_str()) != Some("SpreadElement"))
                 });
             value
-                .get("callee")
+                .field("callee")
                 .and_then(super::shared::utils::json_keypath)
                 .as_deref()
                 .is_some_and(|keypath| {
@@ -5872,7 +5934,7 @@ fn try_coercive_assignment_transform(
     }
 
     // Right side must not be a known primitive
-    if is_known_primitive_json(obj.get("right")) {
+    if is_known_primitive_json(obj.field("right")) {
         return None;
     }
 
@@ -5880,7 +5942,7 @@ fn try_coercive_assignment_transform(
     // `bind:` directive visits (upstream's `path.at(-1)` arm).
     // Reference: AssignmentExpression.js lines 204-215
     if obj
-        .get("start")
+        .field("start")
         .and_then(|v| v.as_u64())
         .is_some_and(|start| {
             context
@@ -5900,13 +5962,13 @@ fn try_coercive_assignment_transform(
     }
 
     // Left side must be a MemberExpression
-    let left_json = obj.get("left")?.as_object()?;
-    let left_type = left_json.get("type")?.as_str()?;
+    let left_json = obj.field("left")?.as_object()?;
+    let left_type = left_json.field("type")?.as_str()?;
     if left_type != "MemberExpression" {
         return None;
     }
 
-    if let Some(left_value) = obj.get("left")
+    if let Some(left_value) = obj.field("left")
         && extract_root_identifier_from_json(left_value)
             .is_some_and(|root| is_each_item_mutation_root(&root, context))
     {
@@ -5928,7 +5990,7 @@ fn try_coercive_assignment_transform(
 
     // Get the property expression
     let computed = left_json
-        .get("computed")
+        .field("computed")
         .and_then(|c| c.as_bool())
         .unwrap_or(false);
 
@@ -5946,16 +6008,19 @@ fn try_coercive_assignment_transform(
     } else {
         // Non-computed: property name as string literal
         let prop_name = left_json
-            .get("property")
+            .field("property")
             .and_then(|p| p.as_object())
-            .and_then(|p| p.get("name"))
+            .and_then(|p| p.field("name"))
             .and_then(|n| n.as_str())
             .unwrap_or("");
         b::string(prop_name)
     };
 
     // Compute the location string: "filename:line:column"
-    let start = left_json.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as usize;
+    let start = left_json
+        .field("start")
+        .and_then(|s| s.as_u64())
+        .unwrap_or(0) as usize;
     let source = &context.state.analysis.source;
     let filename = &context.state.analysis.filename;
     let (line, col) =
@@ -6175,7 +6240,7 @@ fn extract_destructure_paths(
         Some(o) => o,
         None => return,
     };
-    let node_type = obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    let node_type = obj.field("type").and_then(|t| t.as_str()).unwrap_or("");
 
     match node_type {
         "Identifier" | "MemberExpression" => {
@@ -6186,13 +6251,16 @@ fn extract_destructure_paths(
         }
 
         "ObjectPattern" => {
-            if let Some(properties) = obj.get("properties").and_then(|p| p.as_array()) {
+            if let Some(properties) = obj.field("properties").and_then(|p| p.as_array()) {
                 for prop in properties {
                     let prop_obj = match prop.as_object() {
                         Some(o) => o,
                         None => continue,
                     };
-                    let prop_type = prop_obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    let prop_type = prop_obj
+                        .field("type")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("");
 
                     if prop_type == "RestElement" {
                         // Rest element: { ...rest } = obj
@@ -6201,24 +6269,26 @@ fn extract_destructure_paths(
                         for p in properties {
                             if let Some(p_obj) = p.as_object() {
                                 let p_type =
-                                    p_obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                                    p_obj.field("type").and_then(|t| t.as_str()).unwrap_or("");
                                 if p_type == "Property"
-                                    && let Some(key) = p_obj.get("key").and_then(|k| k.as_object())
+                                    && let Some(key) =
+                                        p_obj.field("key").and_then(|k| k.as_object())
                                 {
                                     let key_type =
-                                        key.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                                        key.field("type").and_then(|t| t.as_str()).unwrap_or("");
                                     let computed = p_obj
-                                        .get("computed")
+                                        .field("computed")
                                         .and_then(|c| c.as_bool())
                                         .unwrap_or(false);
 
                                     if key_type == "Identifier" && !computed {
-                                        if let Some(name) = key.get("name").and_then(|n| n.as_str())
+                                        if let Some(name) =
+                                            key.field("name").and_then(|n| n.as_str())
                                         {
                                             key_literals.push(b::string(name));
                                         }
                                     } else if key_type == "Literal" {
-                                        if let Some(val) = key.get("value") {
+                                        if let Some(val) = key.field("value") {
                                             if let Some(s) = val.as_str() {
                                                 key_literals.push(b::string(s));
                                             } else if let Some(n) = val.as_f64() {
@@ -6247,30 +6317,30 @@ fn extract_destructure_paths(
                             vec![expression.clone(), b::array(key_literals)],
                         );
 
-                        if let Some(argument) = prop_obj.get("argument") {
+                        if let Some(argument) = prop_obj.field("argument") {
                             extract_destructure_paths(
                                 paths, inserts, argument, &rest_expr, context,
                             );
                         }
                     } else {
                         // Regular property: { key: value } = obj
-                        let key = prop_obj.get("key");
+                        let key = prop_obj.field("key");
                         let computed = prop_obj
-                            .get("computed")
+                            .field("computed")
                             .and_then(|c| c.as_bool())
                             .unwrap_or(false);
 
                         let member_expr = if let Some(key_val) = key {
                             let key_obj = key_val.as_object();
                             let key_type = key_obj
-                                .and_then(|k| k.get("type"))
+                                .and_then(|k| k.field("type"))
                                 .and_then(|t| t.as_str())
                                 .unwrap_or("");
 
                             if key_type == "Identifier" && !computed {
                                 // obj.key
                                 let name = key_obj
-                                    .and_then(|k| k.get("name"))
+                                    .and_then(|k| k.field("name"))
                                     .and_then(|n| n.as_str())
                                     .unwrap_or("unknown");
                                 b::member(&context.arena, expression.clone(), name)
@@ -6283,7 +6353,7 @@ fn extract_destructure_paths(
                             expression.clone()
                         };
 
-                        let value = prop_obj.get("value").unwrap_or(param);
+                        let value = prop_obj.field("value").unwrap_or(param);
                         extract_destructure_paths(paths, inserts, value, &member_expr, context);
                     }
                 }
@@ -6292,7 +6362,7 @@ fn extract_destructure_paths(
 
         "ArrayPattern" => {
             let elements = obj
-                .get("elements")
+                .field("elements")
                 .and_then(|e| e.as_array())
                 .cloned()
                 .unwrap_or_default();
@@ -6301,7 +6371,7 @@ fn extract_destructure_paths(
             let has_rest = elements
                 .last()
                 .and_then(|e| if e.is_null() { None } else { e.as_object() })
-                .and_then(|o| o.get("type"))
+                .and_then(|o| o.field("type"))
                 .and_then(|t| t.as_str())
                 == Some("RestElement");
 
@@ -6333,7 +6403,10 @@ fn extract_destructure_paths(
                     Some(o) => o,
                     None => continue,
                 };
-                let elem_type = elem_obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                let elem_type = elem_obj
+                    .field("type")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("");
 
                 if elem_type == "RestElement" {
                     // ...rest = array.slice(i)
@@ -6343,7 +6416,7 @@ fn extract_destructure_paths(
                         vec![b::number(i as f64)],
                     );
 
-                    if let Some(argument) = elem_obj.get("argument") {
+                    if let Some(argument) = elem_obj.field("argument") {
                         extract_destructure_paths(paths, inserts, argument, &rest_expr, context);
                     }
                 } else {
@@ -6360,8 +6433,8 @@ fn extract_destructure_paths(
             // Generate: $.fallback(expression, defaultValue) or async thunk variant
             // This matches the official compiler's `build_fallback()` which handles
             // simple values, await expressions, and thunk wrapping.
-            let left = obj.get("left");
-            let right = obj.get("right");
+            let left = obj.field("left");
+            let right = obj.field("right");
 
             if let (Some(left_val), Some(right_val)) = (left, right) {
                 let default_val = convert_json_value(right_val, context);
@@ -6388,7 +6461,7 @@ fn try_build_single_assignment(
     use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 
     let node_obj = path.node.as_object()?;
-    let node_type = node_obj.get("type").and_then(|t| t.as_str())?;
+    let node_type = node_obj.field("type").and_then(|t| t.as_str())?;
 
     // Extract the root identifier name from the target
     let root_name = extract_root_identifier_from_json(&path.node)?;
@@ -6401,7 +6474,11 @@ fn try_build_single_assignment(
     let replacement_id = transform.replacement_id.clone();
 
     if node_type == "Identifier"
-        && root_name == node_obj.get("name").and_then(|n| n.as_str()).unwrap_or("")
+        && root_name
+            == node_obj
+                .field("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("")
     {
         // Direct identifier assignment: x = value -> $.set(x, value)
         if let Some(assign_fn) = assign_fn {
@@ -6462,22 +6539,22 @@ fn extract_root_identifier_from_expr(
 /// This is used to extract the root BEFORE conversion applies read transforms.
 fn extract_root_identifier_from_json(value: &Value) -> Option<String> {
     let obj = value.as_object()?;
-    let node_type = obj.get("type").and_then(|t| t.as_str())?;
+    let node_type = obj.field("type").and_then(|t| t.as_str())?;
 
     match node_type {
         "Identifier" => obj
-            .get("name")
+            .field("name")
             .and_then(|n| n.as_str())
             .map(|s| s.to_string()),
         "MemberExpression" => obj
-            .get("object")
+            .field("object")
             .and_then(extract_root_identifier_from_json),
         "ChainExpression" => obj
-            .get("expression")
+            .field("expression")
             .and_then(extract_root_identifier_from_json),
         // Unwrap TypeScript expression wrappers
         "TSAsExpression" | "TSNonNullExpression" | "TSSatisfiesExpression" => obj
-            .get("expression")
+            .field("expression")
             .and_then(extract_root_identifier_from_json),
         _ => None,
     }
@@ -6486,16 +6563,16 @@ fn extract_root_identifier_from_json(value: &Value) -> Option<String> {
 /// Extract the root identifier's source start from a JSON AST node.
 fn extract_root_identifier_start_from_json(value: &Value) -> Option<u32> {
     let obj = value.as_object()?;
-    match obj.get("type").and_then(|node_type| node_type.as_str())? {
+    match obj.field("type").and_then(|node_type| node_type.as_str())? {
         "Identifier" => obj
-            .get("start")
+            .field("start")
             .and_then(Value::as_u64)
             .and_then(|start| u32::try_from(start).ok()),
         "MemberExpression" => obj
-            .get("object")
+            .field("object")
             .and_then(extract_root_identifier_start_from_json),
         "ChainExpression" | "TSAsExpression" | "TSNonNullExpression" | "TSSatisfiesExpression" => {
-            obj.get("expression")
+            obj.field("expression")
                 .and_then(extract_root_identifier_start_from_json)
         }
         _ => None,
@@ -6516,7 +6593,7 @@ fn is_non_coercive_operator(operator: &str) -> bool {
 /// Identifier -> returns "Identifier".
 fn unwrap_ts_expression_type(value: &Value) -> Option<&str> {
     let obj = value.as_object()?;
-    let node_type = obj.get("type").and_then(|t| t.as_str())?;
+    let node_type = obj.field("type").and_then(|t| t.as_str())?;
 
     match node_type {
         "TSAsExpression"
@@ -6525,7 +6602,7 @@ fn unwrap_ts_expression_type(value: &Value) -> Option<&str> {
         | "TSTypeAssertion"
         | "TSInstantiationExpression" => {
             // Unwrap to the inner expression
-            if let Some(expr) = obj.get("expression") {
+            if let Some(expr) = obj.field("expression") {
                 unwrap_ts_expression_type(expr)
             } else {
                 Some(node_type)
@@ -7084,16 +7161,16 @@ fn collect_param_names_from_jsnode(node: &JsNode, names: &mut Vec<String>) {
 /// Extract the identifier name from a JSON value, unwrapping any TypeScript expression wrappers.
 fn get_identifier_name_from_json(value: &Value) -> Option<&str> {
     let obj = value.as_object()?;
-    let node_type = obj.get("type").and_then(|t| t.as_str())?;
+    let node_type = obj.field("type").and_then(|t| t.as_str())?;
 
     match node_type {
-        "Identifier" => obj.get("name").and_then(|n| n.as_str()),
+        "Identifier" => obj.field("name").and_then(|n| n.as_str()),
         "TSAsExpression"
         | "TSNonNullExpression"
         | "TSSatisfiesExpression"
         | "TSTypeAssertion"
         | "TSInstantiationExpression" => obj
-            .get("expression")
+            .field("expression")
             .and_then(get_identifier_name_from_json),
         _ => None,
     }
@@ -7112,7 +7189,10 @@ fn convert_update_expression(
     obj: &serde_json::Map<String, Value>,
     context: &mut ComponentContext,
 ) -> JsExpr {
-    let operator_str = obj.get("operator").and_then(|o| o.as_str()).unwrap_or("++");
+    let operator_str = obj
+        .field("operator")
+        .and_then(|o| o.as_str())
+        .unwrap_or("++");
 
     let operator = match operator_str {
         "++" => JsUpdateOp::Increment,
@@ -7120,9 +7200,12 @@ fn convert_update_expression(
         _ => JsUpdateOp::Increment,
     };
 
-    let prefix = obj.get("prefix").and_then(|p| p.as_bool()).unwrap_or(true);
+    let prefix = obj
+        .field("prefix")
+        .and_then(|p| p.as_bool())
+        .unwrap_or(true);
 
-    let argument_value = obj.get("argument");
+    let argument_value = obj.field("argument");
     let original_root_name = argument_value.and_then(extract_root_identifier_from_json);
 
     // Before converting the argument (which applies read transforms), check if the
@@ -7148,15 +7231,15 @@ fn convert_update_expression(
 
     // Check if the argument is a MemberExpression with a direct Identifier object
     let is_direct_member_update = if let Some(arg_obj) = argument_value.and_then(|a| a.as_object())
-        && let Some("MemberExpression") = arg_obj.get("type").and_then(|t| t.as_str())
+        && let Some("MemberExpression") = arg_obj.field("type").and_then(|t| t.as_str())
     {
         let computed = arg_obj
-            .get("computed")
+            .field("computed")
             .and_then(|c| c.as_bool())
             .unwrap_or(false);
         if !computed {
-            if let Some(object_obj) = arg_obj.get("object").and_then(|o| o.as_object())
-                && let Some("Identifier") = object_obj.get("type").and_then(|t| t.as_str())
+            if let Some(object_obj) = arg_obj.field("object").and_then(|o| o.as_object())
+                && let Some("Identifier") = object_obj.field("type").and_then(|t| t.as_str())
             {
                 true
             } else {
@@ -7219,7 +7302,7 @@ fn convert_update_expression(
         result,
         original_root_name.as_deref(),
         argument_value
-            .and_then(|argument| argument.get("type"))
+            .and_then(|argument| argument.field("type"))
             .and_then(|node_type| node_type.as_str())
             == Some("MemberExpression"),
         context,
@@ -7246,9 +7329,9 @@ fn convert_update_expression(
 /// Extract an identifier name from a JSON AST node if it's a simple Identifier.
 fn extract_identifier_name_from_json(value: &Value) -> Option<String> {
     let obj = value.as_object()?;
-    let node_type = obj.get("type").and_then(|t| t.as_str())?;
+    let node_type = obj.field("type").and_then(|t| t.as_str())?;
     if node_type == "Identifier" {
-        obj.get("name").and_then(|n| n.as_str()).map(String::from)
+        obj.field("name").and_then(|n| n.as_str()).map(String::from)
     } else {
         None
     }
@@ -7401,7 +7484,7 @@ fn convert_sequence_expression(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let expressions = obj
-        .get("expressions")
+        .field("expressions")
         .and_then(|e| e.as_array())
         .map(|exprs| {
             exprs
@@ -7420,7 +7503,7 @@ fn convert_new_expression(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let callee = obj
-        .get("callee")
+        .field("callee")
         .map(|c| convert_json_chain_boundary(c, context))
         .unwrap_or_else(|| {
             context
@@ -7429,7 +7512,7 @@ fn convert_new_expression(
         });
 
     let arguments = obj
-        .get("arguments")
+        .field("arguments")
         .and_then(|a| a.as_array())
         .map(|args| {
             args.iter()
@@ -7447,12 +7530,12 @@ fn convert_await_expression(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let argument = obj
-        .get("argument")
+        .field("argument")
         .map(|a| convert_json_value(a, context))
         .unwrap_or(JsExpr::Literal(JsLiteral::Null));
 
     // Check if this await is in the pickled_awaits set (needs $.save() wrapping)
-    let start = obj.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as u32;
+    let start = obj.field("start").and_then(|s| s.as_u64()).unwrap_or(0) as u32;
     if context.state.analysis.pickled_awaits.contains(&start)
         && !context.state.suppress_pickled_await_instrumentation.get()
     {
@@ -7510,7 +7593,7 @@ fn convert_yield_expression(
     obj: &serde_json::Map<String, Value>,
     context: &mut ComponentContext,
 ) -> JsExpr {
-    let argument = obj.get("argument").map(|a| {
+    let argument = obj.field("argument").map(|a| {
         Some({
             let __tmp = convert_json_value(a, context);
             context.arena.alloc_expr(__tmp)
@@ -7518,7 +7601,7 @@ fn convert_yield_expression(
     });
 
     let delegate = obj
-        .get("delegate")
+        .field("delegate")
         .and_then(|d| d.as_bool())
         .unwrap_or(false);
 
@@ -7534,7 +7617,7 @@ fn convert_spread_element(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let argument = obj
-        .get("argument")
+        .field("argument")
         .map(|a| {
             let __tmp = convert_json_value(a, context);
             context.arena.alloc_expr(__tmp)
@@ -7550,21 +7633,21 @@ fn convert_template_literal(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let quasis = obj
-        .get("quasis")
+        .field("quasis")
         .and_then(|q| q.as_array())
         .map(|quasis| {
             quasis
                 .iter()
                 .filter_map(|quasi| {
                     let quasi_obj = quasi.as_object()?;
-                    let value_obj = quasi_obj.get("value")?.as_object()?;
-                    let raw = value_obj.get("raw")?.as_str()?.to_string();
+                    let value_obj = quasi_obj.field("value")?.as_object()?;
+                    let raw = value_obj.field("raw")?.as_str()?.to_string();
                     let cooked = value_obj
-                        .get("cooked")
+                        .field("cooked")
                         .and_then(|c| c.as_str())
                         .unwrap_or(&raw)
                         .to_string();
-                    let tail = quasi_obj.get("tail")?.as_bool()?;
+                    let tail = quasi_obj.field("tail")?.as_bool()?;
 
                     Some(JsTemplateElement {
                         raw: raw.into(),
@@ -7577,7 +7660,7 @@ fn convert_template_literal(
         .unwrap_or_default();
 
     let expressions = obj
-        .get("expressions")
+        .field("expressions")
         .and_then(|e| e.as_array())
         .map(|exprs| {
             exprs
@@ -7603,7 +7686,7 @@ fn convert_tagged_template_expression(
 ) -> JsExpr {
     // Convert the tag expression
     let tag = obj
-        .get("tag")
+        .field("tag")
         .map(|t| {
             let __tmp = convert_json_value(t, context);
             context.arena.alloc_expr(__tmp)
@@ -7616,7 +7699,7 @@ fn convert_tagged_template_expression(
 
     // Convert the quasi (template literal)
     let quasi = obj
-        .get("quasi")
+        .field("quasi")
         .and_then(|q| q.as_object())
         .map(|q| {
             // Convert the quasi which is a TemplateLiteral
@@ -7644,7 +7727,7 @@ fn convert_chain_expression(
     context: &mut ComponentContext,
 ) -> JsExpr {
     // The expression inside a ChainExpression
-    if let Some(expression) = obj.get("expression") {
+    if let Some(expression) = obj.field("expression") {
         convert_json_value(expression, context)
     } else {
         JsExpr::Raw("/* ChainExpression: missing expression */".into())

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -17,6 +17,7 @@ use crate::compiler::phases::phase3_transform::client::visitors::shared::element
 use crate::compiler::phases::phase3_transform::client::visitors::shared::events::build_event_handler;
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use indexmap::IndexMap;
 
 /// Component node types.
@@ -962,19 +963,20 @@ pub(in crate::compiler::phases::phase3_transform::client) fn build_destructured_
 /// (`AssignmentExpression`) deliberately bind nothing.
 fn extract_let_binding_names(json: &serde_json::Value, out: &mut Vec<compact_str::CompactString>) {
     let Some(obj) = json.as_object() else { return };
-    match obj.get("type").and_then(|t| t.as_str()) {
+    match obj.field("type").and_then(|t| t.as_str()) {
         Some("Identifier") => {
-            if let Some(name) = obj.get("name").and_then(|n| n.as_str()) {
+            if let Some(name) = obj.field("name").and_then(|n| n.as_str()) {
                 out.push(name.into());
             }
         }
         Some("ObjectExpression") => {
-            if let Some(props) = obj.get("properties").and_then(|p| p.as_array()) {
+            if let Some(props) = obj.field("properties").and_then(|p| p.as_array()) {
                 for prop in props {
-                    let target = if prop.get("type").and_then(|t| t.as_str()) == Some("Property") {
-                        prop.get("value")
+                    let target = if prop.field("type").and_then(|t| t.as_str()) == Some("Property")
+                    {
+                        prop.field("value")
                     } else {
-                        prop.get("argument")
+                        prop.field("argument")
                     };
                     if let Some(target) = target {
                         extract_let_binding_names(target, out);
@@ -983,7 +985,7 @@ fn extract_let_binding_names(json: &serde_json::Value, out: &mut Vec<compact_str
             }
         }
         Some("ArrayExpression") => {
-            if let Some(elements) = obj.get("elements").and_then(|e| e.as_array()) {
+            if let Some(elements) = obj.field("elements").and_then(|e| e.as_array()) {
                 for el in elements {
                     if !el.is_null() {
                         extract_let_binding_names(el, out);
@@ -1003,16 +1005,16 @@ fn expression_to_let_pattern(
     context: &mut ComponentContext,
 ) -> JsPattern {
     let source_slice = |o: &serde_json::Map<String, serde_json::Value>| -> Option<String> {
-        let s = o.get("start").and_then(|v| v.as_u64())? as usize;
-        let e = o.get("end").and_then(|v| v.as_u64())? as usize;
+        let s = o.field("start").and_then(|v| v.as_u64())? as usize;
+        let e = o.field("end").and_then(|v| v.as_u64())? as usize;
         context.state.analysis.source.get(s..e).map(str::to_string)
     };
     let Some(obj) = json.as_object() else {
         return b::id_pattern("$$unknown");
     };
-    match obj.get("type").and_then(|t| t.as_str()) {
+    match obj.field("type").and_then(|t| t.as_str()) {
         Some("Identifier") => b::id_pattern(
-            obj.get("name")
+            obj.field("name")
                 .and_then(|n| n.as_str())
                 .unwrap_or("$$unknown"),
         ),
@@ -1020,34 +1022,37 @@ fn expression_to_let_pattern(
         // so the pattern spellings alias the expression ones here.
         Some("ObjectExpression") | Some("ObjectPattern") => {
             let mut properties = Vec::new();
-            if let Some(props) = obj.get("properties").and_then(|p| p.as_array()) {
+            if let Some(props) = obj.field("properties").and_then(|p| p.as_array()) {
                 for prop in props {
                     let Some(p) = prop.as_object() else { continue };
-                    if p.get("type").and_then(|t| t.as_str()) != Some("Property") {
-                        if let Some(arg) = p.get("argument") {
+                    if p.field("type").and_then(|t| t.as_str()) != Some("Property") {
+                        if let Some(arg) = p.field("argument") {
                             properties.push(JsObjectPatternProperty::Rest(Box::new(
                                 expression_to_let_pattern(arg, context),
                             )));
                         }
                         continue;
                     }
-                    let computed = p.get("computed").and_then(|c| c.as_bool()).unwrap_or(false);
+                    let computed = p
+                        .field("computed")
+                        .and_then(|c| c.as_bool())
+                        .unwrap_or(false);
                     let shorthand = p
-                        .get("shorthand")
+                        .field("shorthand")
                         .and_then(|s| s.as_bool())
                         .unwrap_or(false);
-                    let Some(key_obj) = p.get("key").and_then(|k| k.as_object()) else {
+                    let Some(key_obj) = p.field("key").and_then(|k| k.as_object()) else {
                         continue;
                     };
                     let key = if computed {
                         let raw = source_slice(key_obj).unwrap_or_default();
                         JsPropertyKey::Computed(context.arena.alloc_expr(b::raw(raw)))
-                    } else if let Some(name) = key_obj.get("name").and_then(|n| n.as_str()) {
+                    } else if let Some(name) = key_obj.field("name").and_then(|n| n.as_str()) {
                         JsPropertyKey::Identifier(name.into())
                     } else {
                         let raw = source_slice(key_obj).unwrap_or_default();
                         let cooked = key_obj
-                            .get("value")
+                            .field("value")
                             .and_then(|v| v.as_str())
                             .unwrap_or("")
                             .into();
@@ -1057,7 +1062,7 @@ fn expression_to_let_pattern(
                         })
                     };
                     let value = p
-                        .get("value")
+                        .field("value")
                         .map(|v| expression_to_let_pattern(v, context))
                         .unwrap_or_else(|| b::id_pattern("$$unknown"));
                     properties.push(JsObjectPatternProperty::Property {
@@ -1072,7 +1077,7 @@ fn expression_to_let_pattern(
         }
         Some("ArrayExpression") | Some("ArrayPattern") => {
             let mut elements = Vec::new();
-            if let Some(els) = obj.get("elements").and_then(|e| e.as_array()) {
+            if let Some(els) = obj.field("elements").and_then(|e| e.as_array()) {
                 for el in els {
                     if el.is_null() {
                         elements.push(None);
@@ -1084,17 +1089,17 @@ fn expression_to_let_pattern(
             b::array_pattern(elements)
         }
         Some("SpreadElement") | Some("RestElement") => JsPattern::Rest(Box::new(
-            obj.get("argument")
+            obj.field("argument")
                 .map(|a| expression_to_let_pattern(a, context))
                 .unwrap_or_else(|| b::id_pattern("$$unknown")),
         )),
         Some("AssignmentExpression") | Some("AssignmentPattern") => {
             let left = obj
-                .get("left")
+                .field("left")
                 .map(|l| expression_to_let_pattern(l, context))
                 .unwrap_or_else(|| b::id_pattern("$$unknown"));
             let right_raw = obj
-                .get("right")
+                .field("right")
                 .and_then(|r| r.as_object())
                 .and_then(source_slice)
                 .unwrap_or_else(|| "undefined".to_string());
@@ -2249,13 +2254,13 @@ fn typed_is_store_member_expression(
 /// walk is checked against.
 fn json_is_store_member_expression(val: &serde_json::Value, context: &ComponentContext) -> bool {
     if let Some(obj) = val.as_object()
-        && let Some("MemberExpression") = obj.get("type").and_then(|t| t.as_str())
+        && let Some("MemberExpression") = obj.field("type").and_then(|t| t.as_str())
     {
         // Get the root object of the member expression chain
         let root = get_member_expression_root(obj);
         if let Some(root_obj) = root
-            && let Some("Identifier") = root_obj.get("type").and_then(|t| t.as_str())
-            && let Some(name) = root_obj.get("name").and_then(|n| n.as_str())
+            && let Some("Identifier") = root_obj.field("type").and_then(|t| t.as_str())
+            && let Some(name) = root_obj.field("name").and_then(|n| n.as_str())
             && let Some(binding) = context.state.get_binding(name)
         {
             return binding.kind
@@ -2269,9 +2274,9 @@ fn json_is_store_member_expression(val: &serde_json::Value, context: &ComponentC
 fn get_member_expression_root(
     obj: &serde_json::Map<String, serde_json::Value>,
 ) -> Option<&serde_json::Map<String, serde_json::Value>> {
-    let object = obj.get("object")?;
+    let object = obj.field("object")?;
     if let Some(inner_obj) = object.as_object() {
-        if inner_obj.get("type").and_then(|t| t.as_str()) == Some("MemberExpression") {
+        if inner_obj.field("type").and_then(|t| t.as_str()) == Some("MemberExpression") {
             return get_member_expression_root(inner_obj);
         }
         return Some(inner_obj);
@@ -2284,11 +2289,11 @@ fn get_member_expression_root(
 fn get_store_info_from_member(expr: &Expression) -> Option<(String, String)> {
     let val = expr.as_json();
     if let Some(obj) = val.as_object()
-        && let Some("MemberExpression") = obj.get("type").and_then(|t| t.as_str())
+        && let Some("MemberExpression") = obj.field("type").and_then(|t| t.as_str())
     {
         let root = get_member_expression_root(obj)?;
-        if let Some("Identifier") = root.get("type").and_then(|t| t.as_str())
-            && let Some(name) = root.get("name").and_then(|n| n.as_str())
+        if let Some("Identifier") = root.field("type").and_then(|t| t.as_str())
+            && let Some(name) = root.field("name").and_then(|n| n.as_str())
             && name.starts_with('$')
         {
             // $store -> store
@@ -3540,10 +3545,10 @@ fn get_binding_root_name(expr: &Expression) -> Option<String> {
 
 fn get_root_identifier_from_json(val: &serde_json::Value) -> Option<String> {
     let obj = val.as_object()?;
-    match obj.get("type")?.as_str()? {
-        "Identifier" => obj.get("name")?.as_str().map(|s| s.to_string()),
+    match obj.field("type")?.as_str()? {
+        "Identifier" => obj.field("name")?.as_str().map(|s| s.to_string()),
         "MemberExpression" => {
-            let object = obj.get("object")?;
+            let object = obj.field("object")?;
             get_root_identifier_from_json(object)
         }
         _ => None,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/events.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/events.rs
@@ -14,6 +14,7 @@ use crate::compiler::phases::phase3_transform::client::types::*;
 use crate::compiler::phases::phase3_transform::client::visitors::expression_converter::convert_expression;
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Build an event listener attachment.
 ///
@@ -127,7 +128,7 @@ fn typed_walk_for_call(node: &JsNode, arena: &ParseArena) -> bool {
 fn json_walk_for_call(val: &serde_json::Value) -> bool {
     match val {
         serde_json::Value::Object(obj) => {
-            if let Some(t) = obj.get("type").and_then(|t| t.as_str()) {
+            if let Some(t) = obj.field("type").and_then(|t| t.as_str()) {
                 if t == "CallExpression" {
                     return true;
                 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -11,6 +11,7 @@ use crate::compiler::phases::phase3_transform::client::visitors::shared::assignm
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::builders::is_valid_identifier;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 // The `scope.evaluate` port lives with the server transform, but it is the one
 // shared model of a folded JS value used by Phase 2 and both transforms.
 use crate::compiler::phases::phase3_transform::server::evaluate::{
@@ -3943,9 +3944,9 @@ pub(crate) fn collect_expression_identifiers_for_blockers(
 fn collect_expr_ids_recursive(val: &serde_json::Value, names: &mut Vec<String>) {
     match val {
         serde_json::Value::Object(obj) => {
-            let node_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            let node_type = obj.field("type").and_then(|v| v.as_str()).unwrap_or("");
             if node_type == "Identifier" {
-                if let Some(name) = obj.get("name").and_then(|v| v.as_str())
+                if let Some(name) = obj.field("name").and_then(|v| v.as_str())
                     && !names.contains(&name.to_string())
                 {
                     names.push(name.to_string());
@@ -4156,7 +4157,7 @@ fn eval_value_text(v: &EvalValue) -> Option<Option<String>> {
 /// Fold a template expression through the shared port of upstream
 /// `scope.evaluate`.
 fn get_literal_value_json(jv: &serde_json::Value, context: &ComponentContext) -> Option<EvalValue> {
-    let expr_type = jv.get("type").and_then(|t| t.as_str())?;
+    let expr_type = jv.field("type").and_then(|t| t.as_str())?;
 
     // `build_template_chunk` memoizes first. A call-bearing chunk is therefore
     // an opaque temporary by the time upstream evaluates it, while recursion
@@ -4181,7 +4182,7 @@ fn get_literal_value_json(jv: &serde_json::Value, context: &ComponentContext) ->
     // source binding would evaluate a different expression.
     if expr_type == "Identifier"
         && jv
-            .get("name")
+            .field("name")
             .and_then(|name| name.as_str())
             .is_some_and(|name| context.state.transform.contains_key(name))
     {
@@ -4406,15 +4407,15 @@ pub(crate) fn is_expression_defined(
 /// Dotted keypath of a static estree-JSON callee (`Math.round` → `"Math.round"`).
 pub(crate) fn json_keypath(node: &serde_json::Value) -> Option<String> {
     let obj = node.as_object()?;
-    match obj.get("type").and_then(|t| t.as_str())? {
-        "Identifier" => obj.get("name").and_then(|n| n.as_str()).map(String::from),
-        "MemberExpression" if obj.get("computed").and_then(|c| c.as_bool()) != Some(true) => {
-            let prop = obj.get("property")?.as_object()?;
-            if prop.get("type").and_then(|t| t.as_str()) != Some("Identifier") {
+    match obj.field("type").and_then(|t| t.as_str())? {
+        "Identifier" => obj.field("name").and_then(|n| n.as_str()).map(String::from),
+        "MemberExpression" if obj.field("computed").and_then(|c| c.as_bool()) != Some(true) => {
+            let prop = obj.field("property")?.as_object()?;
+            if prop.field("type").and_then(|t| t.as_str()) != Some("Identifier") {
                 return None;
             }
-            let prop_name = prop.get("name").and_then(|n| n.as_str())?;
-            let base = json_keypath(obj.get("object")?)?;
+            let prop_name = prop.field("name").and_then(|n| n.as_str())?;
+            let base = json_keypath(obj.field("object")?)?;
             Some(format!("{base}.{prop_name}"))
         }
         _ => None,
@@ -4470,7 +4471,7 @@ fn analyze_props_json(
     let Some(obj) = json_value.as_object() else {
         return;
     };
-    let Some(expr_type) = obj.get("type").and_then(|v| v.as_str()) else {
+    let Some(expr_type) = obj.field("type").and_then(|v| v.as_str()) else {
         return;
     };
 
@@ -4479,7 +4480,7 @@ fn analyze_props_json(
             // has_member: no
             // has_await: no
             // has_state: check bindings/transforms
-            if !props.has_state && obj.get("name").and_then(|v| v.as_str()).is_some() {
+            if !props.has_state && obj.field("name").and_then(|v| v.as_str()).is_some() {
                 props.has_state = has_reactive_state_json(json_value, context);
             }
         }
@@ -4494,7 +4495,7 @@ fn analyze_props_json(
 
             // has_await: check object subtree
             if !props.has_await
-                && let Some(object) = obj.get("object")
+                && let Some(object) = obj.field("object")
             {
                 props.has_await = has_await_json(object);
             }
@@ -4507,13 +4508,13 @@ fn analyze_props_json(
 
             // has_member: check callee and arguments
             if !props.has_member {
-                if let Some(callee) = obj.get("callee")
+                if let Some(callee) = obj.field("callee")
                     && has_member_json(callee)
                 {
                     props.has_member = true;
                 }
                 if !props.has_member
-                    && let Some(args) = obj.get("arguments").and_then(|v| v.as_array())
+                    && let Some(args) = obj.field("arguments").and_then(|v| v.as_array())
                 {
                     for arg in args {
                         if has_member_json(arg) {
@@ -4526,13 +4527,13 @@ fn analyze_props_json(
 
             // has_await: check callee and arguments
             if !props.has_await {
-                if let Some(callee) = obj.get("callee")
+                if let Some(callee) = obj.field("callee")
                     && has_await_json(callee)
                 {
                     props.has_await = true;
                 }
                 if !props.has_await
-                    && let Some(args) = obj.get("arguments").and_then(|v| v.as_array())
+                    && let Some(args) = obj.field("arguments").and_then(|v| v.as_array())
                 {
                     for arg in args {
                         if has_await_json(arg) {
@@ -4547,10 +4548,10 @@ fn analyze_props_json(
             // Upstream's `NewExpression` visitor only calls `context.next()`, so a
             // `new` contributes no flag of its own — every flag comes from the
             // callee and the arguments.
-            if let Some(callee) = obj.get("callee") {
+            if let Some(callee) = obj.field("callee") {
                 analyze_props_json(callee, context, props);
             }
-            if let Some(args) = obj.get("arguments").and_then(|v| v.as_array()) {
+            if let Some(args) = obj.field("arguments").and_then(|v| v.as_array()) {
                 for arg in args {
                     analyze_props_json(arg, context, props);
                 }
@@ -4564,15 +4565,15 @@ fn analyze_props_json(
             // has_member: not directly, but don't need to recurse for state/await
         }
         "BinaryExpression" | "LogicalExpression" => {
-            if let Some(left) = obj.get("left") {
+            if let Some(left) = obj.field("left") {
                 analyze_props_json(left, context, props);
             }
-            if let Some(right) = obj.get("right") {
+            if let Some(right) = obj.field("right") {
                 analyze_props_json(right, context, props);
             }
         }
         "UnaryExpression" => {
-            if let Some(argument) = obj.get("argument") {
+            if let Some(argument) = obj.field("argument") {
                 analyze_props_json(argument, context, props);
             }
         }
@@ -4584,19 +4585,19 @@ fn analyze_props_json(
             }
         }
         "TemplateLiteral" => {
-            if let Some(exprs) = obj.get("expressions").and_then(|v| v.as_array()) {
+            if let Some(exprs) = obj.field("expressions").and_then(|v| v.as_array()) {
                 for expr_val in exprs {
                     analyze_props_json(expr_val, context, props);
                 }
             }
         }
         "ChainExpression" => {
-            if let Some(expression) = obj.get("expression") {
+            if let Some(expression) = obj.field("expression") {
                 analyze_props_json(expression, context, props);
             }
         }
         "SequenceExpression" => {
-            if let Some(expressions) = obj.get("expressions").and_then(|v| v.as_array()) {
+            if let Some(expressions) = obj.field("expressions").and_then(|v| v.as_array()) {
                 for expr_val in expressions {
                     analyze_props_json(expr_val, context, props);
                 }
@@ -4634,17 +4635,17 @@ fn analyze_props_json(
             // has_await: not checked for AssignmentExpression by has_await_json
         }
         "ArrayExpression" => {
-            if let Some(elements) = obj.get("elements").and_then(|v| v.as_array()) {
+            if let Some(elements) = obj.field("elements").and_then(|v| v.as_array()) {
                 for elem in elements {
                     analyze_props_json(elem, context, props);
                 }
             }
         }
         "ObjectExpression" => {
-            if let Some(properties) = obj.get("properties").and_then(|v| v.as_array()) {
+            if let Some(properties) = obj.field("properties").and_then(|v| v.as_array()) {
                 for prop in properties {
                     if let Some(prop_obj) = prop.as_object()
-                        && let Some(value) = prop_obj.get("value")
+                        && let Some(value) = prop_obj.field("value")
                     {
                         analyze_props_json(value, context, props);
                     }
@@ -4652,7 +4653,7 @@ fn analyze_props_json(
             }
         }
         "SpreadElement" => {
-            if let Some(argument) = obj.get("argument") {
+            if let Some(argument) = obj.field("argument") {
                 analyze_props_json(argument, context, props);
             }
         }
@@ -4674,10 +4675,10 @@ fn analyze_props_json(
         "ImportExpression" => {
             // Upstream has no visitor either, so `import(x)` is not a call —
             // only what it is given can be reactive.
-            if let Some(source) = obj.get("source") {
+            if let Some(source) = obj.field("source") {
                 analyze_props_json(source, context, props);
             }
-            if let Some(options) = obj.get("options") {
+            if let Some(options) = obj.field("options") {
                 analyze_props_json(options, context, props);
             }
         }
@@ -5293,15 +5294,18 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
     let Some(obj) = json_value.as_object() else {
         return false;
     };
-    let Some(expr_type) = obj.get("type").and_then(|v| v.as_str()) else {
+    let Some(expr_type) = obj.field("type").and_then(|v| v.as_str()) else {
         return false;
     };
 
     match expr_type {
         "Identifier" => {
             // Check if identifier is a reactive binding
-            if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
-                let start = obj.get("start").and_then(|v| v.as_u64()).map(|v| v as u32);
+            if let Some(name) = obj.field("name").and_then(|v| v.as_str()) {
+                let start = obj
+                    .field("start")
+                    .and_then(|v| v.as_u64())
+                    .map(|v| v as u32);
                 return identifier_has_reactive_state(name, start, context);
             }
             false
@@ -5314,7 +5318,7 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
                 return true;
             }
             // Check the object part - recurse directly with JSON reference
-            if let Some(object) = obj.get("object") {
+            if let Some(object) = obj.field("object") {
                 // First check if the object itself references reactive state
                 if has_reactive_state_json(object, context) {
                     return true;
@@ -5325,8 +5329,8 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
                 // Since we can't statically determine if the property is reactive,
                 // conservatively treat all member expressions on local variables as potentially reactive.
                 if let Some(obj_inner) = object.as_object()
-                    && obj_inner.get("type").and_then(|t| t.as_str()) == Some("Identifier")
-                    && let Some(name) = obj_inner.get("name").and_then(|n| n.as_str())
+                    && obj_inner.field("type").and_then(|t| t.as_str()) == Some("Identifier")
+                    && let Some(name) = obj_inner.field("name").and_then(|n| n.as_str())
                 {
                     // Check if this is a local binding (not a global)
                     if context.state.get_binding(name).is_some() {
@@ -5340,8 +5344,8 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
             // `{ … }[size]` where `size` is a reactive prop is reactive even
             // though the object literal is not. (The object-only check above
             // misses this.)
-            if obj.get("computed").and_then(|v| v.as_bool()) == Some(true)
-                && let Some(property) = obj.get("property")
+            if obj.field("computed").and_then(|v| v.as_bool()) == Some(true)
+                && let Some(property) = obj.field("property")
                 && has_reactive_state_json(property, context)
             {
                 return true;
@@ -5351,16 +5355,16 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
         "CallExpression" => {
             // Check if callee is a pure global function that doesn't depend on reactive state
             // Pure functions like Math.*, encodeURIComponent, etc. are not reactive
-            if let Some(callee) = obj.get("callee").and_then(|v| v.as_object()) {
-                let callee_type = callee.get("type").and_then(|t| t.as_str());
+            if let Some(callee) = obj.field("callee").and_then(|v| v.as_object()) {
+                let callee_type = callee.field("type").and_then(|t| t.as_str());
 
                 // Check for pure global functions like Math.max, encodeURIComponent, etc.
                 if callee_type == Some("Identifier")
-                    && let Some(name) = callee.get("name").and_then(|n| n.as_str())
+                    && let Some(name) = callee.field("name").and_then(|n| n.as_str())
                 {
                     if PURE_GLOBALS.contains(&name) {
                         // Check if any arguments are reactive - recurse with JSON reference
-                        if let Some(args) = obj.get("arguments").and_then(|v| v.as_array()) {
+                        if let Some(args) = obj.field("arguments").and_then(|v| v.as_array()) {
                             for arg in args {
                                 if has_reactive_state_json(arg, context) {
                                     return true;
@@ -5381,7 +5385,7 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
                         return true;
                     } else {
                         // Unknown identifier without transform - could be a global, check arguments only
-                        if let Some(args) = obj.get("arguments").and_then(|v| v.as_array()) {
+                        if let Some(args) = obj.field("arguments").and_then(|v| v.as_array()) {
                             for arg in args {
                                 if has_reactive_state_json(arg, context) {
                                     return true;
@@ -5393,13 +5397,13 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
                 }
                 // Check for pure member expressions like Math.max, Math.min, etc.
                 if callee_type == Some("MemberExpression")
-                    && let Some(object) = callee.get("object").and_then(|o| o.as_object())
-                    && let Some("Identifier") = object.get("type").and_then(|t| t.as_str())
-                    && let Some(obj_name) = object.get("name").and_then(|n| n.as_str())
+                    && let Some(object) = callee.field("object").and_then(|o| o.as_object())
+                    && let Some("Identifier") = object.field("type").and_then(|t| t.as_str())
+                    && let Some(obj_name) = object.field("name").and_then(|n| n.as_str())
                     && PURE_OBJECTS.contains(&obj_name)
                 {
                     // Check if any arguments are reactive - recurse with JSON reference
-                    if let Some(args) = obj.get("arguments").and_then(|v| v.as_array()) {
+                    if let Some(args) = obj.field("arguments").and_then(|v| v.as_array()) {
                         for arg in args {
                             if has_reactive_state_json(arg, context) {
                                 return true;
@@ -5413,12 +5417,12 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
             // For other call expressions, check callee and arguments recursively.
             // A call is only reactive if the callee or arguments reference reactive state.
             // This handles cases like console.log('rendering') which should NOT be reactive.
-            if let Some(callee) = obj.get("callee")
+            if let Some(callee) = obj.field("callee")
                 && has_reactive_state_json(callee, context)
             {
                 return true;
             }
-            if let Some(args) = obj.get("arguments").and_then(|v| v.as_array()) {
+            if let Some(args) = obj.field("arguments").and_then(|v| v.as_array()) {
                 for arg in args {
                     if has_reactive_state_json(arg, context) {
                         return true;
@@ -5429,12 +5433,12 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
         }
         "BinaryExpression" | "LogicalExpression" => {
             // Check left and right - recurse with JSON reference
-            if let Some(left) = obj.get("left")
+            if let Some(left) = obj.field("left")
                 && has_reactive_state_json(left, context)
             {
                 return true;
             }
-            if let Some(right) = obj.get("right")
+            if let Some(right) = obj.field("right")
                 && has_reactive_state_json(right, context)
             {
                 return true;
@@ -5442,7 +5446,7 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
             false
         }
         "UnaryExpression" => {
-            if let Some(argument) = obj.get("argument") {
+            if let Some(argument) = obj.field("argument") {
                 return has_reactive_state_json(argument, context);
             }
             false
@@ -5458,7 +5462,7 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
             false
         }
         "TemplateLiteral" => {
-            if let Some(exprs) = obj.get("expressions").and_then(|v| v.as_array()) {
+            if let Some(exprs) = obj.field("expressions").and_then(|v| v.as_array()) {
                 for expr_val in exprs {
                     if has_reactive_state_json(expr_val, context) {
                         return true;
@@ -5469,14 +5473,14 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
         }
         "ChainExpression" => {
             // Optional chaining (e.g., `item?.name`) - recurse into inner expression
-            if let Some(expression) = obj.get("expression") {
+            if let Some(expression) = obj.field("expression") {
                 return has_reactive_state_json(expression, context);
             }
             false
         }
         "SequenceExpression" => {
             // Comma expressions (e.g., `(a, b)`) - check all sub-expressions
-            if let Some(expressions) = obj.get("expressions").and_then(|v| v.as_array()) {
+            if let Some(expressions) = obj.field("expressions").and_then(|v| v.as_array()) {
                 for expr_val in expressions {
                     if has_reactive_state_json(expr_val, context) {
                         return true;
@@ -5487,7 +5491,7 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
         }
         "AssignmentExpression" => {
             // Assignments (e.g., `a = b`) - check right side
-            if let Some(right) = obj.get("right") {
+            if let Some(right) = obj.field("right") {
                 return has_reactive_state_json(right, context);
             }
             false
@@ -5510,12 +5514,12 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
             // marks the enclosing expression `has_state` (it treats `{...x}`
             // like `{...x.values()}`), so a spread always makes the object
             // reactive.
-            if let Some(properties) = obj.get("properties").and_then(|v| v.as_array()) {
+            if let Some(properties) = obj.field("properties").and_then(|v| v.as_array()) {
                 for prop in properties {
-                    if prop.get("type").and_then(|t| t.as_str()) == Some("SpreadElement") {
+                    if prop.field("type").and_then(|t| t.as_str()) == Some("SpreadElement") {
                         return true;
                     }
-                    if let Some(value) = prop.as_object().and_then(|p| p.get("value"))
+                    if let Some(value) = prop.as_object().and_then(|p| p.field("value"))
                         && has_reactive_state_json(value, context)
                     {
                         return true;
@@ -5526,7 +5530,7 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
         }
         "ArrayExpression" => {
             // Check all elements
-            if let Some(elements) = obj.get("elements").and_then(|v| v.as_array()) {
+            if let Some(elements) = obj.field("elements").and_then(|v| v.as_array()) {
                 for elem in elements {
                     if has_reactive_state_json(elem, context) {
                         return true;
@@ -5543,12 +5547,12 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
             // `new Foo(args)` — reactive only if the constructor or any argument
             // references reactive state. This mirrors the official Svelte compiler,
             // where NewExpression does not set has_call/has_state by itself.
-            if let Some(callee) = obj.get("callee")
+            if let Some(callee) = obj.field("callee")
                 && has_reactive_state_json(callee, context)
             {
                 return true;
             }
-            if let Some(args) = obj.get("arguments").and_then(|v| v.as_array()) {
+            if let Some(args) = obj.field("arguments").and_then(|v| v.as_array()) {
                 for arg in args {
                     if has_reactive_state_json(arg, context) {
                         return true;
@@ -5570,12 +5574,12 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
         }
         "ImportExpression" => {
             // Not a call upstream — only its operands can be reactive.
-            if let Some(source) = obj.get("source")
+            if let Some(source) = obj.field("source")
                 && has_reactive_state_json(source, context)
             {
                 return true;
             }
-            if let Some(options) = obj.get("options")
+            if let Some(options) = obj.field("options")
                 && has_reactive_state_json(options, context)
             {
                 return true;
@@ -5603,7 +5607,7 @@ fn is_pure_json(json_value: &serde_json::Value, context: &ComponentContext) -> b
         // Primitives (strings, numbers, booleans, null) are pure
         return true;
     };
-    let Some(expr_type) = obj.get("type").and_then(|v| v.as_str()) else {
+    let Some(expr_type) = obj.field("type").and_then(|v| v.as_str()) else {
         return true;
     };
 
@@ -5611,7 +5615,7 @@ fn is_pure_json(json_value: &serde_json::Value, context: &ComponentContext) -> b
         "Literal" | "BooleanLiteral" | "NumericLiteral" | "StringLiteral" | "NullLiteral"
         | "BigIntLiteral" | "RegExpLiteral" => true,
         "Identifier" => {
-            if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
+            if let Some(name) = obj.field("name").and_then(|v| v.as_str()) {
                 // Rune identifiers ($effect, $state, etc.) are globals with no scope
                 // binding, so they are treated as pure. This matches the official
                 // Svelte compiler's is_pure() which considers globals (binding === null)
@@ -5626,20 +5630,20 @@ fn is_pure_json(json_value: &serde_json::Value, context: &ComponentContext) -> b
         "MemberExpression" => {
             // Special case: $effect.tracking is NOT pure, matching the official compiler's
             // check in is_pure(). This ensures $effect.tracking() gets has_call=true.
-            if obj.get("computed").and_then(|v| v.as_bool()) != Some(true) {
-                let is_tracking =
-                    obj.get("property")
-                        .and_then(|p| p.as_object())
-                        .is_some_and(|p_obj| {
-                            p_obj.get("type").and_then(|t| t.as_str()) == Some("Identifier")
-                                && p_obj.get("name").and_then(|n| n.as_str()) == Some("tracking")
-                        });
+            if obj.field("computed").and_then(|v| v.as_bool()) != Some(true) {
+                let is_tracking = obj
+                    .field("property")
+                    .and_then(|p| p.as_object())
+                    .is_some_and(|p_obj| {
+                        p_obj.field("type").and_then(|t| t.as_str()) == Some("Identifier")
+                            && p_obj.field("name").and_then(|n| n.as_str()) == Some("tracking")
+                    });
                 let is_effect_obj =
-                    obj.get("object")
+                    obj.field("object")
                         .and_then(|o| o.as_object())
                         .is_some_and(|o_obj| {
-                            o_obj.get("type").and_then(|t| t.as_str()) == Some("Identifier")
-                                && o_obj.get("name").and_then(|n| n.as_str()) == Some("$effect")
+                            o_obj.field("type").and_then(|t| t.as_str()) == Some("Identifier")
+                                && o_obj.field("name").and_then(|n| n.as_str()) == Some("$effect")
                         });
                 if is_tracking && is_effect_obj {
                     return false;
@@ -5649,8 +5653,8 @@ fn is_pure_json(json_value: &serde_json::Value, context: &ComponentContext) -> b
             // Walk to the leftmost object
             let mut left = json_value;
             while let Some(left_obj) = left.as_object()
-                && left_obj.get("type").and_then(|t| t.as_str()) == Some("MemberExpression")
-                && let Some(object) = left_obj.get("object")
+                && left_obj.field("type").and_then(|t| t.as_str()) == Some("MemberExpression")
+                && let Some(object) = left_obj.field("object")
             {
                 left = object;
             }
@@ -5658,17 +5662,17 @@ fn is_pure_json(json_value: &serde_json::Value, context: &ComponentContext) -> b
         }
         "CallExpression" => {
             // A call is pure if callee is pure and all args are pure
-            if let Some(callee) = obj.get("callee")
+            if let Some(callee) = obj.field("callee")
                 && !is_pure_json(callee, context)
             {
                 return false;
             }
-            if let Some(args) = obj.get("arguments").and_then(|v| v.as_array()) {
+            if let Some(args) = obj.field("arguments").and_then(|v| v.as_array()) {
                 for arg in args {
                     let arg_val = if let Some(arg_obj) = arg.as_object()
-                        && arg_obj.get("type").and_then(|t| t.as_str()) == Some("SpreadElement")
+                        && arg_obj.field("type").and_then(|t| t.as_str()) == Some("SpreadElement")
                     {
-                        arg_obj.get("argument").unwrap_or(arg)
+                        arg_obj.field("argument").unwrap_or(arg)
                     } else {
                         arg
                     };
@@ -5751,13 +5755,13 @@ fn arg_contains_state_or_raw_state_binding(
     let Some(obj) = json_value.as_object() else {
         return false;
     };
-    let Some(expr_type) = obj.get("type").and_then(|v| v.as_str()) else {
+    let Some(expr_type) = obj.field("type").and_then(|v| v.as_str()) else {
         return false;
     };
 
     match expr_type {
         "Identifier" => {
-            if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
+            if let Some(name) = obj.field("name").and_then(|v| v.as_str()) {
                 return context.state.get_binding(name).is_some_and(|b| {
                     matches!(
                         b.kind,
@@ -5795,13 +5799,13 @@ fn references_any_binding_json(json_value: &serde_json::Value, context: &Compone
     let Some(obj) = json_value.as_object() else {
         return false;
     };
-    let Some(expr_type) = obj.get("type").and_then(|v| v.as_str()) else {
+    let Some(expr_type) = obj.field("type").and_then(|v| v.as_str()) else {
         return false;
     };
 
     match expr_type {
         "Identifier" => obj
-            .get("name")
+            .field("name")
             .and_then(|v| v.as_str())
             .is_some_and(|name| context.state.get_binding(name).is_some()),
         // A non-computed member/key names a property, not a reference.
@@ -5816,7 +5820,7 @@ fn references_any_binding_json(json_value: &serde_json::Value, context: &Compone
             {
                 return true;
             }
-            obj.get("computed").and_then(|v| v.as_bool()) == Some(true)
+            obj.field("computed").and_then(|v| v.as_bool()) == Some(true)
                 && obj
                     .get(name_key)
                     .is_some_and(|name| references_any_binding_json(name, context))
@@ -5850,7 +5854,7 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
     let Some(obj) = json_value.as_object() else {
         return false;
     };
-    let Some(expr_type) = obj.get("type").and_then(|v| v.as_str()) else {
+    let Some(expr_type) = obj.field("type").and_then(|v| v.as_str()) else {
         return false;
     };
 
@@ -5859,12 +5863,12 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
             // Upstream TaggedTemplateExpression.js: has_call iff the TAG is not
             // pure — unlike CallExpression there is NO dependencies term, so
             // `String.raw`…${state}…`` stays unmemoized.
-            if let Some(tag) = obj.get("tag")
+            if let Some(tag) = obj.field("tag")
                 && !is_pure_json(tag, context)
             {
                 return true;
             }
-            if let Some(quasi) = obj.get("quasi")
+            if let Some(quasi) = obj.field("quasi")
                 && has_call_json(quasi, context)
             {
                 return true;
@@ -5880,7 +5884,7 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
             // A call is reactive if either:
             //   1. The callee references a local binding (not pure), or
             //   2. The containing expression has any reactive dependencies.
-            if let Some(callee) = obj.get("callee")
+            if let Some(callee) = obj.field("callee")
                 && !is_pure_json(callee, context)
             {
                 return true;
@@ -5896,14 +5900,14 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
                 || references_any_binding_json(json_value, context)
         }
         "MemberExpression" => {
-            if let Some(object) = obj.get("object")
+            if let Some(object) = obj.field("object")
                 && has_call_json(object, context)
             {
                 return true;
             }
             // Computed member (e.g. `arr[index_expr]`) — the computed key may contain calls.
-            if obj.get("computed").and_then(|v| v.as_bool()) == Some(true)
-                && let Some(property) = obj.get("property")
+            if obj.field("computed").and_then(|v| v.as_bool()) == Some(true)
+                && let Some(property) = obj.field("property")
                 && has_call_json(property, context)
             {
                 return true;
@@ -5911,12 +5915,12 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
             false
         }
         "BinaryExpression" | "LogicalExpression" => {
-            if let Some(left) = obj.get("left")
+            if let Some(left) = obj.field("left")
                 && has_call_json(left, context)
             {
                 return true;
             }
-            if let Some(right) = obj.get("right")
+            if let Some(right) = obj.field("right")
                 && has_call_json(right, context)
             {
                 return true;
@@ -5924,7 +5928,7 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
             false
         }
         "UnaryExpression" => {
-            if let Some(argument) = obj.get("argument") {
+            if let Some(argument) = obj.field("argument") {
                 return has_call_json(argument, context);
             }
             false
@@ -5940,7 +5944,7 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
             false
         }
         "TemplateLiteral" => {
-            if let Some(exprs) = obj.get("expressions").and_then(|v| v.as_array()) {
+            if let Some(exprs) = obj.field("expressions").and_then(|v| v.as_array()) {
                 for expr_val in exprs {
                     if has_call_json(expr_val, context) {
                         return true;
@@ -5950,7 +5954,7 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
             false
         }
         "ArrayExpression" => {
-            if let Some(elements) = obj.get("elements").and_then(|v| v.as_array()) {
+            if let Some(elements) = obj.field("elements").and_then(|v| v.as_array()) {
                 for elem in elements {
                     if has_call_json(elem, context) {
                         return true;
@@ -5960,23 +5964,23 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
             false
         }
         "ObjectExpression" => {
-            if let Some(properties) = obj.get("properties").and_then(|v| v.as_array()) {
+            if let Some(properties) = obj.field("properties").and_then(|v| v.as_array()) {
                 for prop in properties {
                     // A spread member (`...x`) is treated like `...x.values()`:
                     // upstream's SpreadElement visitor marks `has_call = true`.
-                    if prop.get("type").and_then(|t| t.as_str()) == Some("SpreadElement") {
+                    if prop.field("type").and_then(|t| t.as_str()) == Some("SpreadElement") {
                         return true;
                     }
                     if let Some(prop_obj) = prop.as_object() {
                         // Check property value for calls
-                        if let Some(value) = prop_obj.get("value")
+                        if let Some(value) = prop_obj.field("value")
                             && has_call_json(value, context)
                         {
                             return true;
                         }
                         // Check computed property key for calls (e.g., [createAttachmentKey()])
-                        if prop_obj.get("computed").and_then(|v| v.as_bool()) == Some(true)
-                            && let Some(key) = prop_obj.get("key")
+                        if prop_obj.field("computed").and_then(|v| v.as_bool()) == Some(true)
+                            && let Some(key) = prop_obj.field("key")
                             && has_call_json(key, context)
                         {
                             return true;
@@ -5989,7 +5993,7 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
         "SequenceExpression" => {
             // Check all expressions in the sequence for calls
             // e.g., (bar, $effect.tracking()) should return true because of the call
-            if let Some(exprs) = obj.get("expressions").and_then(|v| v.as_array()) {
+            if let Some(exprs) = obj.field("expressions").and_then(|v| v.as_array()) {
                 for expr_val in exprs {
                     if has_call_json(expr_val, context) {
                         return true;
@@ -6001,12 +6005,12 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
         "NewExpression" => {
             // A `new` is not itself a call upstream, but its callee and arguments
             // are still walked, so `new Foo(bar())` does carry `has_call`.
-            if let Some(callee) = obj.get("callee")
+            if let Some(callee) = obj.field("callee")
                 && has_call_json(callee, context)
             {
                 return true;
             }
-            if let Some(args) = obj.get("arguments").and_then(|v| v.as_array()) {
+            if let Some(args) = obj.field("arguments").and_then(|v| v.as_array()) {
                 for arg in args {
                     if has_call_json(arg, context) {
                         return true;
@@ -6016,7 +6020,7 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
             false
         }
         "AssignmentExpression" => {
-            if let Some(right) = obj.get("right") {
+            if let Some(right) = obj.field("right") {
                 return has_call_json(right, context);
             }
             false
@@ -6027,7 +6031,7 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
             true
         }
         "ChainExpression" => {
-            if let Some(expression) = obj.get("expression") {
+            if let Some(expression) = obj.field("expression") {
                 return has_call_json(expression, context);
             }
             false
@@ -6042,19 +6046,19 @@ fn has_member_json(json_value: &serde_json::Value) -> bool {
     let Some(obj) = json_value.as_object() else {
         return false;
     };
-    let Some(expr_type) = obj.get("type").and_then(|v| v.as_str()) else {
+    let Some(expr_type) = obj.field("type").and_then(|v| v.as_str()) else {
         return false;
     };
 
     match expr_type {
         "MemberExpression" => true,
         "CallExpression" | "NewExpression" => {
-            if let Some(callee) = obj.get("callee")
+            if let Some(callee) = obj.field("callee")
                 && has_member_json(callee)
             {
                 return true;
             }
-            if let Some(args) = obj.get("arguments").and_then(|v| v.as_array()) {
+            if let Some(args) = obj.field("arguments").and_then(|v| v.as_array()) {
                 for arg in args {
                     if has_member_json(arg) {
                         return true;
@@ -6064,12 +6068,12 @@ fn has_member_json(json_value: &serde_json::Value) -> bool {
             false
         }
         "BinaryExpression" | "LogicalExpression" => {
-            if let Some(left) = obj.get("left")
+            if let Some(left) = obj.field("left")
                 && has_member_json(left)
             {
                 return true;
             }
-            if let Some(right) = obj.get("right")
+            if let Some(right) = obj.field("right")
                 && has_member_json(right)
             {
                 return true;
@@ -6077,7 +6081,7 @@ fn has_member_json(json_value: &serde_json::Value) -> bool {
             false
         }
         "UnaryExpression" => {
-            if let Some(argument) = obj.get("argument") {
+            if let Some(argument) = obj.field("argument") {
                 return has_member_json(argument);
             }
             false
@@ -6093,7 +6097,7 @@ fn has_member_json(json_value: &serde_json::Value) -> bool {
             false
         }
         "TemplateLiteral" => {
-            if let Some(exprs) = obj.get("expressions").and_then(|v| v.as_array()) {
+            if let Some(exprs) = obj.field("expressions").and_then(|v| v.as_array()) {
                 for expr_val in exprs {
                     if has_member_json(expr_val) {
                         return true;
@@ -6103,7 +6107,7 @@ fn has_member_json(json_value: &serde_json::Value) -> bool {
             false
         }
         "ArrayExpression" => {
-            if let Some(elements) = obj.get("elements").and_then(|v| v.as_array()) {
+            if let Some(elements) = obj.field("elements").and_then(|v| v.as_array()) {
                 for elem in elements {
                     if has_member_json(elem) {
                         return true;
@@ -6113,9 +6117,9 @@ fn has_member_json(json_value: &serde_json::Value) -> bool {
             false
         }
         "ObjectExpression" => {
-            if let Some(properties) = obj.get("properties").and_then(|v| v.as_array()) {
+            if let Some(properties) = obj.field("properties").and_then(|v| v.as_array()) {
                 for prop in properties {
-                    if let Some(value) = prop.as_object().and_then(|p| p.get("value"))
+                    if let Some(value) = prop.as_object().and_then(|p| p.field("value"))
                         && has_member_json(value)
                     {
                         return true;
@@ -6125,7 +6129,7 @@ fn has_member_json(json_value: &serde_json::Value) -> bool {
             false
         }
         "SequenceExpression" => {
-            if let Some(exprs) = obj.get("expressions").and_then(|v| v.as_array()) {
+            if let Some(exprs) = obj.field("expressions").and_then(|v| v.as_array()) {
                 for expr_val in exprs {
                     if has_member_json(expr_val) {
                         return true;
@@ -6193,19 +6197,19 @@ fn has_await_json(json_value: &serde_json::Value) -> bool {
     let Some(obj) = json_value.as_object() else {
         return false;
     };
-    let Some(expr_type) = obj.get("type").and_then(|v| v.as_str()) else {
+    let Some(expr_type) = obj.field("type").and_then(|v| v.as_str()) else {
         return false;
     };
 
     match expr_type {
         "AwaitExpression" => true,
         "CallExpression" | "NewExpression" => {
-            if let Some(callee) = obj.get("callee")
+            if let Some(callee) = obj.field("callee")
                 && has_await_json(callee)
             {
                 return true;
             }
-            if let Some(args) = obj.get("arguments").and_then(|v| v.as_array()) {
+            if let Some(args) = obj.field("arguments").and_then(|v| v.as_array()) {
                 for arg in args {
                     if has_await_json(arg) {
                         return true;
@@ -6215,18 +6219,18 @@ fn has_await_json(json_value: &serde_json::Value) -> bool {
             false
         }
         "MemberExpression" => {
-            if let Some(object) = obj.get("object") {
+            if let Some(object) = obj.field("object") {
                 return has_await_json(object);
             }
             false
         }
         "BinaryExpression" | "LogicalExpression" => {
-            if let Some(left) = obj.get("left")
+            if let Some(left) = obj.field("left")
                 && has_await_json(left)
             {
                 return true;
             }
-            if let Some(right) = obj.get("right")
+            if let Some(right) = obj.field("right")
                 && has_await_json(right)
             {
                 return true;
@@ -6234,7 +6238,7 @@ fn has_await_json(json_value: &serde_json::Value) -> bool {
             false
         }
         "UnaryExpression" => {
-            if let Some(argument) = obj.get("argument") {
+            if let Some(argument) = obj.field("argument") {
                 return has_await_json(argument);
             }
             false
@@ -6250,7 +6254,7 @@ fn has_await_json(json_value: &serde_json::Value) -> bool {
             false
         }
         "TemplateLiteral" => {
-            if let Some(exprs) = obj.get("expressions").and_then(|v| v.as_array()) {
+            if let Some(exprs) = obj.field("expressions").and_then(|v| v.as_array()) {
                 for expr_val in exprs {
                     if has_await_json(expr_val) {
                         return true;
@@ -6260,7 +6264,7 @@ fn has_await_json(json_value: &serde_json::Value) -> bool {
             false
         }
         "ArrayExpression" => {
-            if let Some(elements) = obj.get("elements").and_then(|v| v.as_array()) {
+            if let Some(elements) = obj.field("elements").and_then(|v| v.as_array()) {
                 for elem in elements {
                     if has_await_json(elem) {
                         return true;
@@ -6270,9 +6274,9 @@ fn has_await_json(json_value: &serde_json::Value) -> bool {
             false
         }
         "ObjectExpression" => {
-            if let Some(properties) = obj.get("properties").and_then(|v| v.as_array()) {
+            if let Some(properties) = obj.field("properties").and_then(|v| v.as_array()) {
                 for prop in properties {
-                    if let Some(value) = prop.as_object().and_then(|p| p.get("value"))
+                    if let Some(value) = prop.as_object().and_then(|p| p.field("value"))
                         && has_await_json(value)
                     {
                         return true;
@@ -6282,7 +6286,7 @@ fn has_await_json(json_value: &serde_json::Value) -> bool {
             false
         }
         "SequenceExpression" => {
-            if let Some(expressions) = obj.get("expressions").and_then(|v| v.as_array()) {
+            if let Some(expressions) = obj.field("expressions").and_then(|v| v.as_array()) {
                 for expr_val in expressions {
                     if has_await_json(expr_val) {
                         return true;
@@ -6329,9 +6333,9 @@ impl EvalScope for ClientEvalScope<'_, '_> {
     fn evaluate_override(&self, node: &serde_json::Value, _depth: u8) -> Option<Evaluation> {
         if self.converted
             && self.context.state.options.dev
-            && node.get("type").and_then(|ty| ty.as_str()) == Some("BinaryExpression")
+            && node.field("type").and_then(|ty| ty.as_str()) == Some("BinaryExpression")
             && node
-                .get("operator")
+                .field("operator")
                 .and_then(|operator| operator.as_str())
                 .is_some_and(|operator| matches!(operator, "===" | "!==" | "==" | "!="))
         {
@@ -6368,7 +6372,7 @@ impl EvalScope for ClientEvalScope<'_, '_> {
             }
         }
         let reference_binding = node
-            .get("start")
+            .field("start")
             .and_then(|v| v.as_u64())
             .and_then(|start| {
                 self.context

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/snippet_block.rs
@@ -50,6 +50,7 @@ use crate::compiler::phases::phase3_transform::client::source_anchor::CommentReg
 use crate::compiler::phases::phase3_transform::client::types::ComponentContext;
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Visit a snippet block and generate the corresponding JavaScript code.
 ///
@@ -246,25 +247,25 @@ fn extract_param_names(param: &Expression) -> Vec<String> {
 
 fn extract_param_names_from_json(val: &serde_json::Value, names: &mut Vec<String>) {
     if let serde_json::Value::Object(obj) = val {
-        let param_type = obj.get("type").and_then(|v| v.as_str());
+        let param_type = obj.field("type").and_then(|v| v.as_str());
         match param_type {
             Some("Identifier") => {
-                if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
+                if let Some(name) = obj.field("name").and_then(|v| v.as_str()) {
                     names.push(name.to_string());
                 }
             }
             Some("AssignmentPattern") => {
-                if let Some(left) = obj.get("left") {
+                if let Some(left) = obj.field("left") {
                     extract_param_names_from_json(left, names);
                 }
             }
             Some("ObjectPattern") => {
-                if let Some(properties) = obj.get("properties").and_then(|v| v.as_array()) {
+                if let Some(properties) = obj.field("properties").and_then(|v| v.as_array()) {
                     for prop in properties {
-                        if let Some(value) = prop.get("value") {
+                        if let Some(value) = prop.field("value") {
                             extract_param_names_from_json(value, names);
-                        } else if prop.get("type").and_then(|v| v.as_str()) == Some("RestElement")
-                            && let Some(arg) = prop.get("argument")
+                        } else if prop.field("type").and_then(|v| v.as_str()) == Some("RestElement")
+                            && let Some(arg) = prop.field("argument")
                         {
                             extract_param_names_from_json(arg, names);
                         }
@@ -272,7 +273,7 @@ fn extract_param_names_from_json(val: &serde_json::Value, names: &mut Vec<String
                 }
             }
             Some("ArrayPattern") => {
-                if let Some(elements) = obj.get("elements").and_then(|v| v.as_array()) {
+                if let Some(elements) = obj.field("elements").and_then(|v| v.as_array()) {
                     for elem in elements {
                         if !elem.is_null() {
                             extract_param_names_from_json(elem, names);
@@ -281,7 +282,7 @@ fn extract_param_names_from_json(val: &serde_json::Value, names: &mut Vec<String
                 }
             }
             Some("RestElement") => {
-                if let Some(arg) = obj.get("argument") {
+                if let Some(arg) = obj.field("argument") {
                     extract_param_names_from_json(arg, names);
                 }
             }
@@ -302,11 +303,11 @@ fn process_parameter(
     let val = param.as_json();
 
     if let serde_json::Value::Object(obj) = val {
-        let param_type = obj.get("type").and_then(|v| v.as_str())?;
+        let param_type = obj.field("type").and_then(|v| v.as_str())?;
 
         if param_type == "Identifier" {
             // Simple identifier parameter: param = $.noop
-            let name = obj.get("name").and_then(|v| v.as_str())?;
+            let name = obj.field("name").and_then(|v| v.as_str())?;
 
             // Create assignment pattern: param = $.noop
             let pattern = JsPattern::Assignment(JsAssignmentPattern {
@@ -456,14 +457,14 @@ fn extract_snippet_paths(
         Some(o) => o,
         None => return,
     };
-    match obj.get("type").and_then(|t| t.as_str()) {
+    match obj.field("type").and_then(|t| t.as_str()) {
         Some("Identifier") => {
-            if let Some(name) = obj.get("name").and_then(|n| n.as_str()) {
+            if let Some(name) = obj.field("name").and_then(|n| n.as_str()) {
                 emit_snippet_path(name, base, has_default, paths, context);
             }
         }
         Some("ObjectPattern") => {
-            let props = match obj.get("properties").and_then(|p| p.as_array()) {
+            let props = match obj.field("properties").and_then(|p| p.as_array()) {
                 Some(p) => p,
                 None => return,
             };
@@ -472,13 +473,15 @@ fn extract_snippet_paths(
                     Some(o) => o,
                     None => continue,
                 };
-                match prop_obj.get("type").and_then(|t| t.as_str()) {
+                match prop_obj.field("type").and_then(|t| t.as_str()) {
                     Some("RestElement") => {
                         // `$.exclude_from_object(base, ['k1', 'k2', ...])`
                         let keys: Vec<JsExpr> = props
                             .iter()
                             .filter_map(|p| p.as_object())
-                            .filter(|p| p.get("type").and_then(|t| t.as_str()) == Some("Property"))
+                            .filter(|p| {
+                                p.field("type").and_then(|t| t.as_str()) == Some("Property")
+                            })
                             .filter_map(|p| object_pattern_key_literal(p, context))
                             .collect();
                         let rest_expr = b::call(
@@ -486,7 +489,7 @@ fn extract_snippet_paths(
                             b::member_path(&context.arena, "$.exclude_from_object"),
                             vec![base.clone(), b::array(keys)],
                         );
-                        if let Some(arg) = prop_obj.get("argument") {
+                        if let Some(arg) = prop_obj.field("argument") {
                             extract_snippet_paths(
                                 arg,
                                 rest_expr,
@@ -500,7 +503,7 @@ fn extract_snippet_paths(
                     Some("Property") => {
                         let access =
                             object_pattern_property_access(prop_obj, base.clone(), context);
-                        if let Some(value) = prop_obj.get("value") {
+                        if let Some(value) = prop_obj.field("value") {
                             extract_snippet_paths(
                                 value,
                                 access,
@@ -516,7 +519,7 @@ fn extract_snippet_paths(
             }
         }
         Some("ArrayPattern") => {
-            let elements = match obj.get("elements").and_then(|e| e.as_array()) {
+            let elements = match obj.field("elements").and_then(|e| e.as_array()) {
                 Some(e) => e,
                 None => return,
             };
@@ -524,7 +527,7 @@ fn extract_snippet_paths(
             let has_rest = elements
                 .last()
                 .and_then(|e| e.as_object())
-                .and_then(|o| o.get("type"))
+                .and_then(|o| o.field("type"))
                 .and_then(|t| t.as_str())
                 == Some("RestElement");
 
@@ -568,14 +571,14 @@ fn extract_snippet_paths(
                         vec![b::id(&array_name)],
                     )
                 };
-                if elem_obj.get("type").and_then(|t| t.as_str()) == Some("RestElement") {
+                if elem_obj.field("type").and_then(|t| t.as_str()) == Some("RestElement") {
                     // `$.get($$array).slice(i)`
                     let slice_expr = b::call(
                         &context.arena,
                         b::member(&context.arena, array_get(), "slice"),
                         vec![b::number(i as f64)],
                     );
-                    if let Some(arg) = elem_obj.get("argument") {
+                    if let Some(arg) = elem_obj.field("argument") {
                         extract_snippet_paths(
                             arg,
                             slice_expr,
@@ -595,7 +598,7 @@ fn extract_snippet_paths(
         }
         Some("AssignmentPattern") => {
             // `$.fallback(base, default[, true])`, then recurse the left with has_default.
-            if let (Some(left), Some(right)) = (obj.get("left"), obj.get("right")) {
+            if let (Some(left), Some(right)) = (obj.field("left"), obj.field("right")) {
                 let mut fallback_args = vec![base];
                 fallback_args.extend(build_fallback_args(right, context));
                 let fallback_call = b::call(
@@ -618,17 +621,17 @@ fn object_pattern_property_access(
     context: &mut ComponentContext,
 ) -> JsExpr {
     let computed = prop
-        .get("computed")
+        .field("computed")
         .and_then(|c| c.as_bool())
         .unwrap_or(false);
-    let key = prop.get("key").and_then(|k| k.as_object());
+    let key = prop.field("key").and_then(|k| k.as_object());
     let key_type = key
-        .and_then(|k| k.get("type"))
+        .and_then(|k| k.field("type"))
         .and_then(|t| t.as_str())
         .unwrap_or("");
     if !computed
         && key_type == "Identifier"
-        && let Some(name) = key.and_then(|k| k.get("name")).and_then(|n| n.as_str())
+        && let Some(name) = key.and_then(|k| k.field("name")).and_then(|n| n.as_str())
     {
         return b::member(&context.arena, base, name);
     }
@@ -647,16 +650,16 @@ fn object_pattern_key_literal(
     context: &mut ComponentContext,
 ) -> Option<JsExpr> {
     let computed = prop
-        .get("computed")
+        .field("computed")
         .and_then(|c| c.as_bool())
         .unwrap_or(false);
-    let key = prop.get("key").and_then(|k| k.as_object())?;
-    let key_type = key.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    let key = prop.field("key").and_then(|k| k.as_object())?;
+    let key_type = key.field("type").and_then(|t| t.as_str()).unwrap_or("");
     if key_type == "Identifier" && !computed {
-        let name = key.get("name").and_then(|n| n.as_str())?;
+        let name = key.field("name").and_then(|n| n.as_str())?;
         Some(b::string(name))
     } else if key_type == "Literal" {
-        let val = key.get("value")?;
+        let val = key.field("value")?;
         let s = match val {
             serde_json::Value::String(s) => s.clone(),
             other => other.to_string(),
@@ -690,14 +693,14 @@ fn process_assignment_pattern(
     index: usize,
     context: &mut ComponentContext,
 ) -> Option<ParameterInfo> {
-    let left = obj.get("left").and_then(|l| l.as_object())?;
-    let right = obj.get("right")?;
+    let left = obj.field("left").and_then(|l| l.as_object())?;
+    let right = obj.field("right")?;
 
     // Get the parameter name from the left side
-    let left_type = left.get("type").and_then(|t| t.as_str())?;
+    let left_type = left.field("type").and_then(|t| t.as_str())?;
 
     if left_type == "Identifier" {
-        let name = left.get("name").and_then(|n| n.as_str())?;
+        let name = left.field("name").and_then(|n| n.as_str())?;
         let arg_alias = format!("$$arg{}", index);
 
         // Build the fallback expression
@@ -809,13 +812,13 @@ fn build_fallback_args(
         // When the default is `func()` (CallExpression with 0 args and Identifier callee),
         // just pass `func` instead of `() => func()`. This matches Svelte's `unthunk` in builders.js.
         if let Some(obj) = default_value.as_object()
-            && obj.get("type").and_then(|t| t.as_str()) == Some("CallExpression")
+            && obj.field("type").and_then(|t| t.as_str()) == Some("CallExpression")
             && obj
-                .get("arguments")
+                .field("arguments")
                 .and_then(|a| a.as_array())
                 .is_some_and(|a| a.is_empty())
-            && let Some(callee) = obj.get("callee").and_then(|c| c.as_object())
-            && callee.get("type").and_then(|t| t.as_str()) == Some("Identifier")
+            && let Some(callee) = obj.field("callee").and_then(|c| c.as_object())
+            && callee.field("type").and_then(|t| t.as_str()) == Some("Identifier")
         {
             // Optimization: pass just the callee identifier instead of thunking
             let callee_expr = convert_expression(
@@ -865,7 +868,8 @@ fn preserve_default_parentheses_tree(
         other => preserve_default_parentheses_inner(value, other, context),
     };
 
-    if root && value.get("type").and_then(serde_json::Value::as_str) == Some("SequenceExpression") {
+    if root && value.field("type").and_then(serde_json::Value::as_str) == Some("SequenceExpression")
+    {
         parenthesize_snippet_default(expr, context)
     } else {
         expr
@@ -877,7 +881,10 @@ fn preserve_default_parentheses_inner(
     expr: JsExpr,
     context: &ComponentContext,
 ) -> JsExpr {
-    match (value.get("type").and_then(serde_json::Value::as_str), expr) {
+    match (
+        value.field("type").and_then(serde_json::Value::as_str),
+        expr,
+    ) {
         (Some("ConditionalExpression"), JsExpr::Conditional(mut conditional)) => {
             for (key, slot) in [
                 ("test", &mut conditional.test),
@@ -892,7 +899,7 @@ fn preserve_default_parentheses_inner(
                     // conditional's consequent even though the grammar's
                     // right-associativity makes the grouping optional.
                     if key == "consequent"
-                        && child.get("type").and_then(serde_json::Value::as_str)
+                        && child.field("type").and_then(serde_json::Value::as_str)
                             == Some("ConditionalExpression")
                         && source_parenthesizes(child, &context.state.analysis.source)
                     {
@@ -905,7 +912,7 @@ fn preserve_default_parentheses_inner(
         }
         (Some("SequenceExpression"), JsExpr::Sequence(mut sequence)) => {
             if let Some(children) = value
-                .get("expressions")
+                .field("expressions")
                 .and_then(serde_json::Value::as_array)
             {
                 for (child, current) in children.iter().zip(sequence.expressions.iter_mut()) {
@@ -930,10 +937,10 @@ fn parenthesize_snippet_default(expr: JsExpr, context: &ComponentContext) -> JsE
 }
 
 fn source_parenthesizes(value: &serde_json::Value, source: &str) -> bool {
-    let Some(start) = value.get("start").and_then(serde_json::Value::as_u64) else {
+    let Some(start) = value.field("start").and_then(serde_json::Value::as_u64) else {
         return false;
     };
-    let Some(end) = value.get("end").and_then(serde_json::Value::as_u64) else {
+    let Some(end) = value.field("end").and_then(serde_json::Value::as_u64) else {
         return false;
     };
     let (mut before, mut after) = (start as usize, end as usize);
@@ -958,7 +965,7 @@ fn is_simple_expression_json(value: &serde_json::Value) -> bool {
         None => return true, // Literals are simple
     };
 
-    let expr_type = match obj.get("type").and_then(|t| t.as_str()) {
+    let expr_type = match obj.field("type").and_then(|t| t.as_str()) {
         Some(t) => t,
         None => return true,
     };
@@ -967,32 +974,32 @@ fn is_simple_expression_json(value: &serde_json::Value) -> bool {
         "Literal" | "Identifier" | "ArrowFunctionExpression" | "FunctionExpression" => true,
         "ConditionalExpression" => {
             let test_simple = obj
-                .get("test")
+                .field("test")
                 .map(is_simple_expression_json)
                 .unwrap_or(true);
             let consequent_simple = obj
-                .get("consequent")
+                .field("consequent")
                 .map(is_simple_expression_json)
                 .unwrap_or(true);
             let alternate_simple = obj
-                .get("alternate")
+                .field("alternate")
                 .map(is_simple_expression_json)
                 .unwrap_or(true);
             test_simple && consequent_simple && alternate_simple
         }
         "BinaryExpression" | "LogicalExpression" => {
             let left_simple = obj
-                .get("left")
+                .field("left")
                 .map(is_simple_expression_json)
                 .unwrap_or(true);
             let right_simple = obj
-                .get("right")
+                .field("right")
                 .map(is_simple_expression_json)
                 .unwrap_or(true);
             left_simple && right_simple
         }
         "UnaryExpression" => obj
-            .get("argument")
+            .field("argument")
             .map(is_simple_expression_json)
             .unwrap_or(true),
         // Generic "Expression" fallback from parser (position-only placeholder)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -4,6 +4,7 @@
 
 use super::arena::JsArena;
 use super::nodes::*;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use rustc_hash::FxHashMap;
 use std::cell::RefCell;
 use std::fmt::Write;
@@ -3166,7 +3167,7 @@ pub fn remap_through_sourcemap(mappings: &mut [SourceMapping], preprocessor_map_
         Err(_) => return,
     };
 
-    let pp_mappings_str = match map.get("mappings").and_then(|v| v.as_str()) {
+    let pp_mappings_str = match map.field("mappings").and_then(|v| v.as_str()) {
         Some(s) => s,
         None => return,
     };
@@ -3175,7 +3176,7 @@ pub fn remap_through_sourcemap(mappings: &mut [SourceMapping], preprocessor_map_
 
     // Extract names array for handling named replacements
     let names: Vec<String> = map
-        .get("names")
+        .field("names")
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -24,6 +24,7 @@ pub use js_ast::{JsExpr, JsProgram, JsStatement};
 
 use super::phase2_analyze::ComponentAnalysis;
 use crate::ast::template::Root;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use crate::compiler::{CompileOptions, GenerateMode};
 use memchr::memmem;
 
@@ -353,7 +354,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
         // non-JS sources (CSS, SCSS, etc.) since JS output should never reference
         // style sources.
         if let Ok(map) = serde_json::from_str::<serde_json::Value>(pp_map)
-            && let Some(sources) = map.get("sources").and_then(|v| v.as_array())
+            && let Some(sources) = map.field("sources").and_then(|v| v.as_array())
         {
             let css_source_indices: rustc_hash::FxHashSet<u32> = sources
                 .iter()
@@ -462,7 +463,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
         let pp_info = options.sourcemap.as_ref().and_then(|pp_map| {
             let map: serde_json::Value = serde_json::from_str(pp_map).ok()?;
             let sources = map
-                .get("sources")
+                .field("sources")
                 .and_then(|v| v.as_array())
                 .map(|arr| {
                     arr.iter()
@@ -471,7 +472,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 })
                 .unwrap_or_default();
             let sources_content = map
-                .get("sourcesContent")
+                .field("sourcesContent")
                 .and_then(|v| v.as_array())
                 .map(|arr| {
                     arr.iter()
@@ -480,7 +481,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 })
                 .unwrap_or_default();
             let names = map
-                .get("names")
+                .field("names")
                 .and_then(|v| v.as_array())
                 .map(|arr| {
                     arr.iter()
@@ -718,7 +719,7 @@ pub(crate) fn remap_css_sourcemap(
         Err(_) => return css_map_json.to_string(),
     };
 
-    let css_mappings_str = match css_map.get("mappings").and_then(|v| v.as_str()) {
+    let css_mappings_str = match css_map.field("mappings").and_then(|v| v.as_str()) {
         Some(s) => s,
         None => return css_map_json.to_string(),
     };
@@ -748,13 +749,13 @@ pub(crate) fn remap_css_sourcemap(
     let pp_map: serde_json::Value =
         serde_json::from_str(pp_map_json).unwrap_or(serde_json::Value::Null);
     let original_content = pp_map
-        .get("sourcesContent")
+        .field("sourcesContent")
         .and_then(|v| v.as_array())
         .and_then(|arr| arr.first())
         .and_then(|v| v.as_str())
         .unwrap_or("");
     let names: Vec<String> = pp_map
-        .get("names")
+        .field("names")
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
@@ -768,7 +769,7 @@ pub(crate) fn remap_css_sourcemap(
 
     // Get file and source names from CSS map
     let file_name = css_map
-        .get("file")
+        .field("file")
         .and_then(|v| v.as_str())
         .unwrap_or("input.svelte.css");
     let source_name = options
@@ -783,7 +784,7 @@ pub(crate) fn remap_css_sourcemap(
         })
         .unwrap_or_else(|| {
             css_map
-                .get("sources")
+                .field("sources")
                 .and_then(|v| v.as_array())
                 .and_then(|arr| arr.first())
                 .and_then(|v| v.as_str())

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/const_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/const_tag.rs
@@ -50,6 +50,7 @@ use crate::ast::template::ConstTag;
 use crate::compiler::phases::phase3_transform::server::ast::{
     AsyncConstsGroup, ServerTransformState,
 };
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Visit a `{@const <pattern> = <init>}` tag — async path
 /// (`add_async_const`) when blocked, else the sync `const … = …;` statement.
@@ -67,7 +68,7 @@ fn visit_const_tag_sync<'a>(node: &ConstTag, state: &mut ServerTransformState<'a
     // `id` (pattern) and `init` source spans from its JSON view, mirroring the
     // text oracle's source-slice decomposition.
     let decl_json = node.declaration.as_json();
-    let Some(declarators) = decl_json.get("declarations").and_then(|d| d.as_array()) else {
+    let Some(declarators) = decl_json.field("declarations").and_then(|d| d.as_array()) else {
         return;
     };
     let Some(declarator) = declarators.first() else {
@@ -76,8 +77,8 @@ fn visit_const_tag_sync<'a>(node: &ConstTag, state: &mut ServerTransformState<'a
 
     let span = |v: &serde_json::Value, key: &str| -> Option<(usize, usize)> {
         let obj = v.get(key)?;
-        let s = obj.get("start").and_then(|n| n.as_u64())? as usize;
-        let e = obj.get("end").and_then(|n| n.as_u64())? as usize;
+        let s = obj.field("start").and_then(|n| n.as_u64())? as usize;
+        let e = obj.field("end").and_then(|n| n.as_u64())? as usize;
         (e > s && e <= state.source.len()).then_some((s, e))
     };
 
@@ -132,12 +133,12 @@ fn try_async_const<'a>(node: &ConstTag, state: &mut ServerTransformState<'a>) ->
     // wrongly include `const ` in the `<lhs> = <rhs>` split.
     let decl_json = node.declaration.as_json();
     let Some((start, end)) = decl_json
-        .get("declarations")
+        .field("declarations")
         .and_then(|d| d.as_array())
         .and_then(|d| d.first())
         .and_then(|declarator| {
-            let s = declarator.get("start").and_then(|n| n.as_u64())? as usize;
-            let e = declarator.get("end").and_then(|n| n.as_u64())? as usize;
+            let s = declarator.field("start").and_then(|n| n.as_u64())? as usize;
+            let e = declarator.field("end").and_then(|n| n.as_u64())? as usize;
             Some((s, e))
         })
     else {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/declaration_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/declaration_tag.rs
@@ -44,6 +44,7 @@ use crate::compiler::phases::phase3_transform::server::ast::script::{DeclRune, d
 use crate::compiler::phases::phase3_transform::server::ast::{
     AsyncConstsGroup, ServerTransformState,
 };
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use oxc_ast::ast::{Expression as OxcExpression, Statement};
 
 /// Visit a `{let …}` / `{const …}` declaration tag — lower its declarators and
@@ -254,22 +255,22 @@ pub fn visit_declaration_tag<'a>(node: &DeclarationTag, state: &mut ServerTransf
 /// that value. Reactive (`$state` / `$derived`) inits never fold.
 fn register_constant_folds<'a>(node: &DeclarationTag, state: &mut ServerTransformState<'a>) {
     let decl_json = node.declaration.as_json();
-    let Some(decls) = decl_json.get("declarations").and_then(|d| d.as_array()) else {
+    let Some(decls) = decl_json.field("declarations").and_then(|d| d.as_array()) else {
         return;
     };
     for d in decls {
-        let (Some(id), Some(init)) = (d.get("id"), d.get("init")) else {
+        let (Some(id), Some(init)) = (d.field("id"), d.field("init")) else {
             continue;
         };
-        if init.is_null() || id.get("type").and_then(|t| t.as_str()) != Some("Identifier") {
+        if init.is_null() || id.field("type").and_then(|t| t.as_str()) != Some("Identifier") {
             continue;
         }
-        let Some(name) = id.get("name").and_then(|n| n.as_str()) else {
+        let Some(name) = id.field("name").and_then(|n| n.as_str()) else {
             continue;
         };
         let (Some(s), Some(e)) = (
-            init.get("start").and_then(|v| v.as_u64()),
-            init.get("end").and_then(|v| v.as_u64()),
+            init.field("start").and_then(|v| v.as_u64()),
+            init.field("end").and_then(|v| v.as_u64()),
         ) else {
             continue;
         };
@@ -434,13 +435,13 @@ fn compute_decl_tag_blockers(state: &ServerTransformState, init_refs: &[String])
 /// the un-rewritten assignment target for a destructured async declaration.
 fn raw_declarator_id(node: &DeclarationTag, state: &ServerTransformState) -> Option<String> {
     let decl_json = node.declaration.as_json();
-    let decls = decl_json.get("declarations").and_then(|d| d.as_array())?;
+    let decls = decl_json.field("declarations").and_then(|d| d.as_array())?;
     if decls.len() != 1 {
         return None;
     }
-    let id = decls[0].get("id")?;
-    let s = id.get("start").and_then(|v| v.as_u64())? as usize;
-    let e = id.get("end").and_then(|v| v.as_u64())? as usize;
+    let id = decls[0].field("id")?;
+    let s = id.field("start").and_then(|v| v.as_u64())? as usize;
+    let e = id.field("end").and_then(|v| v.as_u64())? as usize;
     if s >= e || e > state.source.len() {
         return None;
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/render_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/render_tag.rs
@@ -40,6 +40,7 @@ use crate::compiler::phases::phase3_transform::server::ast::ServerTransformState
 use serde_json::Value;
 
 use super::shared::{EMPTY_COMMENT, PromiseOptimiser, TemplateEntry};
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Slice the component source `[start, end)` (the optimiser blocker / await
 /// predicate operates on raw source text). `None` for an out-of-range span.
@@ -57,7 +58,7 @@ pub fn visit_render_tag<'a>(node: &RenderTag, state: &mut ServerTransformState<'
 
     // Unwrap the optional chain to reach the inner `CallExpression`.
     let call_json: &Value = if is_optional {
-        match expr_json.get("expression") {
+        match expr_json.field("expression") {
             Some(v) => v,
             None => return,
         }
@@ -65,18 +66,18 @@ pub fn visit_render_tag<'a>(node: &RenderTag, state: &mut ServerTransformState<'
         expr_json
     };
 
-    if call_json.get("type").and_then(Value::as_str) != Some("CallExpression") {
+    if call_json.field("type").and_then(Value::as_str) != Some("CallExpression") {
         return;
     }
 
     // -- callee -------------------------------------------------------------
-    let callee = match call_json.get("callee") {
+    let callee = match call_json.field("callee") {
         Some(c) => c,
         None => return,
     };
     let (c_start, c_end) = match (
-        callee.get("start").and_then(Value::as_u64),
-        callee.get("end").and_then(Value::as_u64),
+        callee.field("start").and_then(Value::as_u64),
+        callee.field("end").and_then(Value::as_u64),
     ) {
         (Some(s), Some(e)) => (s as usize, e as usize),
         _ => return,
@@ -106,11 +107,11 @@ pub fn visit_render_tag<'a>(node: &RenderTag, state: &mut ServerTransformState<'
     // routed through the optimiser so a blocked argument makes the tag async.
     let mut args = vec![state.b.id("$$renderer")];
     let mut comment_cursor = c_end as u32;
-    if let Some(arg_list) = call_json.get("arguments").and_then(Value::as_array) {
+    if let Some(arg_list) = call_json.field("arguments").and_then(Value::as_array) {
         for arg in arg_list {
             if let (Some(a_start), Some(a_end)) = (
-                arg.get("start").and_then(Value::as_u64),
-                arg.get("end").and_then(Value::as_u64),
+                arg.field("start").and_then(Value::as_u64),
+                arg.field("end").and_then(Value::as_u64),
             ) {
                 let (a_start, a_end) = (a_start as usize, a_end as usize);
                 let mut arg_expr = state.reparse_slice(a_start, a_end);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
@@ -24,6 +24,7 @@
 use crate::ast::js::Expression;
 use crate::ast::template::{Fragment, RegularElement, TemplateNode};
 use crate::compiler::phases::phase3_transform::server::ast::ServerTransformState;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use crate::compiler::phases::phase3_transform::shared::template::escape_html;
 use crate::compiler::phases::phase3_transform::utils::{
     is_svelte_whitespace_only, replace_leading_whitespace, replace_trailing_whitespace,
@@ -883,12 +884,12 @@ fn sort_const_tags<'n, 'b, N: AsRef<TemplateNode<'b>>>(
             // span would wrongly include `const ` in the `<lhs> = <rhs>` split.
             let decl_json = ct.declaration.as_json();
             let (start, end) = decl_json
-                .get("declarations")
+                .field("declarations")
                 .and_then(|d| d.as_array())
                 .and_then(|d| d.first())
                 .and_then(|declarator| {
-                    let s = declarator.get("start").and_then(|n| n.as_u64())? as usize;
-                    let e = declarator.get("end").and_then(|n| n.as_u64())? as usize;
+                    let s = declarator.field("start").and_then(|n| n.as_u64())? as usize;
+                    let e = declarator.field("end").and_then(|n| n.as_u64())? as usize;
                     Some((s, e))
                 })
                 .unwrap_or((0, 0));

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
@@ -33,6 +33,7 @@
 
 use crate::ast::template::SnippetBlock;
 use crate::compiler::phases::phase3_transform::server::ast::ServerTransformState;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use serde_json::Value;
 
 /// Visit a `{#snippet name(params)}...{/snippet}` block.
@@ -184,25 +185,25 @@ pub(super) fn collect_param_pattern_names(
 }
 
 fn collect_pattern_names_json(json: &Value, out: &mut rustc_hash::FxHashSet<String>) {
-    let ty = json.get("type").and_then(Value::as_str).unwrap_or("");
+    let ty = json.field("type").and_then(Value::as_str).unwrap_or("");
     match ty {
         "Identifier" => {
-            if let Some(name) = json.get("name").and_then(Value::as_str) {
+            if let Some(name) = json.field("name").and_then(Value::as_str) {
                 out.insert(name.to_string());
             }
         }
         "AssignmentPattern" => {
-            if let Some(left) = json.get("left") {
+            if let Some(left) = json.field("left") {
                 collect_pattern_names_json(left, out);
             }
         }
         "RestElement" => {
-            if let Some(arg) = json.get("argument") {
+            if let Some(arg) = json.field("argument") {
                 collect_pattern_names_json(arg, out);
             }
         }
         "ArrayPattern" => {
-            if let Some(elems) = json.get("elements").and_then(Value::as_array) {
+            if let Some(elems) = json.field("elements").and_then(Value::as_array) {
                 for el in elems {
                     if !el.is_null() {
                         collect_pattern_names_json(el, out);
@@ -211,14 +212,14 @@ fn collect_pattern_names_json(json: &Value, out: &mut rustc_hash::FxHashSet<Stri
             }
         }
         "ObjectPattern" => {
-            if let Some(props) = json.get("properties").and_then(Value::as_array) {
+            if let Some(props) = json.field("properties").and_then(Value::as_array) {
                 for prop in props {
-                    let pty = prop.get("type").and_then(Value::as_str).unwrap_or("");
+                    let pty = prop.field("type").and_then(Value::as_str).unwrap_or("");
                     if pty == "RestElement" {
-                        if let Some(arg) = prop.get("argument") {
+                        if let Some(arg) = prop.field("argument") {
                             collect_pattern_names_json(arg, out);
                         }
-                    } else if let Some(value) = prop.get("value") {
+                    } else if let Some(value) = prop.field("value") {
                         collect_pattern_names_json(value, out);
                     }
                 }
@@ -235,12 +236,12 @@ fn collect_pattern_names_json(json: &Value, out: &mut rustc_hash::FxHashSet<Stri
 /// patterns are taken from the source span with the type annotation stripped.
 pub(super) fn extract_snippet_param(expr: &crate::ast::js::Expression, source: &str) -> String {
     let json = expr.as_json();
-    let node_type = json.get("type").and_then(Value::as_str).unwrap_or("");
+    let node_type = json.field("type").and_then(Value::as_str).unwrap_or("");
 
     match node_type {
         "AssignmentPattern" => {
-            let left = json.get("left");
-            let right = json.get("right");
+            let left = json.field("left");
+            let right = json.field("right");
 
             let left_str = if let Some(left_val) = left {
                 let left_expr = crate::ast::js::Expression::from_json(left_val.clone());
@@ -264,7 +265,10 @@ pub(super) fn extract_snippet_param(expr: &crate::ast::js::Expression, source: &
                     // A SequenceExpression default (`c = (2, 3)`) covers only the
                     // inner `2, 3` span — re-wrap it in parens to preserve the
                     // comma-expression semantics in parameter position.
-                    let right_type = right_val.get("type").and_then(Value::as_str).unwrap_or("");
+                    let right_type = right_val
+                        .field("type")
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
                     if right_type == "SequenceExpression" {
                         format!("({val})")
                     } else {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/evaluate.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/evaluate.rs
@@ -24,6 +24,7 @@ use serde_json::Value;
 
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase2_analyze::scope::BindingKind;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::OnceCell;
 
@@ -1107,7 +1108,7 @@ fn is_rune(keypath: &str) -> bool {
 // ---------------------------------------------------------------------------
 
 fn node_type(node: &Value) -> Option<&str> {
-    node.get("type").and_then(|t| t.as_str())
+    node.field("type").and_then(|t| t.as_str())
 }
 
 /// Build the dotted keypath of a (possibly nested static) member/identifier
@@ -1116,20 +1117,20 @@ fn get_keypath(node: &Value) -> Option<(String, String)> {
     let mut parts: Vec<&str> = Vec::new();
     let mut n = node;
     while node_type(n) == Some("MemberExpression") {
-        if n.get("computed").and_then(|c| c.as_bool()) == Some(true) {
+        if n.field("computed").and_then(|c| c.as_bool()) == Some(true) {
             return None;
         }
-        let prop = n.get("property")?;
+        let prop = n.field("property")?;
         if node_type(prop) != Some("Identifier") {
             return None;
         }
-        parts.push(prop.get("name")?.as_str()?);
-        n = n.get("object")?;
+        parts.push(prop.field("name")?.as_str()?);
+        n = n.field("object")?;
     }
     if node_type(n) != Some("Identifier") {
         return None;
     }
-    let base = n.get("name")?.as_str()?;
+    let base = n.field("name")?.as_str()?;
     parts.push(base);
     parts.reverse();
     Some((base.to_string(), parts.join(".")))
@@ -1580,19 +1581,22 @@ pub(crate) fn evaluate_estree<S: EvalScope + ?Sized>(
 
     match ty {
         "Literal" => {
-            if let Some(digits) = node.get("bigint").and_then(|b| b.as_str()) {
+            if let Some(digits) = node.field("bigint").and_then(|b| b.as_str()) {
                 return match digits.parse::<i128>() {
                     Ok(v) => Evaluation::single(EvalValue::BigInt(v)),
                     Err(_) => Evaluation::unknown(),
                 };
             }
             // A regex stringifies to its source, but its value is still an object.
-            if let Some(regex) = node.get("regex") {
-                let pattern = regex.get("pattern").and_then(|p| p.as_str()).unwrap_or("");
-                let flags = regex.get("flags").and_then(|f| f.as_str()).unwrap_or("");
+            if let Some(regex) = node.field("regex") {
+                let pattern = regex
+                    .field("pattern")
+                    .and_then(|p| p.as_str())
+                    .unwrap_or("");
+                let flags = regex.field("flags").and_then(|f| f.as_str()).unwrap_or("");
                 return Evaluation::single(EvalValue::Regex(format!("/{}/{}", pattern, flags)));
             }
-            match node.get("value") {
+            match node.field("value") {
                 Some(Value::String(s)) => Evaluation::single(EvalValue::Str(s.clone())),
                 Some(Value::Number(n)) => {
                     Evaluation::single(EvalValue::Num(n.as_f64().unwrap_or(f64::NAN)))
@@ -1604,7 +1608,7 @@ pub(crate) fn evaluate_estree<S: EvalScope + ?Sized>(
         }
 
         "Identifier" => {
-            let Some(name) = node.get("name").and_then(|n| n.as_str()) else {
+            let Some(name) = node.field("name").and_then(|n| n.as_str()) else {
                 return Evaluation::unknown();
             };
             scope.evaluate_identifier(node, name, depth)
@@ -1612,9 +1616,9 @@ pub(crate) fn evaluate_estree<S: EvalScope + ?Sized>(
 
         "BinaryExpression" => {
             let (Some(left), Some(right), Some(op)) = (
-                node.get("left"),
-                node.get("right"),
-                node.get("operator").and_then(|o| o.as_str()),
+                node.field("left"),
+                node.field("right"),
+                node.field("operator").and_then(|o| o.as_str()),
             ) else {
                 return Evaluation::unknown();
             };
@@ -1666,9 +1670,9 @@ pub(crate) fn evaluate_estree<S: EvalScope + ?Sized>(
 
         "ConditionalExpression" => {
             let (Some(test), Some(consequent), Some(alternate)) = (
-                node.get("test"),
-                node.get("consequent"),
-                node.get("alternate"),
+                node.field("test"),
+                node.field("consequent"),
+                node.field("alternate"),
             ) else {
                 return Evaluation::unknown();
             };
@@ -1689,9 +1693,9 @@ pub(crate) fn evaluate_estree<S: EvalScope + ?Sized>(
 
         "LogicalExpression" => {
             let (Some(left), Some(right), Some(op)) = (
-                node.get("left"),
-                node.get("right"),
-                node.get("operator").and_then(|o| o.as_str()),
+                node.field("left"),
+                node.field("right"),
+                node.field("operator").and_then(|o| o.as_str()),
             ) else {
                 return Evaluation::unknown();
             };
@@ -1724,8 +1728,8 @@ pub(crate) fn evaluate_estree<S: EvalScope + ?Sized>(
 
         "UnaryExpression" => {
             let (Some(arg), Some(op)) = (
-                node.get("argument"),
-                node.get("operator").and_then(|o| o.as_str()),
+                node.field("argument"),
+                node.field("operator").and_then(|o| o.as_str()),
             ) else {
                 return Evaluation::unknown();
             };
@@ -1751,12 +1755,12 @@ pub(crate) fn evaluate_estree<S: EvalScope + ?Sized>(
         }
 
         "CallExpression" => {
-            let Some(callee) = node.get("callee") else {
+            let Some(callee) = node.field("callee") else {
                 return Evaluation::unknown();
             };
             let empty = Vec::new();
             let args = node
-                .get("arguments")
+                .field("arguments")
                 .and_then(|a| a.as_array())
                 .unwrap_or(&empty);
 
@@ -1784,10 +1788,10 @@ pub(crate) fn evaluate_estree<S: EvalScope + ?Sized>(
                             if let Some(arg) = args.first()
                                 && node_type(arg) == Some("ArrowFunctionExpression")
                                 && arg
-                                    .get("body")
+                                    .field("body")
                                     .and_then(node_type)
                                     .is_some_and(|t| t != "BlockStatement")
-                                && let Some(body) = arg.get("body")
+                                && let Some(body) = arg.field("body")
                             {
                                 return evaluate_estree(scope, body, depth + 1);
                             }
@@ -1816,16 +1820,16 @@ pub(crate) fn evaluate_estree<S: EvalScope + ?Sized>(
 
         "TemplateLiteral" => {
             let (Some(quasis), Some(exprs)) = (
-                node.get("quasis").and_then(|q| q.as_array()),
-                node.get("expressions").and_then(|e| e.as_array()),
+                node.field("quasis").and_then(|q| q.as_array()),
+                node.field("expressions").and_then(|e| e.as_array()),
             ) else {
                 return Evaluation::unknown();
             };
             let cooked = |i: usize| -> Option<String> {
                 quasis
                     .get(i)?
-                    .get("value")?
-                    .get("cooked")?
+                    .field("value")?
+                    .field("cooked")?
                     .as_str()
                     .map(String::from)
             };
@@ -1867,7 +1871,7 @@ pub(crate) fn evaluate_estree<S: EvalScope + ?Sized>(
         | "TSSatisfiesExpression"
         | "TSTypeAssertion"
         | "ParenthesizedExpression" => {
-            if let Some(inner) = node.get("expression") {
+            if let Some(inner) = node.field("expression") {
                 return evaluate_estree(scope, inner, depth + 1);
             }
             Evaluation::unknown()

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
@@ -7,6 +7,7 @@ use crate::ast::js::Expression;
 use crate::ast::template::{Attribute, RegularElement, TemplateNode};
 use crate::compiler::phases::phase2_analyze::scope::Scope;
 use crate::compiler::phases::phase2_analyze::types::ComponentAnalysis;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use compact_str::CompactString;
 use rustc_hash::FxHashMap;
 use std::borrow::Cow;
@@ -279,11 +280,11 @@ fn extract_const_tag_names_and_deps(declaration: &Expression) -> (Vec<String>, V
             Some(o) => o,
             None => return (vec![], vec![]),
         };
-        let expr_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let expr_type = obj.field("type").and_then(|v| v.as_str()).unwrap_or("");
 
         match expr_type {
             "VariableDeclaration" => {
-                let declarations = match obj.get("declarations").and_then(|v| v.as_array()) {
+                let declarations = match obj.field("declarations").and_then(|v| v.as_array()) {
                     Some(d) => d,
                     None => return (vec![], vec![]),
                 };
@@ -294,11 +295,11 @@ fn extract_const_tag_names_and_deps(declaration: &Expression) -> (Vec<String>, V
                     Some(d) => d,
                     None => return (vec![], vec![]),
                 };
-                let id = match first_decl.get("id") {
+                let id = match first_decl.field("id") {
                     Some(id) => id,
                     None => return (vec![], vec![]),
                 };
-                let init = match first_decl.get("init") {
+                let init = match first_decl.field("init") {
                     Some(init) => init,
                     None => return (vec![], vec![]),
                 };
@@ -312,11 +313,11 @@ fn extract_const_tag_names_and_deps(declaration: &Expression) -> (Vec<String>, V
                 (declared, referenced)
             }
             "AssignmentExpression" => {
-                let left = match obj.get("left") {
+                let left = match obj.field("left") {
                     Some(l) => l,
                     None => return (vec![], vec![]),
                 };
-                let right = match obj.get("right") {
+                let right = match obj.field("right") {
                     Some(r) => r,
                     None => return (vec![], vec![]),
                 };
@@ -336,29 +337,29 @@ fn extract_const_tag_names_and_deps(declaration: &Expression) -> (Vec<String>, V
 
 /// Collect all identifier names from a JSON pattern (destructuring or simple identifier).
 fn collect_identifiers_from_json_pattern(pattern: &serde_json::Value, out: &mut Vec<String>) {
-    let pat_type = pattern.get("type").and_then(|v| v.as_str());
+    let pat_type = pattern.field("type").and_then(|v| v.as_str());
     match pat_type {
         Some("Identifier") => {
-            if let Some(name) = pattern.get("name").and_then(|v| v.as_str()) {
+            if let Some(name) = pattern.field("name").and_then(|v| v.as_str()) {
                 out.push(name.to_string());
             }
         }
         Some("ObjectPattern") | Some("ObjectExpression") => {
-            if let Some(properties) = pattern.get("properties").and_then(|v| v.as_array()) {
+            if let Some(properties) = pattern.field("properties").and_then(|v| v.as_array()) {
                 for prop in properties {
-                    let prop_type = prop.get("type").and_then(|v| v.as_str());
+                    let prop_type = prop.field("type").and_then(|v| v.as_str());
                     if prop_type == Some("RestElement") || prop_type == Some("SpreadElement") {
-                        if let Some(arg) = prop.get("argument") {
+                        if let Some(arg) = prop.field("argument") {
                             collect_identifiers_from_json_pattern(arg, out);
                         }
-                    } else if let Some(value) = prop.get("value") {
+                    } else if let Some(value) = prop.field("value") {
                         collect_identifiers_from_json_pattern(value, out);
                     }
                 }
             }
         }
         Some("ArrayPattern") | Some("ArrayExpression") => {
-            if let Some(elements) = pattern.get("elements").and_then(|v| v.as_array()) {
+            if let Some(elements) = pattern.field("elements").and_then(|v| v.as_array()) {
                 for elem in elements {
                     if !elem.is_null() {
                         collect_identifiers_from_json_pattern(elem, out);
@@ -367,12 +368,12 @@ fn collect_identifiers_from_json_pattern(pattern: &serde_json::Value, out: &mut 
             }
         }
         Some("RestElement") | Some("SpreadElement") => {
-            if let Some(arg) = pattern.get("argument") {
+            if let Some(arg) = pattern.field("argument") {
                 collect_identifiers_from_json_pattern(arg, out);
             }
         }
         Some("AssignmentPattern") | Some("AssignmentExpression") => {
-            if let Some(left) = pattern.get("left") {
+            if let Some(left) = pattern.field("left") {
                 collect_identifiers_from_json_pattern(left, out);
             }
         }
@@ -383,7 +384,7 @@ fn collect_identifiers_from_json_pattern(pattern: &serde_json::Value, out: &mut 
 /// Collect all identifier names referenced in a JSON expression (for dependency analysis).
 /// This walks the expression AST to find all Identifier nodes that are references.
 fn collect_identifiers_from_json_expr(expr: &serde_json::Value, out: &mut Vec<String>) {
-    let expr_type = match expr.get("type").and_then(|v| v.as_str()) {
+    let expr_type = match expr.field("type").and_then(|v| v.as_str()) {
         Some(t) => t,
         None => {
             // Handle arrays (e.g., function arguments)
@@ -398,7 +399,7 @@ fn collect_identifiers_from_json_expr(expr: &serde_json::Value, out: &mut Vec<St
 
     match expr_type {
         "Identifier" => {
-            if let Some(name) = expr.get("name").and_then(|v| v.as_str()) {
+            if let Some(name) = expr.field("name").and_then(|v| v.as_str()) {
                 // Skip JS keywords/literals
                 if !is_js_keyword_or_literal(name) {
                     out.push(name.to_string());
@@ -407,55 +408,55 @@ fn collect_identifiers_from_json_expr(expr: &serde_json::Value, out: &mut Vec<St
         }
         "MemberExpression" => {
             // Only walk the object part, not the property (when not computed)
-            if let Some(object) = expr.get("object") {
+            if let Some(object) = expr.field("object") {
                 collect_identifiers_from_json_expr(object, out);
             }
             // For computed properties like a[b], also walk the property
             if expr
-                .get("computed")
+                .field("computed")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false)
-                && let Some(property) = expr.get("property")
+                && let Some(property) = expr.field("property")
             {
                 collect_identifiers_from_json_expr(property, out);
             }
         }
         "BinaryExpression" | "LogicalExpression" => {
-            if let Some(left) = expr.get("left") {
+            if let Some(left) = expr.field("left") {
                 collect_identifiers_from_json_expr(left, out);
             }
-            if let Some(right) = expr.get("right") {
+            if let Some(right) = expr.field("right") {
                 collect_identifiers_from_json_expr(right, out);
             }
         }
         "UnaryExpression" | "UpdateExpression" => {
-            if let Some(arg) = expr.get("argument") {
+            if let Some(arg) = expr.field("argument") {
                 collect_identifiers_from_json_expr(arg, out);
             }
         }
         "ConditionalExpression" => {
-            if let Some(test) = expr.get("test") {
+            if let Some(test) = expr.field("test") {
                 collect_identifiers_from_json_expr(test, out);
             }
-            if let Some(consequent) = expr.get("consequent") {
+            if let Some(consequent) = expr.field("consequent") {
                 collect_identifiers_from_json_expr(consequent, out);
             }
-            if let Some(alternate) = expr.get("alternate") {
+            if let Some(alternate) = expr.field("alternate") {
                 collect_identifiers_from_json_expr(alternate, out);
             }
         }
         "CallExpression" | "NewExpression" => {
-            if let Some(callee) = expr.get("callee") {
+            if let Some(callee) = expr.field("callee") {
                 collect_identifiers_from_json_expr(callee, out);
             }
-            if let Some(args) = expr.get("arguments").and_then(|v| v.as_array()) {
+            if let Some(args) = expr.field("arguments").and_then(|v| v.as_array()) {
                 for arg in args {
                     collect_identifiers_from_json_expr(arg, out);
                 }
             }
         }
         "ArrayExpression" => {
-            if let Some(elements) = expr.get("elements").and_then(|v| v.as_array()) {
+            if let Some(elements) = expr.field("elements").and_then(|v| v.as_array()) {
                 for elem in elements {
                     if !elem.is_null() {
                         collect_identifiers_from_json_expr(elem, out);
@@ -464,40 +465,40 @@ fn collect_identifiers_from_json_expr(expr: &serde_json::Value, out: &mut Vec<St
             }
         }
         "ObjectExpression" => {
-            if let Some(properties) = expr.get("properties").and_then(|v| v.as_array()) {
+            if let Some(properties) = expr.field("properties").and_then(|v| v.as_array()) {
                 for prop in properties {
                     // For computed keys, walk the key
                     if prop
-                        .get("computed")
+                        .field("computed")
                         .and_then(|v| v.as_bool())
                         .unwrap_or(false)
-                        && let Some(key) = prop.get("key")
+                        && let Some(key) = prop.field("key")
                     {
                         collect_identifiers_from_json_expr(key, out);
                     }
-                    if let Some(value) = prop.get("value") {
+                    if let Some(value) = prop.field("value") {
                         collect_identifiers_from_json_expr(value, out);
                     }
                 }
             }
         }
         "SpreadElement" => {
-            if let Some(arg) = expr.get("argument") {
+            if let Some(arg) = expr.field("argument") {
                 collect_identifiers_from_json_expr(arg, out);
             }
         }
         "TemplateLiteral" => {
-            if let Some(expressions) = expr.get("expressions").and_then(|v| v.as_array()) {
+            if let Some(expressions) = expr.field("expressions").and_then(|v| v.as_array()) {
                 for expression in expressions {
                     collect_identifiers_from_json_expr(expression, out);
                 }
             }
         }
         "TaggedTemplateExpression" => {
-            if let Some(tag) = expr.get("tag") {
+            if let Some(tag) = expr.field("tag") {
                 collect_identifiers_from_json_expr(tag, out);
             }
-            if let Some(quasi) = expr.get("quasi") {
+            if let Some(quasi) = expr.field("quasi") {
                 collect_identifiers_from_json_expr(quasi, out);
             }
         }
@@ -506,14 +507,14 @@ fn collect_identifiers_from_json_expr(expr: &serde_json::Value, out: &mut Vec<St
             // The function's own parameters shadow outer bindings
         }
         "SequenceExpression" => {
-            if let Some(expressions) = expr.get("expressions").and_then(|v| v.as_array()) {
+            if let Some(expressions) = expr.field("expressions").and_then(|v| v.as_array()) {
                 for expression in expressions {
                     collect_identifiers_from_json_expr(expression, out);
                 }
             }
         }
         "AssignmentExpression" => {
-            if let Some(right) = expr.get("right") {
+            if let Some(right) = expr.field("right") {
                 collect_identifiers_from_json_expr(right, out);
             }
         }

--- a/crates/rsvelte_core/src/compiler/print/context.rs
+++ b/crates/rsvelte_core/src/compiler/print/context.rs
@@ -9,6 +9,7 @@
 //!
 //! Reference: esrap npm package Context API
 
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use oxc_allocator::Allocator;
 use std::collections::HashSet;
 
@@ -144,7 +145,7 @@ impl<'a> Context<'a> {
     pub fn has_css_comment_before(&self, end: u64) -> bool {
         self.css_comments
             .get(self.css_comment_index)
-            .and_then(|comment| comment.get("start"))
+            .and_then(|comment| comment.field("start"))
             .and_then(serde_json::Value::as_u64)
             .is_some_and(|start| start < end)
     }
@@ -156,7 +157,7 @@ impl<'a> Context<'a> {
                 self.write(" ");
             }
             let value = self.css_comments[self.css_comment_index]
-                .get("value")
+                .field("value")
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or("")
                 .to_string();
@@ -171,7 +172,7 @@ impl<'a> Context<'a> {
 
     pub fn write_next_css_comment(&mut self) {
         let value = self.css_comments[self.css_comment_index]
-            .get("value")
+            .field("value")
             .and_then(serde_json::Value::as_str)
             .unwrap_or("")
             .to_string();

--- a/crates/rsvelte_core/src/compiler/print/css_visitors.rs
+++ b/crates/rsvelte_core/src/compiler/print/css_visitors.rs
@@ -7,6 +7,7 @@
 //! Reference: `svelte/packages/svelte/src/compiler/print/index.js` (lines 172-325)
 
 use super::Context;
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use serde_json::Value;
 use std::fmt::Write as _;
 
@@ -19,7 +20,7 @@ use std::fmt::Write as _;
 /// * `context` - The context to write to
 /// * `node` - The CSS node to visit (as JSON value)
 pub fn visit_css_node(context: &mut Context, node: &Value) {
-    if let Some(node_type) = node.get("type").and_then(|t| t.as_str()) {
+    if let Some(node_type) = node.field("type").and_then(|t| t.as_str()) {
         match node_type {
             "Atrule" => visit_atrule(context, node),
             "AttributeSelector" => visit_attribute_selector(context, node),
@@ -53,17 +54,20 @@ pub fn visit_css_node(context: &mut Context, node: &Value) {
 /// * `context` - The context to write to
 /// * `node` - The Atrule node
 fn visit_atrule(context: &mut Context, node: &Value) {
-    if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
+    if let Some(name) = node.field("name").and_then(|n| n.as_str()) {
         // For @font-face, the CSS parser may incorrectly parse declarations as selectors.
         // Use source text extraction as a workaround when source is available.
         if name == "font-face"
             && let Some(source) = context.source
         {
             let start = node
-                .get("start")
+                .field("start")
                 .and_then(|s| s.as_u64())
                 .map(|n| n as usize);
-            let end = node.get("end").and_then(|e| e.as_u64()).map(|n| n as usize);
+            let end = node
+                .field("end")
+                .and_then(|e| e.as_u64())
+                .map(|n| n as usize);
             if let (Some(s), Some(e)) = (start, end)
                 && s < e
                 && e <= source.len()
@@ -90,14 +94,14 @@ fn visit_atrule(context: &mut Context, node: &Value) {
         context.write("@");
         context.write(&escape_identifier(name));
 
-        if let Some(prelude) = node.get("prelude").and_then(|p| p.as_str())
+        if let Some(prelude) = node.field("prelude").and_then(|p| p.as_str())
             && !prelude.is_empty()
         {
             context.write(" ");
             context.write(prelude);
         }
 
-        if let Some(block) = node.get("block") {
+        if let Some(block) = node.field("block") {
             if !block.is_null() {
                 context.write(" ");
                 visit_block(context, block);
@@ -195,17 +199,17 @@ fn escape_identifier(name: &str) -> String {
 /// * `context` - The context to write to
 /// * `node` - The AttributeSelector node
 fn visit_attribute_selector(context: &mut Context, node: &Value) {
-    if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
+    if let Some(name) = node.field("name").and_then(|n| n.as_str()) {
         context.write("[");
         context.write(&escape_identifier(name));
 
-        if let Some(matcher) = node.get("matcher").and_then(|m| m.as_str()) {
+        if let Some(matcher) = node.field("matcher").and_then(|m| m.as_str()) {
             context.write(matcher);
-            if let Some(value) = node.get("value").and_then(|v| v.as_str()) {
+            if let Some(value) = node.field("value").and_then(|v| v.as_str()) {
                 // Value includes quotes if originally quoted
                 context.write(value);
 
-                if let Some(flags) = node.get("flags").and_then(|f| f.as_str()) {
+                if let Some(flags) = node.field("flags").and_then(|f| f.as_str()) {
                     context.write(" ");
                     context.write(flags);
                 }
@@ -233,8 +237,8 @@ fn visit_attribute_selector(context: &mut Context, node: &Value) {
 fn visit_block(context: &mut Context, node: &Value) {
     context.write("{");
 
-    let end = node.get("end").and_then(Value::as_u64).unwrap_or(0);
-    if let Some(children) = node.get("children").and_then(|c| c.as_array())
+    let end = node.field("end").and_then(Value::as_u64).unwrap_or(0);
+    if let Some(children) = node.field("children").and_then(|c| c.as_array())
         && (!children.is_empty() || context.has_css_comment_before(end))
     {
         context.indent();
@@ -243,7 +247,7 @@ fn visit_block(context: &mut Context, node: &Value) {
         let mut started = false;
 
         for child in children {
-            let start = child.get("start").and_then(Value::as_u64).unwrap_or(0);
+            let start = child.field("start").and_then(Value::as_u64).unwrap_or(0);
             while context.has_css_comment_before(start) {
                 if started {
                     context.newline();
@@ -283,7 +287,7 @@ fn visit_block(context: &mut Context, node: &Value) {
 /// * `context` - The context to write to
 /// * `node` - The ClassSelector node
 fn visit_class_selector(context: &mut Context, node: &Value) {
-    if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
+    if let Some(name) = node.field("name").and_then(|n| n.as_str()) {
         context.write(".");
         context.write(&escape_identifier(name));
     }
@@ -298,7 +302,7 @@ fn visit_class_selector(context: &mut Context, node: &Value) {
 /// * `context` - The context to write to
 /// * `node` - The ComplexSelector node
 fn visit_complex_selector(context: &mut Context, node: &Value) {
-    if let Some(children) = node.get("children").and_then(|c| c.as_array()) {
+    if let Some(children) = node.field("children").and_then(|c| c.as_array()) {
         for selector in children {
             visit_css_node(context, selector);
         }
@@ -314,8 +318,8 @@ fn visit_complex_selector(context: &mut Context, node: &Value) {
 /// * `context` - The context to write to
 /// * `node` - The Declaration node
 fn visit_declaration(context: &mut Context, node: &Value) {
-    if let Some(property) = node.get("property").and_then(|p| p.as_str())
-        && let Some(value) = node.get("value").and_then(|v| v.as_str())
+    if let Some(property) = node.field("property").and_then(|p| p.as_str())
+        && let Some(value) = node.field("value").and_then(|v| v.as_str())
     {
         context.write(property);
         context.write(": ");
@@ -333,7 +337,7 @@ fn visit_declaration(context: &mut Context, node: &Value) {
 /// * `context` - The context to write to
 /// * `node` - The IdSelector node
 fn visit_id_selector(context: &mut Context, node: &Value) {
-    if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
+    if let Some(name) = node.field("name").and_then(|n| n.as_str()) {
         context.write("#");
         context.write(&escape_identifier(name));
     }
@@ -360,7 +364,7 @@ fn visit_nesting_selector(context: &mut Context, _node: &Value) {
 /// * `context` - The context to write to
 /// * `node` - The Nth node
 fn visit_nth(context: &mut Context, node: &Value) {
-    if let Some(value) = node.get("value").and_then(|v| v.as_str()) {
+    if let Some(value) = node.field("value").and_then(|v| v.as_str()) {
         context.write(value);
     }
 }
@@ -374,7 +378,7 @@ fn visit_nth(context: &mut Context, node: &Value) {
 /// * `context` - The context to write to
 /// * `node` - The Percentage node
 fn visit_percentage(context: &mut Context, node: &Value) {
-    if let Some(value) = node.get("value").and_then(|v| v.as_str()) {
+    if let Some(value) = node.field("value").and_then(|v| v.as_str()) {
         // `value` already contains the trailing `%` (the parser captures the
         // `%` as part of the literal — same shape as upstream's Percentage
         // AST). Mirrors upstream commit `ca3f35bf7` which fixed
@@ -392,16 +396,16 @@ fn visit_percentage(context: &mut Context, node: &Value) {
 /// * `context` - The context to write to
 /// * `node` - The PseudoClassSelector node
 fn visit_pseudo_class_selector(context: &mut Context, node: &Value) {
-    if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
+    if let Some(name) = node.field("name").and_then(|n| n.as_str()) {
         context.write(":");
         context.write(&escape_identifier(name));
 
-        if let Some(args) = node.get("args")
+        if let Some(args) = node.field("args")
             && !args.is_null()
         {
             context.write("(");
 
-            if let Some(children) = args.get("children").and_then(|c| c.as_array()) {
+            if let Some(children) = args.field("children").and_then(|c| c.as_array()) {
                 let mut started = false;
 
                 for arg in children {
@@ -429,15 +433,15 @@ fn visit_pseudo_class_selector(context: &mut Context, node: &Value) {
 /// * `context` - The context to write to
 /// * `node` - The PseudoElementSelector node
 fn visit_pseudo_element_selector(context: &mut Context, node: &Value) {
-    if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
+    if let Some(name) = node.field("name").and_then(|n| n.as_str()) {
         context.write("::");
         context.write(&escape_identifier(name));
-        if let Some(args) = node.get("args")
+        if let Some(args) = node.field("args")
             && !args.is_null()
         {
             context.write("(");
             visit_selector_list(context, args);
-            let end = node.get("end").and_then(Value::as_u64).unwrap_or(0);
+            let end = node.field("end").and_then(Value::as_u64).unwrap_or(0);
             if context.write_css_comments_before(end, true) {
                 context.write(" ");
             }
@@ -455,9 +459,9 @@ fn visit_pseudo_element_selector(context: &mut Context, node: &Value) {
 /// * `context` - The context to write to
 /// * `node` - The RelativeSelector node
 fn visit_relative_selector(context: &mut Context, node: &Value) {
-    if let Some(combinator) = node.get("combinator")
+    if let Some(combinator) = node.field("combinator")
         && !combinator.is_null()
-        && let Some(name) = combinator.get("name").and_then(|n| n.as_str())
+        && let Some(name) = combinator.field("name").and_then(|n| n.as_str())
     {
         if name == " " {
             context.write(" ");
@@ -468,17 +472,20 @@ fn visit_relative_selector(context: &mut Context, node: &Value) {
         }
     }
 
-    if let Some(selectors) = node.get("selectors").and_then(|s| s.as_array()) {
+    if let Some(selectors) = node.field("selectors").and_then(|s| s.as_array()) {
         if selectors.is_empty() {
             // Empty selectors array - try to extract from source text.
             // This happens for keyframe selectors like "50%" that the parser
             // doesn't store as typed selector nodes.
             if let Some(source) = context.source
                 && let Some(s) = node
-                    .get("start")
+                    .field("start")
                     .and_then(|s| s.as_u64())
                     .map(|n| n as usize)
-                && let Some(e) = node.get("end").and_then(|e| e.as_u64()).map(|n| n as usize)
+                && let Some(e) = node
+                    .field("end")
+                    .and_then(|e| e.as_u64())
+                    .map(|n| n as usize)
                 && s < e
                 && e <= source.len()
             {
@@ -508,14 +515,14 @@ fn visit_relative_selector(context: &mut Context, node: &Value) {
 /// * `context` - The context to write to
 /// * `node` - The Rule node
 fn visit_rule(context: &mut Context, node: &Value) {
-    if let Some(prelude) = node.get("prelude")
-        && let Some(children) = prelude.get("children").and_then(|c| c.as_array())
+    if let Some(prelude) = node.field("prelude")
+        && let Some(children) = prelude.field("children").and_then(|c| c.as_array())
     {
         for (index, selector) in children.iter().enumerate() {
             visit_css_node(context, selector);
             if let Some(next) = children.get(index + 1) {
                 context.write(",");
-                let start = next.get("start").and_then(Value::as_u64).unwrap_or(0);
+                let start = next.field("start").and_then(Value::as_u64).unwrap_or(0);
                 if context.has_css_comment_before(start) {
                     context.write(" ");
                     context.write_css_comments_before(start, true);
@@ -527,8 +534,8 @@ fn visit_rule(context: &mut Context, node: &Value) {
 
     context.write(" ");
 
-    if let Some(block) = node.get("block") {
-        let start = block.get("start").and_then(Value::as_u64).unwrap_or(0);
+    if let Some(block) = node.field("block") {
+        let start = block.field("start").and_then(Value::as_u64).unwrap_or(0);
         if context.write_css_comments_before(start, true) {
             context.write(" ");
         }
@@ -545,10 +552,10 @@ fn visit_rule(context: &mut Context, node: &Value) {
 /// * `context` - The context to write to
 /// * `node` - The SelectorList node
 fn visit_selector_list(context: &mut Context, node: &Value) {
-    if let Some(children) = node.get("children").and_then(|c| c.as_array()) {
+    if let Some(children) = node.field("children").and_then(|c| c.as_array()) {
         let mut started = false;
         for selector in children {
-            let start = selector.get("start").and_then(Value::as_u64).unwrap_or(0);
+            let start = selector.field("start").and_then(Value::as_u64).unwrap_or(0);
             if context.has_css_comment_before(start) {
                 if started {
                     context.write(" ");
@@ -575,7 +582,7 @@ fn visit_selector_list(context: &mut Context, node: &Value) {
 /// * `context` - The context to write to
 /// * `node` - The TypeSelector node
 fn visit_type_selector(context: &mut Context, node: &Value) {
-    if let Some(namespace) = node.get("namespace").and_then(|n| n.as_str()) {
+    if let Some(namespace) = node.field("namespace").and_then(|n| n.as_str()) {
         if namespace == "*" {
             context.write("*");
         } else {
@@ -583,7 +590,7 @@ fn visit_type_selector(context: &mut Context, node: &Value) {
         }
         context.write("|");
     }
-    if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
+    if let Some(name) = node.field("name").and_then(|n| n.as_str()) {
         if name == "*" {
             context.write(name);
         } else {

--- a/crates/rsvelte_core/src/compiler/print/helpers.rs
+++ b/crates/rsvelte_core/src/compiler/print/helpers.rs
@@ -4,6 +4,7 @@
 //! such as formatting blocks and handling attributes.
 
 use super::{Context, PrintError};
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 use std::cell::RefCell;
 use std::fmt::Write as _;
 
@@ -184,8 +185,8 @@ pub fn unsupported_nodes_error(recorded: &[String]) -> PrintError {
 }
 
 fn record_unsupported_node(node: &serde_json::Value, node_type: Option<&str>) {
-    let start = node.get("start").and_then(serde_json::Value::as_u64);
-    let end = node.get("end").and_then(serde_json::Value::as_u64);
+    let start = node.field("start").and_then(serde_json::Value::as_u64);
+    let end = node.field("end").and_then(serde_json::Value::as_u64);
     let location = match (start, end) {
         (Some(start), Some(end)) => format!(" at {start}..{end}"),
         (Some(start), None) => format!(" at {start}"),
@@ -277,8 +278,13 @@ fn binary_operator_precedence(operator: &str) -> Option<u8> {
 /// `??` may not sit next to `&&` or `||` unparenthesized, however the two
 /// precedences compare.
 fn mixed_logical_min(parent_operator: &str, child: &serde_json::Value, min_precedence: u8) -> u8 {
-    let child_operator = (child.get("type").and_then(|t| t.as_str()) == Some("LogicalExpression"))
-        .then(|| child.get("operator").and_then(|o| o.as_str()).unwrap_or(""));
+    let child_operator =
+        (child.field("type").and_then(|t| t.as_str()) == Some("LogicalExpression")).then(|| {
+            child
+                .field("operator")
+                .and_then(|o| o.as_str())
+                .unwrap_or("")
+        });
     match (parent_operator, child_operator) {
         ("??", Some("&&" | "||")) | ("&&" | "||", Some("??")) => precedence::PRIMARY,
         _ => min_precedence,
@@ -287,20 +293,24 @@ fn mixed_logical_min(parent_operator: &str, child: &serde_json::Value, min_prece
 
 /// The precedence of an expression node as printed by [`EstreeGenerator`].
 fn node_precedence(node: &serde_json::Value) -> u8 {
-    match node.get("type").and_then(|t| t.as_str()) {
+    match node.field("type").and_then(|t| t.as_str()) {
         Some("SequenceExpression") => precedence::SEQUENCE,
         Some("AssignmentExpression")
         | Some("ArrowFunctionExpression")
         | Some("YieldExpression") => precedence::ASSIGNMENT,
         Some("ConditionalExpression") => precedence::CONDITIONAL,
         Some("BinaryExpression") | Some("LogicalExpression") => node
-            .get("operator")
+            .field("operator")
             .and_then(|o| o.as_str())
             .and_then(binary_operator_precedence)
             .unwrap_or(precedence::PRIMARY),
         Some("UnaryExpression") | Some("AwaitExpression") => precedence::UNARY,
         Some("UpdateExpression") => {
-            if node.get("prefix").and_then(|p| p.as_bool()).unwrap_or(true) {
+            if node
+                .field("prefix")
+                .and_then(|p| p.as_bool())
+                .unwrap_or(true)
+            {
                 precedence::UNARY
             } else {
                 precedence::POSTFIX
@@ -312,7 +322,7 @@ fn node_precedence(node: &serde_json::Value) -> u8 {
         | Some("TaggedTemplateExpression")
         | Some("ImportExpression") => precedence::CALL,
         Some("ChainExpression") => node
-            .get("expression")
+            .field("expression")
             .map(node_precedence)
             .unwrap_or(precedence::CALL),
         _ => precedence::PRIMARY,
@@ -332,7 +342,7 @@ impl EstreeGenerator {
     }
 
     fn generate_node(&mut self, node: &serde_json::Value) {
-        let node_type = node.get("type").and_then(|t| t.as_str());
+        let node_type = node.field("type").and_then(|t| t.as_str());
 
         match node_type {
             Some("Identifier") => self.generate_identifier(node),
@@ -359,33 +369,33 @@ impl EstreeGenerator {
             Some("ThisExpression") => self.output.push_str("this"),
             Some("NewExpression") => self.generate_new_expression(node),
             Some("ChainExpression") => {
-                if let Some(expr) = node.get("expression") {
+                if let Some(expr) = node.field("expression") {
                     self.generate_node(expr);
                 }
             }
             Some("AwaitExpression") => {
                 self.output.push_str("await ");
-                if let Some(arg) = node.get("argument") {
+                if let Some(arg) = node.field("argument") {
                     self.generate_expression(arg, precedence::UNARY);
                 }
             }
             Some("YieldExpression") => {
                 self.output.push_str("yield");
                 if node
-                    .get("delegate")
+                    .field("delegate")
                     .and_then(|d| d.as_bool())
                     .unwrap_or(false)
                 {
                     self.output.push('*');
                 }
-                if let Some(arg) = node.get("argument") {
+                if let Some(arg) = node.field("argument") {
                     self.output.push(' ');
                     self.generate_expression(arg, precedence::ASSIGNMENT);
                 }
             }
             Some("ParenthesizedExpression") => {
                 self.output.push('(');
-                if let Some(expr) = node.get("expression") {
+                if let Some(expr) = node.field("expression") {
                     self.generate_node(expr);
                 }
                 self.output.push(')');
@@ -393,26 +403,26 @@ impl EstreeGenerator {
             Some("Property") => self.generate_property(node),
             Some("Super") => self.output.push_str("super"),
             Some("MetaProperty") => {
-                if let Some(meta) = node.get("meta") {
+                if let Some(meta) = node.field("meta") {
                     self.generate_node(meta);
                 }
                 self.output.push('.');
-                if let Some(property) = node.get("property") {
+                if let Some(property) = node.field("property") {
                     self.generate_node(property);
                 }
             }
             Some("ImportExpression") => self.generate_import_expression(node),
             Some("TaggedTemplateExpression") => {
-                if let Some(tag) = node.get("tag") {
+                if let Some(tag) = node.field("tag") {
                     self.generate_node(tag);
                 }
-                if let Some(quasi) = node.get("quasi") {
+                if let Some(quasi) = node.field("quasi") {
                     self.generate_node(quasi);
                 }
             }
             Some("PrivateIdentifier") => {
                 self.output.push('#');
-                if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
+                if let Some(name) = node.field("name").and_then(|n| n.as_str()) {
                     self.output.push_str(name);
                 }
             }
@@ -426,7 +436,7 @@ impl EstreeGenerator {
             }
             Some("BlockStatement") => self.generate_block_statement(node),
             Some("ExpressionStatement") => {
-                if let Some(expr) = node.get("expression") {
+                if let Some(expr) = node.field("expression") {
                     self.generate_expression_statement(expr);
                 }
                 self.output.push(';');
@@ -438,11 +448,11 @@ impl EstreeGenerator {
             Some("BreakStatement") => self.generate_break_or_continue(node, "break"),
             Some("ContinueStatement") => self.generate_break_or_continue(node, "continue"),
             Some("LabeledStatement") => {
-                if let Some(label) = node.get("label") {
+                if let Some(label) = node.field("label") {
                     self.generate_node(label);
                 }
                 self.output.push_str(": ");
-                if let Some(body) = node.get("body") {
+                if let Some(body) = node.field("body") {
                     self.generate_node(body);
                 }
             }
@@ -455,17 +465,17 @@ impl EstreeGenerator {
             Some("ForOfStatement") => self.generate_for_in_of_statement(node, "of"),
             Some("WhileStatement") => {
                 self.output.push_str("while (");
-                if let Some(test) = node.get("test") {
+                if let Some(test) = node.field("test") {
                     self.generate_node(test);
                 }
                 self.output.push_str(") ");
-                self.generate_body_statement(node.get("body"));
+                self.generate_body_statement(node.field("body"));
             }
             Some("DoWhileStatement") => {
                 self.output.push_str("do ");
-                self.generate_body_statement(node.get("body"));
+                self.generate_body_statement(node.field("body"));
                 self.output.push_str(" while (");
-                if let Some(test) = node.get("test") {
+                if let Some(test) = node.field("test") {
                     self.generate_node(test);
                 }
                 self.output.push_str(");");
@@ -486,15 +496,15 @@ impl EstreeGenerator {
     }
 
     fn generate_identifier(&mut self, node: &serde_json::Value) {
-        if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
+        if let Some(name) = node.field("name").and_then(|n| n.as_str()) {
             self.output.push_str(name);
         }
     }
 
     fn generate_literal(&mut self, node: &serde_json::Value) {
-        if let Some(raw) = node.get("raw").and_then(|r| r.as_str()) {
+        if let Some(raw) = node.field("raw").and_then(|r| r.as_str()) {
             self.output.push_str(raw);
-        } else if let Some(value) = node.get("value") {
+        } else if let Some(value) = node.field("value") {
             match value {
                 serde_json::Value::String(s) => {
                     self.output.push('"');
@@ -525,10 +535,10 @@ impl EstreeGenerator {
     }
 
     fn generate_member_expression(&mut self, node: &serde_json::Value) {
-        if let Some(object) = node.get("object") {
+        if let Some(object) = node.field("object") {
             // A numeric literal receiver needs parens even though it is primary.
-            let needs_parens = (object.get("type").and_then(|t| t.as_str()) == Some("Literal")
-                && object.get("value").and_then(|v| v.as_f64()).is_some())
+            let needs_parens = (object.field("type").and_then(|t| t.as_str()) == Some("Literal")
+                && object.field("value").and_then(|v| v.as_f64()).is_some())
                 || node_precedence(object) < precedence::CALL;
 
             if needs_parens {
@@ -541,11 +551,11 @@ impl EstreeGenerator {
         }
 
         let optional = node
-            .get("optional")
+            .field("optional")
             .and_then(|o| o.as_bool())
             .unwrap_or(false);
         let computed = node
-            .get("computed")
+            .field("computed")
             .and_then(|c| c.as_bool())
             .unwrap_or(false);
 
@@ -561,19 +571,22 @@ impl EstreeGenerator {
             // (previously it was skipped when `optional`, yielding the invalid
             // `obj?.key]`). M-037.
             self.output.push('[');
-            if let Some(property) = node.get("property") {
+            if let Some(property) = node.field("property") {
                 self.generate_node(property);
             }
             self.output.push(']');
-        } else if let Some(property) = node.get("property")
-            && let Some(name) = property.get("name").and_then(|n| n.as_str())
+        } else if let Some(property) = node.field("property")
+            && let Some(name) = property.field("name").and_then(|n| n.as_str())
         {
             self.output.push_str(name);
         }
     }
 
     fn generate_binary_expression(&mut self, node: &serde_json::Value) {
-        let operator = node.get("operator").and_then(|o| o.as_str()).unwrap_or("");
+        let operator = node
+            .field("operator")
+            .and_then(|o| o.as_str())
+            .unwrap_or("");
         let own = binary_operator_precedence(operator).unwrap_or(precedence::PRIMARY);
         // `**` is the one right-associative binary operator.
         let (left_min, right_min) = if operator == "**" {
@@ -582,22 +595,22 @@ impl EstreeGenerator {
             (own, own + 1)
         };
 
-        if let Some(left) = node.get("left") {
+        if let Some(left) = node.field("left") {
             self.generate_expression(left, mixed_logical_min(operator, left, left_min));
         }
         if !operator.is_empty() {
             let _ = write!(self.output, " {operator} ");
         }
-        if let Some(right) = node.get("right") {
+        if let Some(right) = node.field("right") {
             self.generate_expression(right, mixed_logical_min(operator, right, right_min));
         }
     }
 
     fn generate_call_expression(&mut self, node: &serde_json::Value) {
-        if let Some(callee) = node.get("callee") {
+        if let Some(callee) = node.field("callee") {
             // A `function`/`class` callee also has to be parenthesized so the
             // call does not read as a declaration.
-            let min = match callee.get("type").and_then(|t| t.as_str()) {
+            let min = match callee.field("type").and_then(|t| t.as_str()) {
                 Some("FunctionExpression") | Some("ClassExpression") => precedence::PRIMARY + 1,
                 _ => precedence::CALL,
             };
@@ -605,7 +618,7 @@ impl EstreeGenerator {
         }
 
         let optional = node
-            .get("optional")
+            .field("optional")
             .and_then(|o| o.as_bool())
             .unwrap_or(false);
         if optional {
@@ -613,7 +626,7 @@ impl EstreeGenerator {
         }
 
         self.output.push('(');
-        if let Some(args) = node.get("arguments").and_then(|a| a.as_array()) {
+        if let Some(args) = node.field("arguments").and_then(|a| a.as_array()) {
             for (i, arg) in args.iter().enumerate() {
                 if i > 0 {
                     self.output.push_str(", ");
@@ -626,7 +639,7 @@ impl EstreeGenerator {
 
     fn generate_array_expression(&mut self, node: &serde_json::Value) {
         self.output.push('[');
-        if let Some(elements) = node.get("elements").and_then(|e| e.as_array()) {
+        if let Some(elements) = node.field("elements").and_then(|e| e.as_array()) {
             for (i, elem) in elements.iter().enumerate() {
                 if i > 0 {
                     self.output.push_str(", ");
@@ -643,7 +656,7 @@ impl EstreeGenerator {
 
     fn generate_object_expression(&mut self, node: &serde_json::Value) {
         self.output.push_str("{ ");
-        if let Some(properties) = node.get("properties").and_then(|p| p.as_array()) {
+        if let Some(properties) = node.field("properties").and_then(|p| p.as_array()) {
             for (i, prop) in properties.iter().enumerate() {
                 if i > 0 {
                     self.output.push_str(", ");
@@ -655,28 +668,31 @@ impl EstreeGenerator {
     }
 
     fn generate_property(&mut self, node: &serde_json::Value) {
-        let prop_type = node.get("type").and_then(|t| t.as_str());
+        let prop_type = node.field("type").and_then(|t| t.as_str());
 
         if prop_type == Some("SpreadElement") {
             self.output.push_str("...");
-            if let Some(arg) = node.get("argument") {
+            if let Some(arg) = node.field("argument") {
                 self.generate_node(arg);
             }
             return;
         }
 
-        let kind = node.get("kind").and_then(|k| k.as_str()).unwrap_or("init");
+        let kind = node
+            .field("kind")
+            .and_then(|k| k.as_str())
+            .unwrap_or("init");
         let computed = node
-            .get("computed")
+            .field("computed")
             .and_then(|c| c.as_bool())
             .unwrap_or(false);
         let shorthand = node
-            .get("shorthand")
+            .field("shorthand")
             .and_then(|s| s.as_bool())
             .unwrap_or(false);
 
         if shorthand {
-            if let Some(value) = node.get("value") {
+            if let Some(value) = node.field("value") {
                 self.generate_node(value);
             }
             return;
@@ -688,7 +704,7 @@ impl EstreeGenerator {
         let is_method = kind == "get"
             || kind == "set"
             || node
-                .get("method")
+                .field("method")
                 .and_then(|m| m.as_bool())
                 .unwrap_or(false);
 
@@ -701,7 +717,7 @@ impl EstreeGenerator {
             self.output.push('[');
         }
 
-        if let Some(key) = node.get("key") {
+        if let Some(key) = node.field("key") {
             self.generate_node(key);
         }
 
@@ -711,20 +727,23 @@ impl EstreeGenerator {
 
         self.output.push_str(": ");
 
-        if let Some(value) = node.get("value") {
+        if let Some(value) = node.field("value") {
             self.generate_expression(value, precedence::ASSIGNMENT);
         }
     }
 
     fn generate_arrow_function(&mut self, node: &serde_json::Value) {
-        let is_async = node.get("async").and_then(|a| a.as_bool()).unwrap_or(false);
+        let is_async = node
+            .field("async")
+            .and_then(|a| a.as_bool())
+            .unwrap_or(false);
         if is_async {
             self.output.push_str("async ");
         }
 
-        if let Some(params) = node.get("params").and_then(|p| p.as_array()) {
+        if let Some(params) = node.field("params").and_then(|p| p.as_array()) {
             if params.len() == 1
-                && params[0].get("type").and_then(|t| t.as_str()) == Some("Identifier")
+                && params[0].field("type").and_then(|t| t.as_str()) == Some("Identifier")
             {
                 self.generate_node(&params[0]);
             } else {
@@ -741,8 +760,8 @@ impl EstreeGenerator {
 
         self.output.push_str(" => ");
 
-        if let Some(body) = node.get("body") {
-            let body_type = body.get("type").and_then(|t| t.as_str());
+        if let Some(body) = node.field("body") {
+            let body_type = body.field("type").and_then(|t| t.as_str());
             if body_type == Some("BlockStatement") {
                 self.generate_block_statement(body);
             } else {
@@ -759,9 +778,12 @@ impl EstreeGenerator {
     }
 
     fn generate_function_expression(&mut self, node: &serde_json::Value) {
-        let is_async = node.get("async").and_then(|a| a.as_bool()).unwrap_or(false);
+        let is_async = node
+            .field("async")
+            .and_then(|a| a.as_bool())
+            .unwrap_or(false);
         let is_generator = node
-            .get("generator")
+            .field("generator")
             .and_then(|g| g.as_bool())
             .unwrap_or(false);
 
@@ -775,7 +797,7 @@ impl EstreeGenerator {
             self.output.push('*');
         }
 
-        if let Some(id) = node.get("id")
+        if let Some(id) = node.field("id")
             && !id.is_null()
         {
             self.output.push(' ');
@@ -783,7 +805,7 @@ impl EstreeGenerator {
         }
 
         self.output.push('(');
-        if let Some(params) = node.get("params").and_then(|p| p.as_array()) {
+        if let Some(params) = node.field("params").and_then(|p| p.as_array()) {
             for (i, param) in params.iter().enumerate() {
                 if i > 0 {
                     self.output.push_str(", ");
@@ -794,7 +816,7 @@ impl EstreeGenerator {
         self.output.push(')');
 
         self.output.push(' ');
-        if let Some(body) = node.get("body") {
+        if let Some(body) = node.field("body") {
             self.generate_block_statement(body);
         }
     }
@@ -825,15 +847,15 @@ impl EstreeGenerator {
 
     fn generate_import_expression(&mut self, node: &serde_json::Value) {
         self.output.push_str("import(");
-        if let Some(source) = node.get("source") {
+        if let Some(source) = node.field("source") {
             self.generate_node(source);
         }
         // ESTree moved the second argument from `arguments` to `options`;
         // whichever spelling carries it must not be dropped.
-        if let Some(options) = node.get("options").filter(|o| !o.is_null()) {
+        if let Some(options) = node.field("options").filter(|o| !o.is_null()) {
             self.output.push_str(", ");
             self.generate_node(options);
-        } else if let Some(arguments) = node.get("arguments").and_then(|a| a.as_array()) {
+        } else if let Some(arguments) = node.field("arguments").and_then(|a| a.as_array()) {
             for argument in arguments {
                 self.output.push_str(", ");
                 self.generate_node(argument);
@@ -843,7 +865,7 @@ impl EstreeGenerator {
     }
 
     fn generate_block_statement(&mut self, node: &serde_json::Value) {
-        let body = node.get("body").and_then(|b| b.as_array());
+        let body = node.field("body").and_then(|b| b.as_array());
         match body {
             Some(statements) if !statements.is_empty() => {
                 self.output.push_str("{ ");
@@ -872,7 +894,7 @@ impl EstreeGenerator {
             self.output.push_str("{}");
             return;
         };
-        if body.get("type").and_then(|t| t.as_str()) == Some("BlockStatement") {
+        if body.field("type").and_then(|t| t.as_str()) == Some("BlockStatement") {
             self.generate_block_statement(body);
         } else {
             self.output.push_str("{ ");
@@ -883,7 +905,7 @@ impl EstreeGenerator {
 
     fn generate_return_or_throw(&mut self, node: &serde_json::Value, keyword: &str) {
         self.output.push_str(keyword);
-        if let Some(argument) = node.get("argument")
+        if let Some(argument) = node.field("argument")
             && !argument.is_null()
         {
             self.output.push(' ');
@@ -894,7 +916,7 @@ impl EstreeGenerator {
 
     fn generate_break_or_continue(&mut self, node: &serde_json::Value, keyword: &str) {
         self.output.push_str(keyword);
-        if let Some(label) = node.get("label")
+        if let Some(label) = node.field("label")
             && !label.is_null()
         {
             self.output.push(' ');
@@ -904,10 +926,13 @@ impl EstreeGenerator {
     }
 
     fn generate_variable_declaration(&mut self, node: &serde_json::Value, terminate: bool) {
-        let kind = node.get("kind").and_then(|k| k.as_str()).unwrap_or("const");
+        let kind = node
+            .field("kind")
+            .and_then(|k| k.as_str())
+            .unwrap_or("const");
         self.output.push_str(kind);
         self.output.push(' ');
-        if let Some(declarations) = node.get("declarations").and_then(|d| d.as_array()) {
+        if let Some(declarations) = node.field("declarations").and_then(|d| d.as_array()) {
             for (i, declaration) in declarations.iter().enumerate() {
                 if i > 0 {
                     self.output.push_str(", ");
@@ -921,10 +946,10 @@ impl EstreeGenerator {
     }
 
     fn generate_variable_declarator(&mut self, node: &serde_json::Value) {
-        if let Some(id) = node.get("id") {
+        if let Some(id) = node.field("id") {
             self.generate_node(id);
         }
-        if let Some(init) = node.get("init")
+        if let Some(init) = node.field("init")
             && !init.is_null()
         {
             self.output.push_str(" = ");
@@ -934,17 +959,17 @@ impl EstreeGenerator {
 
     fn generate_if_statement(&mut self, node: &serde_json::Value) {
         self.output.push_str("if (");
-        if let Some(test) = node.get("test") {
+        if let Some(test) = node.field("test") {
             self.generate_node(test);
         }
         self.output.push_str(") ");
 
-        let alternate = node.get("alternate").filter(|a| !a.is_null());
+        let alternate = node.field("alternate").filter(|a| !a.is_null());
         if alternate.is_some() {
             // Braced unconditionally: a bare `if (a) if (b) c();` consequent
             // would otherwise capture this statement's `else`.
-            self.generate_body_statement(node.get("consequent"));
-        } else if let Some(consequent) = node.get("consequent") {
+            self.generate_body_statement(node.field("consequent"));
+        } else if let Some(consequent) = node.field("consequent") {
             self.generate_node(consequent);
         }
 
@@ -956,41 +981,45 @@ impl EstreeGenerator {
 
     fn generate_for_statement(&mut self, node: &serde_json::Value) {
         self.output.push_str("for (");
-        if let Some(init) = node.get("init").filter(|i| !i.is_null()) {
+        if let Some(init) = node.field("init").filter(|i| !i.is_null()) {
             self.generate_for_head(init);
         }
         self.output.push_str("; ");
-        if let Some(test) = node.get("test").filter(|t| !t.is_null()) {
+        if let Some(test) = node.field("test").filter(|t| !t.is_null()) {
             self.generate_node(test);
         }
         self.output.push_str("; ");
-        if let Some(update) = node.get("update").filter(|u| !u.is_null()) {
+        if let Some(update) = node.field("update").filter(|u| !u.is_null()) {
             self.generate_node(update);
         }
         self.output.push_str(") ");
-        self.generate_body_statement(node.get("body"));
+        self.generate_body_statement(node.field("body"));
     }
 
     fn generate_for_in_of_statement(&mut self, node: &serde_json::Value, operator: &str) {
         self.output.push_str("for ");
-        if node.get("await").and_then(|a| a.as_bool()).unwrap_or(false) {
+        if node
+            .field("await")
+            .and_then(|a| a.as_bool())
+            .unwrap_or(false)
+        {
             self.output.push_str("await ");
         }
         self.output.push('(');
-        if let Some(left) = node.get("left") {
+        if let Some(left) = node.field("left") {
             self.generate_for_head(left);
         }
         let _ = write!(self.output, " {operator} ");
-        if let Some(right) = node.get("right") {
+        if let Some(right) = node.field("right") {
             self.generate_node(right);
         }
         self.output.push_str(") ");
-        self.generate_body_statement(node.get("body"));
+        self.generate_body_statement(node.field("body"));
     }
 
     /// A declaration in a `for` head carries no terminator of its own.
     fn generate_for_head(&mut self, node: &serde_json::Value) {
-        if node.get("type").and_then(|t| t.as_str()) == Some("VariableDeclaration") {
+        if node.field("type").and_then(|t| t.as_str()) == Some("VariableDeclaration") {
             self.generate_variable_declaration(node, false);
         } else {
             self.generate_node(node);
@@ -999,11 +1028,11 @@ impl EstreeGenerator {
 
     fn generate_switch_statement(&mut self, node: &serde_json::Value) {
         self.output.push_str("switch (");
-        if let Some(discriminant) = node.get("discriminant") {
+        if let Some(discriminant) = node.field("discriminant") {
             self.generate_node(discriminant);
         }
         self.output.push_str(") ");
-        match node.get("cases").and_then(|c| c.as_array()) {
+        match node.field("cases").and_then(|c| c.as_array()) {
             Some(cases) if !cases.is_empty() => {
                 self.output.push_str("{ ");
                 self.generate_statement_list(cases);
@@ -1014,7 +1043,7 @@ impl EstreeGenerator {
     }
 
     fn generate_switch_case(&mut self, node: &serde_json::Value) {
-        match node.get("test").filter(|t| !t.is_null()) {
+        match node.field("test").filter(|t| !t.is_null()) {
             Some(test) => {
                 self.output.push_str("case ");
                 self.generate_node(test);
@@ -1022,7 +1051,7 @@ impl EstreeGenerator {
             }
             None => self.output.push_str("default:"),
         }
-        if let Some(consequent) = node.get("consequent").and_then(|c| c.as_array())
+        if let Some(consequent) = node.field("consequent").and_then(|c| c.as_array())
             && !consequent.is_empty()
         {
             self.output.push(' ');
@@ -1032,16 +1061,16 @@ impl EstreeGenerator {
 
     fn generate_try_statement(&mut self, node: &serde_json::Value) {
         self.output.push_str("try ");
-        if let Some(block) = node.get("block") {
+        if let Some(block) = node.field("block") {
             self.generate_block_statement(block);
         }
-        if let Some(handler) = node.get("handler")
+        if let Some(handler) = node.field("handler")
             && !handler.is_null()
         {
             self.output.push(' ');
             self.generate_node(handler);
         }
-        if let Some(finalizer) = node.get("finalizer")
+        if let Some(finalizer) = node.field("finalizer")
             && !finalizer.is_null()
         {
             self.output.push_str(" finally ");
@@ -1051,41 +1080,41 @@ impl EstreeGenerator {
 
     fn generate_catch_clause(&mut self, node: &serde_json::Value) {
         self.output.push_str("catch ");
-        if let Some(param) = node.get("param")
+        if let Some(param) = node.field("param")
             && !param.is_null()
         {
             self.output.push('(');
             self.generate_node(param);
             self.output.push_str(") ");
         }
-        if let Some(body) = node.get("body") {
+        if let Some(body) = node.field("body") {
             self.generate_block_statement(body);
         }
     }
 
     fn generate_class(&mut self, node: &serde_json::Value) {
         self.output.push_str("class");
-        if let Some(id) = node.get("id")
+        if let Some(id) = node.field("id")
             && !id.is_null()
         {
             self.output.push(' ');
             self.generate_node(id);
         }
-        if let Some(super_class) = node.get("superClass")
+        if let Some(super_class) = node.field("superClass")
             && !super_class.is_null()
         {
             self.output.push_str(" extends ");
             self.generate_node(super_class);
         }
         self.output.push(' ');
-        match node.get("body") {
+        match node.field("body") {
             Some(body) => self.generate_class_body(body),
             None => self.output.push_str("{}"),
         }
     }
 
     fn generate_class_body(&mut self, node: &serde_json::Value) {
-        match node.get("body").and_then(|b| b.as_array()) {
+        match node.field("body").and_then(|b| b.as_array()) {
             Some(members) if !members.is_empty() => {
                 self.output.push_str("{ ");
                 self.generate_statement_list(members);
@@ -1097,28 +1126,28 @@ impl EstreeGenerator {
 
     fn generate_method_definition(&mut self, node: &serde_json::Value) {
         if node
-            .get("static")
+            .field("static")
             .and_then(|s| s.as_bool())
             .unwrap_or(false)
         {
             self.output.push_str("static ");
         }
-        let value = node.get("value");
+        let value = node.field("value");
         if let Some(value) = value {
             if value
-                .get("async")
+                .field("async")
                 .and_then(|a| a.as_bool())
                 .unwrap_or(false)
             {
                 self.output.push_str("async ");
             }
-            match node.get("kind").and_then(|k| k.as_str()) {
+            match node.field("kind").and_then(|k| k.as_str()) {
                 Some("get") => self.output.push_str("get "),
                 Some("set") => self.output.push_str("set "),
                 _ => {}
             }
             if value
-                .get("generator")
+                .field("generator")
                 .and_then(|g| g.as_bool())
                 .unwrap_or(false)
             {
@@ -1128,7 +1157,7 @@ impl EstreeGenerator {
         self.generate_member_key(node);
         self.output.push('(');
         if let Some(params) = value
-            .and_then(|v| v.get("params"))
+            .and_then(|v| v.field("params"))
             .and_then(|p| p.as_array())
         {
             for (i, param) in params.iter().enumerate() {
@@ -1139,7 +1168,7 @@ impl EstreeGenerator {
             }
         }
         self.output.push_str(") ");
-        match value.and_then(|v| v.get("body")) {
+        match value.and_then(|v| v.field("body")) {
             Some(body) => self.generate_block_statement(body),
             None => self.output.push_str("{}"),
         }
@@ -1147,14 +1176,14 @@ impl EstreeGenerator {
 
     fn generate_property_definition(&mut self, node: &serde_json::Value) {
         if node
-            .get("static")
+            .field("static")
             .and_then(|s| s.as_bool())
             .unwrap_or(false)
         {
             self.output.push_str("static ");
         }
         self.generate_member_key(node);
-        if let Some(value) = node.get("value")
+        if let Some(value) = node.field("value")
             && !value.is_null()
         {
             self.output.push_str(" = ");
@@ -1165,13 +1194,13 @@ impl EstreeGenerator {
 
     fn generate_member_key(&mut self, node: &serde_json::Value) {
         let computed = node
-            .get("computed")
+            .field("computed")
             .and_then(|c| c.as_bool())
             .unwrap_or(false);
         if computed {
             self.output.push('[');
         }
-        if let Some(key) = node.get("key") {
+        if let Some(key) = node.field("key") {
             self.generate_node(key);
         }
         if computed {
@@ -1186,24 +1215,24 @@ impl EstreeGenerator {
         let mut namespace_import = None;
         let mut named_imports = Vec::new();
 
-        if let Some(specifiers) = node.get("specifiers").and_then(|s| s.as_array()) {
+        if let Some(specifiers) = node.field("specifiers").and_then(|s| s.as_array()) {
             for specifier in specifiers {
-                match specifier.get("type").and_then(|t| t.as_str()) {
+                match specifier.field("type").and_then(|t| t.as_str()) {
                     Some("ImportDefaultSpecifier") => {
-                        default_import = specifier.get("local").map(estree_to_string);
+                        default_import = specifier.field("local").map(estree_to_string);
                     }
                     Some("ImportNamespaceSpecifier") => {
                         namespace_import = specifier
-                            .get("local")
+                            .field("local")
                             .map(|local| format!("* as {}", estree_to_string(local)));
                     }
                     Some("ImportSpecifier") => {
                         let imported = specifier
-                            .get("imported")
+                            .field("imported")
                             .map(estree_to_string)
                             .unwrap_or_default();
                         let local = specifier
-                            .get("local")
+                            .field("local")
                             .map(estree_to_string)
                             .unwrap_or_default();
                         if imported == local {
@@ -1233,22 +1262,22 @@ impl EstreeGenerator {
             self.output.push_str(" from ");
         }
 
-        if let Some(source) = node.get("source") {
+        if let Some(source) = node.field("source") {
             self.generate_node(source);
         }
         self.output.push(';');
     }
 
     fn generate_export_declaration(&mut self, node: &serde_json::Value) {
-        let node_type = node.get("type").and_then(|t| t.as_str());
+        let node_type = node.field("type").and_then(|t| t.as_str());
 
         if node_type == Some("ExportDefaultDeclaration") {
             self.output.push_str("export default ");
-            if let Some(declaration) = node.get("declaration") {
+            if let Some(declaration) = node.field("declaration") {
                 self.generate_node(declaration);
                 // A declaration terminates itself; an expression does not.
                 let declares = matches!(
-                    declaration.get("type").and_then(|t| t.as_str()),
+                    declaration.field("type").and_then(|t| t.as_str()),
                     Some("FunctionDeclaration") | Some("ClassDeclaration")
                 );
                 if !declares {
@@ -1262,28 +1291,28 @@ impl EstreeGenerator {
 
         if node_type == Some("ExportAllDeclaration") {
             self.output.push('*');
-            if let Some(exported) = node.get("exported")
+            if let Some(exported) = node.field("exported")
                 && !exported.is_null()
             {
                 self.output.push_str(" as ");
                 self.generate_node(exported);
             }
             self.output.push_str(" from ");
-            if let Some(source) = node.get("source") {
+            if let Some(source) = node.field("source") {
                 self.generate_node(source);
             }
             self.output.push(';');
             return;
         }
 
-        if let Some(declaration) = node.get("declaration")
+        if let Some(declaration) = node.field("declaration")
             && !declaration.is_null()
         {
             self.generate_node(declaration);
             return;
         }
 
-        if let Some(specifiers) = node.get("specifiers").and_then(|s| s.as_array())
+        if let Some(specifiers) = node.field("specifiers").and_then(|s| s.as_array())
             && !specifiers.is_empty()
         {
             self.output.push_str("{ ");
@@ -1292,11 +1321,11 @@ impl EstreeGenerator {
                     self.output.push_str(", ");
                 }
                 let exported = specifier
-                    .get("exported")
+                    .field("exported")
                     .map(estree_to_string)
                     .unwrap_or_default();
                 let local = specifier
-                    .get("local")
+                    .field("local")
                     .map(estree_to_string)
                     .unwrap_or_default();
                 if exported == local {
@@ -1308,7 +1337,7 @@ impl EstreeGenerator {
             self.output.push_str(" }");
         }
 
-        if let Some(source) = node.get("source")
+        if let Some(source) = node.field("source")
             && !source.is_null()
         {
             self.output.push_str(" from ");
@@ -1319,19 +1348,25 @@ impl EstreeGenerator {
     }
 
     fn generate_unary_expression(&mut self, node: &serde_json::Value) {
-        let prefix = node.get("prefix").and_then(|p| p.as_bool()).unwrap_or(true);
-        let op = node.get("operator").and_then(|o| o.as_str()).unwrap_or("");
+        let prefix = node
+            .field("prefix")
+            .and_then(|p| p.as_bool())
+            .unwrap_or(true);
+        let op = node
+            .field("operator")
+            .and_then(|o| o.as_str())
+            .unwrap_or("");
 
         if prefix {
             self.output.push_str(op);
             if matches!(op, "typeof" | "void" | "delete") {
                 self.output.push(' ');
             }
-            if let Some(arg) = node.get("argument") {
+            if let Some(arg) = node.field("argument") {
                 self.generate_expression(arg, precedence::UNARY);
             }
         } else {
-            if let Some(arg) = node.get("argument") {
+            if let Some(arg) = node.field("argument") {
                 self.generate_expression(arg, precedence::UNARY);
             }
             self.output.push_str(op);
@@ -1339,16 +1374,22 @@ impl EstreeGenerator {
     }
 
     fn generate_update_expression(&mut self, node: &serde_json::Value) {
-        let prefix = node.get("prefix").and_then(|p| p.as_bool()).unwrap_or(true);
-        let op = node.get("operator").and_then(|o| o.as_str()).unwrap_or("");
+        let prefix = node
+            .field("prefix")
+            .and_then(|p| p.as_bool())
+            .unwrap_or(true);
+        let op = node
+            .field("operator")
+            .and_then(|o| o.as_str())
+            .unwrap_or("");
 
         if prefix {
             self.output.push_str(op);
-            if let Some(arg) = node.get("argument") {
+            if let Some(arg) = node.field("argument") {
                 self.generate_expression(arg, precedence::POSTFIX);
             }
         } else {
-            if let Some(arg) = node.get("argument") {
+            if let Some(arg) = node.field("argument") {
                 self.generate_expression(arg, precedence::POSTFIX);
             }
             self.output.push_str(op);
@@ -1356,15 +1397,15 @@ impl EstreeGenerator {
     }
 
     fn generate_conditional_expression(&mut self, node: &serde_json::Value) {
-        if let Some(test) = node.get("test") {
+        if let Some(test) = node.field("test") {
             self.generate_expression(test, precedence::CONDITIONAL + 1);
         }
         self.output.push_str(" ? ");
-        if let Some(consequent) = node.get("consequent") {
+        if let Some(consequent) = node.field("consequent") {
             self.generate_expression(consequent, precedence::ASSIGNMENT);
         }
         self.output.push_str(" : ");
-        if let Some(alternate) = node.get("alternate") {
+        if let Some(alternate) = node.field("alternate") {
             self.generate_expression(alternate, precedence::ASSIGNMENT);
         }
     }
@@ -1372,13 +1413,13 @@ impl EstreeGenerator {
     fn generate_template_literal(&mut self, node: &serde_json::Value) {
         self.output.push('`');
 
-        if let Some(quasis) = node.get("quasis").and_then(|q| q.as_array()) {
-            let expressions = node.get("expressions").and_then(|e| e.as_array());
+        if let Some(quasis) = node.field("quasis").and_then(|q| q.as_array()) {
+            let expressions = node.field("expressions").and_then(|e| e.as_array());
 
             for (i, quasi) in quasis.iter().enumerate() {
                 if let Some(raw) = quasi
-                    .get("value")
-                    .and_then(|v| v.get("raw"))
+                    .field("value")
+                    .and_then(|v| v.field("raw"))
                     .and_then(|r| r.as_str())
                 {
                     self.output.push_str(raw);
@@ -1399,7 +1440,7 @@ impl EstreeGenerator {
 
     fn generate_array_pattern(&mut self, node: &serde_json::Value) {
         self.output.push('[');
-        if let Some(elements) = node.get("elements").and_then(|e| e.as_array()) {
+        if let Some(elements) = node.field("elements").and_then(|e| e.as_array()) {
             for (i, elem) in elements.iter().enumerate() {
                 if i > 0 {
                     self.output.push_str(", ");
@@ -1416,44 +1457,44 @@ impl EstreeGenerator {
 
     fn generate_object_pattern(&mut self, node: &serde_json::Value) {
         self.output.push_str("{ ");
-        if let Some(properties) = node.get("properties").and_then(|p| p.as_array()) {
+        if let Some(properties) = node.field("properties").and_then(|p| p.as_array()) {
             for (i, prop) in properties.iter().enumerate() {
                 if i > 0 {
                     self.output.push_str(", ");
                 }
 
-                let prop_type = prop.get("type").and_then(|t| t.as_str());
+                let prop_type = prop.field("type").and_then(|t| t.as_str());
                 if prop_type == Some("RestElement") {
                     self.output.push_str("...");
-                    if let Some(arg) = prop.get("argument") {
+                    if let Some(arg) = prop.field("argument") {
                         self.generate_node(arg);
                     }
                 } else {
                     let shorthand = prop
-                        .get("shorthand")
+                        .field("shorthand")
                         .and_then(|s| s.as_bool())
                         .unwrap_or(false);
                     let computed = prop
-                        .get("computed")
+                        .field("computed")
                         .and_then(|c| c.as_bool())
                         .unwrap_or(false);
 
                     if shorthand {
-                        if let Some(value) = prop.get("value") {
+                        if let Some(value) = prop.field("value") {
                             self.generate_expression(value, precedence::ASSIGNMENT);
                         }
                     } else {
                         if computed {
                             self.output.push('[');
                         }
-                        if let Some(key) = prop.get("key") {
+                        if let Some(key) = prop.field("key") {
                             self.generate_node(key);
                         }
                         if computed {
                             self.output.push(']');
                         }
                         self.output.push_str(": ");
-                        if let Some(value) = prop.get("value") {
+                        if let Some(value) = prop.field("value") {
                             self.generate_node(value);
                         }
                     }
@@ -1465,44 +1506,44 @@ impl EstreeGenerator {
 
     fn generate_rest_element(&mut self, node: &serde_json::Value) {
         self.output.push_str("...");
-        if let Some(arg) = node.get("argument") {
+        if let Some(arg) = node.field("argument") {
             self.generate_expression(arg, precedence::ASSIGNMENT);
         }
     }
 
     fn generate_spread_element(&mut self, node: &serde_json::Value) {
         self.output.push_str("...");
-        if let Some(arg) = node.get("argument") {
+        if let Some(arg) = node.field("argument") {
             self.generate_expression(arg, precedence::ASSIGNMENT);
         }
     }
 
     fn generate_assignment_pattern(&mut self, node: &serde_json::Value) {
-        if let Some(left) = node.get("left") {
+        if let Some(left) = node.field("left") {
             self.generate_node(left);
         }
         self.output.push_str(" = ");
-        if let Some(right) = node.get("right") {
+        if let Some(right) = node.field("right") {
             self.generate_node(right);
         }
     }
 
     fn generate_assignment_expression(&mut self, node: &serde_json::Value) {
-        if let Some(left) = node.get("left") {
+        if let Some(left) = node.field("left") {
             self.generate_node(left);
         }
-        if let Some(op) = node.get("operator").and_then(|o| o.as_str()) {
+        if let Some(op) = node.field("operator").and_then(|o| o.as_str()) {
             self.output.push(' ');
             self.output.push_str(op);
             self.output.push(' ');
         }
-        if let Some(right) = node.get("right") {
+        if let Some(right) = node.field("right") {
             self.generate_expression(right, precedence::ASSIGNMENT);
         }
     }
 
     fn generate_sequence_expression(&mut self, node: &serde_json::Value) {
-        if let Some(expressions) = node.get("expressions").and_then(|e| e.as_array()) {
+        if let Some(expressions) = node.field("expressions").and_then(|e| e.as_array()) {
             for (i, expr) in expressions.iter().enumerate() {
                 if i > 0 {
                     self.output.push_str(", ");
@@ -1514,16 +1555,16 @@ impl EstreeGenerator {
 
     fn generate_new_expression(&mut self, node: &serde_json::Value) {
         self.output.push_str("new ");
-        if let Some(callee) = node.get("callee") {
+        if let Some(callee) = node.field("callee") {
             // `new f()()` must not re-read as `new (f()())`.
-            let min = match callee.get("type").and_then(|t| t.as_str()) {
+            let min = match callee.field("type").and_then(|t| t.as_str()) {
                 Some("CallExpression") => precedence::PRIMARY + 1,
                 _ => precedence::CALL,
             };
             self.generate_expression(callee, min);
         }
         self.output.push('(');
-        if let Some(args) = node.get("arguments").and_then(|a| a.as_array()) {
+        if let Some(args) = node.field("arguments").and_then(|a| a.as_array()) {
             for (i, arg) in args.iter().enumerate() {
                 if i > 0 {
                     self.output.push_str(", ");
@@ -1563,8 +1604,8 @@ impl EstreeGenerator {
 pub fn is_shorthand_identifier(expr: &crate::ast::js::Expression, name: &str) -> bool {
     let value = expr.as_json();
     if let Some(obj) = value.as_object()
-        && obj.get("type") == Some(&serde_json::Value::String("Identifier".to_string()))
-        && let Some(expr_name) = obj.get("name").and_then(|v| v.as_str())
+        && obj.field("type") == Some(&serde_json::Value::String("Identifier".to_string()))
+        && let Some(expr_name) = obj.field("name").and_then(|v| v.as_str())
     {
         return expr_name == name;
     }
@@ -1623,9 +1664,12 @@ pub fn format_variable_declaration_from_source(
     let json = expr.as_json();
 
     // Extract kind (should be "const")
-    let kind = json.get("kind").and_then(|k| k.as_str()).unwrap_or("const");
+    let kind = json
+        .field("kind")
+        .and_then(|k| k.as_str())
+        .unwrap_or("const");
 
-    if let Some(declarations) = json.get("declarations").and_then(|d| d.as_array()) {
+    if let Some(declarations) = json.field("declarations").and_then(|d| d.as_array()) {
         let mut result = format!("{} ", kind);
 
         for (i, decl) in declarations.iter().enumerate() {
@@ -1635,10 +1679,13 @@ pub fn format_variable_declaration_from_source(
 
             // Get the declarator's start..end from source if available
             let decl_start = decl
-                .get("start")
+                .field("start")
                 .and_then(|s| s.as_u64())
                 .map(|n| n as usize);
-            let decl_end = decl.get("end").and_then(|e| e.as_u64()).map(|n| n as usize);
+            let decl_end = decl
+                .field("end")
+                .and_then(|e| e.as_u64())
+                .map(|n| n as usize);
 
             if let (Some(src), Some(s), Some(e)) = (source, decl_start, decl_end)
                 && s < e
@@ -1649,10 +1696,10 @@ pub fn format_variable_declaration_from_source(
             }
 
             // Fallback: construct from AST
-            if let Some(id) = decl.get("id") {
+            if let Some(id) = decl.field("id") {
                 result.push_str(&estree_to_string(id));
             }
-            if let Some(init) = decl.get("init")
+            if let Some(init) = decl.field("init")
                 && !init.is_null()
             {
                 result.push_str(" = ");
@@ -1727,12 +1774,12 @@ fn get_program_body_positions(program: &crate::ast::js::Expression) -> Vec<(usiz
     // The typed path would require ParseArena to resolve IdRange;
     // as_json() handles arena resolution internally via to_value().
     let json = program.as_json();
-    if let Some(body) = json.get("body").and_then(|v| v.as_array()) {
+    if let Some(body) = json.field("body").and_then(|v| v.as_array()) {
         return body
             .iter()
             .filter_map(|stmt| {
-                let s = stmt.get("start").and_then(|s| s.as_u64())? as usize;
-                let e = stmt.get("end").and_then(|e| e.as_u64())? as usize;
+                let s = stmt.field("start").and_then(|s| s.as_u64())? as usize;
+                let e = stmt.field("end").and_then(|e| e.as_u64())? as usize;
                 Some((s, e))
             })
             .collect();
@@ -1795,7 +1842,7 @@ fn strip_base_indent(text: &str, base_indent: usize) -> String {
 /// Returns the formatted JavaScript code as a string.
 pub fn format_program(program: &serde_json::Value) -> String {
     // For a Program node, we need to handle the body array
-    if let Some(body) = program.get("body").and_then(|v| v.as_array()) {
+    if let Some(body) = program.field("body").and_then(|v| v.as_array()) {
         if body.is_empty() {
             return String::new();
         }

--- a/crates/rsvelte_core/src/compiler/print/visitors.rs
+++ b/crates/rsvelte_core/src/compiler/print/visitors.rs
@@ -16,6 +16,7 @@ use crate::ast::css::StyleSheet;
 use crate::ast::{
     Attribute, AttributeValue, AttributeValuePart, Fragment, Root, TemplateNode, Text,
 };
+use crate::compiler::phases::phase3_transform::shared::json_field::Field;
 
 /// Visit the root node and generate source code.
 ///
@@ -681,11 +682,11 @@ fn visit_attribute_node(context: &mut Context, attr: &crate::ast::AttributeNode)
 /// * `attr` - The attribute as JSON value
 fn visit_json_attribute(context: &mut Context, attr: &serde_json::Value) {
     // Extract name and value from JSON
-    if let Some(name) = attr.get("name").and_then(|n| n.as_str()) {
+    if let Some(name) = attr.field("name").and_then(|n| n.as_str()) {
         context.write(name);
 
         // Check if it has a value
-        if let Some(value) = attr.get("value")
+        if let Some(value) = attr.field("value")
             && !value.is_null()
             && value.as_bool() != Some(true)
             && let Some(val_str) = value.as_str()
@@ -1165,7 +1166,7 @@ fn visit_css_stylesheet(context: &mut Context, stylesheet: &StyleSheet) {
 
         for child in &stylesheet.children {
             let start = child
-                .get("start")
+                .field("start")
                 .and_then(serde_json::Value::as_u64)
                 .unwrap_or(0);
             while context.has_css_comment_before(start) {


### PR DESCRIPTION
`shared::json_field::Field` was introduced for `3_transform/css.rs`, where a
four-to-six-key node made a SipHash of the key plus an `IndexMap` probe the
expensive half of `node.get("type")`. That is not a property of CSS nodes: every
JSON AST this compiler walks has the same shape, and the same profile attributes
only a quarter of its 4.57% hash-and-probe bucket to the CSS pruner.

This applies the trait to the rest: 1,813 sites over 53 files under
`compiler/` and `ast/`, the largest being `client/visitors/expression_converter.rs`
(351), `print/helpers.rs` (177), `2_analyze/css/analyze.rs` (146),
`client/visitors/shared/utils.rs` (134), `each_block.rs` (97) and
`await_block.rs` (88).

The conversion was mechanical and then narrowed by the compiler, which is the
whole safety argument: **41 sites were `HashMap`/`BTreeMap` receivers** that `no
method named field` rejected, and 11 more files turned out to use the trait only
from their test module and were reverted whole rather than left with a
`#[cfg(test)]`-only import.

Measured single-threaded over 3,000 corpus components against the CSS-only
parent, both arms built from one tree (hashes differ), 12 ABBA-ordered pairs per
target, on a quiesced box:

| target | median CPU ratio parent/new | pairs favouring new | range |
|---|---|---|---|
| client | 1.0140 | 12/12 | 1.0098 .. 1.0177 |
| client-dev | 1.0115 | 12/12 | 1.0090 .. 1.0139 |
| server | 1.0121 | 12/12 | 1.0066 .. 1.0151 |
| server-dev | 1.0150 | 12/12 | 1.0110 .. 1.0181 |

Against `main`, the two together are client 1.0510, client-dev 1.0423, server
1.0557 and server-dev 1.0567.

`corpus_hash --map` over all **33,897 corpus components** — hashing `js.code`,
`css.code`, both source maps and every warning's code, message and position —
reports **0 differing rows** on client and 0 on server, with the same both-arms
`ERR` rows either side; its positive control, the same arm's client against its
own server output, differs on 65,310 rows. The source-map gate,
`compiler_fixtures`, `css`, `ssr`, `runtime` and the 1,964 lib tests are
unchanged.

Stacked on #4266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyd6xc1EN5Jt4yNWeiWtuy