### PR TITLE
docs(fmt): one sidecar label was three mechanisms plus a reject path

### DIFF
--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -1210,29 +1210,43 @@ boundary in its *line-breaking* facet (e.g.
 does not), but that facet has no pin either, so it is recorded here as a
 hypothesis rather than as a mechanism.
 
-### Entries by mechanism (2026-09-02)
+### Entries by mechanism (2026-09-04)
 
 **This table is generated from a one-to-one id → mechanism assignment**
 (`compatibility/fmt-mechanisms.json`), **and the `n` column is derived from it** —
 `known-failures-md-check.mjs` fails if a row disagrees with the sidecar, if an
-entry carries no mechanism, or if a mechanism carries no entry. Both are
+entry carries no mechanism, or if a mechanism carries no entry. Every row is
 `pinned: none`, which is the whole finding: this ratchet's end state is
 elimination for every entry it holds.
 
-The five candidates are `layerchart/docs/src/routes/+page.svelte` (Cluster 8),
-the two Cluster 11 fixtures (`css-nth-of-minified`, `css-escape-sequences`) and
-`pattern/issues/3404-{repeated-combinators,unhandled-combinator-scope}.svelte`.
-The remaining 519 are one bucket rather than seven because the mechanical
+The embedded-CSS engine split was a single label until 2026-09-04, and a key that
+cannot tell its members apart suppresses all of them. Re-measured by running the
+gate's own two production stages — `oxfmt -c … <paths>` for the oracle and
+`rsvelte-fmt . -c … --oxfmt-bin …` for the actual, over the five sources staged at
+their corpus paths — it is the set of rows below rather than one row. Only the
+first is a *reject* path, and its fingerprint is in the output rather than in the
+diff: tabs survive in rsvelte's text while the config says `useTabs: false`, with
+the other three CSS candidates at 0 tab-bearing lines in the same run, so the body
+was copied rather than printed. None of the five changes the compiled CSS —
+`#\31\32\33` / `.a\5c` and the gradient indent are byte-identical through the
+official compiler after scope-hash normalization, and the other three carry their
+spelling through verbatim with identical scoping — so what a pin here would record
+is the engine choice, not a claim about which side is correct.
+
+The remaining entries are one bucket rather than seven because the mechanical
 `20`-`26` split above is recomputed from `compatibility/fmt-report.json`, which is
 a build artifact of a full oracle run and is not in the tree — assigning those
 buckets per entry from the doc would be transcription, not measurement.
 
 | n | mechanism | pinned |
 |---|---|---|
-| 5 | the embedded-CSS engine split — rsvelte-fmt prints through `oxc_formatter_css` and the oracle's Svelte path through PostCSS; a candidate for `deliberate-divergences`, but the pin there covers value spelling and none of these entries | none — candidate, not pinned for this facet |
+| 1 | `oxc_formatter_css` rejects the `<style>` body, so `native_style_formatter` returns it verbatim and the source's own indentation survives — measured as 6 tab-bearing lines in rsvelte's output under `useTabs: false`, against 0 in the oracle's own output for the same file and 0 on both sides for three of the four sibling candidates (the fourth reads 1 on both sides, inside a declaration value); the oracle's PostCSS path accepts the same body and reformats it | none — candidate, not pinned for this facet |
+| 2 | the two engines disagree about whitespace around a selector token neither models — the column combinator and a `nth-child(… of <selector>)` clause: rsvelte's `oxc_formatter_css` prints the space, the oracle's PostCSS path closes it up; the official compiler carries either spelling through verbatim and scopes both identically | none — candidate, not pinned for this facet |
+| 1 | a hex escape ending a selector: rsvelte emits the escape's terminating space and the separator before `{` as two spaces where the oracle emits one — the same file's 18 other selectors, including every hex escape followed by more text, agree; the official compiler's scoped CSS is byte-identical for the two spellings | none — candidate, not pinned for this facet |
+| 1 | continuation indent of a comma-separated multi-value declaration: rsvelte's engine prints every continuation at one depth where the oracle's PostCSS path keeps the source's uneven depth; the official compiler's scoped CSS is byte-identical for the two spellings | none — candidate, not pinned for this facet |
 | 519 | no upstream report and no pinned deliberate divergence; elimination is the only end state open to these entries | none |
 
