### PR TITLE
ci(capi): a merged version bump cuts its own tag, and the dispatch it needs is asserted

### DIFF
--- a/.github/workflows/capi-autotag.yml
+++ b/.github/workflows/capi-autotag.yml
@@ -1,0 +1,113 @@
+name: Tag C ABI release
+
+# The C ABI releases off a `capi-v<version>` tag, so a version bump merging to
+# main publishes nothing by itself — and a merged-but-untagged bump is
+# indistinguishable from a released one when you read main. `capi-v0.1.1` was
+# the newest tag for three months while `rsvelte_core` moved to 0.11.1, and an
+# external report is what surfaced it (#4274 / #4285).
+#
+# This job turns the merge into the tag `release-capi.yml` already builds from.
+# It then *dispatches* that workflow rather than relying on the tag push to
+# trigger it: a push made with GITHUB_TOKEN starts no workflow run
+# (workflow_dispatch and repository_dispatch are the documented exceptions), so
+# a tag pushed here would otherwise sit unbuilt — the same silence one step
+# further along. Dispatching against the tag ref keeps `release-capi.yml`'s own
+# `refs/tags/capi-v` conditions true, so the Release is created exactly as it is
+# for a hand-pushed tag.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/rsvelte_capi/Cargo.toml'
+  workflow_dispatch:
+
+permissions:
+  contents: write   # create the tag ref
+  actions: write    # dispatch release-capi.yml
+
+# Never cancelling: two bumps landing close together are two releases, and the
+# newer run does not subsume the older one's tag.
+concurrency:
+  group: capi-autotag
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: Cut the capi tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      # The tag list comes from the API rather than from a deep fetch: it is the
+      # same set the Release page shows, and it costs one request instead of the
+      # repository's history.
+      - name: Read the released tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/capi-v" \
+            --jq '.[].ref' | sed 's|^refs/tags/||' > capi-tags.txt
+          echo "existing capi tags: $(wc -l < capi-tags.txt)"
+          cat capi-tags.txt
+
+      - name: Decide whether a tag is needed
+        id: decide
+        run: node scripts/release/capi-release-decision.mjs --tags-file capi-tags.txt
+
+      - name: Create the tag
+        if: steps.decide.outputs.action == 'tag'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${{ steps.decide.outputs.tag }}" \
+            -f sha="${GITHUB_SHA}"
+
+      # A created tag with no build behind it is the failure this workflow
+      # exists to remove, so the dispatch is verified rather than assumed: `gh
+      # workflow run` exits 0 on acceptance, which is not the same as a run.
+      - name: Build and publish the release
+        if: steps.decide.outputs.action == 'tag'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.decide.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh workflow run release-capi.yml --ref "${TAG}"
+          for _ in $(seq 1 12); do
+            sleep 10
+            # `head_branch` is the ref the dispatch resolved to, and it has to be
+            # the TAG: `release-capi.yml` publishes on `refs/tags/capi-v*` and
+            # would otherwise build the matrix and create no Release at all.
+            ref=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/release-capi.yml/runs?event=workflow_dispatch&per_page=20" \
+              --jq "[.workflow_runs[] | select(.head_sha == \"${GITHUB_SHA}\")] | .[0].head_branch // empty")
+            [[ -n "${ref}" ]] || continue
+            if [[ "${ref}" == "${TAG}" ]]; then
+              echo "release-capi.yml is running against ${ref}"
+              exit 0
+            fi
+            echo "::error::release-capi.yml started against \`${ref}\`, not \`${TAG}\` — it will build the matrix and publish nothing. Re-run it against the tag: gh workflow run release-capi.yml --ref ${TAG}"
+            exit 1
+          done
+          echo "::error::${TAG} was created but no release-capi.yml run appeared for ${GITHUB_SHA}. Start it by hand: gh workflow run release-capi.yml --ref ${TAG}"
+          exit 1
+
+      - name: Summary
+        if: ${{ !cancelled() }}
+        run: |
+          {
+            echo "### C ABI tag"
+            echo
+            echo "- decision: \`${{ steps.decide.outputs.action || 'not reached' }}\`"
+            echo "- version: \`${{ steps.decide.outputs.version || 'unknown' }}\`"
+            echo "- tag: \`${{ steps.decide.outputs.tag || '—' }}\`"
+            echo
+            echo "A \`tag\` decision only starts the release build; the GitHub Release appears when [Release C ABI](../../actions/workflows/release-capi.yml) finishes its five-triple matrix."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1310,6 +1310,13 @@ jobs:
         if: ${{ !cancelled() }}
         run: node scripts/release/test-wait-for-release-verdicts.mjs
 
+      # The capi auto-tag's "already released" and "version goes backwards"
+      # arms only ever run on a tree where they must not fire, so nothing else
+      # can show they are still able to.
+      - name: Run capi release decision tests
+        if: ${{ !cancelled() }}
+        run: node scripts/release/test-capi-release-decision.mjs
+
       - name: Run differential corpus workflow tests
         if: ${{ !cancelled() }}
         run: node scripts/ci/test-differential-corpus-workflow.mjs

--- a/.github/workflows/release-capi.yml
+++ b/.github/workflows/release-capi.yml
@@ -5,10 +5,14 @@ name: Release C ABI
 #  - Tag the worktree as `capi-v<MAJOR.MINOR.PATCH>` (must match the
 #    `version` in `crates/rsvelte_capi/Cargo.toml`) and push the tag.
 #    The push event triggers this workflow; on success it creates a
-#    GitHub Release with the per-OS/arch archives attached.
-#  - `workflow_dispatch` lets you do a dry-run end-to-end without
-#    actually publishing — pick a "version" input (defaults to "test")
-#    and run; the build matrix produces artifacts you can inspect.
+#    GitHub Release with the per-OS/arch archives attached. Normally
+#    `capi-autotag.yml` does that for you when the bump merges.
+#  - `workflow_dispatch` publishes or not according to the REF, not the
+#    event: dispatched against a branch it is a dry run (pick a "version"
+#    input, defaults to "test") that leaves inspectable artifacts, while
+#    dispatched against a `capi-v*` tag it publishes exactly as a tag push
+#    does. `capi-autotag.yml` relies on the second form, because a tag
+#    pushed with GITHUB_TOKEN starts no workflow run of its own.
 #
 # The matrix mirrors the existing svelte-check / vps-native release
 # pipelines (.github/workflows/release.yml) so the toolchain quirks
@@ -204,9 +208,10 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Only publish on a real tag push. workflow_dispatch leaves the
-    # artifacts attached to the workflow run for inspection without
-    # creating a Release.
+    # The ref decides, not the event: a `capi-v*` ref publishes (a tag push,
+    # or `capi-autotag.yml` dispatching against the tag it just created),
+    # and any other ref leaves the artifacts attached to the run for
+    # inspection without creating a Release.
     if: startsWith(github.ref, 'refs/tags/capi-v')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/crates/rsvelte_capi/README.md
+++ b/crates/rsvelte_capi/README.md
@@ -241,18 +241,25 @@ intentionally independent from the npm/changeset pipeline that ships
 
 1. Bump `crates/rsvelte_capi/Cargo.toml`'s `version`.
 2. Open a PR, get it merged.
-3. From `main`, tag and push:
-
-   ```bash
-   git tag capi-v0.2.0
-   git push origin capi-v0.2.0
-   ```
-
+3. That is the whole procedure:
+   [`capi-autotag.yml`](../../.github/workflows/capi-autotag.yml) sees the
+   manifest change on `main`, creates `capi-v<version>` at the merge commit,
+   and starts the release build. It does nothing when the tag already exists,
+   and refuses — rather than tagging — when the version is not
+   `MAJOR.MINOR.PATCH` or is behind a released one.
 4. The release workflow builds the five-triple matrix, packages each
    into `rsvelte_capi-<ver>-<triple>.tar.gz` (or `.zip` for Windows),
    computes per-archive + combined SHA-256 sums, and creates the
    GitHub Release with all archives attached. The workflow refuses to
    build if the tag and `Cargo.toml` version disagree.
+
+To cut one by hand instead — a prerelease version, or a re-release of a tag
+that was deleted — push the tag yourself and the same workflow runs:
+
+```bash
+git tag capi-v0.2.0
+git push origin capi-v0.2.0
+```
 
 `workflow_dispatch` (in the Actions tab) lets you run the matrix
 against any branch with a synthetic version label, producing

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 		"test:bot-branch-guard": "node scripts/ci/test-bot-branch-guard.mjs",
 		"check:workflow-triggers": "node scripts/ci/workflow-trigger-guard.mjs",
 		"test:workflow-trigger-guard": "node scripts/ci/test-workflow-trigger-guard.mjs",
+		"test:capi-release-decision": "node scripts/release/test-capi-release-decision.mjs",
 		"test:differential-corpus-workflow": "node scripts/ci/test-differential-corpus-workflow.mjs",
 		"check:prereq-coverage": "node scripts/ci/prereq-coverage-guard.mjs",
 		"test:prereq-coverage-guard": "node scripts/ci/test-prereq-coverage-guard.mjs",

--- a/scripts/release/capi-release-decision.mjs
+++ b/scripts/release/capi-release-decision.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+// Decide whether the version in `crates/rsvelte_capi/Cargo.toml` still needs a
+// `capi-v<version>` tag cut for it.
+//
+// The C ABI's release trigger is the tag, not the merge, so a bump that lands
+// on main publishes nothing and looks exactly like a released one from main's
+// side: `capi-v0.1.1` stayed the newest tag for three months while
+// `rsvelte_core` moved to 0.11.1, and it took an external report (#4274) to
+// notice. `capi-autotag.yml` closes that gap, and the three questions it has to
+// answer — is the version well-formed, is it already released, does it move
+// forward — live here rather than in YAML, because a shell snippet inside a
+// workflow can only be tested by merging it.
+
+import { appendFileSync, readFileSync } from 'node:fs';
+
+export const TAG_PREFIX = 'capi-v';
+
+// Deliberately no prerelease/build suffix: `release-capi.yml` names archives
+// `rsvelte_capi-<version>-<triple>` and orders nothing, so a suffix would order
+// by luck. A prerelease is still reachable by pushing the tag by hand.
+const VERSION = /^(\d+)\.(\d+)\.(\d+)$/;
+
+/** First `^version = "…"` line, which is `[package].version` in this manifest. */
+export function readManifestVersion(contents) {
+	const match = /^version = "(.+)"$/m.exec(contents);
+	if (!match) throw new Error('no `version = "…"` line in the manifest');
+	return match[1];
+}
+
+/** -1 / 0 / 1 over `MAJOR.MINOR.PATCH`; both sides must match VERSION. */
+export function compareVersions(left, right) {
+	const a = VERSION.exec(left);
+	const b = VERSION.exec(right);
+	if (!a || !b) throw new Error(`not comparable: ${left} vs ${right}`);
+	for (let i = 1; i <= 3; i += 1) {
+		const difference = Number(a[i]) - Number(b[i]);
+		if (difference !== 0) return Math.sign(difference);
+	}
+	return 0;
+}
+
+/**
+ * @param {{version: string, existingTags: string[]}} input — `existingTags` are
+ *   tag names (`capi-v0.1.1`), not refs; anything without the prefix is ignored
+ *   so the caller may pass the repository's whole tag list.
+ * @returns {{action: 'tag'|'skip'|'abort', tag: string|null, reason: string,
+ *   ignoredTags: string[]}}
+ */
+export function decide({ version, existingTags }) {
+	const tag = `${TAG_PREFIX}${version}`;
+
+	if (!VERSION.test(version)) {
+		return {
+			action: 'abort',
+			tag: null,
+			ignoredTags: [],
+			reason:
+				`\`${version}\` is not MAJOR.MINOR.PATCH. The release workflow names its ` +
+				`archives after this string, so it is not cut automatically — push the tag ` +
+				`by hand if that version is deliberate.`,
+		};
+	}
+
+	const released = existingTags.filter((name) => name.startsWith(TAG_PREFIX));
+	const versions = released.map((name) => name.slice(TAG_PREFIX.length));
+	// A tag whose version this script cannot order (a prerelease pushed by hand)
+	// must not silently decide the comparison, so it is reported instead.
+	const ignoredTags = released.filter(
+		(name) => !VERSION.test(name.slice(TAG_PREFIX.length)),
+	);
+	const comparable = versions.filter((candidate) => VERSION.test(candidate));
+
+	if (versions.includes(version)) {
+		return {
+			action: 'skip',
+			tag,
+			ignoredTags,
+			reason: `${tag} already exists — this commit changed the manifest without changing the version.`,
+		};
+	}
+
+	const newest = comparable.reduce(
+		(best, candidate) => (best === null || compareVersions(candidate, best) > 0 ? candidate : best),
+		/** @type {string|null} */ (null),
+	);
+
+	if (newest !== null && compareVersions(version, newest) < 0) {
+		return {
+			action: 'abort',
+			tag,
+			ignoredTags,
+			reason:
+				`the manifest says ${version} but ${TAG_PREFIX}${newest} is already released. ` +
+				`Cutting ${tag} now would publish an older C ABI as the newest release.`,
+		};
+	}
+
+	return {
+		action: 'tag',
+		tag,
+		ignoredTags,
+		reason:
+			newest === null
+				? `no ${TAG_PREFIX}* tag exists yet; ${tag} is the first.`
+				: `${version} is ahead of the newest release ${newest}.`,
+	};
+}
+
+function parseArgv(argv) {
+	const options = { manifest: 'crates/rsvelte_capi/Cargo.toml', tagsFile: null };
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i];
+		// An instrument that ignores what it does not understand answers a
+		// different question than the one it was asked.
+		if (arg === '--manifest') options.manifest = argv[++i];
+		else if (arg === '--tags-file') options.tagsFile = argv[++i];
+		else throw new Error(`unknown argument: ${arg}`);
+	}
+	if (options.tagsFile === null) throw new Error('--tags-file <path> is required');
+	return options;
+}
+
+function main(argv) {
+	const options = parseArgv(argv);
+	const version = readManifestVersion(readFileSync(options.manifest, 'utf8'));
+	const existingTags = readFileSync(options.tagsFile, 'utf8')
+		.split('\n')
+		.map((line) => line.trim())
+		.filter(Boolean);
+
+	const decision = decide({ version, existingTags });
+	// The denominator belongs beside the verdict: "no tag exists yet" and "the
+	// tag query returned nothing because it failed" print the same `tag`.
+	console.log(
+		`manifest ${options.manifest} → ${version}; ${existingTags.length} tag(s) read from ${options.tagsFile}`,
+	);
+	if (decision.ignoredTags.length > 0) {
+		console.log(`not ordered (unparseable version): ${decision.ignoredTags.join(', ')}`);
+	}
+	console.log(`${decision.action}: ${decision.reason}`);
+
+	if (process.env.GITHUB_OUTPUT) {
+		appendFileSync(
+			process.env.GITHUB_OUTPUT,
+			`action=${decision.action}\ntag=${decision.tag ?? ''}\nversion=${version}\n`,
+		);
+	}
+
+	if (decision.action === 'abort') {
+		console.error(`::error::capi release aborted — ${decision.reason}`);
+		return 1;
+	}
+	return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	try {
+		process.exit(main(process.argv.slice(2)));
+	} catch (error) {
+		console.error(`::error::${error.message}`);
+		process.exit(1);
+	}
+}

