### PR TITLE
ci(release): a changeset owns the C ABI version, and a forgotten bump goes red on the PR

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -47,6 +47,7 @@
     ]
   ],
   "linked": [],
+  "privatePackages": { "version": true, "tag": false },
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/apps/npm/capi/README.md
+++ b/apps/npm/capi/README.md
@@ -1,0 +1,18 @@
+# `@rsvelte/capi` — version carrier, not a package
+
+Nothing here is published. The C ABI ships as the per-OS/arch archives on
+[GitHub Releases](https://github.com/baseballyama/rsvelte/releases) under the
+`capi-v*` tags, built by
+[`release-capi.yml`](../../../.github/workflows/release-capi.yml).
+
+This directory exists so **Changesets owns the C ABI's version**: Changesets
+versions workspace packages, and the C ABI is a Rust crate. A changeset naming
+`@rsvelte/capi` bumps the version here, `scripts/release/sync-version.mjs`
+mirrors it into `crates/rsvelte_capi/Cargo.toml` (the same way every other crate
+tracks the npm package it ships in), and merging the Version PR lets
+[`capi-autotag.yml`](../../../.github/workflows/capi-autotag.yml) cut
+`capi-v<version>` and start the release.
+
+So the release procedure for the C ABI is: **write a changeset**. Do not edit
+`crates/rsvelte_capi/Cargo.toml`'s version by hand — `sync-version.mjs` would
+overwrite it from this file at the next release.

--- a/apps/npm/capi/README.md
+++ b/apps/npm/capi/README.md
@@ -14,5 +14,8 @@ tracks the npm package it ships in), and merging the Version PR lets
 `capi-v<version>` and start the release.
 
 So the release procedure for the C ABI is: **write a changeset**. Do not edit
-`crates/rsvelte_capi/Cargo.toml`'s version by hand — `sync-version.mjs` would
-overwrite it from this file at the next release.
+`crates/rsvelte_capi/Cargo.toml`'s version by hand: a hand edit below this
+version is overwritten at the next release, and one above it makes
+`sync-version.mjs` refuse to run at all rather than walk the C ABI backwards.
+
+The version here starts at the crate's own, which #4274 takes to 0.2.0.

--- a/apps/npm/capi/package.json
+++ b/apps/npm/capi/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@rsvelte/capi",
+  "version": "0.1.1",
+  "private": true,
+  "description": "Version carrier for the C ABI (crates/rsvelte_capi). Never published to npm — the artifacts are the cdylib archives on GitHub Releases under capi-v*.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/baseballyama/rsvelte.git",
+    "directory": "crates/rsvelte_capi"
+  },
+  "bugs": {
+    "url": "https://github.com/baseballyama/rsvelte/issues"
+  }
+}

--- a/apps/npm/capi/package.json
+++ b/apps/npm/capi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsvelte/capi",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "description": "Version carrier for the C ABI (crates/rsvelte_capi). Never published to npm — the artifacts are the cdylib archives on GitHub Releases under capi-v*.",
   "license": "MIT",

