### PR TITLE
fix(fmt): a `<style>` body's residual tabs are re-expressed as the indent unit

### DIFF
--- a/.changeset/fmt-css-tab-reindent.md
+++ b/.changeset/fmt-css-tab-reindent.md
@@ -1,5 +1,6 @@
 ---
 "@rsvelte/fmt": patch
+"@rsvelte/language-server": patch
 ---
 
 Re-express a `<style>` body's residual tabs as the configured indent unit. The block indent prepended to the CSS is built from that unit, so a tab-indented body the engine passed through verbatim — a rejected body, or a comment's own leading whitespace inside a declaration value — came out as spaces and tabs on one line, honouring neither `useTabs` setting.

--- a/.changeset/fmt-css-tab-reindent.md
+++ b/.changeset/fmt-css-tab-reindent.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+Re-express a `<style>` body's residual tabs as the configured indent unit. The block indent prepended to the CSS is built from that unit, so a tab-indented body the engine passed through verbatim — a rejected body, or a comment's own leading whitespace inside a declaration value — came out as spaces and tabs on one line, honouring neither `useTabs` setting.

--- a/crates/rsvelte_formatter/src/style.rs
+++ b/crates/rsvelte_formatter/src/style.rs
@@ -149,7 +149,7 @@ fn format_nested_style(
         tag_indent.clone()
     };
     let width = css_width(options, &body_indent);
-    let dedented = dedent(body);
+    let dedented = dedent(body, &unit);
     let css_output = formatter(&dedented, "css", width).map_err(FormatError::StyleFormat)?;
     let reindented =
         restore_comment_adjacent_selector_indent(body, reindent(&css_output, &body_indent));
@@ -213,7 +213,7 @@ pub fn collect_style_edit(
         tag_indent.to_string()
     };
     let width = css_width(options, &body_indent);
-    let dedented = dedent(body);
+    let dedented = dedent(body, &indent_unit(options));
     let css_output = formatter(&dedented, &lang, width).map_err(FormatError::StyleFormat)?;
     let reindented =
         restore_comment_adjacent_selector_indent(body, reindent(&css_output, &body_indent));
@@ -264,7 +264,7 @@ fn css_width(options: &FormatOptions, body_indent: &str) -> usize {
         .max(20)
 }
 