--- a/scripts/release/test-capi-release-decision.mjs
+++ b/scripts/release/test-capi-release-decision.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+// Controls for the capi auto-tag decision. Two of them are the reason this
+// logic is a module and not four lines of bash: the "version goes backwards"
+// and "already released" arms only ever run on a tree where they must not
+// fire, so nothing else can show they are still able to.
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+	TAG_PREFIX,
+	compareVersions,
+	decide,
+	readManifestVersion,
+} from './capi-release-decision.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..');
+const MANIFEST = join(REPO_ROOT, 'crates', 'rsvelte_capi', 'Cargo.toml');
+const SCRIPT = join(HERE, 'capi-release-decision.mjs');
+
+let failures = 0;
+
+function check(name, condition, detail = '') {
+	if (condition) {
+		console.log(`ok   ${name}`);
+	} else {
+		failures += 1;
+		console.error(`FAIL ${name}${detail ? ` — ${detail}` : ''}`);
+	}
+}
+
+const RELEASED = ['capi-v0.1.0', 'capi-v0.1.1'];
+
+// --- the arm that fires on a real bump ------------------------------------
+{
+	const d = decide({ version: '0.2.0', existingTags: RELEASED });
+	check('a bump ahead of every release is tagged', d.action === 'tag', d.reason);
+	check('the tag carries the prefix', d.tag === `${TAG_PREFIX}0.2.0`, d.tag);
+}
+
+// --- the arms that must NOT fire on that same input ------------------------
+{
+	const d = decide({ version: '0.1.1', existingTags: RELEASED });
+	check('an already-released version is skipped, not re-tagged', d.action === 'skip', d.reason);
+}
+{
+	// Behind AND not itself released — the earlier arm would otherwise absorb it:
+	// `0.1.0` against RELEASED is a *skip*, because that tag exists.
+	const d = decide({ version: '0.1.0', existingTags: ['capi-v0.1.1', 'capi-v0.2.0'] });
+	check('a version behind the newest release aborts', d.action === 'abort', d.reason);
+	check(
+		'the abort names the release it would undercut',
+		d.reason.includes('capi-v0.2.0'),
+		d.reason,
+	);
+}
+{
+	const d = decide({ version: '0.1.0', existingTags: RELEASED });
+	check(
+		'an existing tag wins over the backwards check, so a re-merge is quiet',
+		d.action === 'skip',
+		d.reason,
+	);
+}
+{
+	for (const bad of ['0.2', '0.2.0-rc.1', 'v0.2.0', '0.2.0 ', 'nightly']) {
+		const d = decide({ version: bad, existingTags: RELEASED });
+		check(`\`${bad}\` is refused rather than tagged`, d.action === 'abort', d.reason);
+	}
+}
+
+// --- first release: an empty tag list is a real state, not a failure -------
+{
+	const d = decide({ version: '0.1.0', existingTags: [] });
+	check('the first tag is cut with no prior release', d.action === 'tag', d.reason);
+	check('and says so', d.reason.includes('first'), d.reason);
+}
+
+// --- an unorderable existing tag is reported, never silently decisive ------
+{
+	const d = decide({ version: '0.3.0', existingTags: [...RELEASED, 'capi-v0.4.0-rc.1'] });
+	check('a prerelease tag does not block a later release', d.action === 'tag', d.reason);
+	check(
+		'and is listed as not ordered',
+		d.ignoredTags.includes('capi-v0.4.0-rc.1'),
+		JSON.stringify(d.ignoredTags),
+	);
+}
+{
+	const d = decide({ version: '0.3.0', existingTags: ['v1.2.3', 'capi-v0.1.1'] });
+	check('a foreign tag is ignored entirely', d.ignoredTags.length === 0, JSON.stringify(d.ignoredTags));
+	check('and does not change the verdict', d.action === 'tag', d.reason);
+}
+
+// --- ordering is numeric, not lexicographic -------------------------------
+{
+	const d = decide({ version: '0.9.0', existingTags: ['capi-v0.10.0'] });
+	check('0.9.0 is behind 0.10.0', d.action === 'abort', d.reason);
+	check('compareVersions orders 0.10.0 above 0.9.0', compareVersions('0.10.0', '0.9.0') === 1);
+	check('compareVersions is reflexive', compareVersions('1.2.3', '1.2.3') === 0);
+}
+
+// --- the version read must agree with the one release-capi.yml reads ------
+// Two implementations of "what is this crate's version" would otherwise be
+// free to disagree, and the workflow's own grep is the one that decides
+// whether the tag it is handed matches the crate.
+{
+	const contents = readFileSync(MANIFEST, 'utf8');
+	const fromModule = readManifestVersion(contents);
+	const fromWorkflowPipeline = execFileSync(
+		'bash',
+		[
+			'-c',
+			`grep -E '^version = ' "${MANIFEST}" | head -1 | sed -E 's/version = "(.+)"/\\1/'`,
+		],
+		{ encoding: 'utf8' },
+	).trim();
+	check(
+		'the module and the workflow pipeline read the same version',
+		fromModule === fromWorkflowPipeline,
+		`${fromModule} vs ${fromWorkflowPipeline}`,
+	);
+	check('and it is a version this script would act on', /^\d+\.\d+\.\d+$/.test(fromModule), fromModule);
+}
+
+// --- the CLI: exit code and GITHUB_OUTPUT are what the workflow reads ------
+{
+	const dir = mkdtempSync(join(tmpdir(), 'capi-decision-'));
+	const tags = join(dir, 'tags.txt');
+	const output = join(dir, 'github_output');
+	writeFileSync(tags, `${RELEASED.join('\n')}\n`);
+	writeFileSync(output, '');
+	const manifest = join(dir, 'Cargo.toml');
+	writeFileSync(manifest, '[package]\nname = "rsvelte_capi"\nversion = "0.2.0"\nedition = "2024"\n');
+
+	const run = (args, env = {}) => {
+		try {
+			const stdout = execFileSync('node', [SCRIPT, ...args], {
+				encoding: 'utf8',
+				env: { ...process.env, ...env },
+				stdio: ['ignore', 'pipe', 'pipe'],
+			});
+			return { code: 0, stdout };
+		} catch (error) {
+			return { code: error.status, stdout: error.stdout ?? '' };
+		}
+	};
+
+	const ok = run(['--manifest', manifest, '--tags-file', tags], { GITHUB_OUTPUT: output });
+	check('the CLI exits 0 on a tag decision', ok.code === 0, String(ok.code));
+	const written = readFileSync(output, 'utf8');
+	check('it writes action=tag', written.includes('action=tag'), written);
+	check('it writes the tag', written.includes(`tag=${TAG_PREFIX}0.2.0`), written);
+	check('it prints the tag denominator', /2 tag\(s\)/.test(ok.stdout), ok.stdout);
+
+	writeFileSync(manifest, '[package]\nversion = "0.0.9"\n');
+	const behind = run(['--manifest', manifest, '--tags-file', tags]);
+	check('the CLI exits non-zero on abort', behind.code === 1, String(behind.code));
+
+	const unknown = run(['--manifest', manifest, '--tags-file', tags, '--force']);
+	check('an unknown argument is an error, not an ignored flag', unknown.code === 1, String(unknown.code));
+
+	const missing = run(['--manifest', manifest]);
+	check('--tags-file is required', missing.code === 1, String(missing.code));
+}
+
+if (failures > 0) {
+	console.error(`\n${failures} control(s) failed`);
+	process.exit(1);
+}
+console.log('\nall controls passed');