--- a/crates/rsvelte_capi/README.md
+++ b/crates/rsvelte_capi/README.md
@@ -239,8 +239,14 @@ own workflow ([`.github/workflows/release-capi.yml`](../../.github/workflows/rel
 intentionally independent from the npm/changeset pipeline that ships
 `@rsvelte/compiler` et al.
 
-1. Bump `crates/rsvelte_capi/Cargo.toml`'s `version`.
-2. Open a PR, get it merged.
+1. Write a changeset naming **`@rsvelte/capi`**
+   (`pnpm changeset`, then tick `@rsvelte/capi`). That package
+   ([`apps/npm/capi`](../../apps/npm/capi)) is private and publishes nothing —
+   it exists so a changeset owns this crate's version, and
+   `scripts/release/sync-version.mjs` mirrors it into `Cargo.toml` when the
+   Release PR is cut. Do not edit the crate's `version` by hand; the sync
+   refuses to move it backwards.
+2. Merge the PR, then merge the Release PR Changesets opens.
 3. That is the whole procedure:
    [`capi-autotag.yml`](../../.github/workflows/capi-autotag.yml) sees the
    manifest change on `main`, creates `capi-v<version>` at the merge commit,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,8 @@ importers:
         specifier: ^2.7.3
         version: 2.7.3
 
+  apps/npm/capi: {}
+
   apps/npm/compiler:
     dependencies:
       svelte:

--- a/scripts/release/check-core-consumer-changesets.mjs
+++ b/scripts/release/check-core-consumer-changesets.mjs
@@ -96,9 +96,19 @@ const RULES = [
     prefix: 'crates/rsvelte_language_server/src/',
     requires: ['@rsvelte/language-server'],
   },
-  // NOTE: `crates/rsvelte_capi/**` and `crates/rsvelte_fmt_wasm/**` are
-  // deliberately absent because they are published NOWHERE — neither appears in
-  // release.yml's build matrix, so there is no artifact to leave stale.
+  {
+    prefix: 'crates/rsvelte_capi/src/',
+    // The C ABI is not on npm, but it is published: `release-capi.yml` attaches
+    // five per-OS/arch archives to a `capi-v*` Release. `@rsvelte/capi` is a
+    // private carrier whose only job is to let a changeset decide that version
+    // (see apps/npm/capi/README.md), so naming it here is what turns "the C ABI
+    // changed" into a release rather than into a stale artifact — capi-v0.1.1
+    // was the newest tag for three months for exactly that reason (#4285).
+    requires: ['@rsvelte/capi'],
+  },
+  // NOTE: `crates/rsvelte_fmt_wasm/**` is deliberately absent because it is
+  // published NOWHERE — it does not appear in release.yml's build matrix, so
+  // there is no artifact to leave stale.
   // NOTE: `crates/rsvelte_lint/**` and `crates/rsvelte_lint_bindings/**` are
   // intentionally NOT listed. Their code ships in two separate artifacts — the
   // `@rsvelte/compiler` wasm (`build:wasm:core`, built from the bindings crate)

--- a/scripts/release/sync-version.mjs
+++ b/scripts/release/sync-version.mjs
@@ -79,6 +79,15 @@ const MAPPINGS = [
 		cargoToml: 'crates/rsvelte_language_server/Cargo.toml',
 		lockName: 'rsvelte_language_server',
 	},
+	{
+		// `@rsvelte/capi` publishes nothing; it exists so a changeset can decide
+		// the C ABI's version. `rsvelte_version()` returns this crate's
+		// `CARGO_PKG_VERSION`, and `capi-autotag.yml` cuts `capi-v<version>` from
+		// the same string, so the carrier is what a consumer ends up reading.
+		npm: 'apps/npm/capi/package.json',
+		cargoToml: 'crates/rsvelte_capi/Cargo.toml',
+		lockName: 'rsvelte_capi',
+	},
 ];
 
 // Exact crates.io edges whose requirement must move with the mapped compiler
@@ -132,6 +141,28 @@ function patchCargoToml(cargoRelPath, targetVersion) {
 	}
 	if (match[2] === targetVersion) return;
 	writeFileSync(cargoTomlPath, original.replace(re, `$1${targetVersion}$3`));
+}
+
+function compareVersions(a, b) {
+	const pa = a.split('.').map(Number);
+	const pb = b.split('.').map(Number);
+	for (let i = 0; i < 3; i += 1) {
+		if ((pa[i] ?? 0) !== (pb[i] ?? 0)) return (pa[i] ?? 0) - (pb[i] ?? 0);
+	}
+	return 0;
+}
+
+// A crate version can be hand-edited ahead of its carrier (the C ABI was, before
+// `@rsvelte/capi` existed), and the sync would then silently walk it back.
+function assertNotBackwards({ npm, cargoToml, targetVersion }) {
+	const current = readCargoVersion(cargoToml);
+	if (compareVersions(current, targetVersion) <= 0) return;
+	console.error(
+		`${cargoToml} is at ${current} but ${npm} says ${targetVersion}: syncing would ` +
+			`move the crate backwards. Bump ${npm} (write a changeset) rather than editing ` +
+			'the crate version by hand.',
+	);
+	process.exit(1);
 }
 
 function readCargoVersion(cargoRelPath) {
@@ -191,6 +222,7 @@ const locks = CARGO_LOCKS.map((rel) => ({
 
 for (const { npm, cargoToml, lockName } of MAPPINGS) {
 	const targetVersion = readTargetVersion(npm);
+	assertNotBackwards({ npm, cargoToml, targetVersion });
 	patchCargoToml(cargoToml, targetVersion);
 	for (const lock of locks) {
 		lock.text = patchCargoLock(lock.text, lockName, targetVersion, {


### PR DESCRIPTION
Stacked on #4288 — its `README` §Cutting a release is the text this PR rewrites, so the base is `ci/capi-autotag-release` rather than `main`. GitHub retargets this to `main` when #4288 lands.

Closes the other half of #4285. **#4274 is already merged**, so the crate is at **0.2.0** and this carrier starts there.

## Why

`crates/rsvelte_capi` had no version owner. Its `Cargo.toml` was hand-edited, `release-capi.yml` read the tag, and nothing connected a source change to a release — `capi-v0.1.1` was the newest tag for three months while the C ABI kept changing. #4288 automates the *tag*; this PR automates the *decision*, so the whole path from "I changed the C ABI" to "an archive is on a Release" is one changeset.

## What

`apps/npm/capi` is a **private** Changesets carrier. It publishes nothing — the artifacts are the five per-OS/arch cdylib archives on a `capi-v*` Release — and exists so a changeset can own the C ABI's version.

| piece | effect |
|---|---|
| `apps/npm/capi/package.json` (private, **0.2.0** = the crate after #4274) | the thing a changeset names |
| `sync-version.mjs` mapping | mirrors the carrier into `crates/rsvelte_capi/Cargo.toml` + `Cargo.lock` when the Version PR is cut |
| `check-core-consumer-changesets.mjs` rule | a PR touching `crates/rsvelte_capi/src/` with no `@rsvelte/capi` changeset fails on the PR |
| `.changeset/config.json` `privatePackages` | lets Changesets version a private package |
| `assertNotBackwards` in `sync-version.mjs` | refuses a sync that would lower a crate version |

The C ABI also gets a `CHANGELOG.md`, which it had no way to have before.

### Why the carrier is 0.2.0 and not 0.1.1

`assertNotBackwards` refuses a sync that would lower a crate version, so a carrier **behind** the crate blocks every release rather than one. #4274 took the crate to 0.2.0, so the carrier has to start there or the next Version PR could not be generated at all. Measured on this branch: carrier 0.2.0 / crate 0.2.0 → `sync-version.mjs` exits 0 reporting `rsvelte_capi@0.2.0`, a clean no-op.

### `privatePackages` blast radius

The key was **absent**, which `@changesets/config` normalizes to `{version: false, tag: false}`. Enabling `version` affects the two private workspace packages:

- `@rsvelte/capi` — the point of the change.
- `rsvelte-vscode` — checked in at **0.4.1** against `@rsvelte/language-server`'s **0.5.5**, its fixed-group partner. `publish-vscode.mjs` already forces `extPkg.version = target` (the language-server version) before packaging, so **no published artifact moves**; this only stops the checked-in file from silently diverging.

`tag` stays `false` — capi's tag comes from `capi-autotag.yml` (#4288), not from Changesets.

## Controls

Both two-sided, run on this tree.

**Injection on the new rule** — a commit touching `crates/rsvelte_capi/src/`:

```
ARM A (no @rsvelte/capi changeset)  -> exit=1, "✗ @rsvelte/capi  (touched: crates/rsvelte_capi/src/)"
ARM B (changeset names it)          -> exit=0, "✓ @rsvelte/capi ... All required consumer packages are named."
```

**`assertNotBackwards`:**

```
ARM A carrier behind crate -> exit=1, crate untouched
ARM B carrier == crate     -> exit=0, "... rsvelte_capi@0.2.0"
```

Tree restored byte-identical after each; `git status` shows only this PR's files.

Every guard `changeset.yml` runs is green: `check-changeset-package-names`, `test-core-consumer-changesets` (8 controls), `check-core-consumer-changesets`, `test-esrap-version-bump-check`, `check-esrap-version-bump`, plus `test:capi-release-decision`.

## Known gap

`assertNotBackwards` is covered by the manual control above and **by no gate**. `sync-version.mjs` performs its work at import time, so a test file cannot import it without running the sync. Making it importable is a separate change, not folded in here.