### PR TITLE
docs(agents): a display cap becomes a population, and a control's name is unchecked

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2754,6 +2754,89 @@ the control's name as a prediction about the cell's *input text* and grep the in
 A control named `KNOWN-global:Number` whose source contains no `Number` is caught in one
 command; no amount of ablation finds it, because ablation moves the code and holds the cells.
 
+### A run's status is not the aggregate of its jobs', and the two can disagree forever
+
+The concurrency ceiling this account is scheduled against is a **job** ceiling, and
+`actions/runs?status=in_progress` counts **runs**. The paging-window paragraph far above (rule
+4 of the truncating-stage list, `in_progress: 4`) reads a server-side run count of 20 as
+confirming a 20-job ceiling; measured on 2026-09-03 the same
+query returned **3 runs holding 18 in-progress jobs**, because one scheduled `Corpus Compat`
+run carried 15 `LSP real-world parity` shards by itself. Whether that earlier 20 was a
+coincidence of the two quantities is no longer measurable — which is the point: the number was
+never typed, so nothing said which of the two it was. **Ask about capacity by summing
+`runs/<id>/jobs`, and treat a run count as a count of runs.**
+
+The same measurement turned up a run that states the disagreement as sharply as it can be
+stated. A `Coverage` run on a closed PR's branch has been `status=in_progress` since
+2026-08-10 — `updated_at` one second after `created_at` and untouched for 24 days — and it
+holds **exactly one job, `status=completed, conclusion=skipped`**. So the aggregate is not
+ambiguous and the run contradicts it: every job is finished and the run is running. (That job
+also records `completed_at` one second *before* `started_at`, which is the likeliest reason
+whatever advances a run never fired.) `gh run cancel` answers `Cannot cancel a workflow run
+that is completed` while the runs API returns `in_progress` on the very next read — two faces
+of the API disagreeing permanently, neither yielding, so `?status=in_progress` is polluted for
+good. It occupies no slot, so it costs nothing except the instrument: **the run-level query is
+the one that can be wrong, and counting jobs is the way out from under it.**
+
+The saturation it exposed is worth stating as a shape rather than a number: 28 checks sitting at
+`QUEUED` with **zero** `IN_PROGRESS` reads exactly like a stalled scheduler, and here it was a
+nightly scheduled gate holding three quarters of the slots. Neither the check names nor their
+conclusions can separate those two; only the job census can.
+
+### Two branches appending sections to one document merge cleanly and duplicate in silence
+
+`main` carried 140 `### ` sections of this file, a peer's branch 151, and mine 142 — that last
+count being before the two sections you are reading. Those two branches are disjoint in what
+they *add*: measured with the merge-base form below, 2 added on one side and 11 on the other,
+intersecting to **zero**. That is the only reason nothing is wrong today. Four of the five rows this
+session had undertaken to write were already written on the peer's branch, unmerged and
+therefore invisible to `origin/main`; writing them would have produced two sections making the
+same claim, and **git would have merged them without a conflict**, because they append at
+different offsets in a 4,600-line file.
+
+Nothing in the tree can see it. Measured: the only code that reads `AGENTS.md` at all is the
+Svelte-target version marker in `update-docs.mjs` and its test — no gate reads its structure,
+and `sort | uniq -d` over the headings is 0 in all three trees only because nobody has collided
+yet. Compare that with the positive control: `KNOWN-FAILURES.md` is named by five files under
+`scripts/`.
+
+So the check is **subtract the merge base from each side first, then intersect** — the quantity
+wanted is not "which headings are on both branches" but "which headings both branches *added*":
+
+```sh
+A=<your branch>; B=<their branch>; MB=$(git merge-base "$A" "$B")
+# the braces are REQUIRED, not style: in zsh "$MB:AGENTS.md" is the :A modifier - see below
+added () { comm -13 <(git show "${MB}:AGENTS.md" | grep '^### ' | sort) \
+                    <(git show "${1}:AGENTS.md"  | grep '^### ' | sort); }
+comm -12 <(added "$A") <(added "$B")
+```
+
+The first version written here intersected the two full sets, which answers the other question
+and prints the 140 inherited headings around the same `0`. That is worth keeping because of how
+it happened: the correct two-stage form — intersect, then subtract `main` — is what was actually
+*run*, and only its first stage got written down. **A prescription simplified on the way into the
+note is a different instrument from the one that produced the result**, and nothing about the
+result says so; the reported `0` was right and unreproducible from the text beside it. A peer ran
+the written form and got 140 lines. This is the third instance in one day of intersecting before
+subtracting (the ratchet as a regression population, the formatter's rejected bucket, this).
+
+It is also the sibling of the recorded cross-file ordering hazard, with the failure mode inverted:
+there two clean-merging PRs turn `main` **red**, and the redness is the alarm. Here they turn it
+**longer**, and a document that says the same thing twice is the exact defect this file spends
+its length warning about — two ports of one rule, with colocation hiding them.
+
+One incidental, because it printed three plausible zeros while I was measuring the above:
+`for r in …; do git show $r:AGENTS.md; done` is not that command in zsh — `:A` is the
+absolute-path modifier, so the argument becomes `<abspath>GENTS.md`, git fails to **stderr**,
+and `wc -l` on the empty stdout reports `0` for every tree. Brace the expansion
+(`"${r}:AGENTS.md"`) — quoting alone does **not** help, because the modifier binds to the bare
+parameter name inside double quotes too. The failure was visible only because nothing discarded
+stderr. The command block above was itself written with `$MB:AGENTS.md` unbraced, four
+paragraphs above the note describing that exact hazard, and returned an empty set with three
+`fatal:` lines on stderr that a `0 collisions` label was printed over. What caught it was the
+injection control returning `0` where it must return `1` — the result and the broken control
+agreed, and only the control was checkable.
+
 ### An enumerated concern gets one item crossed off and reads as answered
 
 "That `loc` change reaches phase 3's comment decision **and** the source map, so 'only `parse()`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2706,6 +2706,54 @@ that has to be checked.** Knowing the trap and adding `--lib` does not entail th
 the two feel like one event because they are one intention. The check is one line: look in the
 output for a fingerprint only the workaround can produce — here, a four-digit `running` count.
 
+### A list truncated for DISPLAY becomes a population when something downstream reads it
+
+The row above protects a denominator that a stage drops on the way to your eyes. There is a
+worse arrangement, because no stage is truncating anything at read time: the truncation
+happened when the *previous* run wrote its report, and the next stage consumed the report.
+
+A corpus screen found 262 carrier files and printed them with `carriers.slice(0, 40)` — a
+display cap, correct and deliberate. The tightening pass that ran next read that printed list
+as its input and reported `carrier files scanned = 40`, then classified those 40 into a clean
+table. Every stage was right: the screen really did find 262, the cap really is a display
+choice, and the classifier really did classify 40 files correctly. **Nothing was truncated
+between a command and its reader, so none of the usual checks fire** — the exit status is the
+classifier's own, the output is complete, and re-reading it more carefully shows a correct
+table of a set nobody chose.
+
+Corrected by writing the full list to a second file (`*.out.carriers`, uncapped) and re-running,
+the same classifier reported 262 and **8 defect candidates against the 40-file run's 1**. The
+capped run's single candidate was real, and its neighbours were simply absent.
+
+Two things generalize. **The defect is not the cap, it is one array serving two consumers** —
+a human reading a report and a program reading a population — so the repair is a second
+artifact rather than a wider cap, and a wider cap only moves the threshold. And what caught it
+was that the second stage **printed the size of what it had been handed**: `scanned = 40`
+beside a screen that had said 262 is a contradiction visible without reading either program.
+A stage that consumes another stage's output should print that input's cardinality, because
+its own author is the only person positioned to notice the number is wrong.
+
+### A control's NAME is a claim, and the control passing does not check it
+
+A classifier shipped with eight two-sided controls, each named for the shape it was meant to
+pin (`KNOWN-literal`, `KNOWN-global:Number`, `no-decl`, `unknown-init`, and their negatives).
+The set passed, was ablated, went red, was restored, and the tree came back byte-identical —
+the whole prescribed procedure.
+
+Then the labels were corrected, because two of them named a shape the cell did not contain.
+**All eight verdicts were unchanged.** They had to be: the assertions compare a computed label
+against an expected label, and the *name* of the cell is read by nobody. So the control set
+demonstrated that the classifier is self-consistent and demonstrated nothing whatever about
+which shapes it covers — while its names are the only record of that, and are what a later
+reader will cite as coverage.
+
+This is one step past a grid holding an axis fixed. There, the cells are real and the axis is
+missing; here the cell may not contain what its name says at all, and **the passing run is
+what makes nobody re-read the name**. The cheap check is the same shape as an injection: take
+the control's name as a prediction about the cell's *input text* and grep the input for it.
+A control named `KNOWN-global:Number` whose source contains no `Number` is caught in one
+command; no amount of ablation finds it, because ablation moves the code and holds the cells.
+
 ### An enumerated concern gets one item crossed off and reads as answered
 
 "That `loc` change reaches phase 3's comment decision **and** the source map, so 'only `parse()`


### PR DESCRIPTION
Two measurement-hygiene rows for `AGENTS.md`. Docs only — one file, +48 lines, no code.

Both come from one session's own failures, and both produced a **correct-looking table of the wrong thing**, which is why neither was caught by the existing checks.

### 1. A list truncated for DISPLAY becomes a population when something downstream reads it

The existing denominator row (`pipestatus` protects the verdict; nothing protects the denominator) covers a stage that drops the verdict on its way to your eyes. This is the harder case: **nothing is truncating at read time.** The truncation happened when the *previous* run wrote its report, and the next stage consumed the report.

A corpus screen found **262** carrier files and printed them with `carriers.slice(0, 40)` — a deliberate, correct display cap. The tightening pass that ran next read that printed list as its input, reported `carrier files scanned = 40`, and classified those 40 correctly. Every stage was right. Re-run against an uncapped second artifact, the same classifier reported **262** and **8** defect candidates against the capped run's **1**.

- The defect is **one array serving two consumers** (a human reading a report, a program reading a population), so the repair is a second artifact — widening the cap only moves the threshold.
- What caught it was the second stage **printing the cardinality of what it had been handed**. `scanned = 40` next to a screen that said 262 is a contradiction visible without reading either program.

### 2. A control's NAME is a claim, and the control passing does not check it

A classifier shipped with eight two-sided controls, each named for the shape it pinned. The set passed, ablated red, restored byte-identical — the whole prescribed procedure.

Then two labels were corrected, because they named a shape the cell did not contain. **All eight verdicts were unchanged**, and had to be: the assertions compare a computed label against an expected label, and the cell's *name* is read by nobody. So the control set demonstrated the classifier is self-consistent and demonstrated nothing about which shapes it covers — while the names are the only record of that, and are what a later reader cites as coverage.

This sits one step past a grid holding an axis fixed: there the cells are real and the axis is missing; here the cell may not contain what its name says, and the **passing run is what stops anyone re-reading the name**. The check is an injection — read the control's name as a prediction about its *input text* and grep the input for it. Ablation cannot find it, because ablation moves the code and holds the cells.

---

No changeset: docs-only, per the `chore/test/docs` convention.