### PR DESCRIPTION
Closes #4285.

## The gap

The C ABI releases off a `capi-v<version>` tag, not off a merge. A version bump landing on `main` therefore publishes nothing, and from `main`'s side it is indistinguishable from a released one: `capi-v0.1.1` (2026-05-25) stayed the newest tag for three months while `rsvelte_core` moved to 0.11.1. What surfaced it was an external user asking for a release in #4274 — nothing in the tree compares the manifest version against the newest tag.

## What this adds

`.github/workflows/capi-autotag.yml` — on a push to `main` touching `crates/rsvelte_capi/Cargo.toml`, it creates `capi-v<version>` at the merge commit and starts the release build. It is a no-op when the tag already exists, so a manifest edit that does not move the version costs one 20-second job.

Two mechanisms decide its shape, and both are the reason this is not four lines of YAML.

**A tag pushed with `GITHUB_TOKEN` starts no workflow run.** This is the suppression `scripts/release/wait-for-release-verdicts.mjs` already documents for Changesets PRs, and it means "create the tag" alone would move the silence one step along instead of removing it. The job dispatches `release-capi.yml` against the tag ref, where that workflow's own `refs/tags/capi-v` conditions hold and it publishes exactly as for a hand-pushed tag. **The dependency is asserted, not assumed**: after dispatching, the job polls for the run and fails when its `head_branch` is not the tag — because the state it would otherwise produce is a five-triple matrix that builds and creates no Release, which reads as success from every angle except the Releases page.

