### PR TITLE
Please release a new version of C API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_capi"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "cbindgen",
  "rsvelte_core",

--- a/crates/rsvelte_capi/Cargo.toml
+++ b/crates/rsvelte_capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_capi"
-version = "0.11.1"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.95"
 description = "C ABI bindings for the rsvelte Svelte 5 compiler — drive the compiler from C, Go, Python, Ruby, PHP, Zig, Java (JDK 22+ FFM), or any language with a C FFI"

--- a/crates/rsvelte_capi/Cargo.toml
+++ b/crates/rsvelte_capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_capi"
-version = "0.1.1"
+version = "0.11.1"
 edition = "2024"
 rust-version = "1.95"
 description = "C ABI bindings for the rsvelte Svelte 5 compiler — drive the compiler from C, Go, Python, Ruby, PHP, Zig, Java (JDK 22+ FFM), or any language with a C FFI"

--- a/crates/rsvelte_capi/README.md
+++ b/crates/rsvelte_capi/README.md
@@ -41,7 +41,7 @@ library, the static archive (where applicable), and `include/rsvelte.h`.
 #   darwin-arm64, darwin-x64,
 #   linux-x64-gnu, linux-arm64-gnu,
 #   win32-x64-msvc
-VERSION=0.1.1
+VERSION=0.2.0
 TRIPLE=darwin-arm64
 
 curl -L -o rsvelte_capi.tar.gz \
@@ -90,7 +90,7 @@ git dependency in the meantime:
 
 ```toml
 [dependencies]
-rsvelte_capi = { git = "https://github.com/baseballyama/rsvelte", tag = "capi-v0.1.1" }
+rsvelte_capi = { git = "https://github.com/baseballyama/rsvelte", tag = "capi-v0.2.0" }
 ```
 
 ## API at a glance
@@ -102,7 +102,7 @@ typedef struct RsvelteBuf {
   uintptr_t cap;    // reserved for rsvelte_free / rsvelte_free_raw
 } RsvelteBuf;
 
-const char *rsvelte_version(void);                    // static string, do not free
+const char *rsvelte_version(void);                    // this crate's version, not the compiler's; do not free
 void        rsvelte_free(RsvelteBuf buf);             // release any returned buffer (struct-by-value)
 void        rsvelte_free_raw(uint8_t *data,           // out-of-band variant for hosts that can't
                              uintptr_t len,           //   pass structs by value (Ruby Fiddle, etc.)
@@ -161,7 +161,9 @@ Every call returns one of:
 
 `opts_json` is the same shape as the existing NAPI options object
 (camelCase, all fields optional). Pass `NULL` / length 0 to use the
-defaults.
+defaults. An unrecognised key is **rejected** with an
+`Unrecognised compiler option <key>` envelope, mirroring the official
+compiler — 0.1.1 ignored unknown keys silently.
 
 ### Memory ownership
 
@@ -171,7 +173,9 @@ defaults.
   (or `rsvelte_free_raw` for hosts that can't pass structs by value).
 - A zero-initialised buffer (`{NULL, 0, 0}`) is safe to free.
 - `rsvelte_version` returns a pointer into static storage — do **not**
-  free it.
+  free it. It reports this crate's own version (the independent
+  `capi-vX.Y.Z` scheme), not the `rsvelte_core` / `@rsvelte/compiler`
+  version.
 
 ## Examples
 
@@ -240,8 +244,8 @@ intentionally independent from the npm/changeset pipeline that ships
 3. From `main`, tag and push:
 
    ```bash
-   git tag capi-v0.1.1
-   git push origin capi-v0.1.1
+   git tag capi-v0.2.0
+   git push origin capi-v0.2.0
    ```
 
 4. The release workflow builds the five-triple matrix, packages each

--- a/crates/rsvelte_capi/include/rsvelte.h
+++ b/crates/rsvelte_capi/include/rsvelte.h
@@ -136,7 +136,9 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Library version (matches the `rsvelte_core` crate version).
+ * Library version — this crate's own version. The C ABI follows an
+ * independent `capi-vX.Y.Z` scheme, so it does NOT track `rsvelte_core`
+ * or the npm `@rsvelte/compiler` version.
  *
  * Returns a static, NUL-terminated UTF-8 string. The caller MUST NOT
  * free the returned pointer.

--- a/crates/rsvelte_capi/src/lib.rs
+++ b/crates/rsvelte_capi/src/lib.rs
@@ -186,7 +186,9 @@ unsafe impl Send for Userdata {}
 // SAFETY: see the `Send` impl above — same rationale.
 unsafe impl Sync for Userdata {}
 
-/// Library version (matches the `rsvelte_core` crate version).
+/// Library version — this crate's own version. The C ABI follows an
+/// independent `capi-vX.Y.Z` scheme, so it does NOT track `rsvelte_core`
+/// or the npm `@rsvelte/compiler` version.
 ///
 /// Returns a static, NUL-terminated UTF-8 string. The caller MUST NOT
 /// free the returned pointer.


### PR DESCRIPTION
Per https://github.com/baseballyama/rsvelte/blob/main/crates/rsvelte_capi/README.md, to release the C API binaries the crate version should be bumped & merged.

As of today, only 2 CAPI releases occurred, and they are very old. Could you please release newer?

Context: I am developing a package that compiles `.svelte` without needing Node.js tooling. The cleanest option I got is fetching the `.so` from here. However the released version have bugs that I cannot sidestep without self-compiling the `.so`, and I want not to make the developer using the package to have the Rust toolchain installed.

And also as a question: Why is it not being released automatically, as it surely compiles? 