### PR TITLE
test(lsp): the custom-property guard in the CSS scan had no witness

### DIFF
--- a/crates/rsvelte_language_server/src/css.rs
+++ b/crates/rsvelte_language_server/src/css.rs
@@ -477,11 +477,14 @@ mod tests {
 
     #[test]
     fn reports_unknown_css_properties() {
-        let diagnostics = diagnostics("<style>a { colro: red; --theme: blue }</style>");
-        assert_eq!(diagnostics.len(), 1);
+        let typo = diagnostics("<style>a { colro: red; --theme: blue }</style>");
+        assert_eq!(typo.len(), 1);
         assert_eq!(
-            diagnostics[0].code,
+            typo[0].code,
             Some(NumberOrString::String("css_unknown_property".to_string()))
         );
+        // The scan stops at the first `:` on a line, so the `--theme` above is
+        // never read and the custom-property guard decides nothing there.
+        assert!(diagnostics("<style>a {\n  --theme: blue;\n}</style>").is_empty());
     }
 }


### PR DESCRIPTION
`css::diagnostics` skips a property whose name opens with `--`, and
`reports_unknown_css_properties` reads as covering that guard because its input
carries a custom property. It does not.

The scan takes `line.find(':')` — one colon per line — so on

```css
a { colro: red; --theme: blue }
```

it stops at the typo's colon and the `--theme` after it is never read. The guard
decides nothing on that input.

Measured by ablation, both halves in one run (release, this branch):

- with the `--` guard deleted, the two existing assertions still hold — the
  panic lands on the line this PR adds, and nowhere else;
- with the guard restored, the new assertion passes.

So the added input is the guard's only witness, and it is a witness in both
directions. Test-only; no behaviour change.

Refs #4267.