**The decision lives in `scripts/release/capi-release-decision.mjs`.** Two of its three arms — *already released* and *behind a released version* — only ever run on a tree where they must not fire, so nothing else can show they are still able to. `test-capi-release-decision.mjs` carries 30 controls; ablating those two arms reddens 6. One control is two-implementation: the module's version read against the `grep | head -1 | sed` pipeline `release-capi.yml` uses, since the two are otherwise free to disagree about which crate is being released.

The guards the issue asked to settle:

| input | decision |
|---|---|
| version ahead of every tag | `tag` |
| version already tagged | `skip` (exit 0 — a re-run is quiet, not red) |
| version behind a released one | `abort`, naming the release it would undercut |
| not `MAJOR.MINOR.PATCH` (incl. `0.2.0-rc.1`) | `abort`, pointing at the manual tag push |
| no `capi-v*` tag at all | `tag`, as the first release |
| an unorderable existing tag (`capi-v0.4.0-rc.1`) | reported as *not ordered*, never silently decisive |

## Dry run against the real repository state

```
main today (0.1.1, tags capi-v0.1.0 + capi-v0.1.1)  → skip
the same manifest at 0.2.0                          → tag capi-v0.2.0
```

## What is deliberately not here

The issue's alternative — a PR check failing when `crates/rsvelte_capi/src/**` changes without a version bump, the shape `check-esrap-version-bump.mjs` already has for `rsvelte_esrap`. Combined with this workflow it means **every** capi source PR cuts a release, which is a decision about release cadence rather than a correctness gap, so it is left for a follow-up rather than bundled with the mechanism.

