### PR TITLE
fix(client): six port defects across each / assign / props / invalidate, and the 13 entries they retire

### DIFF
--- a/.changeset/assign-chain-site-claim.md
+++ b/.changeset/assign-chain-site-claim.md
@@ -1,0 +1,11 @@
+---
+'@rsvelte/compiler': patch
+---
+
+In dev mode, each link of a chained assignment to a computed member now reports its own source position instead of the outermost link's.
+
+`$.assign(…, '<file>:<line>:<column>')` locates the assignment's left-hand side. rsvelte matches
+the lowered target back against a source-order site list keyed `(root, path, operator)`, and a
+computed member contributes a valueless `Computed` element — so `o.p[2]` and `o.p[3]` share a key
+and only the order the sites are consumed in separates them. The visitor claimed its site after
+descending, so the inner link of a chain took the outer's site.

--- a/.changeset/const-reexpands-into-snippet-wrapper.md
+++ b/.changeset/const-reexpands-into-snippet-wrapper.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/compiler": patch
+---
+
+An enclosing `{@const}` is re-expanded into an element's snippet wrapper
+
+`RegularElement.js:333` hands the children the parent's `consts` array itself when the element
+declares none of its own, and `:443` splices that same array into the `{ … }` wrapper a
+`{#snippet}` in its fragment creates.

--- a/.changeset/destructure-rhs-cache-visited-read.md
+++ b/.changeset/destructure-rhs-cache-visited-read.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/compiler": patch
+---
+
+A destructuring assignment caches its right-hand side from the visited read
+
+`shared/assignments.js:20-22` decides `should_cache` with `value.type !== 'Identifier'` on the
+**visited** node, so a runes prop that is never written — which reads as `$$props.data` — is
+cached in `$$value`. rsvelte answered that from the list of props eligible as assignment
+targets, which excludes exactly those.

--- a/.changeset/each-reassigned-item-dependency.md
+++ b/.changeset/each-reassigned-item-dependency.md
@@ -1,0 +1,11 @@
+---
+'@rsvelte/compiler': patch
+---
+
+An each item that is reassigned now reads as `collection[$index]` inside an inner `bind:`'s invalidation dependency list, as it already did everywhere else.
+
+Upstream reads a reassigned each item as `collection[$index]` and never as `$.get(item)`
+(`EachBlock.js:216-227`). rsvelte ports that rule as `build_reassigned_item_read` and applies it
+at eight sites; the dependency list an inner `bind:` hands to `$.invalidate_inner_signals` is a
+ninth, built by a string loop that consults `state.transform` directly, so the rule never reached
+it. Every other read of the item in the same output was already correct.

--- a/.changeset/legacy-prop-default-dev-equality.md
+++ b/.changeset/legacy-prop-default-dev-equality.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/compiler": patch
+---
+
+A legacy `export let` default holding an equality operator is lazy in dev only
+
+Upstream runs `is_simple_expression` on the visited default, and dev rewrites `===` / `!==` /
+`==` / `!=` into `$.strict_equals` / `$.equals` calls — so the same default is eager in
+production and thunked in dev. The scan deciding it also read a `(` after an operator as a
+call, which made `a || (b === 'x')` lazy in production where official is eager.

--- a/.changeset/prop-default-leading-comment.md
+++ b/.changeset/prop-default-leading-comment.md
@@ -1,0 +1,10 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A JSDoc comment before a parenthesised prop default no longer makes it a lazy thunk.
+
+`is_simple_expression_str` decides whether a prop default is emitted as a value or as
+`() => value`, and its call test — "ends in `)` and something precedes the matching `(`" — read a
+leading comment as the callee. Neither axis reproduces it alone: the comment without parentheses
+does not end in `)`, and the parentheses without a comment have nothing before the `(`.

--- a/.changeset/reactive-import-after-module-snippets.md
+++ b/.changeset/reactive-import-after-module-snippets.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Legacy `$.reactive_import` declarations follow the hoisted module snippets
+
+`transform-client.js:201` unshifts them onto the module program's body and `:513` assembles
+`[...imports, ...module_level_snippets, ...body]`, so a hoisted `{#snippet}` comes first.

--- a/.changeset/store-member-write-invalidate-tail.md
+++ b/.changeset/store-member-write-invalidate-tail.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+---
+
+A `<select bind:value={$store.x}>`'s indirect bindings now attach to the `$store`
+binding, so a store member write emits the `$.invalidate_inner_signals` tail
+upstream emits — while `$store.x++` still does not, because `UpdateExpression.js`
+never imports `build_assignment`.

--- a/.changeset/tagged-template-pure-tag.md
+++ b/.changeset/tagged-template-pure-tag.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/compiler": patch
+---
+
+A tagged template with a pure tag no longer forces a `$.template_effect`
+
+`TaggedTemplateExpression.js` sets `has_state` from the tag's purity alone, so
+`pattern={String.raw`…`}` is written once at init. rsvelte's `has_reactive_state_json` had no
+arm for the node type and fell into its conservative `_ => true`.

--- a/.changeset/update-expression-no-invalidate-tail.md
+++ b/.changeset/update-expression-no-invalidate-tail.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/compiler": patch
+---
+
+An `++` / `--` on a state or prop member no longer grows the
+`$.invalidate_inner_signals` tail. `UpdateExpression.js` does not import
+`build_assignment`, so upstream attaches that tail only to an assignment; the
+same binding's `=` and `+=` keep it. The wrapper was applied in four places —
+the AST and in-place ports of both the legacy-state and the prop member
+mutation transforms.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4246,6 +4246,57 @@ on — and when the answer looks like "this family never reaches that code", che
 "reaches it and cannot tell two answers apart" is the commoner case and the two prescribe
 different fixes.
 
+### A catch-all whose default is the SAFE answer is invisible to every gate but byte equality
+
+`has_reactive_state_json` is rsvelte's port of upstream's `has_state`, written as a `match` over
+node-type strings with `_ => true` and a comment explaining the choice: wrapping a static
+expression in a `$.template_effect` is slower and correct, while not wrapping a reactive one is
+a bug. That reasoning is right, and it is exactly what made the missing arm unfindable.
+`TaggedTemplateExpression` had none, so `pattern={String.raw`a`}` was wrapped where upstream
+writes the attribute once at init — output that behaves identically, passes every runtime
+fixture, parses, and is *only* wrong as bytes. Measured: 15 expression kinds x 2 hosts, **24 EQ
+/ 6 DIFF**, and all six are a tagged template whose tag is pure; a local tag and a member tag
+rooted at a local stay wrapped, which is what separates the fix from "never wrap a tagged
+template".
+
+Two things generalize. **A conservative default converts a missing enumeration entry from a
+crash into a silent divergence**, so the usual defence — the arm that is absent throws — does not
+apply, and which gate can see it is decided by the *direction* of the default: over-approximating
+is visible to output equality alone, under-approximating is visible to a runtime test. And the
+enumeration's own members are the census: this `match` names 20 types, `has_call_json` beside it
+names `TaggedTemplateExpression` correctly with a comment citing the upstream file, so **the two
+ports of one upstream visitor disagreed about which node types exist** — the sibling was the
+cheapest place to find the gap and nothing compares them.
+
+**And the one defence this file names against the two-ports class was present, and pinned the
+wrong value.** `typed_reactive_state_front_end_agrees_with_the_json_walk` compares the typed
+front end to the JSON walk **and spells out the expected answer** — exactly so that "a front end
+that always says `false` can't pass by agreeing with an equally broken oracle". Its row for
+`` tag`x` `` read `true`, under a comment saying the typed walk does not answer this shape so the
+two "agree by construction". Both halves are accurate; the number was transcribed from what the
+JSON walk did, which was the `_ => true` fallback. Fixing the compiler turned the test red, and
+the oracle says `false` for an unbound tag and `true` for a bound one. So an independently
+pinned expectation is only independent of the *other port*, not of the port it was read from —
+generate the value from the oracle even when the assertion's purpose is to compare two ports,
+and note that the shape a comment calls "unanswered" is the one whose expectation nobody
+derived.
+
+### A predicate's NAME can name a construct that cannot reach it
+
+`RegularElement.js:324` computes `has_declarations` as `!node.fragment.metadata.transparent`, and
+the grid cell written to exercise the `true` branch — an element holding its own `{@const}` — is
+rejected by the compiler: `{@const}` must be the immediate child of a block, a snippet or a
+component, never of a plain element. What actually clears `transparent` is a **`DeclarationTag`**
+(`{const x = …}` / `{let x = …}`, no `@`; `1-parse/state/tag.js:41`, `1-parse/index.js:310`),
+which is the one declaration form an element may hold. The cell threw, which is the lucky
+outcome — the same inference could as easily have produced a cell that compiles and exercises the
+other branch.
+
+The rule is the grid-construction twin of "generate an expected value from the oracle, do not
+back it out of its output": when a cell exists to reach a named flag, derive the input from the
+**code that sets the flag**, not from what the flag is called. Here the two are one `grep` apart
+and the name is actively misleading.
+
 ### Working with Subagents
 
 Use the `Agent` tool for substantial work — feature implementation, multi-file refactors, broad code exploration, or anything likely to consume meaningful context.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4155,6 +4155,97 @@ The cheap discriminator is not the PR state, which is what was stale: it is
 `git log --oneline origin/main | grep '(#N)'`. Ask whether the work is on `main` before treating
 a missing branch, an `UNKNOWN` mergeable, or a fresh conflict as something to repair.
 
+### A ratchet entry's own NAME can be the wrong axis, and the fixture agrees with it
+
+`known-failures.client-dev.json` carried
+`svelte/…/snapshot/samples/delegated-locally-declared-shadowed/index.svelte`, whose one
+differing line is a `console.log` wrapped in `$.log_if_contains_state` that upstream leaves
+plain. The name says shadowing, the fixture is a locally declared `const index` masking an
+each index, and a grid built on that axis passes half its cells and reads as done.
+
+Shadowing is not the axis. The discriminating cell is one where **no outer name of that
+spelling exists at all** — `const q = Number(e.currentTarget.dataset.i); console.log(q)` in an
+`onclick` diverges exactly as the fixture does. What separates the cells is the **host**:
+crossing 4 hosts × 6 declaration shapes gives 3 divergences, all in the `template arrow` host
+and none in the instance-function, instance-top-level or module-script hosts, because
+`console_wrap.rs` answers the same question through two ports and only the estree one is wrong.
+
+This is one level earlier than "a justification names the wrong axis to reproduce on": here the
+*corpus id itself* names it, so the wrong axis arrives with the entry rather than with someone's
+prose. When a ratchet id reads like a diagnosis, treat it as a report of what someone hit.
+
+### The refutation can be inside a line you already read
+
+Two people chased the same defect from the same `DEBUG_EVAL` line:
+
+```
+[evaluate] name=q kind=Normal scope=2 decl_start=None updated=false initial=None initial_type=None
+```
+
+Both read `initial=None`, found a mechanism that predicts it (`process_binding_pattern_typed`
+never writes `binding.initial`), and implemented a fix that moved **0 of 44 cells**. The same
+line says `decl_start=None`, and that function writes `declaration_start` unconditionally — so
+the record `evaluate` resolves was never the one that function creates, and the whole search was
+in the wrong file. Every assignment to `declaration_start` in the tree is `Some(...)` (13 sites,
+none clearing it), which closes it: not "cleared after being set", but "a different record".
+
+This is not an unmeasured quantity. It is a measured one that was **printed and not read**,
+because a mechanism consistent with the first field arrived before the second field was looked
+at. No additional instrumentation can surface it — only finishing the line.
+
+### Count the WRITERS of a field, not the callers of the function you suspect
+
+Chasing that record, `#[track_caller]` was added to `declare_binding` and all 22 call sites were
+printed. The picture stayed contradictory, and the reason is that `declare_binding` is not the
+only writer of `bindings`: `ScopeRoot::push_binding` is a fifth, with six call sites of its own,
+and `2_analyze/visitors/shared/utils.rs`'s statement walker pushes a *temporary* record through
+it. The instrumentation was complete and the population was wrong.
+
+The failure signature is worth separating from the ordinary one: an incomplete instrument goes
+**silent**, and a complete instrument over the wrong population produces a **contradictory
+picture** — every line correct, and no line explaining what you observe. When a value has more
+than one way in, enumerate the field's writers before instrumenting any one of them.
+
+### A key with a valueless element leaves ORDER as the only discriminator
+
+`assign_dev_ast.rs` matches a lowered assignment back against a source-order site list keyed
+`(root, path, operator)`, and a computed member contributes `PathElement::Computed`, which
+carries no value. So `o.p[2]` and `o.p[3]` have the *same* key, and the only thing separating
+their two sites is which is still unclaimed — which makes the visit order part of the rule. The
+visitor claimed its site post-order, after descending, so the inner link of a chain took the
+outer's site and every `$.assign` in a computed chain reported the same column.
+
+The cell that says so is the one that was already **passing**: a static-key chain
+(`o.a = o.b = s`) has two distinct keys and was correct throughout, so a grid of computed chains
+alone cannot tell "claims in source order" from "always claims the first site". Ask of any
+key-matched rewrite which of its key's fields are *valueless*; each one converts a lookup into
+an ordering dependency that nothing in the key documents.
+
+### The constant a grid holds fixed was fixed by a PREDICTION, and being wrong is green
+
+`AGENTS.md` already records a grid whose held constant turned out to be the branch condition
+(`node.pos` was 0 in every cell). Two more landed on one day, and both are the *reaching is not
+discriminating* shape rather than the *never entered* one — which is the part that had to be
+measured rather than assumed, because the first write-up of this row asserted the second and was
+wrong. A prop-default grid held the declaration at **one prop**: every cell reached esrap's
+comment cursor and every cell agreed, because with nothing before it the annotation can only be
+flushed ahead of the value. Add a second prop and the same rule trails it on the *first*
+`$.prop` instead, which is where rsvelte drops it. A `console_wrap` grid held `target` at
+**client-dev**: all 44 cells reached `scope.evaluate` — the client calls the server's port since
+#3027 — and the regression it missed is on `server`, because only the server consumer inlines
+the folded value into a template string. The corpus sweep says so directly: the carrier moved on
+`server` and `server-dev` and did not move on `client` or `client-dev`, same input, same fold.
+
+Two things generalize. The held constant is fixed because someone judged it irrelevant, and that
+judgement is a *prediction*, not a measurement — so the axis worth adding is on the side you did
+**not** vary, which is why enumerating more failing shapes never finds it. And the symptom is a
+**green** grid, so nothing prompts the check: 8/8 against the oracle and 44/44, both while the
+mechanism they were written for had a branch no cell could separate. Before trusting a green
+family, list what every one of its cells has in common and ask which of those the oracle branches
+on — and when the answer looks like "this family never reaches that code", check it, because
+"reaches it and cannot tell two answers apart" is the commoner case and the two prescribe
+different fixes.
+
 ### Working with Subagents
 
 Use the `Agent` tool for substantial work — feature implementation, multi-file refactors, broad code exploration, or anything likely to consume meaningful context.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4297,6 +4297,97 @@ back it out of its output": when a cell exists to reach a named flag, derive the
 **code that sets the flag**, not from what the flag is called. Here the two are one `grep` apart
 and the name is actively misleading.
 
+### A completion predicate can be satisfied by the PREVIOUS run's output file
+
+`until [ -f /tmp/sw-head.json ]; do sleep 20; done` fired instantly and reported
+`SWEEP HEAD DONE 20765747 bytes` for a run that was 40 seconds old. The file was
+two days old, from a sweep of a different tree. Nothing was empty, nothing was
+truncated, the byte count was plausible, and the arm's own probes had already
+printed correctly — the only thing wrong was *which run wrote it*.
+
+It is the stale-verdict class with the artifact in the role of the check-run,
+and the tell is the same one that catches an `awk` key collapse: a **shape** that
+cannot occur. The base arm's JSON had 6 top-level keys (`arm`, `sha256`,
+`probe`, `rows`, `hashes`, `liveness`) and the "head" had 104,439, because the
+older instrument wrote a flat `{key: hash}` map. Comparing the two structures is
+what exposed it; comparing their sizes would not have.
+
+The structural tell was luck, and reading it as the rule is the mistake to
+avoid: the two files had different shapes only because the instrument's output
+format had changed two days earlier. With a stable format, 29 MB against 21 MB
+reads as "a different tree" and nothing looks wrong. The format-independent
+test is **freshness** — `touch out.START` before launching and wait on
+`[ out.json -nt out.START ]`.
+
+Three fixes, and rank them by which way they fail rather than by what they
+buy. Deleting the output before launching is the only one whose failure is
+safe: if the run crashes and writes nothing, `-f` stays false forever, so a
+false green becomes a hang — the same property as a settle predicate an empty
+population cannot satisfy. Keying the wait on the **job** rather than its
+artifact is what a harness that tracks background commands already offers.
+Stamping the artifact with the arm's sha256 and reading it back is the only
+one that survives someone else's run landing in the same path — and note the
+sweep here already wrote `arm` and `sha256` at the top level and nobody read
+them, which is the declared-but-unread-field row wearing a different hat.
+
+### A control must traverse the stage the measurement died on
+
+The recorded rule is that a control has to bypass at least one stage the
+measurement passes through — that buys *independence*. It does not buy
+*reachability*, and the two fail separately. Looking for a peer's shared script,
+`find /tmp -maxdepth 4 -name 'port-probe2.py'` returned nothing; the positive
+control `find /tmp -maxdepth 4 -name 'cc-socks'` returned a hit, and that was
+read as "so `find` works, so the file is absent". The file existed. `/tmp` is a
+symlink to `private/tmp` and bare `find` does not descend one, and the original
+was a level deeper than `-maxdepth 4` reaches. The control was satisfied at
+**depth 2 through a different root**, so it exercised neither property that was
+killing the measurement.
+
+Measured both ways on the same tree: `find /tmp -maxdepth 4 …` → 0 hits with the
+file present; `find /tmp/ …` and `find -L /tmp …` → the path. The rule that
+covers it: **a control has to be satisfied by the same path the measurement
+takes** — same root, same depth, same traversal — and only then does its
+success say the instrument reached your question. A control that succeeds
+somewhere easier proves the command exists, which nobody doubted.
+
+### A stage that MERGES two measurements is the truncation table's other half
+
+Every row of the truncating-stage table loses a datum. A stage can instead make
+two data look like one, and that reads as a smaller population rather than as a
+missing one. A probe runner extracted results with
+`code.match(/console\.log\([^\n]*/g)` and joined the matches with `' ~~ '`.
+Each match runs to **end of line** and `g` advances `lastIndex` past the whole
+match, so a second call on the same line is swallowed: a cell with three
+`console.log` calls printed two `~~` pieces, and the piece count reads as a call
+count. It also manufactured a false finding — one piece read
+`console.log(n); else console.log(1);`, which was proposed as evidence that a
+`$: if` body had been split at the statement level, when the regex cannot
+produce a piece beginning with `else` at all and the two calls were simply on
+one line.
+
+The same runner mixed two scopes in one line: its WRAP/plain verdict tested the
+**whole file** while the displayed arguments were **per line**, so a cell with
+one wrapped and one unwrapped call reports `WRAP`. Ask of any result line what
+scope each of its fields was computed at; a merging stage is invisible to
+`pipestatus`, to a truncation check, and to re-reading the output.
+
+### A bundle's price cannot be set from one of its members
+
+Two defects were bundled as one batch because they share a *rule* (where an
+`$.invalidate_inner_signals` tail belongs), and the batch was then priced —
+"this needs new plumbing through the port" — from a `grep` in **one** of the two
+files: 0 hits, positive control 40. The measurement was right and the price was
+wrong, because the other member lives in a different file where the same grep
+returns 6, and its missing wrapper sits in the *same function* as a sibling
+branch that already calls the helper, 140 lines away. One member needed a new
+parameter threaded through; the other needed a call the enclosing function
+already makes.
+
+Sharing a rule is what makes two defects one story; it says nothing about
+whether they share a cost. Price each member, or split the bundle — and note
+that the cheap member is the one that looks unnecessary to measure, because the
+expensive member's number is already in hand and reads like the batch's.
+
 ### Working with Subagents
 
 Use the `Agent` tool for substantial work — feature implementation, multi-file refactors, broad code exploration, or anything likely to consume meaningful context.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2950,11 +2950,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 7 entries)