-Partition of `fmt-known-failures.json` by mechanism: `5 + 519`
+Partition of `fmt-known-failures.json` by mechanism: `1 + 2 + 1 + 1 + 519`
 
 ### Cluster 1 — close-tag-dangle / open-tag hugging for inline & void children (3)
 

--- a/compatibility/fmt-mechanisms.json
+++ b/compatibility/fmt-mechanisms.json
@@ -1,8 +1,20 @@
 {
 	"$schema-note": "id -> mechanism slug for every entry of fmt-known-failures.json. The `Entries by mechanism` table in KNOWN-FAILURES.md is derived from this file: one row per `mechanisms` key, `n` = how many `entries` name it, and `known-failures-md-check.mjs` compares the table to it. The assignment is one-to-one, so a double count is unwritable.",
 	"mechanisms": {
-		"css-engine-boundary-candidate": {
-			"description": "the embedded-CSS engine split — rsvelte-fmt prints through `oxc_formatter_css` and the oracle's Svelte path through PostCSS; a candidate for `deliberate-divergences`, but the pin there covers value spelling and none of these entries",
+		"css-engine-rejects-block": {
+			"description": "`oxc_formatter_css` rejects the `<style>` body, so `native_style_formatter` returns it verbatim and the source's own indentation survives — measured as 6 tab-bearing lines in rsvelte's output under `useTabs: false`, against 0 in the oracle's own output for the same file and 0 on both sides for three of the four sibling candidates (the fourth reads 1 on both sides, inside a declaration value); the oracle's PostCSS path accepts the same body and reformats it",
+			"pinned": "none — candidate, not pinned for this facet"
+		},
+		"css-engine-selector-token-spacing": {
+			"description": "the two engines disagree about whitespace around a selector token neither models — the column combinator and a `nth-child(… of <selector>)` clause: rsvelte's `oxc_formatter_css` prints the space, the oracle's PostCSS path closes it up; the official compiler carries either spelling through verbatim and scopes both identically",
+			"pinned": "none — candidate, not pinned for this facet"
+		},
+		"css-engine-trailing-escape-space": {
+			"description": "a hex escape ending a selector: rsvelte emits the escape's terminating space and the separator before `{` as two spaces where the oracle emits one — the same file's 18 other selectors, including every hex escape followed by more text, agree; the official compiler's scoped CSS is byte-identical for the two spellings",
+			"pinned": "none — candidate, not pinned for this facet"
+		},
+		"css-engine-multi-value-indent": {
+			"description": "continuation indent of a comma-separated multi-value declaration: rsvelte's engine prints every continuation at one depth where the oracle's PostCSS path keeps the source's uneven depth; the official compiler's scoped CSS is byte-identical for the two spellings",
 			"pinned": "none — candidate, not pinned for this facet"
 		},
 		"unattributed": {
@@ -195,7 +207,7 @@
 		"layercake/src/_components/AxisY.percent-range.html.svelte": "unattributed",
 		"layercake/src/_components/AxisYRight.percent-range.html.svelte": "unattributed",
 		"layerchart/docs/src/examples/components/Chart/facet-wrap.svelte": "unattributed",
-		"layerchart/docs/src/routes/+page.svelte": "css-engine-boundary-candidate",
+		"layerchart/docs/src/routes/+page.svelte": "css-engine-multi-value-indent",
 		"layerchart/packages/layerchart/src/lib/components/Labels/Labels.base.svelte": "unattributed",
 		"mathesar/mathesar_ui/src/component-library/select/Select.svelte": "unattributed",
 		"mathesar/mathesar_ui/src/systems/table-view/TableView.svelte": "unattributed",
@@ -322,8 +334,8 @@
 		"paaster/paaster/src/routes/settings/+page.svelte": "unattributed",
 		"pattern/issues/3195-nth-of-selector-list.svelte": "unattributed",
 		"pattern/issues/3195-style-printed-from-ast.svelte": "unattributed",
-		"pattern/issues/3404-repeated-combinators.svelte": "css-engine-boundary-candidate",
-		"pattern/issues/3404-unhandled-combinator-scope.svelte": "css-engine-boundary-candidate",
+		"pattern/issues/3404-repeated-combinators.svelte": "css-engine-rejects-block",
+		"pattern/issues/3404-unhandled-combinator-scope.svelte": "css-engine-selector-token-spacing",
 		"pattern/issues/3498-class-rune-linebreak-separators.svelte": "unattributed",
 		"pattern/issues/3714-template-quoted-property-key.svelte": "unattributed",
 		"pattern/issues/4046-each-const-parameter-comment.svelte": "unattributed",
@@ -501,8 +513,8 @@
 		"svelte-ux/packages/svelte-ux/src/routes/+error.svelte": "unattributed",
 		"svelte-ux/packages/svelte-ux/src/routes/docs/components/Gooey/+page.svelte": "unattributed",
 		"svelte/packages/svelte/tests/parser-modern/samples/const-tag-parenthesized-init/input.svelte": "unattributed",
-		"svelte/packages/svelte/tests/parser-modern/samples/css-nth-of-minified/input.svelte": "css-engine-boundary-candidate",
-		"svelte/packages/svelte/tests/print/samples/css-escape-sequences/input.svelte": "css-engine-boundary-candidate",
+		"svelte/packages/svelte/tests/parser-modern/samples/css-nth-of-minified/input.svelte": "css-engine-selector-token-spacing",
+		"svelte/packages/svelte/tests/print/samples/css-escape-sequences/input.svelte": "css-engine-trailing-escape-space",
 		"sveltekit/packages/enhanced-img/test/Output.svelte": "unattributed",
 		"sveltekit/packages/kit/test/apps/async/src/routes/remote/form/value/+page.svelte": "unattributed",
 		"sveltekit/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte": "unattributed",


### PR DESCRIPTION
## What

`compatibility/fmt-mechanisms.json` assigned all five embedded-CSS entries of
`fmt-known-failures.json` to one slug, `css-engine-boundary-candidate`. A key
that cannot tell its members apart suppresses all of them, so this splits it
into the four mechanisms that are actually there and rewrites the derived
`Entries by mechanism` table.

**This attributes nothing.** Every row stays `pinned: none`, and
`fmt-known-failures.json` stays in `attribution-pending.json`.
`attribution-check.mjs` reports the same 5 problems before and after.

## How it was measured

Both arms are the gate's own production stages, so no fidelity argument is
needed for the comparison itself — `fmt-verify.mjs` compares with
`oracle === actual`, raw bytes, no normalization:

| arm | command |
|---|---|
| oracle | `oxfmt -c scripts/fixtures/fmt-corpus.oxfmtrc.json <paths>` |
| actual | `rsvelte-fmt . -c scripts/fixtures/fmt-corpus.oxfmtrc.json --oxfmt-bin <oxfmt>` |

The five sources were staged **at their corpus id paths**, from the real files
(`compatibility/pattern-corpus/…`, `submodules/svelte/…`, `submodules/layerchart/…`).
Re-running with a flat layout gives the identical per-file differing-line counts
(12 / 14 / 38 / 14 / 4), which removes the staging-layout premise.

`rsvelte_fmt` links `oxc_formatter_css v0.64.0 (rev 0389c401)` and `oxfmt` is
`0.64.0`, so the two binaries carry the **same** CSS engine; what differs is
rsvelte's embedding versus the oracle's PostCSS path for *embedded* styles.

## The split

| n | slug | carrier | what differs |
|---|---|---|---|
| 1 | `css-engine-rejects-block` | `pattern/issues/3404-repeated-combinators.svelte` | the engine rejects the body and it is spliced back verbatim |
| 2 | `css-engine-selector-token-spacing` | `3404-unhandled-combinator-scope`, `css-nth-of-minified` | whitespace around a selector token neither engine models |
| 1 | `css-engine-trailing-escape-space` | `css-escape-sequences` | a hex escape ending a selector |
| 1 | `css-engine-multi-value-indent` | `layerchart/docs/src/routes/+page.svelte` | continuation indent of a comma-separated value |

### The reject path is confirmed from the output, not from unchanged text

"The file did not change" would not have shown this — an unchanged file and a
file whose CSS block was skipped look the same. Two independent confirmations:

**Tab survival.** The config says `useTabs: false`. Tab-bearing lines per file
in one run:

```
file                                     src  oracle  actual
3404-repeated-combinators                 14       0       6
3404-unhandled-combinator-scope           22       0       0
css-nth-of-minified                       24       0       0
css-escape-sequences                      20       0       0
layerchart +page                         325       1       1
```

rsvelte emitting 6 tab-bearing lines under `useTabs: false` can only mean the
body was copied. The three zero rows are live negative controls in the same
run: the formatter does convert tabs when it formats. (layerchart reads 1 on
both sides — inside a declaration value, not indentation.)

**A constructed two-cell probe**, same file except the combinator:

```
input (both cells)          rsvelte output
<div    class="card"   >    <div class="card">        ← markup reformatted in BOTH
  .card>>.a {                 .card>>.a {             ← frozen
        color:green;                color:green;      ← frozen (8 spaces kept)
  .card>.a {                  .card > .a {            ← normalized
        color:green;            color: green;         ← normalized (4 spaces)
```

The markup moves in both cells, so the file was processed; only the rejected
block froze. The `>` cell is the control that shows the probe can move.

The mechanism is `style_css.rs`'s `native_style_formatter`:
`.map_or_else(|_| Ok(body.trim_start_matches('\n').to_string()), Ok)`.

## None of the five changes the compiled CSS

Run through `submodules/svelte/packages/svelte/src/compiler/index.js`, scope
hash normalized:

| pair | verdict |
|---|---|
| `#\31\32\33  {` vs `#\31\32\33 {` | **identical** compiled CSS |
| `.a\5c  {` vs `.a\5c {` | **identical** compiled CSS |
| gradient continuation indent | **identical** compiled CSS |
| `.card >> .a` vs `.card>>.a` | same scoping; the spelling is carried through verbatim, so the compiled text differs by the same whitespace |
| `.a \|\| .b` vs `.a\|\|.b` | same |
| `of .important` vs `of.important` | same — and the fixture's own comment states the equivalence ("minifiers drop the whitespace after `of`") |

### Retraction carried in the doc

An earlier reading of this set said the oracle **changes the meaning** for
`.a\5c `, which would have been the strongest possible pin justification. It is
false for the line that actually diverges. The escape terminator *is*
meaning-bearing — `.a\5c  b` is class `a\` descendant `b` while `.a\5c b` is the
single class `a\b`, and the official compiler emits `b:where(…)` for one and not
the other — but that pair is not what diverges here. Both diverging lines end
the selector, where the space is only the separator before `{`.

So a pin here would record the engine choice, not a claim about which side is
correct. The doc now says that.

## Checks

- `known-failures-md-check.mjs` — green, with two positive controls: changing an
  `n` gives *"the table says 2 … but fmt-mechanisms.json assigns it 1"*, changing
  one character of a description gives *"no row for … its cell must be the
  sidecar's `description` verbatim"*. Restored, green again.
- `attribution-check.mjs` — 5 problems, unchanged from `main`.