-fn dedent(s: &str) -> String {
+fn dedent(s: &str, unit: &str) -> String {
     let cont = comment_continuation_flags(s);
     let lines: Vec<&str> = s.lines().collect();
     let mut min_indent = usize::MAX;
@@ -285,7 +285,10 @@ fn dedent(s: &str) -> String {
         } else if l.trim().is_empty() {
             out.push(String::new());
         } else {
-            out.push(l.get(min_indent..).unwrap_or(l).to_string());
+            out.push(normalize_leading_tabs(
+                l.get(min_indent..).unwrap_or(l),
+                unit,
+            ));
         }
     }
     out.join("\n")
@@ -298,6 +301,29 @@ fn dedent(s: &str) -> String {
 /// byte length that slices mid-character).
 fn leading_ascii_ws(l: &str) -> usize {
     l.bytes().take_while(|&b| b == b' ' || b == b'\t').count()
+}
+
+/// Re-express a line's leading tabs as the configured indent unit. The CSS
+/// engine prints code with that unit, so a leading tab reaching here was passed
+/// through verbatim from the source — a rejected body returned unchanged, or a
+/// comment's own leading whitespace inside a declaration value. Prepending the
+/// block indent to it would emit spaces and tabs on one line, which honours
+/// neither `useTabs` setting.
+fn normalize_leading_tabs(line: &str, unit: &str) -> String {
+    let ws = leading_ascii_ws(line);
+    if !line.as_bytes()[..ws].contains(&b'\t') {
+        return line.to_string();
+    }
+    let mut out = String::with_capacity(line.len());
+    for &b in &line.as_bytes()[..ws] {
+        if b == b'\t' {
+            out.push_str(unit);
+        } else {
+            out.push(' ');
+        }
+    }
+    out.push_str(&line[ws..]);
+    out
 }
 
 /// prettier-plugin-svelte keeps the source indentation from a block comment
@@ -526,8 +552,20 @@ mod tests {
         // three bytes and min_indent as two — and `l[2..]` on line 2 sliced the
         // middle of U+00A0 and panicked. Counting only ASCII space/tab keeps
         // min_indent at one, a valid char boundary on both lines.
-        let out = dedent("  a\n \u{a0}b");
+        let out = dedent("  a\n \u{a0}b", "  ");
         assert_eq!(out, " a\n\u{a0}b");
+    }
+
+    #[test]
+    fn dedent_reexpresses_residual_tabs_as_the_indent_unit() {
+        // `min_indent` is a byte count, so a tab-indented body loses exactly one
+        // tab and the deeper levels keep theirs. Whatever the CSS engine passes
+        // through verbatim then carries a tab into a space-indented block.
+        assert_eq!(dedent("\ta {\n\t\tb: c;\n\t}", "  "), "a {\n  b: c;\n}");
+        // With a tab unit the same input is unchanged.
+        assert_eq!(dedent("\ta {\n\t\tb: c;\n\t}", "\t"), "a {\n\tb: c;\n}");
+        // Space-indented input never reaches the conversion.
+        assert_eq!(dedent("  a {\n    b: c;\n  }", "  "), "a {\n  b: c;\n}");
     }
 
     #[test]

--- a/crates/rsvelte_formatter/tests/style_block.rs
+++ b/crates/rsvelte_formatter/tests/style_block.rs
@@ -98,3 +98,63 @@ fn multiline_comment_interior_does_not_accumulate_indent() {
         "multi-line comment indentation accumulates across passes:\n{once}"
     );
 }
+
+/// Format `src` with a style callback that returns its input unchanged — the
+/// shape of the real fallback for a body the CSS engine rejects, and the only
+/// double that exercises what `dedent` hands the callback.
+fn fmt_verbatim_css(src: &str) -> String {
+    let opts = FormatOptions::default().with_style_formatter(Arc::new(
+        |body: &str, _lang: &str, _width: usize| Ok(body.to_string()),
+    ));
+    format(src, &opts).expect("format ok")
+}
+
+fn mixed_indent_lines(s: &str) -> Vec<&str> {
+    s.lines()
+        .filter(|l| {
+            let ws = &l[..l.len() - l.trim_start_matches([' ', '\t']).len()];
+            ws.contains(' ') && ws.contains('\t')
+        })
+        .collect()
+}
+
+#[test]
+fn a_tab_indented_body_never_mixes_tabs_into_the_block_indent() {
+    // The block indent is spaces under the default `useTabs: false`, and the
+    // body's own levels are tabs. Prepending one to the other left `  \tcolor`.
+    let src = "<div></div>\n\n<style>\n\t.a >> .b {\n\t\tcolor: green;\n\t}\n</style>\n";
+    let out = fmt_verbatim_css(src);
+    assert_eq!(
+        mixed_indent_lines(&out),
+        Vec::<&str>::new(),
+        "tabs survived into a space-indented block:\n{out}"
+    );
+    // Every level is the configured unit, and the body sits one level under the
+    // tag. (The double returns the body verbatim, leading newline included, so
+    // the block opens with a blank line — an artefact of the double, not of the
+    // indentation under test.)
+    assert!(
+        out.contains("\n  .a >> .b {\n    color: green;\n  }\n"),
+        "body not re-indented with the configured unit:\n{out}"
+    );
+}
+
+#[test]
+fn tab_and_space_indented_bodies_format_identically() {
+    // The property, not a transcribed expectation: the indent character a source
+    // happens to use is not an input to the formatted result.
+    let with = |unit: &str| {
+        format!(
+            "<div></div>\n\n<style>\n{u}.a >> .b {{\n{u}{u}color: green;\n{u}}}\n</style>\n",
+            u = unit
+        )
+    };
+    let tabs = fmt_verbatim_css(&with("\t"));
+    let spaces = fmt_verbatim_css(&with("  "));
+    assert_eq!(tabs, spaces, "tab-indented source formatted differently");
+    // A formatter that emitted nothing would satisfy the equality above.
+    assert!(
+        tabs.contains("color: green;"),
+        "no CSS in the output:\n{tabs}"
+    );
+}


### PR DESCRIPTION
`dedent` removes a `<style>` body's common leading whitespace as a **byte** prefix and `reindent` prepends the block indent, which is built from the configured indent **unit**. That pair is sound only while every line's remaining indentation is in the same character as the unit — true wherever the CSS engine reprints the code, and false for the whitespace it passes through verbatim.

Two shapes reach the verbatim path, and both are in the corpus:

| trigger | source | before | after |
|---|---|---|---|
| a body the engine rejects (`>>`), returned unchanged | `\t\tcolor: green;` | `··»color: green;` | `····color: green;` |
| a comment's own leading whitespace inside a declaration value | `\t\t\t/* … */` | `··»»/* … */` | `······/* … */` |

(`·` = space, `»` = tab.) Both outputs mix spaces and tabs on one line, honouring **neither** `useTabs` setting — the run's config is `useTabs: false`.

Sites: `crates/rsvelte_formatter/src/style.rs:267` (`dedent`, `min_indent` is a byte count) and `:448` (`reindent`).

## What the tests assert

The property, not a transcribed expectation: **a tab-indented source and a space-indented source formatting the same CSS must produce identical output.** A 2×2 grid (two triggers × two indent characters) makes the space-indented half its own control — those cells were already correct and stay correct.

* `style::tests::dedent_reexpresses_residual_tabs_as_the_indent_unit` — the mechanism, including the `useTabs: true` direction (a tab unit leaves tabs alone) and the space-indented input that never reaches the conversion.
* `style_block::a_tab_indented_body_never_mixes_tabs_into_the_block_indent`
* `style_block::tab_and_space_indented_bodies_format_identically` — with a non-emptiness assert, because an equality between two empty outputs would otherwise satisfy it.

**Ablation:** removing the one call reddens exactly those three and leaves the six neighbouring `style_block` tests green; restoring it returns the tree byte-identical (`sha256` verified).

## Ratchet movement: measured, not predicted

An earlier draft of this description asserted the ratchet does not move. That was a prediction, so it was replaced by a measurement.

The fix can only change a file whose **old** output already carried a tab in a `<style>` line's leading whitespace — the tab it converts had to survive into the output to be observable. Screening the materialised `compatibility/fmt/actual` tree (33,666 files) gives **195 carriers**. That 195 is a scan of the **product** — the formatted output the previous run wrote — not a count of inputs someone selected, which is why it can be re-derived rather than trusted. 193 stage from a primary source and the 2 markdown-code-block carriers were extracted from their `.md` by hand, so the measured set is all 195 and **nothing is left unmeasured**.

```
carriers                                   195
  oracle-excluded (the gate skips them)      3
  compared against the oracle              192
    listed  & still differ                   7
    listed  & NOW MATCHES                    0   <- no re-baseline needed
    unlisted & still match                 185
    unlisted & NOW DIFFERS                   0   <- no new failure

files whose bytes this changes: 5 of 195
  EXCLUDED  css-pseudo-classes/input.svelte             3 lines
  EXCLUDED  css-nth-syntax/input.svelte                 4 lines
  EXCLUDED  pattern/adversarial/css/rejected-global-keyframes-selector.svelte   4 lines
  listed    layerchart/docs/src/routes/+page.svelte     1 line
  listed    pattern/issues/3404-repeated-combinators.svelte   6 lines
```

**Blast radius on the cluster table.** `compatibility/KNOWN-FAILURES.md`'s cluster table is keyed on each entry's *first differing line*, so it re-partitions whenever the formatter changes. The entries whose label this PR can move are exactly those whose current output carries a tab in a `<style>` line's leading whitespace, and over the 524 listed entries that set is **3** — an upper bound, since carrying the signature does not mean the fix reaches it:

```
layerchart/docs/src/routes/+page.svelte                bytes change
pattern/issues/3404-repeated-combinators.svelte        bytes change
open-webui/src/lib/components/chat/Chat.svelte         bytes unchanged
```

So at most 3 of 524 labels move, and measured, 2 do.

The two listed entries stay listed, so `fmt-known-failures.json` and `compatibility/KNOWN-FAILURES.md` are untouched. The three excluded ids are skipped by `fmt-verify.mjs` before any comparison; their divergence from the oracle pre-dates this change (verified: their old output already differed byte-for-byte).

Calibration note: `fmt-verify.mjs` compares `oracle === actual` with a plain read, so a local byte comparison reproduces the gate exactly. It was run first against ids the gate has already ruled on — the four listed-but-byte-equal entries it turned up are the four #4297 retires, which is what identifies the materialised `actual` tree as that branch's arm rather than `main`'s.

## What this does not fix

`layerchart/docs/src/routes/+page.svelte` still diverges on that one line, for a different reason: the oracle preserves a value comment's leading whitespace **verbatim** (it emits the source's three tabs) while rsvelte dedents it. `pattern/issues/3404-repeated-combinators.svelte` still diverges because oxc rejects `>>` where PostCSS accepts and reformats it. Both remain listed, and both are the subject of the CSS-engine attribution work that follows.

## Hard gates run locally

* `svelte_dev_corpus_parity` — ok (no baseline tolerance)
* `svelte_dev_markdown_cli_parity` — ok
* `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0
* `cargo fmt --all` — no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrgGJ3k8oYjSkWY1RNKgND