+### Client (`known-failures.client.json`, 4 entries)
 
-Partition of `known-failures.client.json` by verdict: `7`
+Partition of `known-failures.client.json` by verdict: `4`
 
-- **7 — the generated JS differs** (`js` / `code-differs`).
+- **4 — the generated JS differs** (`js` / `code-differs`).
 
 No CSS entry survives on this target: the one that did left with the ancestor-scoping fix
 below.
@@ -3285,7 +3285,43 @@ comments and compare" said the opposite, because official's line reduces to a ba
 the stripper invents a structural difference; that is the stricter-reconstruction hazard two
 paragraphs above, reached from the other side.
 
-Every one of the remaining 7 arrived with the wave-2 enrolment (#3176) and is described
+Three entries left this target and `client-dev` on three separate decisions, each measured with
+its own grid.
+
+`headscale-ui/…/ServerSettings.svelte` carried `pattern={String.raw`…`}`.
+`TaggedTemplateExpression.js` gives a tagged template `has_state` only when its TAG is not pure,
+and `is_pure` calls any identifier with no binding a global — so `String.raw`…`` is inert and the
+attribute is written once at init. rsvelte's `has_reactive_state_json` has no arm for the node
+type at all and fell into its conservative `_ => true`, wrapping every tagged template in a
+`$.template_effect`. That default is why nothing found it earlier: over-wrapping is correct
+behaviour and wrong bytes, so only output equality can see it. 15 expression kinds × 2 hosts
+reads 24 EQ / 6 DIFF, and all six are a pure tag; a local tag and a member tag rooted at a local
+stay wrapped, which separates the fix from "never wrap a tagged template". The sibling
+`has_call_json` names the node type correctly, citing the upstream file — two ports of one
+visitor disagreeing about which node types exist, and nothing compares them.
+
+`photon/…/navbar/Profile.svelte` was an ordering divergence with no other content:
+`transform-client.js:201` unshifts the legacy `$.reactive_import(…)` declarations onto the
+MODULE program's body and `:513` assembles `[...imports, ...module_level_snippets, ...body]`, so
+a hoisted `{#snippet}` precedes them. rsvelte emitted them straight after the imports. Both
+outputs were 593 lines; moving two declarations 60 lines made 62 lines differ, which is what a
+first-differing-line reading would have called a large divergence. Each control in the 4-cell
+grid holds only one of the two declarations and so cannot express an order at all.
+
+`trakt-web/…/navbar/_internal/NavbarHeader.svelte` is upstream aliasing an array.
+`RegularElement.js:333` gives an element's children the PARENT's `consts` array itself when
+`has_declarations` is false, and `:443` splices that same array into the `{ … }` wrapper the
+element grows for a `{#snippet}` — so an enclosing `{@const}` is declared a second time inside
+the wrapper. `has_declarations` is `!fragment.metadata.transparent`, which only a
+**`DeclarationTag`** (`{const x = …}` / `{let x = …}`, no `@`) clears; `{@const}` cannot be an
+element's immediate child at all, so the first version of that cell was rejected by both
+compilers. `<svelte:element>` delegates to `Fragment.js:68`, whose `consts` is a fresh `[]`, and
+is the cell that separates the aliasing from "an element with a snippet re-expands".
+
+Two arms over the corpus moved 6 of 134,180 units (129,450 live) — the three files on `client`
+and `client-dev` and nothing else — `MISMATCH -> match: 6`, `match -> MISMATCH: 0`.
+
+Every one of the remaining 4 arrived with the wave-2 enrolment (#3176) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3389,11 +3425,11 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 12 entries)
+### Client dev (`known-failures.client-dev.json`, 9 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `12`
+Partition of `known-failures.client-dev.json` by verdict: `9`
 
-- **12 — the generated JS differs.**
+- **9 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
@@ -3430,7 +3466,7 @@ the innermost link of `a[i] = a[j] = a[k] = gray` because `scope.evaluate(gray)`
 binding's initializer to `Math.round(…)` and calls it primitive, which rsvelte answers from the
 expression's shape alone. A moved unit is not a retired entry.
 
-All remaining 12 arrived with the wave-2 enrolment (#3176); this target was at 0 before
+All remaining 9 arrived with the wave-2 enrolment (#3176); this target was at 0 before
 it, and it is the largest of the four — 5 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2998,10 +2998,23 @@ placement, and scores it a pass. The line that moved went **to** official's spel
 `$_('descending')` → `$_()('descending')`, which is what upstream emits — and that direction was
 measured against the oracle rather than inferred from the entry leaving.
 
-`primo/…/ui/Button.svelte` was expected to move with this fix and **does not**: its output is
-byte-identical across the two arms on both targets. It sits on the same prop-default path and is
-a different defect (a JSDoc annotation attached to the default is dropped), which is a
-measurement about that entry rather than a limit of this fix.
+`primo/…/ui/Button.svelte` carried two defects on one line pair, and the first is closed.
+`is_simple_expression_str` read a leading JSDoc comment as the callee of the parentheses after
+it, so `type = /** @type {…} */ ('button')` took the lazy branch — `19, (/** … */) => 'button'`
+where official emits `3, 'button'`. Neither axis reproduces it alone (a comment without
+parentheses does not end in `)`, parentheses without a comment have nothing before the matching
+`(`), so `crates/rsvelte_core/tests/prop_default_leading_comment.rs` crosses them.
+
+What remains is comment PLACEMENT, and the oracle's rule is not the one a single-prop grid can
+show. Measured on one, two and three props: official emits the annotation after the value of the
+**first** `$.prop` in the declaration — `let a = $.prop($$props, 'a', 3, '' /** … */)` — however
+many props precede the one that carried it, because esrap flushes a pending comment at the first
+located node past it and the `$.prop` calls are builder-made. A one-prop cell reaches that rule
+and cannot separate it from "place it ahead of the value", since there is nothing before it to
+trail; rsvelte agrees there and drops the comment everywhere else. A two-arm sweep over 134,180
+units moved exactly this entry's two targets and left the verdict `MISMATCH -> MISMATCH`, which
+is why it is still listed: the eager/lazy line is now byte-identical and the comment line is
+untouched.
 
 The error classes this section used to carry are gone: the run behind this
 baseline reports `error-mismatch: 0` and `js-unparseable: 0` on every target, so

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -3409,6 +3409,21 @@ correct throughout, which is what separates "claims in source order" from "alway
 first site"; a grid of computed chains alone cannot. Two arms over the corpus moved 2 of 134,180
 units (129,450 live), `MISMATCH -> match: 1`, `match -> MISMATCH: 0`.
 
+`svelvet/…/Edge/Edge.svelte` moved on this target without leaving it. Upstream runs
+`is_simple_expression` on the **visited** default of a legacy `export let`, and in dev
+`BinaryExpression.js` rewrites all four equality operators into `$.strict_equals` / `$.equals`
+CALLS unconditionally — so `export let straight = edgeStyle === 'straight'` is simple in
+production and not simple in dev, where it becomes `$.prop(…, 24, () => …)`. rsvelte answered
+from the source shape, and the same reduction found a second, opposite defect in the text scan
+that decides it: a `(` after an operator opens a parenthesised operand, not a call, so
+`a || (b === 'x')` was read as a call and made lazy in production where official is eager. A
+13-shape × 2-mode grid separates the two directions and holds five mode-invariant rows
+(`a < 1`, `a + 1`, a literal, an identifier, and an arrow whose body holds the operator — an
+arrow is simple whatever it contains, which is what fails a text search for the token). Two arms
+over the corpus moved 1 of 134,180 units (129,450 live). The entry stays because its remaining
+line is comment placement: esrap attaches a trailing `//` to the literal inside
+`$.mutable_source(false)` and rsvelte keeps it at end of line.
+
 The other moved unit is `svelte-bits/…/MetallicPaint.svelte`, whose verdict did **not** change:
 its location is now right and its remaining line is the other half — upstream declines to wrap
 the innermost link of `a[i] = a[j] = a[k] = gray` because `scope.evaluate(gray)` follows the

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -3376,16 +3376,34 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 13 entries)
+### Client dev (`known-failures.client-dev.json`, 12 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `13`
+Partition of `known-failures.client-dev.json` by verdict: `12`
 
-- **13 — the generated JS differs.**
+- **12 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 13 arrived with the wave-2 enrolment (#3176); this target was at 0 before
-it, and it is the largest of the four — 6 JS entries that `client` does not
+`huly/…/HelpAndSupport.svelte` left this target with the site claim in
+`assign_dev_ast.rs`. `$.assign(…, '<file>:<line>:<column>')` locates the assignment's own
+left-hand side, and rsvelte finds that by matching the lowered target back against a
+source-order site list keyed `(root, path, operator)` — where a computed member contributes a
+valueless `Computed` element, so `o.p[2]` and `o.p[3]` share a key and only the order the sites
+are consumed in separates them. The visitor claimed its site *after* descending, so the inner
+link of `loc.path[2] = loc.path[3] = settingId` took the outer's site and reported `53:4` where
+official reports `53:18`. A static-key chain (`o.a = o.b = s`) has two distinct keys and was
+correct throughout, which is what separates "claims in source order" from "always claims the
+first site"; a grid of computed chains alone cannot. Two arms over the corpus moved 2 of 134,180
+units (129,450 live), `MISMATCH -> match: 1`, `match -> MISMATCH: 0`.
+
+The other moved unit is `svelte-bits/…/MetallicPaint.svelte`, whose verdict did **not** change:
+its location is now right and its remaining line is the other half — upstream declines to wrap
+the innermost link of `a[i] = a[j] = a[k] = gray` because `scope.evaluate(gray)` follows the
+binding's initializer to `Math.round(…)` and calls it primitive, which rsvelte answers from the
+expression's shape alone. A moved unit is not a retired entry.
+
+All remaining 12 arrived with the wave-2 enrolment (#3176); this target was at 0 before
+it, and it is the largest of the four — 5 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 
 `immich/…/asset-viewer/ActivityViewer.svelte` left this target and `client` for the other half of

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2950,11 +2950,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 4 entries)
+### Client (`known-failures.client.json`, 3 entries)
 
-Partition of `known-failures.client.json` by verdict: `4`
+Partition of `known-failures.client.json` by verdict: `3`
 
-- **4 — the generated JS differs** (`js` / `code-differs`).
+- **3 — the generated JS differs** (`js` / `code-differs`).
 
 No CSS entry survives on this target: the one that did left with the ancestor-scoping fix
 below.
@@ -3285,6 +3285,17 @@ comments and compare" said the opposite, because official's line reduces to a ba
 the stripper invents a structural difference; that is the stricter-reconstruction hazard two
 paragraphs above, reached from the other side.
 
+`syntaxfm-website/…/guests/+page.svelte` left this target and `client-dev` on the right-hand
+side of a destructuring assignment. `shared/assignments.js:20-22` reads
+`should_cache = value.type !== 'Identifier'` off the **visited** node, so a prop is cached in
+`$$value` whichever read form it takes; rsvelte answered from the list of props eligible as
+assignment *targets*, which in runes mode excludes a prop that is never written — and that is
+exactly the prop whose read is `$$props.data`, a member expression. A 7-row grid over the
+binding kind of the right-hand side separates it from "cache whenever the binding is reactive":
+a `$state` object reads as a bare identifier and must NOT be cached, while a `$derived` reads as
+`$.get(data)` and must be. Two arms moved 2 of 134,180 units (129,450 live),
+`MISMATCH -> match: 2`, `match -> MISMATCH: 0`.
+
 Three entries left this target and `client-dev` on three separate decisions, each measured with
 its own grid.
 
@@ -3321,7 +3332,7 @@ is the cell that separates the aliasing from "an element with a snippet re-expan
 Two arms over the corpus moved 6 of 134,180 units (129,450 live) — the three files on `client`
 and `client-dev` and nothing else — `MISMATCH -> match: 6`, `match -> MISMATCH: 0`.
 
-Every one of the remaining 4 arrived with the wave-2 enrolment (#3176) and is described
+Every one of the remaining 3 arrived with the wave-2 enrolment (#3176) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3425,11 +3436,11 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 9 entries)
+### Client dev (`known-failures.client-dev.json`, 8 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `9`
+Partition of `known-failures.client-dev.json` by verdict: `8`
 
-- **9 — the generated JS differs.**
+- **8 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
@@ -3466,7 +3477,7 @@ the innermost link of `a[i] = a[j] = a[k] = gray` because `scope.evaluate(gray)`
 binding's initializer to `Math.round(…)` and calls it primitive, which rsvelte answers from the
 expression's shape alone. A moved unit is not a retired entry.
 
-All remaining 9 arrived with the wave-2 enrolment (#3176); this target was at 0 before
+All remaining 8 arrived with the wave-2 enrolment (#3176); this target was at 0 before
 it, and it is the largest of the four — 5 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2950,14 +2950,25 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 8 entries)
+### Client (`known-failures.client.json`, 7 entries)
 
-Partition of `known-failures.client.json` by verdict: `8`
+Partition of `known-failures.client.json` by verdict: `7`
 
-- **8 — the generated JS differs** (`js` / `code-differs`).
+- **7 — the generated JS differs** (`js` / `code-differs`).
 
 No CSS entry survives on this target: the one that did left with the ancestor-scoping fix
 below.
+
+`ha-fusion/…/Modal/VisibilityConfig/Index.svelte` left this target and `client-dev` with the
+ninth application site of one upstream rule. Upstream reads a **reassigned** each item as
+`collection[$index]` and never as `$.get(item)` (`EachBlock.js:216-227`); rsvelte ports that as
+`build_reassigned_item_read` and calls it from eight places, and the dependency list an inner
+`bind:` hands to `$.invalidate_inner_signals` is a ninth — built by a string loop that reads
+`state.transform` directly, so the rule never reached it. Every *other* read of the item in the
+same file was already correct, which is why the divergence was one line of 336 and why a grid
+over each-block shapes with one read per cell would have been green: the axis is which read, not
+which block. Two arms over the whole corpus moved **2 of 134,180 units** (129,450 live), both
+this file, `MISMATCH -> match: 2`, `match -> MISMATCH: 0`.
 
 `svelteui/…/Modal/ModalForm.svelte` and `mathesar/…/sort-entry/SortEntry.svelte` left this target
 and `client-dev` when a **write** inside a prop's default value started reaching the passes an
@@ -3261,7 +3272,7 @@ comments and compare" said the opposite, because official's line reduces to a ba
 the stripper invents a structural difference; that is the stricter-reconstruction hazard two
 paragraphs above, reached from the other side.
 
-Every one of the remaining 8 arrived with the wave-2 enrolment (#3176) and is described
+Every one of the remaining 7 arrived with the wave-2 enrolment (#3176) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3365,15 +3376,15 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 14 entries)
+### Client dev (`known-failures.client-dev.json`, 13 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `14`
+Partition of `known-failures.client-dev.json` by verdict: `13`
 
-- **14 — the generated JS differs.**
+- **13 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
-All remaining 14 arrived with the wave-2 enrolment (#3176); this target was at 0 before
+All remaining 13 arrived with the wave-2 enrolment (#3176); this target was at 0 before
 it, and it is the largest of the four — 6 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2950,11 +2950,11 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 2 entries)
+### Client (`known-failures.client.json`, 1 entry)
 
-Partition of `known-failures.client.json` by verdict: `2`
+Partition of `known-failures.client.json` by verdict: `1`
 
-- **2 — the generated JS differs** (`js` / `code-differs`).
+- **1 — the generated JS differs** (`js` / `code-differs`).
 
 No CSS entry survives on this target: the one that did left with the ancestor-scoping fix
 below.
@@ -3020,16 +3020,26 @@ where official emits `3, 'button'`. Neither axis reproduces it alone (a comment 
 parentheses does not end in `)`, parentheses without a comment have nothing before the matching
 `(`), so `crates/rsvelte_core/tests/prop_default_leading_comment.rs` crosses them.
 
-What remains is comment PLACEMENT, and the oracle's rule is not the one a single-prop grid can
+**It has now left both targets, and the local sweep said it would not.** What remains in the
+output is comment PLACEMENT, and the oracle's rule there is not the one a single-prop grid can
 show. Measured on one, two and three props: official emits the annotation after the value of the
 **first** `$.prop` in the declaration — `let a = $.prop($$props, 'a', 3, '' /** … */)` — however
 many props precede the one that carried it, because esrap flushes a pending comment at the first
 located node past it and the `$.prop` calls are builder-made. A one-prop cell reaches that rule
 and cannot separate it from "place it ahead of the value", since there is nothing before it to
-trail; rsvelte agrees there and drops the comment everywhere else. A two-arm sweep over 134,180
-units moved exactly this entry's two targets and left the verdict `MISMATCH -> MISMATCH`, which
-is why it is still listed: the eager/lazy line is now byte-identical and the comment line is
-untouched.
+trail; rsvelte agrees there and drops the comment everywhere else. That line is still divergent
+and the entry still passes, because the gate hands every byte-different output to
+`ast_equiv_batch`, **which does not represent comment placement** — the same rescue the
+`SettingsPopup` paragraph above describes.
+
+The lesson is the one this repository already records about reconstructions, arriving from its
+other side. A two-arm sweep over 134,180 units moved exactly this entry's two targets and scored
+them `MISMATCH -> MISMATCH`, so the PR was prepared with the entry kept — and the sweep's
+comparison stops at the normalized byte diff, which makes it **stricter** than the gate. A
+non-zero from a stricter reconstruction is a list of candidates, never a verdict; here it
+produced two false keeps, and CI's two-sided ratchet caught them as `already PASS`. When a
+retained entry's own justification is "what remains is comment placement", that is precisely the
+sentence that predicts the gate will rescue it.
 
 The error classes this section used to carry are gone: the run behind this
 baseline reports `error-mismatch: 0` and `js-unparseable: 0` on every target, so
@@ -3347,7 +3357,7 @@ is the cell that separates the aliasing from "an element with a snippet re-expan
 Two arms over the corpus moved 6 of 134,180 units (129,450 live) — the three files on `client`
 and `client-dev` and nothing else — `MISMATCH -> match: 6`, `match -> MISMATCH: 0`.
 
-Every one of the remaining 2 arrived with the wave-2 enrolment (#3176) and is described
+The remaining 1 entry arrived with the wave-2 enrolment (#3176) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3451,11 +3461,11 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 7 entries)
+### Client dev (`known-failures.client-dev.json`, 5 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `7`
+Partition of `known-failures.client-dev.json` by verdict: `5`
 
-- **7 — the generated JS differs.**
+- **5 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
@@ -3482,9 +3492,15 @@ that decides it: a `(` after an operator opens a parenthesised operand, not a ca
 13-shape × 2-mode grid separates the two directions and holds five mode-invariant rows
 (`a < 1`, `a + 1`, a literal, an identifier, and an arrow whose body holds the operator — an
 arrow is simple whatever it contains, which is what fails a text search for the token). Two arms
-over the corpus moved 1 of 134,180 units (129,450 live). The entry stays because its remaining
-line is comment placement: esrap attaches a trailing `//` to the literal inside
-`$.mutable_source(false)` and rsvelte keeps it at end of line.
+over the corpus moved 1 of 134,180 units (129,450 live).
+
+**The entry has left this target.** It was kept on the reading that its remaining line is comment
+placement — esrap attaches a trailing `//` to the literal inside `$.mutable_source(false)` and
+rsvelte keeps it at end of line — and that reading is still correct about the bytes. It is wrong
+about the verdict for the same reason the `Button.svelte` paragraph above gives: comment
+placement is exactly what `ast_equiv_batch` cannot represent, so the gate rescues it once the
+code line matches. Both keeps came from the same stricter-than-the-gate local sweep, and both
+were caught by CI's stale-entry check rather than by any local instrument.
 
 The other moved unit is `svelte-bits/…/MetallicPaint.svelte`, whose verdict did **not** change:
 its location is now right and its remaining line is the other half — upstream declines to wrap
@@ -3492,7 +3508,7 @@ the innermost link of `a[i] = a[j] = a[k] = gray` because `scope.evaluate(gray)`
 binding's initializer to `Math.round(…)` and calls it primitive, which rsvelte answers from the
 expression's shape alone. A moved unit is not a retired entry.
 
-All remaining 7 arrived with the wave-2 enrolment (#3176); this target was at 0 before
+All remaining 5 arrived with the wave-2 enrolment (#3176); this target was at 0 before
 it, and it is the largest of the four — 5 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -2950,14 +2950,29 @@ checked-in pattern corpus (#2019) surfaced are gone too: the two SSR
 destructuring ones (#2033, #2034) were fixed by #2036, and the block-local
 snippet render tag (#2031) by #2057.
 
-### Client (`known-failures.client.json`, 3 entries)
+### Client (`known-failures.client.json`, 2 entries)
 
-Partition of `known-failures.client.json` by verdict: `3`
+Partition of `known-failures.client.json` by verdict: `2`
 
-- **3 — the generated JS differs** (`js` / `code-differs`).
+- **2 — the generated JS differs** (`js` / `code-differs`).
 
 No CSS entry survives on this target: the one that did left with the ancestor-scoping fix
 below.
+
+`musicat/…/settings/SettingsPopup.svelte` left this target and `client-dev` with a phase-2
+filter whose comment asserted the opposite of upstream. `2-analyze/index.js:445` declares each
+`$name` as a real `store_sub` binding, so `scope.get('$s')` returns one and
+`RegularElement.js:81` attaches a `<select bind:value={…}>`'s indirect bindings to it like any
+other binding; rsvelte discarded exactly that case in two places, so the store branch of the
+setter and every `$s.a = …` in the file lost the `$.invalidate_inner_signals` tail. Upstream's
+exclusion of `store_sub` is on the **assign** arm's proxy flag (`AssignmentExpression.js:147`)
+and the mutate arm at `:154-181` has no condition on binding kind at all — which is why the same
+grid separates the two: `$s.a = 2` and `$s.a += 2` must gain the tail and `$s.a++` must not,
+since `UpdateExpression.js` never imports `build_assignment`. The first version of the fix
+wrapped both and the six store cells went 6 DIFF → 4 EQ / 2 DIFF, which is what named the
+update arm. **17 of 18 cells EQ after** (the one that stays is a separate defect: `$: st.a++`
+loses its `$.mutate` entirely). Two arms over the corpus moved **2 of 134,180 units**,
+`MISMATCH -> match: 2`, `match -> MISMATCH: 0`.
 
 `ha-fusion/…/Modal/VisibilityConfig/Index.svelte` left this target and `client-dev` with the
 ninth application site of one upstream rule. Upstream reads a **reassigned** each item as
@@ -3332,7 +3347,7 @@ is the cell that separates the aliasing from "an element with a snippet re-expan
 Two arms over the corpus moved 6 of 134,180 units (129,450 live) — the three files on `client`
 and `client-dev` and nothing else — `MISMATCH -> match: 6`, `match -> MISMATCH: 0`.
 
-Every one of the remaining 3 arrived with the wave-2 enrolment (#3176) and is described
+Every one of the remaining 2 arrived with the wave-2 enrolment (#3176) and is described
 in § *Wave-2 enrolment*. The list was **0** before it, and the one entry it ever
 held — #2031, a `{#snippet}` declared inside
 an `{#if}` branch and `{@render}`ed as a sibling in that same branch, lowered
@@ -3436,11 +3451,11 @@ that became unparseable only with `dev: true`; #3877 corrected the component
 callback tail-comment insertion point, so both its parse and output entries have
 been retired.
 
-### Client dev (`known-failures.client-dev.json`, 8 entries)
+### Client dev (`known-failures.client-dev.json`, 7 entries)
 
-Partition of `known-failures.client-dev.json` by verdict: `8`
+Partition of `known-failures.client-dev.json` by verdict: `7`
 
-- **8 — the generated JS differs.**
+- **7 — the generated JS differs.**
 
 Unlike `client`, no CSS entry survives on this target.
 
@@ -3477,7 +3492,7 @@ the innermost link of `a[i] = a[j] = a[k] = gray` because `scope.evaluate(gray)`
 binding's initializer to `Math.round(…)` and calls it primitive, which rsvelte answers from the
 expression's shape alone. A moved unit is not a retired entry.
 
-All remaining 8 arrived with the wave-2 enrolment (#3176); this target was at 0 before
+All remaining 7 arrived with the wave-2 enrolment (#3176); this target was at 0 before
 it, and it is the largest of the four — 5 JS entries that `client` does not
 carry, which is the reason it is ratcheted separately.
 

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -6,6 +6,5 @@
 	"svelte-lexical/packages/svelte-lexical/src/lib/core/NestedComposer.svelte",
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte",
 	"svelte/packages/svelte/tests/snapshot/samples/delegated-locally-declared-shadowed/index.svelte",
-	"svelvet/src/lib/components/Edge/Edge.svelte",
-	"syntaxfm-website/src/routes/(site)/guests/+page.svelte"
+	"svelvet/src/lib/components/Edge/Edge.svelte"
 ]

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,5 +1,4 @@
 [
-	"ha-fusion/src/lib/Modal/VisibilityConfig/Index.svelte",
 	"headscale-ui/src/lib/settings/ServerSettings.svelte",
 	"huly/plugins/workbench-resources/src/components/HelpAndSupport.svelte",
 	"immich/web/src/lib/components/timeline/Timeline.svelte",

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,6 +1,5 @@
 [
 	"headscale-ui/src/lib/settings/ServerSettings.svelte",
-	"huly/plugins/workbench-resources/src/components/HelpAndSupport.svelte",
 	"immich/web/src/lib/components/timeline/Timeline.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
 	"photon/src/lib/ui/navbar/Profile.svelte",

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,14 +1,11 @@
 [
-	"headscale-ui/src/lib/settings/ServerSettings.svelte",
 	"immich/web/src/lib/components/timeline/Timeline.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
-	"photon/src/lib/ui/navbar/Profile.svelte",
 	"primo/src/lib/builder/ui/Button.svelte",
 	"svelte-bits/src/lib/components/library/Animations/MetallicPaint/MetallicPaint.svelte",
 	"svelte-lexical/packages/svelte-lexical/src/lib/core/NestedComposer.svelte",
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte",
 	"svelte/packages/svelte/tests/snapshot/samples/delegated-locally-declared-shadowed/index.svelte",
 	"svelvet/src/lib/components/Edge/Edge.svelte",
-	"syntaxfm-website/src/routes/(site)/guests/+page.svelte",
-	"trakt-web/projects/client/src/lib/sections/navbar/_internal/NavbarHeader.svelte"
+	"syntaxfm-website/src/routes/(site)/guests/+page.svelte"
 ]

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,9 +1,7 @@
 [
 	"immich/web/src/lib/components/timeline/Timeline.svelte",
-	"primo/src/lib/builder/ui/Button.svelte",
 	"svelte-bits/src/lib/components/library/Animations/MetallicPaint/MetallicPaint.svelte",
 	"svelte-lexical/packages/svelte-lexical/src/lib/core/NestedComposer.svelte",
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte",
-	"svelte/packages/svelte/tests/snapshot/samples/delegated-locally-declared-shadowed/index.svelte",
-	"svelvet/src/lib/components/Edge/Edge.svelte"
+	"svelte/packages/svelte/tests/snapshot/samples/delegated-locally-declared-shadowed/index.svelte"
 ]

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,6 +1,5 @@
 [
 	"immich/web/src/lib/components/timeline/Timeline.svelte",
-	"musicat/src/lib/settings/SettingsPopup.svelte",
 	"primo/src/lib/builder/ui/Button.svelte",
 	"svelte-bits/src/lib/components/library/Animations/MetallicPaint/MetallicPaint.svelte",
 	"svelte-lexical/packages/svelte-lexical/src/lib/core/NestedComposer.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -1,9 +1,6 @@
 [
-	"headscale-ui/src/lib/settings/ServerSettings.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
-	"photon/src/lib/ui/navbar/Profile.svelte",
 	"primo/src/lib/builder/ui/Button.svelte",
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte",
-	"syntaxfm-website/src/routes/(site)/guests/+page.svelte",
-	"trakt-web/projects/client/src/lib/sections/navbar/_internal/NavbarHeader.svelte"
+	"syntaxfm-website/src/routes/(site)/guests/+page.svelte"
 ]

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -1,6 +1,5 @@
 [
 	"musicat/src/lib/settings/SettingsPopup.svelte",
 	"primo/src/lib/builder/ui/Button.svelte",
-	"svelte-tweakpane-ui/src/lib/control/Point.svelte",
-	"syntaxfm-website/src/routes/(site)/guests/+page.svelte"
+	"svelte-tweakpane-ui/src/lib/control/Point.svelte"
 ]

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -1,5 +1,4 @@
 [
-	"ha-fusion/src/lib/Modal/VisibilityConfig/Index.svelte",
 	"headscale-ui/src/lib/settings/ServerSettings.svelte",
 	"musicat/src/lib/settings/SettingsPopup.svelte",
 	"photon/src/lib/ui/navbar/Profile.svelte",

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -1,4 +1,3 @@
 [
-	"primo/src/lib/builder/ui/Button.svelte",
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte"
 ]

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -1,5 +1,4 @@
 [
-	"musicat/src/lib/settings/SettingsPopup.svelte",
 	"primo/src/lib/builder/ui/Button.svelte",
 	"svelte-tweakpane-ui/src/lib/control/Point.svelte"
 ]

--- a/compatibility/pattern-corpus/store-member-write-invalidates-inner-signals.svelte
+++ b/compatibility/pattern-corpus/store-member-write-invalidates-inner-signals.svelte
@@ -1,0 +1,20 @@
+<script>
+	import { writable } from 'svelte/store';
+
+	export const shape = writable({ a: 1, t: 'x' });
+	let opts = ['x', 'y'];
+
+	function bump() {
+		$shape.a = 2;
+		$shape.a += 3;
+		$shape.a++;
+	}
+</script>
+
+<button onclick={bump}>bump</button>
+
+<select bind:value={$shape.t}>
+	{#each opts as o}
+		<option value={o}>{o}</option>
+	{/each}
+</select>

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -935,20 +935,13 @@ pub fn visit<'a, 'b: 'a>(
                     // is a valid indirect binding upstream and must be reachable
                     // through the ancestor chain.
                     let scope_idx = context.scope;
-                    // Upstream `scope.get('$store')` returns null (a store
-                    // auto-subscription is not a real scope binding), so a
-                    // `bind:value={$store}` root never gets indirect bindings;
-                    // rsvelte synthesizes a StoreSub binding, so skip it here.
-                    let binding_idx = context
-                        .analysis
-                        .root
-                        .get_binding(root_name, scope_idx)
-                        .filter(|&i| {
-                            !matches!(
-                                context.analysis.root.bindings[i].kind,
-                                crate::compiler::phases::phase2_analyze::scope::BindingKind::StoreSub
-                            )
-                        });
+                    // A `$store` IS a scope binding upstream — `scope.get('$name')`
+                    // returning a `store_sub` is what every `?.kind === 'store_sub'`
+                    // test in the compiler reads. `AssignmentExpression.js:147`
+                    // excludes `store_sub` from the ASSIGN arm's proxy flag only; the
+                    // mutate arm at :164 applies `legacy_indirect_bindings` with no
+                    // kind condition at all.
+                    let binding_idx = context.analysis.root.get_binding(root_name, scope_idx);
 
                     if let Some(binding_idx) = binding_idx {
                         // Collect scope references that have template references.
@@ -1053,19 +1046,15 @@ pub fn visit<'a, 'b: 'a>(
                                 if &name == root_name || !seen.insert(name.clone()) {
                                     continue;
                                 }
-                                // Resolve like the official `scope.get(name)`: only
-                                // add when it maps to an enclosing-scope binding that
-                                // is not a synthesized store-subscription alias.
+                                // Resolve like the official `scope.get(name)`: add when
+                                // it maps to an enclosing-scope binding. `index.js:445`
+                                // declares `$name` as a real `store_sub` binding, so
+                                // upstream's `scope.get` finds one like any other.
                                 if let Some(bi) =
                                     context.analysis.root.get_binding(&name, scope_idx)
                                 {
                                     let b = &context.analysis.root.bindings[bi];
-                                    if ancestor_scopes.contains(&b.scope_index)
-                                        && !matches!(
-                                            b.kind,
-                                            crate::compiler::phases::phase2_analyze::scope::BindingKind::StoreSub
-                                        )
-                                    {
+                                    if ancestor_scopes.contains(&b.scope_index) {
                                         comp_names.push(name);
                                     }
                                 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/assign_dev_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/assign_dev_ast.rs
@@ -18,7 +18,7 @@ use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::GetSpan;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::ast_rewrite::Edit;
 use super::visitors::shared::utils::{is_global_constant, is_known_defined_global_call};
@@ -160,6 +160,55 @@ enum PathElement {
     Computed,
 }
 
+/// Everything the rewrite reads off an assignment's target, in one place: the
+/// site key and the spans, so the claim on the way down and the edit on the way
+/// back up cannot disagree about which site an assignment owns.
+struct AssignTarget {
+    root: String,
+    path: Vec<PathElement>,
+    operator: &'static str,
+    root_span: u32,
+    object_span: oxc_span::Span,
+    property: String,
+}
+
+fn assign_target(assign: &AssignmentExpression<'_>, source: &str) -> Option<AssignTarget> {
+    let operator = non_coercive(assign.operator)?;
+    let mut path = Vec::new();
+    let (root, root_span, object_span, property) = match &assign.left {
+        AssignmentTarget::StaticMemberExpression(member) => {
+            let (root, root_span) = member_root(&member.object, &mut path)?;
+            path.push(PathElement::Name(member.property.name.to_string()));
+            (
+                root,
+                root_span,
+                member.object.span(),
+                format!("'{}'", member.property.name),
+            )
+        }
+        AssignmentTarget::ComputedMemberExpression(member) => {
+            let (root, root_span) = member_root(&member.object, &mut path)?;
+            path.push(PathElement::Computed);
+            let expr_span = member.expression.span();
+            (
+                root,
+                root_span,
+                member.object.span(),
+                source[expr_span.start as usize..expr_span.end as usize].to_string(),
+            )
+        }
+        _ => return None,
+    };
+    Some(AssignTarget {
+        root,
+        path,
+        operator,
+        root_span,
+        object_span,
+        property,
+    })
+}
+
 /// The root identifier of a member chain, pushing each element it walks past
 /// onto `path` in source order. `None` when the root is not a plain identifier.
 fn member_root(expr: &Expression<'_>, path: &mut Vec<PathElement>) -> Option<(String, u32)> {
@@ -239,6 +288,7 @@ pub(super) fn collect_assign_edits(
         // here is not a component binding and only the fragment resolves it.
         resolved: resolved_reference_spans(program),
         component_bindings,
+        reserved: FxHashMap::default(),
         edits: Vec::new(),
     };
     collector.visit_program(program);
@@ -262,6 +312,8 @@ struct AssignCollector<'src> {
     /// Every name the component declares anywhere, which is what carries the
     /// hoisted imports this fragment no longer contains.
     component_bindings: &'src FxHashSet<&'src str>,
+    /// Assignment span start -> the site reserved for it on the way down.
+    reserved: FxHashMap<u32, (usize, usize)>,
     edits: Vec<Edit>,
 }
 
@@ -281,44 +333,34 @@ impl<'a> Visit<'a> for AssignCollector<'_> {
     }
 
     fn visit_assignment_expression(&mut self, assign: &AssignmentExpression<'a>) {
+        // A `Computed` path element carries no value, so the two targets of
+        // `o.p[2] = o.p[3] = s` have the same site key and only the order the
+        // sites are consumed in tells them apart. The walk below is post-order,
+        // which consumes the inner assignment first and hands it the outer's
+        // column, so the site is claimed here in source order instead.
+        if let Some(target) = assign_target(assign, self.source)
+            && let Some(location) = self.sites.take(&target.root, &target.path, target.operator)
+        {
+            self.reserved.insert(assign.span.start, location);
+        }
         walk::walk_assignment_expression(self, assign);
 
-        let Some(operator) = non_coercive(assign.operator) else {
+        let Some(target) = assign_target(assign, self.source) else {
             return;
         };
-        let mut path = Vec::new();
+        let AssignTarget {
+            root,
+            operator,
+            root_span,
+            object_span,
+            property,
+            ..
+        } = target;
         let slice = |span: oxc_span::Span| &self.source[span.start as usize..span.end as usize];
-        let (root, root_span, object_span, property) = match &assign.left {
-            AssignmentTarget::StaticMemberExpression(member) => {
-                let Some((root, root_span)) = member_root(&member.object, &mut path) else {
-                    return;
-                };
-                path.push(PathElement::Name(member.property.name.to_string()));
-                (
-                    root,
-                    root_span,
-                    member.object.span(),
-                    format!("'{}'", member.property.name),
-                )
-            }
-            AssignmentTarget::ComputedMemberExpression(member) => {
-                let Some((root, root_span)) = member_root(&member.object, &mut path) else {
-                    return;
-                };
-                path.push(PathElement::Computed);
-                (
-                    root,
-                    root_span,
-                    member.object.span(),
-                    slice(member.expression.span()).to_string(),
-                )
-            }
-            _ => return,
-        };
-        // Consumed before the decision below, not after: two identical member
+        // Claimed before the decision below, not after: two identical member
         // chains in one script are told apart only by which site is still
         // unused, so a site the decision rejects still has to be spent.
-        let Some((line, column)) = self.sites.take(&root, &path, operator) else {
+        let Some((line, column)) = self.reserved.remove(&assign.span.start) else {
             return;
         };
         // Upstream's `if (!binding) return null` — a chain rooted at a global

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -72,20 +72,29 @@ pub(super) fn transform_destructure_assignments(
     state_vars: &[String],
     store_sub_vars: &[String],
 ) -> String {
-    transform_destructure_assignments_with_props(statement, state_vars, &[], store_sub_vars, &[])
-        .into_owned()
+    transform_destructure_assignments_with_props(
+        statement,
+        state_vars,
+        &[],
+        store_sub_vars,
+        &[],
+        &[],
+    )
+    .into_owned()
 }
 
 /// Transform destructure assignments, with knowledge of prop variables.
 ///
 /// `prop_vars` are variable names that will be transformed to function calls
-/// (e.g., `numbers` → `numbers()` for prop getters). They matter twice: a prop
-/// *target* makes the destructure eligible for the expansion just like a state
-/// or store target (upstream routes every extracted path through the ordinary
-/// assignment lowering), and a prop on the *right-hand side* forces the IIFE
-/// form (with `$$value` caching) because the official compiler visits the RHS
-/// first, turning it into a CallExpression, and then checks
-/// `should_cache = value.type !== 'Identifier'`.
+/// (e.g., `numbers` → `numbers()` for prop getters); a prop *target* makes the
+/// destructure eligible for the expansion just like a state or store target
+/// (upstream routes every extracted path through the ordinary assignment
+/// lowering).
+///
+/// `rhs_cache_prop_vars` is every prop, including the ones that are not
+/// assignment targets: upstream visits the right-hand side before testing
+/// `should_cache = value.type !== 'Identifier'`, and a prop reads as `name()`
+/// or `$$props.name` — neither is an `Identifier`, so either forces the IIFE.
 ///
 /// `non_reactive_state_vars` is subtracted from `state_vars` for that same
 /// right-hand-side test: only a state variable whose read becomes `$.get(…)`
@@ -96,6 +105,7 @@ pub(super) fn transform_destructure_assignments_with_props<'a>(
     non_reactive_state_vars: &[String],
     store_sub_vars: &[String],
     prop_vars: &[String],
+    rhs_cache_prop_vars: &[String],
 ) -> Cow<'a, str> {
     #[cfg(feature = "measure-destructure-scanner")]
     crate::measure_destructure_scanner::record_entry();
@@ -122,6 +132,11 @@ pub(super) fn transform_destructure_assignments_with_props<'a>(
     let store_set: rustc_hash::FxHashSet<&str> =
         store_sub_vars.iter().map(|s| s.as_str()).collect();
     let prop_set: rustc_hash::FxHashSet<&str> = prop_vars.iter().map(|s| s.as_str()).collect();
+    // Every prop, not only the ones eligible as a destructure TARGET: upstream's
+    // `should_cache` looks at the visited right-hand side, and a prop reads as
+    // `name()` or `$$props.name` — neither is an `Identifier`.
+    let rhs_cache_prop_set: rustc_hash::FxHashSet<&str> =
+        rhs_cache_prop_vars.iter().map(|s| s.as_str()).collect();
     let reactive_state_set: rustc_hash::FxHashSet<&str> = state_vars
         .iter()
         .map(|s| s.as_str())
@@ -135,6 +150,7 @@ pub(super) fn transform_destructure_assignments_with_props<'a>(
         store_sub_vars,
         &store_set,
         &prop_set,
+        &rhs_cache_prop_set,
         &reactive_state_set,
     ) {
         #[cfg(feature = "measure-destructure-scanner")]
@@ -162,6 +178,7 @@ pub(super) fn find_and_transform_one_destructure(
     store_sub_vars: &[String],
     store_set: &rustc_hash::FxHashSet<&str>,
     prop_set: &rustc_hash::FxHashSet<&str>,
+    rhs_cache_prop_set: &rustc_hash::FxHashSet<&str>,
     reactive_state_set: &rustc_hash::FxHashSet<&str>,
 ) -> Option<String> {
     #[cfg(feature = "measure-destructure-scanner")]
@@ -451,7 +468,7 @@ pub(super) fn find_and_transform_one_destructure(
 
     // Check if RHS will become a function call
     let rhs_trimmed = rhs_str.trim();
-    let rhs_will_be_call = prop_set.contains(rhs_trimmed)
+    let rhs_will_be_call = rhs_cache_prop_set.contains(rhs_trimmed)
         || store_set.contains(rhs_trimmed)
         || reactive_state_set.contains(rhs_trimmed);
 
@@ -2104,6 +2121,7 @@ mod tests {
             &[],
             &[],
             &props,
+            &props,
         );
         assert!(out.contains("a = value.café"), "{out}");
     }
@@ -2114,6 +2132,7 @@ mod tests {
         let out = transform_destructure_assignments_with_props(
             "query((res) => { ;[doc] = res }, options);",
             &state,
+            &[],
             &[],
             &[],
             &[],
@@ -2132,6 +2151,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &[],
         );
 
         assert!(out.contains("})(priorities[value])"), "{out}");
@@ -2143,8 +2163,14 @@ mod tests {
     fn destructure_scanner_measurement_counts_a_real_rewrite_and_final_rescan() {
         crate::measure_destructure_scanner::reset();
         let state = vec!["a".to_string()];
-        let out =
-            transform_destructure_assignments_with_props("({ a } = value);", &state, &[], &[], &[]);
+        let out = transform_destructure_assignments_with_props(
+            "({ a } = value);",
+            &state,
+            &[],
+            &[],
+            &[],
+            &[],
+        );
         assert!(out.contains("a = value.a"), "{out}");
 
         let stats = crate::measure_destructure_scanner::snapshot();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/legacy_state_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/legacy_state_member_mutate_ast.rs
@@ -321,15 +321,9 @@ impl<'ast> Visit<'ast> for LegacyStateMemberMutateCollector<'_, '_> {
 
         let outer_text = &self.source[expr.span.start as usize..expr.span.end as usize];
         let mutate = format!("$.mutate({}, {})", root_name, outer_text);
-        let rewrite = match self.invalidate_bodies.get(root_name) {
-            Some(body) if !body.is_empty() => {
-                format!(
-                    "({}, $.invalidate_inner_signals(() => {{ {} }}))",
-                    mutate, body
-                )
-            }
-            _ => mutate,
-        };
+        // `UpdateExpression.js` does not import `build_assignment`, so upstream
+        // never grows the `$.invalidate_inner_signals` tail on a `++` / `--`.
+        let rewrite = mutate;
         self.replacements
             .push((expr.span.start, expr.span.end, rewrite));
     }
@@ -880,13 +874,9 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for LegacyStateMemberMutateRewriter<'a,
             let root = root.to_string();
             let taken = std::mem::replace(expr, self.b.void0());
             let mutate = self.b.call("$.mutate", vec![self.b.id(&root), taken]);
-            *expr = match self.invalidate_bodies.get(&root) {
-                Some(body) if !body.is_empty() => match self.invalidate_call(body) {
-                    Some(invalidate) => self.b.sequence(vec![mutate, invalidate]),
-                    None => mutate,
-                },
-                _ => mutate,
-            };
+            // `UpdateExpression.js` does not import `build_assignment`, so upstream
+            // never grows the `$.invalidate_inner_signals` tail on a `++` / `--`.
+            *expr = mutate;
             self.changed = true;
             return;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -7741,6 +7741,18 @@ fn transform_instance_script_for_visitors(
         .map(|b| b.name.clone())
         .collect();
 
+    // Every prop, unfiltered: a destructure's right-hand side is cached when the
+    // VISITED read is not an `Identifier` (`shared/assignments.js:21`), and a
+    // prop reads as `name()` or `$$props.name` whether or not it is ever
+    // assigned — which is what the list above filters on.
+    let destructure_rhs_prop_vars: Vec<String> = analysis
+        .root
+        .bindings
+        .iter()
+        .filter(|b| matches!(b.kind, BindingKind::Prop | BindingKind::BindableProp))
+        .map(|b| b.name.clone())
+        .collect();
+
     // For each prop binding that carries `legacy_indirect_bindings` (legacy
     // `<select bind:value={prop…}>` whose subtree references other variables),
     // precompute the `$.invalidate_inner_signals(() => { … })` body — the read
@@ -8360,6 +8372,7 @@ fn transform_instance_script_for_visitors(
                         non_reactive_state_vars,
                         store_sub_vars,
                         prop_assignment_transform_vars,
+                        &destructure_rhs_prop_vars,
                     ))
                     .map(Cow::Owned)
                     .unwrap_or(t)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -2347,13 +2347,14 @@ pub(crate) fn transform_client(
         }
     }
 
-    // Add legacy reactive imports (after all imports, before other declarations)
-    // Reference: transform-client.js line 211: module.body.unshift(...state.legacy_reactive_imports)
-    body.extend(legacy_reactive_imports);
-
     // Add module-level snippets (after imports, before module script exports)
     // This ensures `const foo = ...` comes before `export { foo }`
     body.extend(module_level_snippets);
+
+    // `transform-client.js:201` unshifts these onto `module.body`, and `:513`
+    // then puts `module_level_snippets` ahead of it — so they follow the
+    // snippets, not the imports.
+    body.extend(legacy_reactive_imports);
 
     // Add module script non-import content (exports, declarations, etc.)
     // This comes after module_level_snippets so that `export { foo }` can reference `const foo`

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -8102,7 +8102,7 @@ fn transform_instance_script_for_visitors(
                     super::profile::PA_EL_TRANSFORM,
                     statement.len() as u64,
                 );
-                transform_export_let(&statement, analysis)
+                transform_export_let(&statement, analysis, dev)
             };
             // After converting to $.prop(), apply prop read wrapping to the DEFAULT VALUE
             // inside $.prop() calls. wrap_prop_source_reads skips lines containing $.prop(),
@@ -8212,7 +8212,8 @@ fn transform_instance_script_for_visitors(
                     || first_line_trimmed.starts_with("var "))
             {
                 // Check if any of the declarators are BindableProp
-                if let Some(transformed) = transform_let_with_reexported_props(&statement, analysis)
+                if let Some(transformed) =
+                    transform_let_with_reexported_props(&statement, analysis, dev)
                 {
                     result.push_str(&transformed);
                     result.push('\n');

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -8191,6 +8191,7 @@ fn transform_instance_script_for_visitors(
                         prop_assignment_transform_vars,
                         state_vars,
                         non_reactive_state_vars,
+                        &prop_invalidate_bodies,
                     )
                 } else {
                     transformed
@@ -8562,6 +8563,7 @@ fn transform_instance_script_for_visitors(
                         prop_assignment_transform_vars,
                         state_vars,
                         non_reactive_state_vars,
+                        &prop_invalidate_bodies,
                     ))
                 });
                 stage("store_reads", transformed, |t| {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_member_mutate_ast.rs
@@ -359,15 +359,9 @@ impl<'a, 'sem, 'ast> Visit<'ast> for PropMemberMutateCollector<'a, 'sem> {
         let before = &self.source[expr.span.start as usize..root_span.start as usize];
         let after = &self.source[root_span.end as usize..expr.span.end as usize];
         let mutation = format!("{}({}{}(){}, true)", root_name, before, root_name, after);
-        let rewrite = match self.prop_invalidate_bodies.get(root_name) {
-            Some(body) if !body.is_empty() => {
-                format!(
-                    "({}, $.invalidate_inner_signals(() => {{ {} }}))",
-                    mutation, body
-                )
-            }
-            _ => mutation,
-        };
+        // `UpdateExpression.js` does not import `build_assignment`, so upstream
+        // never grows the `$.invalidate_inner_signals` tail on a `++` / `--`.
+        let rewrite = mutation;
         self.replacements
             .push((expr.span.start, expr.span.end, rewrite));
     }
@@ -592,10 +586,9 @@ impl<'a> oxc_ast_visit::VisitMut<'a> for PropMemberMutateRewriter<'a, '_> {
             let wrapped = self
                 .b
                 .call(prop.as_str(), vec![mutation, self.b.bool(true)]);
-            *expr = match self.invalidate_call(&prop) {
-                Some(invalidate) => self.b.sequence(vec![wrapped, invalidate]),
-                None => wrapped,
-            };
+            // `UpdateExpression.js` does not import `build_assignment`, so upstream
+            // never grows the `$.invalidate_inner_signals` tail on a `++` / `--`.
+            *expr = wrapped;
             self.changed = true;
             return;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -517,6 +517,7 @@ pub(super) fn transform_prop_reads_in_expr(expr: &str, prop_vars: &[String]) -> 
 pub(super) fn transform_let_with_reexported_props(
     line: &str,
     analysis: &ComponentAnalysis,
+    dev: bool,
 ) -> Option<String> {
     use crate::compiler::phases::phase2_analyze::scope::BindingKind;
 
@@ -668,7 +669,7 @@ pub(super) fn transform_let_with_reexported_props(
                 // because after transforms it would become a function call (e.g., v2 -> v2()).
                 // The official compiler checks is_simple_expression on the VISITED (transformed)
                 // expression, where prop identifiers become CallExpressions.
-                let mut is_simple = is_simple_expression_str(val, analysis);
+                let mut is_simple = is_simple_expression_str(val, analysis, dev);
                 // Track if the identifier refers to a prop (it will be a no-arg call after transform,
                 // and the official compiler unwraps no-arg calls to just the callee)
                 let mut is_prop_ref = false;
@@ -1042,7 +1043,7 @@ pub(super) fn apply_prop_writes_in_prop_default_values(
     .unwrap_or_else(|| line.to_string())
 }
 
-pub(super) fn transform_export_let(line: &str, analysis: &ComponentAnalysis) -> String {
+pub(super) fn transform_export_let(line: &str, analysis: &ComponentAnalysis, dev: bool) -> String {
     // Strip leading block comments so that a declaration like:
     //   `/* ... */ export let name = value;`
     // (where `/* ... */` may span multiple lines) is still recognised and
@@ -1247,7 +1248,7 @@ pub(super) fn transform_export_let(line: &str, analysis: &ComponentAnalysis) -> 
             } else {
                 // Check if the value is a "simple expression" that can be passed directly
                 // Non-simple expressions need to be wrapped in a thunk and use PROPS_IS_LAZY_INITIAL
-                let mut is_simple = is_simple_expression_str(value, analysis);
+                let mut is_simple = is_simple_expression_str(value, analysis, dev);
                 // An identifier is NOT simple if it refers to another prop/state variable
                 // because after transforms it would become a function call (e.g., v2 -> v2()).
                 let mut is_prop_ref = false;
@@ -2294,7 +2295,11 @@ fn has_top_level_arrow(s: &str) -> bool {
 /// - Object literals: { a: 1 }
 /// - Call expressions: foo()
 /// - Template literals: `hello`, `${x}` (TemplateLiteral != Literal in AST)
-pub(super) fn is_simple_expression_str(value: &str, analysis: &ComponentAnalysis) -> bool {
+pub(super) fn is_simple_expression_str(
+    value: &str,
+    analysis: &ComponentAnalysis,
+    dev: bool,
+) -> bool {
     // A leading comment is not part of the expression, and leaving it on makes
     // the call test below read `/** … */ ('a')` as a call whose callee is the
     // comment. The comment alone and the parentheses alone are both handled;
@@ -2365,9 +2370,14 @@ pub(super) fn is_simple_expression_str(value: &str, analysis: &ComponentAnalysis
                     depth -= 1;
                     if depth == 0 {
                         // Check if this is a call expression or a function definition
-                        let before = &trimmed[..i];
-                        // If there's a valid identifier before the paren, it's a call
-                        if !before.is_empty()
+                        let before = trimmed[..i].trim_end();
+                        // A `(` opens a CALL only where a callee can end; after an
+                        // operator it opens a parenthesised operand, so
+                        // `a || (b === 'x')` is a LogicalExpression, not a call.
+                        let ends_a_callee = before.chars().next_back().is_some_and(|c| {
+                            c.is_alphanumeric() || c == '_' || c == '$' || c == ')' || c == ']'
+                        });
+                        if ends_a_callee
                             && !before.ends_with("function")
                             && !has_top_level_arrow(before)
                         {
@@ -2418,7 +2428,7 @@ pub(super) fn is_simple_expression_str(value: &str, analysis: &ComponentAnalysis
     // `solid() ? "a" : "b"` (whose test is a CallExpression) was wrongly treated
     // as simple, dropping PROPS_IS_LAZY_INITIAL and the default thunk. Defer to an
     // exact AST check; only flips a heuristic `true` to `false`, never the reverse.
-    if ast_expr_is_simple(trimmed, analysis) == Some(false) {
+    if ast_expr_is_simple(trimmed, analysis, dev) == Some(false) {
         return false;
     }
 
@@ -2442,7 +2452,7 @@ pub(super) fn is_simple_expression_str(value: &str, analysis: &ComponentAnalysis
 /// and `None` when it cannot be parsed (callers then keep the string-heuristic
 /// result). The text passed here is post-transform (prop reads are already
 /// `name()` calls), so a `CallExpression` operand is correctly non-simple.
-fn ast_expr_is_simple(value: &str, analysis: &ComponentAnalysis) -> Option<bool> {
+fn ast_expr_is_simple(value: &str, analysis: &ComponentAnalysis, dev: bool) -> Option<bool> {
     use oxc_allocator::Allocator;
     use oxc_ast::ast::Statement;
     use oxc_parser::Parser;
@@ -2463,7 +2473,7 @@ fn ast_expr_is_simple(value: &str, analysis: &ComponentAnalysis) -> Option<bool>
     let Some(Statement::ExpressionStatement(stmt)) = parsed.program.body.first() else {
         return None;
     };
-    Some(expr_is_simple(&stmt.expression, analysis))
+    Some(expr_is_simple(&stmt.expression, analysis, dev))
 }
 
 /// Exact `should_proxy` check via the OXC parser, mirroring upstream's
@@ -2608,10 +2618,14 @@ fn is_call_becoming_binding(name: &str, analysis: &ComponentAnalysis) -> bool {
 /// Recursive AST predicate matching upstream `is_simple_expression`
 /// (`utils/ast.js`), evaluated as if prop/state reads were already rewritten to
 /// getter calls (so a reactive-binding identifier is non-simple).
-fn expr_is_simple(expr: &oxc_ast::ast::Expression, analysis: &ComponentAnalysis) -> bool {
+fn expr_is_simple(
+    expr: &oxc_ast::ast::Expression,
+    analysis: &ComponentAnalysis,
+    dev: bool,
+) -> bool {
     use oxc_ast::ast::Expression;
     match expr {
-        Expression::ParenthesizedExpression(p) => expr_is_simple(&p.expression, analysis),
+        Expression::ParenthesizedExpression(p) => expr_is_simple(&p.expression, analysis, dev),
         Expression::NumericLiteral(_)
         | Expression::StringLiteral(_)
         | Expression::BooleanLiteral(_)
@@ -2624,15 +2638,28 @@ fn expr_is_simple(expr: &oxc_ast::ast::Expression, analysis: &ComponentAnalysis)
         // prop/state/derived binding is rewritten to `name()` (a call) later.
         Expression::Identifier(id) => !is_call_becoming_binding(id.name.as_str(), analysis),
         Expression::ConditionalExpression(c) => {
-            expr_is_simple(&c.test, analysis)
-                && expr_is_simple(&c.consequent, analysis)
-                && expr_is_simple(&c.alternate, analysis)
+            expr_is_simple(&c.test, analysis, dev)
+                && expr_is_simple(&c.consequent, analysis, dev)
+                && expr_is_simple(&c.alternate, analysis, dev)
         }
         Expression::BinaryExpression(b) => {
-            expr_is_simple(&b.left, analysis) && expr_is_simple(&b.right, analysis)
+            // In dev these four become `$.strict_equals` / `$.equals` CALLS
+            // (`BinaryExpression.js`), and upstream tests the visited node.
+            if dev
+                && matches!(
+                    b.operator,
+                    oxc_syntax::operator::BinaryOperator::StrictEquality
+                        | oxc_syntax::operator::BinaryOperator::StrictInequality
+                        | oxc_syntax::operator::BinaryOperator::Equality
+                        | oxc_syntax::operator::BinaryOperator::Inequality
+                )
+            {
+                return false;
+            }
+            expr_is_simple(&b.left, analysis, dev) && expr_is_simple(&b.right, analysis, dev)
         }
         Expression::LogicalExpression(l) => {
-            expr_is_simple(&l.left, analysis) && expr_is_simple(&l.right, analysis)
+            expr_is_simple(&l.left, analysis, dev) && expr_is_simple(&l.right, analysis, dev)
         }
         _ => false,
     }
@@ -3404,7 +3431,7 @@ pub(super) fn transform_props_destructuring(
             // CallExpression, hence non-simple → thunked + PROPS_IS_LAZY_INITIAL.
             // Checking the bare `defValue` (an Identifier) instead would wrongly
             // treat it as simple and emit a non-lazy, un-thunked default.
-            let is_simple = is_simple_expression_str(&proxy_wrapped, analysis);
+            let is_simple = is_simple_expression_str(&proxy_wrapped, analysis, dev);
 
             // Calculate flags using the official logic
             let flags = calculate_prop_flags(local_name, analysis, !is_simple);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -2295,7 +2295,11 @@ fn has_top_level_arrow(s: &str) -> bool {
 /// - Call expressions: foo()
 /// - Template literals: `hello`, `${x}` (TemplateLiteral != Literal in AST)
 pub(super) fn is_simple_expression_str(value: &str, analysis: &ComponentAnalysis) -> bool {
-    let trimmed = value.trim();
+    // A leading comment is not part of the expression, and leaving it on makes
+    // the call test below read `/** … */ ('a')` as a call whose callee is the
+    // comment. The comment alone and the parentheses alone are both handled;
+    // only the two together miss.
+    let trimmed = super::expression_utils::strip_leading_comments(value.trim()).trim();
 
     // Empty is not simple
     if trimmed.is_empty() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -971,6 +971,7 @@ pub(super) fn apply_store_transforms_in_prop_default_values(
     prop_vars: &[String],
     state_vars: &[String],
     non_reactive_state_vars: &[String],
+    invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
 ) -> String {
     use super::store_transforms::{
         transform_store_assignments_client, transform_store_reads_client, transform_store_sub_calls,
@@ -987,6 +988,7 @@ pub(super) fn apply_store_transforms_in_prop_default_values(
             prop_vars,
             state_vars,
             non_reactive_state_vars,
+            invalidate_bodies,
         );
         Some(as_expression(
             default,
@@ -5468,6 +5470,7 @@ mod split_declarators_tests {
                 &[],
                 &[],
                 &[],
+                &rustc_hash::FxHashMap::default(),
             ),
             "$.prop($$props, '名', 24, () => $items());",
         );

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
@@ -391,6 +391,9 @@ pub(super) fn transform_reactive_statement(
                 non_reactive_state_vars,
                 store_sub_vars,
                 prop_assignment_transform_vars,
+                // `$:` is legacy-only, where every prop reads as `name()` and so
+                // is already in the list above.
+                prop_assignment_transform_vars,
             );
             let body: &str = body;
             let temp = transform_update_expressions(
@@ -627,6 +630,7 @@ pub(super) fn transform_reactive_statement(
             state_vars,
             non_reactive_state_vars,
             store_sub_vars,
+            prop_assignment_transform_vars,
             prop_assignment_transform_vars,
         );
         let body: &str = body;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
@@ -715,6 +715,7 @@ pub(super) fn transform_reactive_statement(
             prop_assignment_transform_vars,
             state_vars,
             non_reactive_state_vars,
+            prop_invalidate_bodies,
         );
         transform_store_reads_client(&transformed_body, store_sub_vars)
     } else {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_member_mutate_ast.rs
@@ -60,6 +60,7 @@ pub fn transform_store_member_mutate_ast_with_props(
     prop_vars: &[String],
     state_vars: &[String],
     non_reactive_state_vars: &[String],
+    invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
 ) -> Option<String> {
     let spliced = || {
         transform_store_member_mutate_spliced(
@@ -68,6 +69,7 @@ pub fn transform_store_member_mutate_ast_with_props(
             prop_vars,
             state_vars,
             non_reactive_state_vars,
+            invalidate_bodies,
         )
     };
     ast_rewrite::dual_run::resolve("store_member_mutate_ast:inplace", source, spliced, || {
@@ -77,6 +79,7 @@ pub fn transform_store_member_mutate_ast_with_props(
             prop_vars,
             state_vars,
             non_reactive_state_vars,
+            invalidate_bodies,
         )
     })
 }
@@ -87,6 +90,7 @@ fn transform_store_member_mutate_spliced(
     prop_vars: &[String],
     state_vars: &[String],
     non_reactive_state_vars: &[String],
+    invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
 ) -> Option<String> {
     if store_subs.is_empty() {
         return None;
@@ -112,6 +116,7 @@ fn transform_store_member_mutate_spliced(
                     prop_vars,
                     state_vars,
                     non_reactive_state_vars,
+                    invalidate_bodies,
                     replacements: Vec::new(),
                 };
                 collector.visit_program(program);
@@ -127,6 +132,7 @@ struct MemberMutateCollector<'a> {
     prop_vars: &'a [String],
     state_vars: &'a [String],
     non_reactive_state_vars: &'a [String],
+    invalidate_bodies: &'a rustc_hash::FxHashMap<String, String>,
     replacements: Vec<Edit>,
 }
 
@@ -167,7 +173,13 @@ impl<'a> MemberMutateCollector<'a> {
         Self::walk_object_chain_to_root(object)
     }
 
-    fn emit_rewrite(&mut self, outer_span: Span, root_name: &str, root_span: Span) {
+    fn emit_rewrite(
+        &mut self,
+        outer_span: Span,
+        root_name: &str,
+        root_span: Span,
+        is_update: bool,
+    ) {
         if !self.store_subs.iter().any(|s| s == root_name) {
             return;
         }
@@ -195,10 +207,25 @@ impl<'a> MemberMutateCollector<'a> {
         wrapped.push(')');
         wrapped.push_str(&outer_text[re..]);
 
-        let rewrite = format!(
+        let mutate = format!(
             "$.store_mutate({}, {}, $.untrack({}))",
             store_access, wrapped, store_sub
         );
+        // `AssignmentExpression.js:164` appends the tail on the MUTATE arm with no
+        // condition on the binding's kind, and a `$store` is a `store_sub` binding
+        // upstream — so a store member write invalidates the same indirect bindings
+        // a state member write does.
+        // `UpdateExpression.js` does not import `build_assignment`, so upstream
+        // never grows the tail on a `++` / `--`.
+        let rewrite = match self.invalidate_bodies.get(store_sub) {
+            Some(body) if !body.is_empty() && !is_update => {
+                format!(
+                    "({}, $.invalidate_inner_signals(() => {{ {} }}))",
+                    mutate, body
+                )
+            }
+            _ => mutate,
+        };
         self.replacements
             .push((outer_span.start, outer_span.end, rewrite));
     }
@@ -208,14 +235,14 @@ impl<'a, 'ast> Visit<'ast> for MemberMutateCollector<'a> {
     fn visit_assignment_expression(&mut self, expr: &AssignmentExpression<'ast>) {
         walk::walk_assignment_expression(self, expr);
         if let Some((root_name, root_span)) = Self::root_of_assignment_target(&expr.left) {
-            self.emit_rewrite(expr.span, root_name, root_span);
+            self.emit_rewrite(expr.span, root_name, root_span, false);
         }
     }
 
     fn visit_update_expression(&mut self, expr: &UpdateExpression<'ast>) {
         walk::walk_update_expression(self, expr);
         if let Some((root_name, root_span)) = Self::root_of_simple_target(&expr.argument) {
-            self.emit_rewrite(expr.span, root_name, root_span);
+            self.emit_rewrite(expr.span, root_name, root_span, true);
         }
     }
 }
@@ -230,7 +257,14 @@ mod tests {
 
     /// Test helper: the non-prop case (no prop-backed store sources).
     fn transform_store_member_mutate_ast(source: &str, store_subs: &[String]) -> Option<String> {
-        transform_store_member_mutate_ast_with_props(source, store_subs, &[], &[], &[])
+        transform_store_member_mutate_ast_with_props(
+            source,
+            store_subs,
+            &[],
+            &[],
+            &[],
+            &rustc_hash::FxHashMap::default(),
+        )
     }
 
     #[test]
@@ -261,6 +295,7 @@ mod tests {
             &ssv(&["store"]),
             &[],
             &[],
+            &rustc_hash::FxHashMap::default(),
         )
         .unwrap();
         assert_eq!(
@@ -280,6 +315,7 @@ mod tests {
             &[],
             &ssv(&["store"]),
             &[],
+            &rustc_hash::FxHashMap::default(),
         )
         .unwrap();
         assert_eq!(
@@ -298,6 +334,7 @@ mod tests {
             &ssv(&["store"]),
             &ssv(&["store"]),
             &[],
+            &rustc_hash::FxHashMap::default(),
         )
         .unwrap();
         assert_eq!(
@@ -314,6 +351,7 @@ mod tests {
             &[],
             &ssv(&["store"]),
             &ssv(&["store"]),
+            &rustc_hash::FxHashMap::default(),
         )
         .unwrap();
         assert_eq!(
@@ -481,6 +519,7 @@ pub(crate) fn transform_store_member_mutate_in_place(
     prop_vars: &[String],
     state_vars: &[String],
     non_reactive_state_vars: &[String],
+    invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
 ) -> ast_rewrite::Rewrite {
     if store_subs.is_empty() {
         return ast_rewrite::Rewrite::Unchanged;
@@ -499,10 +538,12 @@ pub(crate) fn transform_store_member_mutate_in_place(
         |allocator, program| {
             let mut rewriter = MemberMutateRewriter {
                 b: crate::compiler::phases::phase3_transform::builders::B::new(allocator),
+                allocator,
                 store_subs,
                 prop_vars,
                 state_vars,
                 non_reactive_state_vars,
+                invalidate_bodies,
                 changed: false,
             };
             oxc_ast_visit::VisitMut::visit_program(&mut rewriter, program);
@@ -513,14 +554,34 @@ pub(crate) fn transform_store_member_mutate_in_place(
 
 struct MemberMutateRewriter<'a, 'b> {
     b: crate::compiler::phases::phase3_transform::builders::B<'a>,
+    allocator: &'a oxc_allocator::Allocator,
     store_subs: &'b [String],
     prop_vars: &'b [String],
     state_vars: &'b [String],
     non_reactive_state_vars: &'b [String],
+    invalidate_bodies: &'b rustc_hash::FxHashMap<String, String>,
     changed: bool,
 }
 
 impl<'a> MemberMutateRewriter<'a, '_> {
+    /// `$.invalidate_inner_signals(() => { <body> })`, parsed from the precomputed
+    /// text body. `None` when the body does not parse, in which case the mutation is
+    /// emitted unwrapped rather than wrongly.
+    fn invalidate_call(&self, body: &str) -> Option<Expression<'a>> {
+        let owned = self.allocator.alloc_str(body);
+        let parsed = oxc_parser::Parser::new(self.allocator, owned, SourceType::mjs()).parse();
+        if !parsed.diagnostics.is_empty() {
+            return None;
+        }
+        let stmts: Vec<Statement<'a>> = parsed.program.body.into_iter().collect();
+        let mut call = self.b.call(
+            "$.invalidate_inner_signals",
+            vec![self.b.thunk_block(stmts, false)],
+        );
+        ast_rewrite::mark_synthesized_expression(&mut call);
+        Some(call)
+    }
+
     /// The leftmost identifier of a member chain — the only part of a mutation
     /// target that is itself a store read.
     fn chain_root<'e>(expr: &'e mut Expression<'a>) -> Option<&'e mut Expression<'a>> {
@@ -570,6 +631,7 @@ impl<'a> oxc_ast_visit::VisitMut<'a> for MemberMutateRewriter<'a, '_> {
     fn visit_expression(&mut self, expr: &mut Expression<'a>) {
         oxc_ast_visit::walk_mut::walk_expression(self, expr);
 
+        let is_update = matches!(expr, Expression::UpdateExpression(_));
         let Some(root) = Self::mutation_root(expr) else {
             return;
         };
@@ -602,9 +664,22 @@ impl<'a> oxc_ast_visit::VisitMut<'a> for MemberMutateRewriter<'a, '_> {
         let published = self
             .b
             .call("$.untrack", vec![self.b.id(store_sub.as_str())]);
-        *expr = self
+        let mutate = self
             .b
             .call("$.store_mutate", vec![store_access, mutation, published]);
+        // `AssignmentExpression.js:164` appends the tail on the MUTATE arm with no
+        // condition on the binding's kind, and a `$store` is a `store_sub` binding
+        // upstream — so a store member write invalidates the same indirect bindings
+        // a state member write does.
+        // `UpdateExpression.js` does not import `build_assignment`, so upstream
+        // never grows the tail on a `++` / `--`.
+        *expr = match self.invalidate_bodies.get(store_sub.as_str()) {
+            Some(body) if !body.is_empty() && !is_update => match self.invalidate_call(body) {
+                Some(invalidate) => self.b.sequence(vec![mutate, invalidate]),
+                None => mutate,
+            },
+            _ => mutate,
+        };
         self.changed = true;
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -53,6 +53,7 @@ pub(super) fn transform_store_assignments_client(
     prop_vars: &[String],
     state_vars: &[String],
     non_reactive_state_vars: &[String],
+    invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
 ) -> String {
     if store_sub_vars.is_empty() {
         return line.to_string();
@@ -101,6 +102,7 @@ pub(super) fn transform_store_assignments_client(
         prop_vars,
         state_vars,
         non_reactive_state_vars,
+        invalidate_bodies,
     )
 }
 
@@ -654,6 +656,7 @@ pub(super) fn transform_store_member_mutations(
     prop_vars: &[String],
     state_vars: &[String],
     non_reactive_state_vars: &[String],
+    invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
 ) -> String {
     super::store_member_mutate_ast::transform_store_member_mutate_ast_with_props(
         line,
@@ -661,6 +664,7 @@ pub(super) fn transform_store_member_mutations(
         prop_vars,
         state_vars,
         non_reactive_state_vars,
+        invalidate_bodies,
     )
     .unwrap_or_else(|| line.to_string())
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
@@ -335,7 +335,24 @@ pub fn each_block(node: &EachBlock, context: &mut ComponentContext) {
                     // prop() for props). If no transform exists but the binding is in
                     // transitive_deps (e.g., import bindings), use the raw identifier since
                     // it still needs to be included in $.invalidate_inner_signals().
-                    let expr = if let Some(transform) = context.state.transform.get(&binding.name) {
+                    let reassigned_parent_item = context
+                        .state
+                        .each_binding_context
+                        .iter()
+                        .rev()
+                        .find(|ctx| ctx.item_name == binding.name && ctx.item_reassigned)
+                        .map(|ctx| {
+                            crate::compiler::phases::phase3_transform::client::visitors::shared::utils::build_reassigned_item_read(
+                                ctx,
+                                &context.arena,
+                            )
+                        });
+                    let expr = if let Some(read) = reassigned_parent_item {
+                        // A reassigned each item reads as `collection[$$index]`, never as
+                        // `$.get(item)` (`EachBlock.js:216-227`), and the `transform` map
+                        // does not carry that rule.
+                        read
+                    } else if let Some(transform) = context.state.transform.get(&binding.name) {
                         if let Some(read_fn) = &transform.read {
                             // A reactive import's read expects the identifier already
                             // swapped for its `$$_import_` alias; the raw name reads the

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -1567,6 +1567,11 @@ pub fn visit_regular_element(
             if let Some(stmt) = child_async_consts_stmt {
                 block_body.push(stmt);
             }
+        } else {
+            // `RegularElement.js:333` hands the children the PARENT's `consts`
+            // array itself, so the splice at `:443` re-emits every enclosing
+            // declaration inside the wrapper as well as outside it.
+            block_body.extend(context.state.consts.iter().cloned());
         }
         block_body.extend(child_init);
         block_body.extend(element_state_init);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -1938,12 +1938,17 @@ fn process_bind_directive<'a>(
                 b::id("$$value"),
             );
             let store_source = build_store_source(&store_name, context);
+            let mutate = b::call(
+                &context.arena,
+                b::member_path(&context.arena, "$.store_mutate"),
+                vec![store_source, assignment_expr, untrack_call],
+            );
+            // The indirect bindings hang off the `$store` binding, which is what
+            // `RegularElement.js:81` resolves `object(attribute.expression)` to.
             vec![b::stmt(
                 &context.arena,
-                b::call(
-                    &context.arena,
-                    b::member_path(&context.arena, "$.store_mutate"),
-                    vec![store_source, assignment_expr, untrack_call],
+                crate::compiler::phases::phase3_transform::client::visitors::expression_converter::wrap_with_legacy_invalidate(
+                    mutate, &store_prefix, context,
                 ),
             )]
         } else {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -5583,6 +5583,17 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
             }
             false
         }
+        "TaggedTemplateExpression" => {
+            // `TaggedTemplateExpression.js` sets `has_state` from the TAG's
+            // purity alone; the quasi is reached by the ordinary walk.
+            if let Some(tag) = obj.get("tag")
+                && (!is_pure_json(tag, context) || has_reactive_state_json(tag, context))
+            {
+                return true;
+            }
+            obj.get("quasi")
+                .is_some_and(|quasi| has_reactive_state_json(quasi, context))
+        }
         _ => {
             // Unknown expression type - conservatively assume reactive
             // (using set_text for a static expression is safe but slower,
@@ -6771,8 +6782,12 @@ mod tests {
             // pure and therefore follows the dynamic member-expression path.
             ("this.foo", true),
             // Shapes the typed walk deliberately does NOT answer — these reach
-            // the JSON fallback, so they agree by construction.
-            ("tag`x`", true),
+            // the JSON fallback, so they agree by construction. The tagged
+            // templates still pin a value: upstream reads the TAG's purity, so
+            // an unbound tag is inert and a bound one is not.
+            ("tag`x`", false),
+            ("count`x`", true),
+            ("konst`x`", true),
             ("(class {})", true),
         ];
 

--- a/crates/rsvelte_core/tests/assign_chain_location.rs
+++ b/crates/rsvelte_core/tests/assign_chain_location.rs
@@ -1,0 +1,146 @@
+//! `$.assign(object, key, op, value, '<file>:<line>:<column>')` locates the
+//! assignment's own left-hand side (`locate_node(left)` in
+//! `AssignmentExpression.js`), and rsvelte finds it by matching the lowered
+//! target back against a source-order list of assignment sites.
+//!
+//! A site's key is `(root, path, operator)`, and a computed member contributes
+//! a valueless `Computed` element — so the two targets of
+//! `o.p[2] = o.p[3] = s` have the SAME key and only the order the sites are
+//! consumed in tells them apart. The visitor walked post-order, so the inner
+//! assignment claimed the outer's site and every link of a computed chain
+//! reported the same column.
+//!
+//! A static-key chain (`o.a = o.b = s`) has two different keys and was correct
+//! throughout, which is why the negative cells below are the ones that matter:
+//! a grid of only computed chains cannot tell "claims in source order" from
+//! "always claims the first site".
+//!
+//! Every expected string was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// The `'M.svelte:<line>:<column>'` literals in output order.
+fn locations(statement: &str) -> Vec<String> {
+    // The right-hand side is an import so `scope.evaluate(right).is_primitive`
+    // is false — with a literal there, upstream wraps nothing and every cell
+    // below reads as agreement.
+    let src = format!(
+        "<script>\n\timport {{ s }} from './x.js';\n\tlet o = {{ p: [], a: 0, b: 0 }};\n\tlet a = 0, b = 0;\n\tfunction go() {{\n{statement}\n\t}}\n</script>\n<button on:click={{go}}>x</button>\n"
+    );
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("M.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    let mut out = Vec::new();
+    let mut rest = js.as_str();
+    while let Some(i) = rest.find("'M.svelte:") {
+        rest = &rest[i + 1..];
+        let Some(end) = rest.find('\'') else { break };
+        out.push(rest[..end].to_string());
+        rest = &rest[end + 1..];
+    }
+    out
+}
+
+/// `(name, statement, official's location literals in output order)`.
+const CELLS: &[(&str, &str, &[&str])] = &[
+    (
+        "computed chain depth 2",
+        "    o.p[2] = o.p[3] = s",
+        &["M.svelte:6:13"],
+    ),
+    (
+        "computed chain depth 3",
+        "    o.p[1] = o.p[2] = o.p[3] = s",
+        &["M.svelte:6:22", "M.svelte:6:13"],
+    ),
+    (
+        "computed chain depth 4",
+        "    o.p[0] = o.p[1] = o.p[2] = o.p[3] = s",
+        &["M.svelte:6:31", "M.svelte:6:22", "M.svelte:6:13"],
+    ),
+    (
+        // A whole-statement assignment is upstream's
+        // `path.at(-1) !== 'ExpressionStatement'` guard, so nothing is wrapped
+        // — but its site is still spent, which is what keeps the chains above
+        // off the outer link's column.
+        "plain computed member, no chain",
+        "    o.p[2] = s",
+        &[],
+    ),
+    ("identifier chain", "    a = b = s", &[]),
+    ("member then identifier", "    o.p[2] = a = s", &[]),
+    (
+        "identifier then member",
+        "    a = o.p[2] = s",
+        &["M.svelte:6:8"],
+    ),
+    (
+        // Two distinct keys: correct before the fix, so it is the cell that
+        // separates a source-order claim from one that always takes site 0.
+        "static-key chain",
+        "    o.a = o.b = s",
+        &["M.svelte:6:10"],
+    ),
+    (
+        "static then computed",
+        "    o.a = o.p[3] = s",
+        &["M.svelte:6:10"],
+    ),
+    (
+        "computed chain with a coercing inner operator",
+        "    o.p[2] = o.p[3] ??= s",
+        &["M.svelte:6:13"],
+    ),
+    (
+        // `scope.evaluate(right).is_primitive` — nothing is wrapped, on either
+        // side, so a fix that started wrapping everything fails here.
+        "primitive right-hand side",
+        "    o.p[2] = o.p[3] = 1",
+        &[],
+    ),
+    (
+        // A sequence puts the first chain's OUTER link off an
+        // `ExpressionStatement` too, so all four links are wrapped and the
+        // ordering has to hold across two chains.
+        "two chains in one sequence",
+        "    o.p[2] = o.p[3] = s, o.a = o.b = s",
+        &[
+            "M.svelte:6:13",
+            "M.svelte:6:4",
+            "M.svelte:6:31",
+            "M.svelte:6:25",
+        ],
+    ),
+];
+
+#[test]
+fn an_assignment_claims_the_site_of_its_own_left_hand_side() {
+    // Cells in both directions, and a live denominator: a grid where every cell
+    // expects nothing is satisfied by a compiler that emits no `$.assign` at all.
+    assert!(
+        CELLS.iter().filter(|(_, _, want)| !want.is_empty()).count() >= 6,
+        "too few cells expect a location"
+    );
+    assert!(
+        CELLS.iter().any(|(_, _, want)| want.is_empty()),
+        "no cell expects no location"
+    );
+
+    for (name, statement, want) in CELLS {
+        assert_eq!(
+            locations(statement),
+            want.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            "cell `{name}`"
+        );
+    }
+}

--- a/crates/rsvelte_core/tests/const_reexpands_into_a_snippet_wrapper.rs
+++ b/crates/rsvelte_core/tests/const_reexpands_into_a_snippet_wrapper.rs
@@ -1,0 +1,86 @@
+//! `RegularElement.js:333` gives an element's children the PARENT's `consts`
+//! array itself whenever the element declares none of its own
+//! (`has_declarations` is `!fragment.metadata.transparent`, and only a
+//! `DeclarationTag` — `{const x = …}`, no `@` — clears that flag). `:443` then
+//! splices that same array into the `{ … }` wrapper an element grows when its
+//! fragment holds a `{#snippet}`, so an enclosing `{@const}` is declared a
+//! second time inside the wrapper.
+//!
+//! Every expected count was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// How many times `const h = …` is declared in the client output.
+fn declarations_of_h(template: &str) -> usize {
+    let src = format!("<script>\n\tlet {{ v }} = $props();\n</script>\n{template}\n");
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("M.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    js.lines().filter(|l| l.contains("const h = ")).count()
+}
+
+/// `(name, template, official's count)`.
+const CELLS: &[(&str, &str, usize)] = &[
+    (
+        "element, no snippet: nothing wraps",
+        "{#if v}{@const h = v}<div>{h}</div>{/if}",
+        1,
+    ),
+    (
+        // `{const g = h}` makes the fragment non-transparent, so the children get
+        // a FRESH array and the wrapper carries only what the element declares.
+        // This is the cell that separates \"splice whenever a snippet wraps\" from
+        // \"splice only when the array is the parent's\".
+        "element with its own `{const}` + snippet",
+        "{#if v}{@const h = v}<div>{const g = h}{#snippet s()}{h}{g}{/snippet}{@render s()}</div>{/if}",
+        1,
+    ),
+    (
+        "element with its own `{const}`, no snippet",
+        "{#if v}{@const h = v}<div>{const g = h}{h}{g}</div>{/if}",
+        1,
+    ),
+    (
+        "element, no declaration of its own, WITH a snippet",
+        "{#if v}{@const h = v}<div>{#snippet s()}{h}{/snippet}{@render s()}</div>{/if}",
+        2,
+    ),
+    (
+        // `SvelteElement.js:110` delegates to `Fragment.js:68`, whose `consts` is a
+        // fresh `[]` — so the same arrangement does NOT re-expand here.
+        "`<svelte:element>` with a snippet",
+        "{#if v}{@const h = v}<svelte:element this={'div'}>{#snippet s()}{h}{/snippet}{@render s()}</svelte:element>{/if}",
+        1,
+    ),
+    (
+        "no enclosing `{@const}` at all",
+        "{#if v}<div>{#snippet s()}{v}{/snippet}{@render s()}</div>{/if}",
+        0,
+    ),
+];
+
+#[test]
+fn an_enclosing_const_is_re_expanded_into_an_elements_snippet_wrapper() {
+    // A rule that always splices, or never does, fails one of these halves.
+    assert!(
+        CELLS.iter().any(|(_, _, n)| *n == 2),
+        "no cell observes the re-expansion"
+    );
+    assert!(
+        CELLS.iter().filter(|(_, _, n)| *n == 1).count() >= 4,
+        "too few cells pin the single-declaration shape"
+    );
+
+    for (name, template, want) in CELLS {
+        assert_eq!(declarations_of_h(template), *want, "cell `{name}`");
+    }
+}

--- a/crates/rsvelte_core/tests/destructure_rhs_cache_reads_the_visited_value.rs
+++ b/crates/rsvelte_core/tests/destructure_rhs_cache_reads_the_visited_value.rs
@@ -1,0 +1,94 @@
+//! `shared/assignments.js:20-22` decides whether a destructuring assignment's
+//! right-hand side is cached in `$$value` with `value.type !== 'Identifier'`,
+//! where `value` is the **visited** node — so a binding whose read is rewritten
+//! is cached and a plain local is not. rsvelte answered that from a list of
+//! props eligible as assignment TARGETS, which in runes mode excludes a prop
+//! that is never written; such a prop reads as `$$props.data`, a member
+//! expression, and upstream caches it.
+//!
+//! Every expected string was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// The body of `go()`, whitespace-collapsed.
+fn go_body(declaration: &str) -> String {
+    let src = format!(
+        "<script>\n\t{declaration}\n\tlet g = $state([]);\n\texport function go() {{ ({{ g }} = data); }}\n</script>\n<p>{{g}}</p>\n"
+    );
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("M.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    let start = js.find("function go(").expect("go()");
+    let end = js[start..].find("\n\t}").expect("end of go()") + start + 3;
+    js[start..end]
+        .lines()
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// `(name, declaration of `data`, official's body)`.
+const CELLS: &[(&str, &str, &str)] = &[
+    (
+        // Reads as `$$props.data` — a member expression, so cached.
+        "a runes prop that is never written",
+        "let { data } = $props();",
+        "function go() { (($$value) => { $.set(g, $$value.g, true); })($$props.data); }",
+    ),
+    (
+        // Reads as `data()`; this shape was already right, because a prop with
+        // a default is an assignment target too.
+        "a runes prop with a default",
+        "let { data = {} } = $props();",
+        "function go() { (($$value) => { $.set(g, $$value.g, true); })(data()); }",
+    ),
+    (
+        "a `$bindable()` prop that is never written",
+        "let { data = $bindable() } = $props();",
+        "function go() { (($$value) => { $.set(g, $$value.g, true); })($$props.data); }",
+    ),
+    (
+        // A `$state` read is a bare identifier when the source is never
+        // reassigned, so upstream does NOT cache — the control that fails if
+        // the rule becomes "cache whenever the binding is reactive".
+        "a `$state` object",
+        "let data = $state({});",
+        "function go() { ($.set(g, data.g, true)); }",
+    ),
+    (
+        "a `$derived`",
+        "let src = $state({});\n\tlet data = $derived(src);",
+        "function go() { (($$value) => { $.set(g, $$value.g, true); })($.get(data)); }",
+    ),
+    (
+        "a plain local `const`",
+        "const data = { g: 1 };",
+        "function go() { ($.set(g, data.g, true)); }",
+    ),
+    (
+        "a module-level import",
+        "import { data } from './d.js';",
+        "function go() { ($.set(g, data.g, true)); }",
+    ),
+];
+
+#[test]
+fn a_destructures_right_hand_side_is_cached_from_its_visited_read() {
+    // Both forms occur, so a rule that always caches — or never does — fails
+    // one half.
+    assert!(CELLS.iter().any(|(_, _, b)| b.contains("$$value")));
+    assert!(CELLS.iter().any(|(_, _, b)| !b.contains("$$value")));
+
+    for (name, declaration, want) in CELLS {
+        assert_eq!(go_body(declaration), *want, "cell `{name}`");
+    }
+}

--- a/crates/rsvelte_core/tests/each_reassigned_item_dependency.rs
+++ b/crates/rsvelte_core/tests/each_reassigned_item_dependency.rs
@@ -1,0 +1,119 @@
+//! Upstream reads a **reassigned** each item as `collection[$index]` and never
+//! as `$.get(item)` (`EachBlock.js:216-227`), and rsvelte ports that rule as
+//! `build_reassigned_item_read`. The rule is applied at eight sites — and the
+//! dependency list an inner `bind:` hands to `$.invalidate_inner_signals` is a
+//! ninth, built by a string loop that consults `state.transform` directly, so
+//! it never saw it.
+//!
+//! Which reads move is the axis, not which block: every other read of `item` in
+//! the same output was already correct, so a grid over each-block *shapes* with
+//! one read per cell would be green. The cells below therefore fix the shape
+//! and vary whether the item is reassigned, plus a three-level cell where the
+//! collection expression is itself a read of an outer item — the only one that
+//! separates "substitute the item" from "substitute the whole read".
+//!
+//! Every expected string was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`), not inferred
+//! from rsvelte's output.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn invalidate_calls(template: &str, dev: bool) -> Vec<String> {
+    let src = format!(
+        "<script>\n\timport C from './C.svelte';\n\timport D from './D.svelte';\n\tlet items = [];\n</script>\n{template}\n"
+    );
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("M.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    js.lines()
+        .map(str::trim)
+        .filter(|l| l.starts_with("$.invalidate_inner_signals("))
+        .map(str::to_string)
+        .collect()
+}
+
+/// `(name, template, official's `invalidate_inner_signals` calls in order)`.
+const CELLS: &[(&str, &str, &[&str])] = &[
+    (
+        "outer item reassigned by bind:",
+        "{#each items as item (item.id)}<D bind:item bind:items />{#each item.kids as sub (sub.id)}<C bind:item={sub} bind:items />{/each}{/each}",
+        &[
+            "$.invalidate_inner_signals(() => ($.get(items)))",
+            "$.invalidate_inner_signals(() => ($.get(items)[$$index_1], $.get(items)))",
+        ],
+    ),
+    (
+        // The negative half: nothing writes `item`, so upstream keeps the
+        // signal read and the fix must not touch this cell.
+        "outer item not reassigned",
+        "{#each items as item (item.id)}{#each item.kids as sub (sub.id)}<C bind:item={sub} bind:items />{/each}{/each}",
+        &["$.invalidate_inner_signals(() => ($.get(item), $.get(items)))"],
+    ),
+    (
+        // `reassigned` is about any write, so an event handler qualifies too;
+        // reaching the rule only through `bind:` would pass the cell above.
+        "outer item reassigned by an event handler",
+        "{#each items as item (item.id)}<button onclick={() => (item = 1)}>x</button>{#each item.kids as sub (sub.id)}<C bind:item={sub} bind:items />{/each}{/each}",
+        &[
+            "$.invalidate_inner_signals(() => ($.get(items)[$$index_1], $.get(items)))",
+            "$.invalidate_inner_signals(() => ($.get(items)))",
+        ],
+    ),
+    (
+        "unkeyed outer each, item reassigned",
+        "{#each items as item}<D bind:item bind:items />{#each item.kids as sub (sub.id)}<C bind:item={sub} bind:items />{/each}{/each}",
+        &[
+            "$.invalidate_inner_signals(() => ($.get(items)))",
+            "$.invalidate_inner_signals(() => ($.get(items)[$$index_1], $.get(items)))",
+        ],
+    ),
+    (
+        // The collection is `a.kids`, a read of the enclosing each's item, so
+        // the replacement is the whole `$.get(a).kids[$$index_1]` and not the
+        // identifier alone.
+        "three levels, middle item reassigned",
+        "{#each items as a (a.id)}{#each a.kids as b (b.id)}<D bind:item={b} />{#each b.kids as c (c.id)}<C bind:item={c} bind:items />{/each}{/each}{/each}",
+        &[
+            "$.invalidate_inner_signals(() => ($.get(a), $.get(items)))",
+            "$.invalidate_inner_signals(() => ($.get(a).kids[$$index_1], $.get(items), $.get(a)))",
+        ],
+    ),
+];
+
+#[test]
+fn a_reassigned_each_item_is_read_by_index_in_an_invalidation_dependency() {
+    // Both directions have to be present, or a rule that rewrote every item —
+    // or none — would satisfy the grid.
+    assert!(
+        CELLS
+            .iter()
+            .any(|(_, _, want)| want.iter().any(|l| l.contains("$$index_1"))),
+        "no cell expects an indexed read"
+    );
+    assert!(
+        CELLS
+            .iter()
+            .any(|(_, _, want)| want.iter().all(|l| !l.contains("$$index_1"))),
+        "no cell expects the signal read to survive"
+    );
+
+    for (name, template, want) in CELLS {
+        for dev in [false, true] {
+            let got = invalidate_calls(template, dev);
+            assert_eq!(
+                got,
+                want.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                "cell `{name}` (dev = {dev})"
+            );
+        }
+    }
+}

--- a/crates/rsvelte_core/tests/prop_default_equality_is_lazy_in_dev.rs
+++ b/crates/rsvelte_core/tests/prop_default_equality_is_lazy_in_dev.rs
@@ -1,0 +1,161 @@
+//! A legacy `export let` default is emitted eagerly (`$.prop(…, 8, <expr>)`) when
+//! upstream's `is_simple_expression` accepts it and lazily (`24, () => <expr>`)
+//! otherwise — and upstream runs that test on the **visited** expression, not on
+//! the source. In dev the four equality operators are rewritten to
+//! `$.strict_equals` / `$.equals` CALLS unconditionally (`BinaryExpression.js`),
+//! so a default containing one is non-simple in dev and simple in prod.
+//!
+//! rsvelte answered from the source shape, so `export let straight = edgeStyle ===
+//! 'straight'` came out eager in dev where official thunks it.
+//!
+//! The rows below therefore cross the operator with `dev`: the same cell must be
+//! eager in one column and lazy in the other, which no single-mode grid can state.
+//! Every expected string was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// The `$.prop(...)` call for `p`, with the `let p = ` prefix and the `;` removed.
+fn prop_call(default_expr: &str, dev: bool) -> String {
+    let src = format!(
+        "<script>\n\tconst a = 'x';\n\tconst b = 'y';\n\tconst c = 'z';\n\tfunction f() {{ return 1; }}\n\texport let p = {default_expr};\n</script>\n<p>{{p}}</p>\n"
+    );
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("M.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    let line = js
+        .lines()
+        .map(str::trim)
+        .find(|l| l.contains("$.prop($$props, 'p'"))
+        .unwrap_or_else(|| panic!("no `$.prop` line for `{default_expr}` (dev={dev}) in:\n{js}"));
+    let start = line.find("$.prop($$props, 'p'").expect("call");
+    line[start..].trim_end_matches(';').to_string()
+}
+
+/// `(name, default, official prod, official dev)`.
+const CELLS: &[(&str, &str, &str, &str)] = &[
+    (
+        "=== at the top level",
+        "a === 'x'",
+        "$.prop($$props, 'p', 8, a === 'x')",
+        "$.prop($$props, 'p', 24, () => $.strict_equals(a, 'x'))",
+    ),
+    (
+        "!== at the top level",
+        "a !== 'x'",
+        "$.prop($$props, 'p', 8, a !== 'x')",
+        "$.prop($$props, 'p', 24, () => $.strict_equals(a, 'x', false))",
+    ),
+    (
+        "== at the top level",
+        "a == 'x'",
+        "$.prop($$props, 'p', 8, a == 'x')",
+        "$.prop($$props, 'p', 24, () => $.equals(a, 'x'))",
+    ),
+    (
+        "!= at the top level",
+        "a != 'x'",
+        "$.prop($$props, 'p', 8, a != 'x')",
+        "$.prop($$props, 'p', 24, () => $.equals(a, 'x', false))",
+    ),
+    (
+        // A relational operator is not rewritten, so this cell must NOT move with
+        // `dev` — it is what separates "an equality operator" from "a binary
+        // expression".
+        "< is not rewritten",
+        "a < 1",
+        "$.prop($$props, 'p', 8, a < 1)",
+        "$.prop($$props, 'p', 8, a < 1)",
+    ),
+    (
+        "+ is not rewritten",
+        "a + 1",
+        "$.prop($$props, 'p', 8, a + 1)",
+        "$.prop($$props, 'p', 8, a + 1)",
+    ),
+    (
+        // The recursion reaches it through a logical operator.
+        "=== inside ||",
+        "a || (b === 'x')",
+        "$.prop($$props, 'p', 8, a || b === 'x')",
+        "$.prop($$props, 'p', 24, () => a || $.strict_equals(b, 'x'))",
+    ),
+    (
+        "=== in a ternary consequent",
+        "a ? b === 'x' : c",
+        "$.prop($$props, 'p', 8, a ? b === 'x' : c)",
+        "$.prop($$props, 'p', 24, () => a ? $.strict_equals(b, 'x') : c)",
+    ),
+    (
+        "=== in a ternary alternate",
+        "a ? b : (c === 'x')",
+        "$.prop($$props, 'p', 8, a ? b : c === 'x')",
+        "$.prop($$props, 'p', 24, () => a ? b : $.strict_equals(c, 'x'))",
+    ),
+    (
+        "a literal",
+        "1",
+        "$.prop($$props, 'p', 8, 1)",
+        "$.prop($$props, 'p', 8, 1)",
+    ),
+    (
+        "an identifier",
+        "a",
+        "$.prop($$props, 'p', 8, a)",
+        "$.prop($$props, 'p', 8, a)",
+    ),
+    (
+        // Lazy in BOTH modes, and through the no-arg-callee unwrap rather than a
+        // thunk — so a fix that made everything lazy still has to spell this one
+        // differently.
+        "a no-argument call",
+        "f()",
+        "$.prop($$props, 'p', 24, f)",
+        "$.prop($$props, 'p', 24, f)",
+    ),
+    (
+        // An arrow is simple whatever its body holds, so the recursion never
+        // enters it: this is the cell that fails if the check is a text search
+        // for the operator rather than a walk of the simple-expression positions.
+        "=== inside an arrow body",
+        "() => a === 'x'",
+        "$.prop($$props, 'p', 8, () => a === 'x')",
+        "$.prop($$props, 'p', 8, () => $.strict_equals(a, 'x'))",
+    ),
+];
+
+#[test]
+fn an_equality_operator_makes_a_legacy_prop_default_lazy_in_dev_only() {
+    // Both directions, and cells that must NOT move with `dev`: a rule keyed on
+    // `dev` alone, or on "is this a BinaryExpression", fails one of these halves.
+    assert!(
+        CELLS.iter().any(|(_, _, prod, dev)| prod != dev),
+        "no cell distinguishes the two modes"
+    );
+    assert!(
+        CELLS.iter().filter(|(_, _, prod, dev)| prod == dev).count() >= 5,
+        "too few cells are mode-invariant"
+    );
+
+    for (name, default_expr, want_prod, want_dev) in CELLS {
+        assert_eq!(
+            prop_call(default_expr, false),
+            *want_prod,
+            "cell `{name}` (prod)"
+        );
+        assert_eq!(
+            prop_call(default_expr, true),
+            *want_dev,
+            "cell `{name}` (dev)"
+        );
+    }
+}

--- a/crates/rsvelte_core/tests/prop_default_leading_comment.rs
+++ b/crates/rsvelte_core/tests/prop_default_leading_comment.rs
@@ -1,0 +1,166 @@
+//! A prop default is emitted as a value (`$.prop($$props, 'type', 3, 'button')`)
+//! when upstream's `is_simple_expression` accepts it and as a lazy thunk
+//! (`19, () => …`) otherwise. rsvelte answers that from the default's TEXT, and
+//! its call test — "ends in `)` and something precedes the matching `(`" — read
+//! a leading JSDoc comment as the callee, so
+//! `/** @type {"a"} */ ('button')` became `19, (/** @type {"a"} */) => 'button'`.
+//!
+//! Neither axis reproduces it alone: the comment without parentheses is EQ
+//! because the text does not end in `)`, and the parentheses without a comment
+//! are EQ because nothing precedes the matching `(`. Only the product diverges,
+//! so the cells below cross them rather than listing the shape that broke.
+//!
+//! Every expected string was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// The `$.prop(...)` line for a single destructured prop with a default.
+fn prop_line(initializer: &str) -> String {
+    let src = format!(
+        "<script>\n\tlet {{ type = {initializer} }} = $props();\n</script>\n<button {{type}}>x</button>\n"
+    );
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("M.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    let line = js
+        .lines()
+        .map(str::trim)
+        .find(|l| l.contains("$.prop($$props,"))
+        .unwrap_or_else(|| panic!("no `$.prop` line for `{initializer}` in:\n{js}"));
+    // From the call, not the whole statement: the declaration keyword and name
+    // are the same in every cell and only lengthen the failure message.
+    line[line.find("$.prop($$props,").expect("call")..].to_string()
+}
+
+/// `(name, initializer, official's `$.prop` line)`.
+const CELLS: &[(&str, &str, &str)] = &[
+    (
+        "bare literal",
+        "'button'",
+        "$.prop($$props, 'type', 3, 'button');",
+    ),
+    (
+        "parenthesised literal",
+        "('button')",
+        "$.prop($$props, 'type', 3, 'button');",
+    ),
+    (
+        "comment then literal",
+        "/** @type {\"a\"} */ 'button'",
+        "$.prop($$props, 'type', 3, /** @type {\"a\"} */ 'button');",
+    ),
+    (
+        // The product of the two cells above — the only one that diverged.
+        "comment then parenthesised literal",
+        "/** @type {\"a\"} */ ('button')",
+        "$.prop($$props, 'type', 3, /** @type {\"a\"} */ 'button');",
+    ),
+    (
+        "doubly parenthesised literal",
+        "(('button'))",
+        "$.prop($$props, 'type', 3, 'button');",
+    ),
+    (
+        "comment then parenthesised number",
+        "/** @type {number} */ (1)",
+        "$.prop($$props, 'type', 3, /** @type {number} */ 1);",
+    ),
+    (
+        // The negative half: an object default IS lazy on both sides, so a fix
+        // that stopped thunking altogether fails here.
+        "parenthesised object",
+        "({ a: 1 })",
+        "$.prop($$props, 'type', 19, () => ({ a: 1 }));",
+    ),
+    (
+        // Where the default really is lazy, official puts the comment in the
+        // arrow's PARAMETER list — the same shape rsvelte produced for the
+        // broken cell above, which is why the fix has to change which branch is
+        // taken and not how the comment is printed.
+        "comment then parenthesised object",
+        "/** @type {{a: number}} */ ({ a: 1 })",
+        "$.prop($$props, 'type', 19, (/** @type {{a: number}} */) => ({ a: 1 }));",
+    ),
+];
+
+#[test]
+fn a_leading_comment_does_not_make_a_parenthesised_default_a_call() {
+    // Both directions present: a rule that made everything eager, or everything
+    // lazy, satisfies neither half.
+    assert!(
+        CELLS.iter().any(|(_, _, want)| want.contains("', 3, ")),
+        "no cell expects an eager default"
+    );
+    assert!(
+        CELLS.iter().any(|(_, _, want)| want.contains("', 19, ")),
+        "no cell expects a lazy default"
+    );
+
+    for (name, initializer, want) in CELLS {
+        assert_eq!(prop_line(initializer), *want, "cell `{name}`");
+    }
+}
+
+/// The `$.prop` call for the prop named `type`, in a declaration that may hold
+/// others before it.
+fn typed_prop_line(decl: &str) -> String {
+    let src = format!(
+        "<script>\n\tlet {{ {decl} }} = $props();\n</script>\n<button {{type}}>x</button>\n"
+    );
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("M.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    js.lines()
+        .map(str::trim)
+        .find(|l| l.contains("$.prop($$props, 'type'"))
+        .unwrap_or_else(|| panic!("no `type` prop line for `{decl}` in:\n{js}"))
+        .to_string()
+}
+
+/// The grid above holds the declaration at ONE prop, and that is the branch the
+/// oracle's comment cursor keys on: with a prop before it, official moves the
+/// annotation to the FIRST `$.prop`'s value and leaves `type` bare. The
+/// eager/lazy digit — the only thing this fix decides — does not move with the
+/// prop count, and that is what these cells pin; the placement divergence is
+/// separate and `primo/…/ui/Button.svelte` is its carrier.
+#[test]
+fn the_eager_lazy_branch_does_not_depend_on_how_many_props_precede() {
+    for decl in [
+        "type = /** @type {\"a\"} */ ('button')",
+        "a = '', type = /** @type {\"a\"} */ ('button')",
+        "a = '', b = 0, type = /** @type {\"a\"} */ ('button')",
+    ] {
+        let line = typed_prop_line(decl);
+        assert!(
+            line.contains("'type', 3, "),
+            "`{decl}` took the lazy branch: {line}"
+        );
+    }
+    // The negative half, on the same host: an object default stays lazy however
+    // many props precede it, so the assertion above is not satisfied by a
+    // compiler that made every default eager.
+    assert!(
+        typed_prop_line("a = '', type = /** @type {{a: number}} */ ({ x: 1 })")
+            .contains("'type', 19, "),
+        "an object default did not stay lazy"
+    );
+}

--- a/crates/rsvelte_core/tests/reactive_import_follows_module_snippets.rs
+++ b/crates/rsvelte_core/tests/reactive_import_follows_module_snippets.rs
@@ -1,0 +1,69 @@
+//! `transform-client.js:201` unshifts the legacy `$.reactive_import(…)`
+//! declarations onto the MODULE program's body, and `:513` then assembles the
+//! output as `[...imports, ...module_level_snippets, ...body]` — so a hoisted
+//! `{#snippet}` is emitted before them, not after. rsvelte placed them
+//! immediately after the imports.
+//!
+//! A `$.reactive_import` is produced only in legacy mode and only for an
+//! instance-script import whose binding is MUTATED (`theme.x = 1`); a
+//! reassignment is a compile error, so that is not the shape that reaches it.
+//!
+//! Every expected order was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// The order of the two module-level declarations, as `"snippet"` /
+/// `"reactive_import"` in the order they appear.
+fn declaration_order(src: &str) -> Vec<&'static str> {
+    let js = compile(
+        src,
+        CompileOptions {
+            filename: Some("M.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    js.lines()
+        .map(str::trim)
+        .filter_map(|l| {
+            if l.starts_with("const s = ") {
+                Some("snippet")
+            } else if l.contains("$.reactive_import") {
+                Some("reactive_import")
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+const MUTATED_IMPORT_AND_SNIPPET: &str = "<script>\n\timport { theme } from './t.js';\n\tfunction go() { theme.x = 1; }\n</script>\n{#snippet s()}<b>x</b>{/snippet}\n<button on:click={go}>{@render s()}</button>\n";
+
+const TWO_MUTATED_IMPORTS_AND_SNIPPET: &str = "<script>\n\timport { theme } from './t.js';\n\timport { chords } from './c.js';\n\tfunction go() { theme.x = 1; chords.y = 2; }\n</script>\n{#snippet s()}<b>x</b>{/snippet}\n<button on:click={go}>{@render s()}</button>\n";
+
+/// Neither declaration exists without the other's trigger, so each control has
+/// exactly one of the two and cannot express an order at all.
+const MUTATED_IMPORT_ONLY: &str = "<script>\n\timport { theme } from './t.js';\n\tfunction go() { theme.x = 1; }\n</script>\n<button on:click={go}>x</button>\n";
+
+const SNIPPET_ONLY: &str = "<script>\n\timport { theme } from './t.js';\n</script>\n{#snippet s()}<b>{theme}</b>{/snippet}\n<button>{@render s()}</button>\n";
+
+#[test]
+fn a_hoisted_snippet_precedes_the_legacy_reactive_imports() {
+    assert_eq!(
+        declaration_order(MUTATED_IMPORT_AND_SNIPPET),
+        ["snippet", "reactive_import"]
+    );
+    assert_eq!(
+        declaration_order(TWO_MUTATED_IMPORTS_AND_SNIPPET),
+        ["snippet", "reactive_import", "reactive_import"]
+    );
+
+    // Each half on its own still appears, so a fix that drops one of them
+    // rather than reordering fails here.
+    assert_eq!(declaration_order(MUTATED_IMPORT_ONLY), ["reactive_import"]);
+    assert_eq!(declaration_order(SNIPPET_ONLY), ["snippet"]);
+}

--- a/crates/rsvelte_core/tests/tagged_template_attribute_is_not_reactive.rs
+++ b/crates/rsvelte_core/tests/tagged_template_attribute_is_not_reactive.rs
@@ -1,0 +1,97 @@
+//! `TaggedTemplateExpression.js` gives a tagged template `has_state` (and
+//! `has_call`) only when its TAG is not pure — `is_pure` calls any identifier
+//! with no binding a global, so `String.raw`…`` is inert and an attribute
+//! holding one is written once at init rather than from a `$.template_effect`.
+//!
+//! rsvelte's `has_reactive_state_json` had no arm for the node type at all, so
+//! it fell into the conservative `_ => true` and wrapped every tagged template.
+//!
+//! Every expected verdict was taken from the official Svelte compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// `"wrap"` when the attribute is written from a `$.template_effect`, `"plain"`
+/// when it is written once at init.
+fn attribute_shape(script: &str, expr: &str) -> &'static str {
+    let src = format!(
+        "<script>\n\t{script}\n\tfunction ltag(x) {{ return x[0]; }}\n</script>\n<input pattern={{{expr}}} />\n"
+    );
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("M.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    if js.contains("$.template_effect") {
+        "wrap"
+    } else if js.contains("$.set_attribute") {
+        "plain"
+    } else {
+        "neither"
+    }
+}
+
+/// `(name, script, attribute expression, official's shape)`.
+const CELLS: &[(&str, &str, &str, &str)] = &[
+    (
+        "pure tag, no interpolation",
+        "let n = 0;",
+        "String.raw`a`",
+        "plain",
+    ),
+    ("bare global tag", "let n = 0;", "globalTag`a`", "plain"),
+    (
+        // A local binding is not pure, so this one must STAY wrapped — it is
+        // what separates the fix from \"never wrap a tagged template\".
+        "local tag",
+        "let n = 0;",
+        "ltag`a`",
+        "wrap",
+    ),
+    (
+        // The tag is pure but the quasi reads a real state source, which the
+        // ordinary walk reaches: this cell fails if the arm returns `false`
+        // without recursing.
+        "pure tag, mutated state in the quasi",
+        "let n = $state(0);\n\texport function go() { n++; }",
+        "String.raw`${n}`",
+        "wrap",
+    ),
+    (
+        // A member tag rooted at a local binding is not pure either.
+        "member tag rooted at a local",
+        "let o = { f: (x) => x[0] };",
+        "o.f`a`",
+        "wrap",
+    ),
+    (
+        // The sibling node type, already correct: a pure callee is inert.
+        "pure call (control)",
+        "let n = 0;",
+        "Math.max(1, 2)",
+        "plain",
+    ),
+    (
+        "local call (control)",
+        "function lf() { return 1; }",
+        "lf()",
+        "wrap",
+    ),
+];
+
+#[test]
+fn a_tagged_template_with_a_pure_tag_is_written_once() {
+    // Both verdicts occur, so a rule that answers one of them everywhere fails.
+    assert!(CELLS.iter().any(|(_, _, _, w)| *w == "plain"));
+    assert!(CELLS.iter().any(|(_, _, _, w)| *w == "wrap"));
+
+    for (name, script, expr, want) in CELLS {
+        assert_eq!(attribute_shape(script, expr), *want, "cell `{name}`");
+    }
+}

--- a/crates/rsvelte_core/tests/update_expression_has_no_invalidate_tail.rs
+++ b/crates/rsvelte_core/tests/update_expression_has_no_invalidate_tail.rs
@@ -1,0 +1,173 @@
+//! `UpdateExpression.js` does not import `build_assignment`, so upstream never
+//! grows the `$.invalidate_inner_signals` tail on a `++` / `--` — while the same
+//! binding's `=` and `+=` keep it. rsvelte wrapped all three, in four places:
+//! the AST and in-place ports of both `legacy_state_member_mutate_ast` and
+//! `prop_member_mutate_ast`.
+//!
+//! The key is the mutation each tail is attached to, not a count: an
+//! over-wrap and a moved wrap have the same count. Expectations are the
+//! oracle's own output.
+//!
+//! What this cannot see: `$: st.a++` loses its `$.mutate` wrapper entirely,
+//! which changes no tail and so leaves every row here unmoved.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+const NEEDLE: &str = "$.invalidate_inner_signals";
+
+/// The balanced expression the tail is appended to, one per occurrence.
+fn tail_hosts(js: &str) -> Vec<String> {
+    let b = js.as_bytes();
+    let mut out = Vec::new();
+    let mut from = 0;
+    while let Some(rel) = js[from..].find(NEEDLE) {
+        let i = from + rel;
+        let mut end = i;
+        while end > 0 && b[end - 1].is_ascii_whitespace() {
+            end -= 1;
+        }
+        if end > 0 && b[end - 1] == b',' {
+            end -= 1;
+        }
+        while end > 0 && b[end - 1].is_ascii_whitespace() {
+            end -= 1;
+        }
+        let mut depth = 0usize;
+        let mut j = end;
+        while j > 0 {
+            match b[j - 1] {
+                b')' => depth += 1,
+                b'(' => {
+                    if depth == 0 {
+                        break;
+                    }
+                    depth -= 1;
+                }
+                _ => {}
+            }
+            j -= 1;
+        }
+        out.push(js[j..end].split_whitespace().collect::<Vec<_>>().join(" "));
+        from = i + NEEDLE.len();
+    }
+    out
+}
+
+fn compile_cell(decl: &str, reference: &str, op: &str, host: &str) -> String {
+    let body = match host {
+        "fn" => format!("\tfunction go() {{ {op} }}"),
+        "reactive" => format!("\tlet tick = 0;\n\t$: if (tick) {{ {op} }}"),
+        other => panic!("unknown host {other}"),
+    };
+    let src = format!(
+        "<script>\n\t{decl}\n\tlet opts = ['x', 'y'];\n{body}\n</script>\n\
+         <select bind:value={{{reference}.t}}>{{#each opts as o}}<option value={{o}}>{{o}}</option>{{/each}}</select>\n\
+         <button on:click={{() => {{}}}}>go</button>"
+    );
+    compile(
+        &src,
+        CompileOptions {
+            filename: Some("M.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn an_update_expression_carries_no_invalidate_tail() {
+    let kinds: [(&str, &str, &str); 2] = [
+        ("state", "let st = { a: 1, t: 'x' };", "st"),
+        ("prop", "export let p = { a: 1, t: 'x' };", "p"),
+    ];
+    let ops: [(&str, &str); 3] = [
+        ("assign", ".a = 2;"),
+        ("compound", ".a += 2;"),
+        ("update", ".a++;"),
+    ];
+
+    let expected: Vec<((&str, &str, &str), Vec<&str>)> = vec![
+        (
+            ("state", "assign", "fn"),
+            vec![
+                "$.mutate(st, $.get(st).a = 2)",
+                "$.mutate(st, $.get(st).t = $$value)",
+            ],
+        ),
+        (
+            ("state", "assign", "reactive"),
+            vec![
+                "$.mutate(st, $.get(st).a = 2)",
+                "$.mutate(st, $.get(st).t = $$value)",
+            ],
+        ),
+        (
+            ("state", "compound", "fn"),
+            vec![
+                "$.mutate(st, $.get(st).a += 2)",
+                "$.mutate(st, $.get(st).t = $$value)",
+            ],
+        ),
+        (
+            ("state", "compound", "reactive"),
+            vec![
+                "$.mutate(st, $.get(st).a += 2)",
+                "$.mutate(st, $.get(st).t = $$value)",
+            ],
+        ),
+        (
+            ("state", "update", "fn"),
+            vec!["$.mutate(st, $.get(st).t = $$value)"],
+        ),
+        (
+            ("state", "update", "reactive"),
+            vec!["$.mutate(st, $.get(st).t = $$value)"],
+        ),
+        (
+            ("prop", "assign", "fn"),
+            vec!["p(p().a = 2, true)", "p(p().t = $$value, true)"],
+        ),
+        (
+            ("prop", "assign", "reactive"),
+            vec!["p(p().a = 2, true)", "p(p().t = $$value, true)"],
+        ),
+        (
+            ("prop", "compound", "fn"),
+            vec!["p(p().a += 2, true)", "p(p().t = $$value, true)"],
+        ),
+        (
+            ("prop", "compound", "reactive"),
+            vec!["p(p().a += 2, true)", "p(p().t = $$value, true)"],
+        ),
+        (("prop", "update", "fn"), vec!["p(p().t = $$value, true)"]),
+        (
+            ("prop", "update", "reactive"),
+            vec!["p(p().t = $$value, true)"],
+        ),
+    ];
+
+    let mut failures = Vec::new();
+    for (kind, decl, reference) in kinds {
+        for (op_name, suffix) in ops {
+            for host in ["fn", "reactive"] {
+                let op = format!("{reference}{suffix}");
+                let js = compile_cell(decl, reference, &op, host);
+                let got = tail_hosts(&js);
+                let want = &expected
+                    .iter()
+                    .find(|(k, _)| *k == (kind, op_name, host))
+                    .expect("cell listed")
+                    .1;
+                if got != *want {
+                    failures.push(format!(
+                        "{kind}/{op_name}/{host}\n  want {want:?}\n  got  {got:?}"
+                    ));
+                }
+            }
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}

--- a/crates/rsvelte_core/tests/update_expression_has_no_invalidate_tail.rs
+++ b/crates/rsvelte_core/tests/update_expression_has_no_invalidate_tail.rs
@@ -2,7 +2,9 @@
 //! grows the `$.invalidate_inner_signals` tail on a `++` / `--` — while the same
 //! binding's `=` and `+=` keep it. rsvelte wrapped all three, in four places:
 //! the AST and in-place ports of both `legacy_state_member_mutate_ast` and
-//! `prop_member_mutate_ast`.
+//! `prop_member_mutate_ast`; the `store_member_mutate_ast` rows are the same
+//! rule at a third port, which grew a tail for the first time in the same
+//! change and had to be gated on the way in.
 //!
 //! The key is the mutation each tail is attached to, not a count: an
 //! over-wrap and a moved wrap have the same count. Expectations are the
@@ -79,9 +81,14 @@ fn compile_cell(decl: &str, reference: &str, op: &str, host: &str) -> String {
 
 #[test]
 fn an_update_expression_carries_no_invalidate_tail() {
-    let kinds: [(&str, &str, &str); 2] = [
+    let kinds: [(&str, &str, &str); 3] = [
         ("state", "let st = { a: 1, t: 'x' };", "st"),
         ("prop", "export let p = { a: 1, t: 'x' };", "p"),
+        (
+            "store",
+            "import { writable } from 'svelte/store';\n\texport const s = writable({ a: 1, t: 'x' });",
+            "$s",
+        ),
     ];
     let ops: [(&str, &str); 3] = [
         ("assign", ".a = 2;"),
@@ -146,6 +153,42 @@ fn an_update_expression_carries_no_invalidate_tail() {
         (
             ("prop", "update", "reactive"),
             vec!["p(p().t = $$value, true)"],
+        ),
+        (
+            ("store", "assign", "fn"),
+            vec![
+                "$.store_mutate(s, $.untrack($s).a = 2, $.untrack($s))",
+                "$.store_mutate(s, $.untrack($s).t = $$value, $.untrack($s))",
+            ],
+        ),
+        (
+            ("store", "assign", "reactive"),
+            vec![
+                "$.store_mutate(s, $.untrack($s).a = 2, $.untrack($s))",
+                "$.store_mutate(s, $.untrack($s).t = $$value, $.untrack($s))",
+            ],
+        ),
+        (
+            ("store", "compound", "fn"),
+            vec![
+                "$.store_mutate(s, $.untrack($s).a += 2, $.untrack($s))",
+                "$.store_mutate(s, $.untrack($s).t = $$value, $.untrack($s))",
+            ],
+        ),
+        (
+            ("store", "compound", "reactive"),
+            vec![
+                "$.store_mutate(s, $.untrack($s).a += 2, $.untrack($s))",
+                "$.store_mutate(s, $.untrack($s).t = $$value, $.untrack($s))",
+            ],
+        ),
+        (
+            ("store", "update", "fn"),
+            vec!["$.store_mutate(s, $.untrack($s).t = $$value, $.untrack($s))"],
+        ),
+        (
+            ("store", "update", "reactive"),
+            vec!["$.store_mutate(s, $.untrack($s).t = $$value, $.untrack($s))"],
         ),
     ];
 


### PR DESCRIPTION
Six client/analysis defects, each with an oracle-generated grid, and the
thirteen `known-failures` entries they retire.

`known-failures.client.json` **8 → 1**, `known-failures.client-dev.json` **14 → 5**.

The last three came off after CI reported them as already passing — see § *Two false
keeps* below.

## 1. A reassigned each item reads by index in an invalidation dependency too

Upstream reads a **reassigned** each item as `collection[$index]`, never as
`$.get(item)` (`EachBlock.js:216-227`). rsvelte ports that as
`build_reassigned_item_read` and calls it from eight places; the
`$.invalidate_inner_signals` dependency list in `each_block.rs` is a ninth, and it
read `state.transform` directly, which does not carry the rule.

## 2. An assignment claims its OWN site, not the first one with its shape

`$.assign(…, '<file>:<line>:<column>')` locates the assignment's left-hand side.
rsvelte finds it by matching the lowered target back against a source-order site
list keyed `(root, path, operator)` — and a computed member contributes a
**valueless** `PathElement::Computed`, so `o.p[2]` and `o.p[3]` share a key and
only the order the sites are consumed in separates them. The visitor claimed its
site *after* descending, so the inner link of a chain took the outer's column.
The site is now claimed on the way down.

The cell that says so is one that was **already passing**: a static-key chain
(`o.a = o.b = s`) has two distinct keys and was correct throughout, so a grid of
computed chains alone cannot tell "claims in source order" from "always claims
the first site".

## 3. A leading comment does not make a parenthesised prop default a call

`is_simple_expression_str` decides eager-vs-lazy from the default's text, and its
call test — "ends in `)` and something precedes the matching `(`" — read a leading
JSDoc comment as the callee. Neither axis reproduces it alone; only the product
does.

## 4. A legacy prop default holding an equality operator is lazy in dev only

Upstream runs `is_simple_expression` on the **visited** default, so the dev-mode
`$.strict_equals` rewrite is already in the tree when the flag is decided.

## 5. An `++` on a state or prop member grows no invalidate tail

`UpdateExpression.js` does not import `build_assignment`, so upstream never
appends `$.invalidate_inner_signals` to a `++` / `--` — while the same binding's
`=` and `+=` keep it. rsvelte wrapped all three, in four places.

The rule is closed from **upstream's import graph**, not from a count of ports:
the four ports were the ones someone had found, and §6 below is the fifth,
reached in this same PR.

## 6. A `$store` member write invalidates the same inner signals a state one does

`2-analyze/index.js:445` declares each `$name` as a real `store_sub` binding, so
`scope.get('$s')` returns one and `RegularElement.js:81` attaches a
`<select bind:value={…}>`'s indirect bindings to it like any other binding.
rsvelte discarded exactly that case in two places in `regular_element.rs`, under
a comment asserting upstream returns null — so the store branch of the setter and
every `$s.a = …` lost the tail.

Upstream's exclusion of `store_sub` is on the **assign** arm's proxy flag
(`AssignmentExpression.js:147`); the mutate arm at `:154-181` has no condition on
binding kind at all. The first version of this fix wrapped `++` too and took the
six store cells to 4 EQ / 2 DIFF — which is what named §5's fifth port, in the
same grid, so a partial fix could not read as a complete one.

`compatibility/pattern-corpus/store-member-write-invalidates-inner-signals.svelte`
is the repro: byte-equal on all four targets after the fix, and `client` /
`client-dev` DIFF on the pre-fix arm — while `server` / `server-dev` are equal on
**both**, which is what records the defect as client-only rather than asserting it.

## Measurement

Two NAPI arms per fix, distinct `sha256`, each with a discriminating probe plus
controls that must **not** move, run in separate processes. Per fix, stage 1 is the
moved set over 134,180 corpus units (`rows == distinct keys`) and stage 2 is the
verdict for the moved set only, through the gate's own normalization:

| fix | MOVED | `MISMATCH -> match` | `match -> MISMATCH` |
|---|---|---|---|
| each | 2 | 2 | 0 |
| assign | 2 | 1 | 0 (the other is `MetallicPaint`, moved, verdict unchanged) |
| props | 2 | 0 | 0 (both `MISMATCH -> MISMATCH`) |
| `++` tail | 0 | 0 | 0 (arms distinct by `sha256`, probes flip) |
| store tail | 2 | 2 | 0 |

For §5 the sweep's zero is a real zero and not a dead instrument: the two arms
hash differently and the discriminating probe answers differently through each,
so "same artifact twice" and "mislabelled arm" are both closed. §6's own probe
pair is the other half — `$s.a = 2` gains the tail on the head arm only, while
`$s.a++` is byte-identical through both.

## Docs

Five `AGENTS.md` rows — a ratchet id can name the wrong axis; a printed field can
refute a search you already read; count a field's *writers*, not one function's
callers; a valueless key element turns a lookup into an ordering dependency; and a
green grid's held constant is a prediction, whose failure mode is that every cell
reaches the rule and none can tell two answers apart.

## Two false keeps, and why a stricter local check produced them

CI's two-sided ratchet reported three baseline entries already passing:
`primo/…/ui/Button.svelte` on `client` and `client-dev`, and
`svelvet/…/Edge/Edge.svelte` on `client-dev`. Both were **kept** on a local
two-arm sweep that scored them `MISMATCH -> MISMATCH`.

The sweep's comparison stops at the normalized byte diff and never runs
`ast_equiv_batch`, which makes it **stricter** than the gate. A zero from a
stricter reconstruction needs no fidelity argument; a **non-zero** is a candidate
list, not a verdict. These two are what that costs.

They were predictable from their own justifications: each says "what remains is
comment placement", and `ast_equiv_batch` is exactly the stage that does not
represent comment placement. A retained entry whose stated residue is comment
placement is one the gate rescues the moment its code line matches.

The bytes did not move — both files still differ from official on their comment
line, and both paragraphs keep the measurement of that rule. Only the verdict did.

## Issues verified closed at this PR's head

Each issue below names one or more corpus files; every one of them compiles
byte-identically to the oracle on **all four targets** at `e4be31bf8`, through the
gate's own normalization (oxfmt + blank-line stripping) and without the gate's
`ast_equiv_batch` rescue — so the comparison is *stricter* than the gate, and a
`match` under it is a match under the gate.

Closes #4120
Closes #4122
Closes #4123
Closes #4124
Closes #4125
Closes #4126
Closes #4127
Closes #4128
Closes #4132
Closes #4143
Closes #4153
Closes #4226
Closes #4227
Closes #4231
Closes #4232
Closes #4233
Closes #4234
Closes #4236
Closes #4237
Closes #4229

`#4153` is CSS, so it was checked on `css.code` and the warning set rather than on
`js.code`; `#4143` additionally has a constructed repro, which is EQ on all four.

**`#4229` is closed on its own repro rather than on a file match**, which is the
distinction its neighbour makes below: its `svelvet/…/Edge.svelte` carrier still
differs from official on one comment line, so a file-level check would say no. Its
11-cell grid — four equality operators crossed with prod/dev, five mode-invariant
shapes, and two not-simple controls — is **11/11 EQ** at this head, with the
discriminating column reproduced (`a === b` is `8` in prod and `24` in dev on
*both* sides).

**`#4230` is deliberately NOT closed, and it is half fixed.** Its two DIFF cells
were `/** @type {…} */ ('button')` and `(f())`; measured at this head the first is
EQ in prod and dev and the second still reports `off [19, f]` against
`rsv [19, () => f()]`. Upstream's zero-argument-call unwrapping
(`client/utils.js:88-93`) is reached for a bare `f()` and still missed when the
call is parenthesised. The issue is updated with that split rather than closed.

**`#4135` is deliberately not in that list.** Its three named files match, and its own
constructed repro is still `client` / `client-dev` DIFF — a file-level `match` is not
the issue's symptom, and running the repro is what separates them.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmNuq3boYDqe9CWwSfxi8