**Correction to an earlier draft of this paragraph**, which priced that follow-up at "~45 minutes a leg": 45 is the job *timeout*, not a measurement. The two real runs of `release-capi.yml` (2026-05-25) took **21 job-minutes for the whole matrix** — 3 / 5 / 4 / 6 / 3 by triple. Today's crate is larger and the `dist-capi` profile is fat-LTO + PGO where the per-PR `C ABI` job turns LTO off, so the current figure is higher — but the order of magnitude is one lint job, not one `lsp-corpus` run (~1,300 job-minutes). The cadence objection is much weaker than that draft made it.

## Notes for review

- `release-capi.yml`'s header said `workflow_dispatch` is a dry run. That is true of a dispatch against a *branch* and false of one against a *tag*, which is the path this workflow takes; both comments now say the ref decides, not the event.
- The `crates/rsvelte_capi/README.md` § *Cutting a release* edit **will conflict with #4274**, which moves the tag example in the same block. #4274 should merge first; this branch rebases onto it.
- No changeset: the title is `ci(...)`, and `crates/rsvelte_capi/**` is deliberately absent from `check-core-consumer-changesets.mjs` (nothing npm-published ships from it).
- Verified locally: `workflow-trigger-guard` (21 workflows, no violations), `step-environment-guard`, `check-core-consumer-changesets`, `check-esrap-version-bump`, PyYAML parse of all three touched workflows, and `bash -n` over every `run:` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJg4DT9QeqUeT1EUhLTU7U

