### PR TITLE
chore(lsp-gate): twelve mechanism terminals, and a check that the report's scope is a set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1229,6 +1229,10 @@ jobs:
         if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
         run: node scripts/ci/test-attribution-progress-check.mjs
 
+      - name: Check the hover terminal scope check's own controls
+        if: ${{ !cancelled() && steps.flags-env.outcome == 'success' }}
+        run: node scripts/ci/test-lsp-hover-terminal-scope-check.mjs
+
       # The CSS-prune sweep's comparison key. Same reason it lives here: the
       # comparator is a pure module, so it needs neither the NAPI binding nor
       # submodules that the sweep itself does.
@@ -1456,3 +1460,11 @@ jobs:
       - name: Verify the LSP mechanism sidecar
         if: ${{ !cancelled() }}
         run: node scripts/ci/lsp-mechanisms-check.mjs
+
+      # The sidecar checker validates a terminal's SHAPE; nothing checks the SET
+      # of labels one report is made to answer. Nine point at the tsgo hover
+      # report because `TS_RENDER_RULES` implements its renderings one rewrite
+      # each, and a tenth rule added later would inherit that by name alone.
+      - name: Verify the hover report's terminal scope
+        if: ${{ !cancelled() }}
+        run: node scripts/ci/lsp-hover-terminal-scope-check.mjs

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -5324,6 +5324,37 @@ Attribution of `lsp-known-failures.json`:
 |---|---|---|
 | 5 | `deliberate-divergences` | `initialize` capabilities rsvelte declares differently on purpose, each pinned by a test: the `" "` completion trigger, the two `source.fixAll` code-action kinds, `workspace.workspaceFolders`, `positionEncoding`, `diagnosticProvider.identifier` |
 | 1 | `upstream_issues/svelte-language-server-duplicate-completion-trigger-character.md` | upstream lists `"@"` twice in `completionProvider.triggerCharacters`, so the arrays differ as multisets |
+| 1218 | `upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md` | `textDocument/hover` on the real-world corpus, where every label in the entry's mechanism set is one of the seven renderings that report measures on a plain `.ts` file: `rsvelte-empty-import-only` 1116, `ts-render-union-order` 104, `ts-render-overload-count` 74, `ts-render-import-line` 40, `ts-render-local-modifier` 38, `ts-render-multiple` 16, `ts-render-declaration-order` 4 |
+
+The 1218 are derived from `lsp-mechanisms.json` rather than read off the ratchet key, which for an
+`aggregate:` entry carries no field at all. Twelve labels were given a terminal; the correspondence
+is between the classifier's RULES and the report's differences, not between their names.
+`mechanism.mjs`'s `TS_RENDER_RULES` implements the report's seven renderings one text rewrite each
+(`sortUnions`, `normalizeImportQuotes`, `dropLocalModifier`, `dropJsdocTags`, `dropImportLine`,
+`dropOverloadCount`, `sortDeclarationLines`), `ts-render-multiple` is two or more of the same seven,
+and `rsvelte-empty-import-only` is the degenerate case of one of them — `classifyHover` returns it
+only when official's whole hover is a fenced block holding exactly `import <Name>` and rsvelte's is
+empty, which is that report's dropped origin line with nothing behind it.
+
+**Two of the twelve terminals unblock nothing today and are still required.** The checker's
+predicate is a conjunction — an entry is attributable only when *every* label in its set has a
+terminal — so `completion-commit-characters-presence-rsvelte-only` (6908 carriers),
+`completion-commit-characters-value-extra-paren` (4522) and `completion-item-pairing-key-kind-ts`
+(6748) contribute 0 entries while their carriers still hold a label that has none. Read a label's
+carrier count as what it unlocks *eventually*, never as what a terminal on it buys now: the twelve
+labels above carry 14,010 entries between them and finish 1218 of them. Every count in this block
+is derived from `lsp-mechanisms.json` at `bf6fe3c63` — the sidecar is primary and this prose is
+not gated, so recompute rather than cite; only the table's `n` column is checked, against the
+ratchet, by `attribution-check`.
+
+Three labels were deliberately left at `null` after being examined, because a terminal is where
+re-reading stops and a wrong one is the misclassification nothing corrects. `ts-render` (2483) is
+the residue of the same seven rewrites and `mechanism.mjs` says in the source that it is *not*
+attributed to tsgo — the probe shows `tsc` and `tsgo` agreeing on the shapes it holds, so which
+side is wrong is unmeasured. `completion-is-incomplete` (3894) reads `/isIncomplete:`, a different
+field from the `isNewIdentifierLocation` the commit-characters report is about, and tsgo does return
+`isIncomplete`; the two are one vocabulary apart, not one mechanism. `completion-commit-characters-value-other`
+(2116) is by construction the values that are *not* the report's `(` branch.
 
 This table is **partial**, and its coverage is the sum of its own `n` column against the entry count declared above -- `attribution-check` prints the two side by side, so neither is repeated here. The remaining entries are unattributed, not
 attributed to nothing — the `aggregate:` half carries no field in its key, so what an entry is

--- a/compatibility/lsp-mechanisms.json
+++ b/compatibility/lsp-mechanisms.json
@@ -5,34 +5,34 @@
 			"terminal": null
 		},
 		"ts-render-union-order": {
-			"terminal": null
+			"terminal": "upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md"
 		},
 		"ts-render-quote-style": {
-			"terminal": null
+			"terminal": "upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md"
 		},
 		"ts-render-local-modifier": {
-			"terminal": null
+			"terminal": "upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md"
 		},
 		"ts-render-jsdoc-tag": {
-			"terminal": null
+			"terminal": "upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md"
 		},
 		"ts-render-import-line": {
-			"terminal": null
+			"terminal": "upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md"
 		},
 		"ts-render-overload-count": {
-			"terminal": null
+			"terminal": "upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md"
 		},
 		"ts-render-declaration-order": {
-			"terminal": null
+			"terminal": "upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md"
 		},
 		"rsvelte-empty-import-only": {
-			"terminal": null
+			"terminal": "upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md"
 		},
 		"official-empty-target-is-the-request": {
 			"terminal": null
 		},
 		"ts-render-multiple": {
-			"terminal": null
+			"terminal": "upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md"
 		},
 		"ts-type-any": {
 			"terminal": null
@@ -134,7 +134,7 @@
 			"terminal": null
 		},
 		"completion-item-pairing-key-kind-ts": {
-			"terminal": null
+			"terminal": "upstream_issues/tsgo-lsp-completion-item-omits-the-typescript-kind.md"
 		},
 		"completion-item-pairing-key-kind-html": {
 			"terminal": null
@@ -305,13 +305,13 @@
 			"terminal": null
 		},
 		"completion-commit-characters-value-extra-paren": {
-			"terminal": null
+			"terminal": "upstream_issues/tsgo-lsp-completion-omits-the-commit-character-inputs.md"
 		},
 		"completion-commit-characters-value-other": {
 			"terminal": null
 		},
 		"completion-commit-characters-presence-rsvelte-only": {
-			"terminal": null
+			"terminal": "upstream_issues/tsgo-lsp-completion-omits-the-commit-character-inputs.md"
 		},
 		"completion-commit-characters-presence-official-only": {
 			"terminal": null

--- a/package.json
+++ b/package.json
@@ -181,7 +181,9 @@
 		"test:lsp-mechanisms-check": "node scripts/dev/test-lsp-mechanisms-check.mjs",
 		"test:attribution-check": "node scripts/ci/test-attribution-check.mjs",
 		"test:attribution-progress-check": "node scripts/ci/test-attribution-progress-check.mjs",
-		"check:ratchet-unit-delta": "node scripts/ci/ratchet-unit-delta.mjs"
+		"check:ratchet-unit-delta": "node scripts/ci/ratchet-unit-delta.mjs",
+		"check:lsp-hover-terminal-scope": "node scripts/ci/lsp-hover-terminal-scope-check.mjs",
+		"test:lsp-hover-terminal-scope-check": "node scripts/ci/test-lsp-hover-terminal-scope-check.mjs"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^3.0.0",

--- a/scripts/ci/lsp-hover-terminal-scope-check.mjs
+++ b/scripts/ci/lsp-hover-terminal-scope-check.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// The hover report's terminal covers a SET of labels, and the set is a claim.
+//
+// `lsp-mechanisms.json` points nine labels at
+// `tsgo-lsp-hover-renders-declarations-differently-from-tsc.md`, and the reason
+// is that `mechanism.mjs`'s `TS_RENDER_RULES` implements that report's
+// renderings one rewrite each. Nothing enforces the correspondence: a tenth
+// rendering rule added later inherits the attribution by name, and a report
+// whose scope someone narrows leaves the extra labels pointing at it.
+//
+// So the invariant is stated as a set equality rather than as a count -- a
+// count in a comment is the thing that goes stale, and this file would be
+// where it went stale.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { MECHANISMS } from "../compat-lsp/mechanism.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const REPORT =
+  "upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md";
+// The one label answered by that report whose name is not a rendering rule:
+// `classifyHover` returns it when official's whole hover is the origin line the
+// report says tsgo drops, so it is that rendering with nothing left behind it.
+const DEGENERATE = "rsvelte-empty-import-only";
+// The residue of the same rewrites. `mechanism.mjs` states in the source that it
+// is NOT attributed to tsgo, so a terminal here would be the misclassification
+// nothing corrects.
+const RESIDUE = "ts-render";
+
+export function check(declared) {
+  const problems = [];
+  const terminalOf = (label) => declared[label]?.terminal ?? null;
+  const renderingRules = MECHANISMS.filter(
+    (label) => label.startsWith("ts-render-"),
+  );
+  const pointedAtReport = MECHANISMS.filter(
+    (label) => terminalOf(label) === REPORT,
+  );
+  const expected = new Set([...renderingRules, DEGENERATE]);
+  const actual = new Set(pointedAtReport);
+  for (const label of expected)
+    if (!actual.has(label))
+      problems.push(
+        `${label} is a rendering rule and does not name ${REPORT} (terminal ${JSON.stringify(terminalOf(label))})`,
+      );
+  for (const label of actual)
+    if (!expected.has(label))
+      problems.push(
+        `${label} names ${REPORT} and is neither a \`ts-render-*\` rule nor ${DEGENERATE}`,
+      );
+  if (terminalOf(RESIDUE) !== null)
+    problems.push(
+      `${RESIDUE} has terminal ${JSON.stringify(terminalOf(RESIDUE))}; mechanism.mjs states it is the residue the report does not explain, so which side is wrong is unmeasured`,
+    );
+  return problems;
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const sidecar = JSON.parse(
+    fs.readFileSync(path.join(ROOT, "compatibility/lsp-mechanisms.json"), "utf8"),
+  );
+  const declared = sidecar.mechanisms ?? {};
+  const problems = check(declared);
+  const covered = Object.keys(declared).filter(
+    (label) => declared[label]?.terminal === REPORT,
+  ).length;
+  console.log(
+    `[lsp-hover-terminal-scope] ${covered} labels answered by ${path.basename(REPORT)}; ${RESIDUE} unattributed`,
+  );
+  if (problems.length) {
+    for (const problem of problems) console.error(problem);
+    process.exit(1);
+  }
+}

--- a/scripts/ci/test-lsp-hover-terminal-scope-check.mjs
+++ b/scripts/ci/test-lsp-hover-terminal-scope-check.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Each control names the shape it pins, and the name is checked against the
+// mutation it applies: a control whose name does not describe its own input is
+// read later as coverage it does not have.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { check } from "./lsp-hover-terminal-scope-check.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const REPORT =
+  "upstream_issues/tsgo-lsp-hover-renders-declarations-differently-from-tsc.md";
+const real = JSON.parse(
+  fs.readFileSync(path.join(ROOT, "compatibility/lsp-mechanisms.json"), "utf8"),
+).mechanisms;
+const clone = () => JSON.parse(JSON.stringify(real));
+
+let failures = 0;
+const expect = (name, problems, wanted) => {
+  const got = problems.length > 0;
+  if (got !== wanted) {
+    console.error(
+      `FAIL ${name}: expected ${wanted ? "problems" : "none"}, got ${problems.length ? problems.join(" / ") : "none"}`,
+    );
+    failures += 1;
+  } else console.log(`ok   ${name}`);
+};
+
+expect("the tree as committed", check(clone()), false);
+
+// A rendering rule added later inherits the attribution by name only if someone
+// writes it; with no terminal it must be reported rather than assumed.
+const added = clone();
+added["ts-render-tuple-order"] = { terminal: null };
+const withAdded = check(added);
+// The label is not in MECHANISMS, so the checker cannot see it: this control
+// records that limit rather than pretending it is covered.
+expect("a label absent from MECHANISMS is invisible here", withAdded, false);
+
+const dropped = clone();
+dropped["ts-render-union-order"].terminal = null;
+expect("a rendering rule losing its terminal", check(dropped), true);
+
+const widened = clone();
+widened["ts-type-any"].terminal = REPORT;
+expect("a non-rendering label pointed at the report", check(widened), true);
+
+const residue = clone();
+residue["ts-render"].terminal = REPORT;
+expect("the residue given the report as a terminal", check(residue), true);
+
+const degenerate = clone();
+degenerate["rsvelte-empty-import-only"].terminal = null;
+expect("the degenerate case losing its terminal", check(degenerate), true);
+
+if (failures) {
+  console.error(`\n[test-lsp-hover-terminal-scope-check] ${failures} control(s) failed.`);
+  process.exit(1);
+}
+console.log("all lsp-hover-terminal-scope-check controls pass");


### PR DESCRIPTION
Twelve terminals in `compatibility/lsp-mechanisms.json`, all naming a filed `upstream_issues/`
report, plus a checker that holds one of those reports to a claim its terminals depend on.

`attribution-check` on this branch: **`lsp-known-failures.json` 6 → 1224 of 23742 attributed.**

## What the twelve are

Nine go to `tsgo-lsp-hover-renders-declarations-differently-from-tsc.md`, two to
`tsgo-lsp-completion-omits-the-commit-character-inputs.md`, one to
`tsgo-lsp-completion-item-omits-the-typescript-kind.md`. All three exist on disk;
`check-upstream-issues.mjs` passes.

The correspondence is between the classifier's **rules** and the report's **differences**, not
between their names. `mechanism.mjs`'s `TS_RENDER_RULES` implements the report's seven renderings
one text rewrite each; `ts-render-multiple` is two or more of the same seven; and
`rsvelte-empty-import-only` is the degenerate case where official's whole hover is a fenced
`import <Name>` and rsvelte's is empty — that report's dropped origin line with nothing behind it.

## Two things measured that a carrier ranking would have got wrong

**The checker's predicate is a conjunction**, so a label's carrier count is not what a terminal on
it buys. `completion-commit-characters-presence-rsvelte-only` (6908 carriers),
`completion-commit-characters-value-extra-paren` (4522) and `completion-item-pairing-key-kind-ts`
(6748) contribute **0** finished entries, because their carriers still hold a label with no
terminal. The twelve labels carry 14,010 entries between them and finish 1218.

**Three labels were examined and deliberately left `null`.** A terminal is where re-reading stops,
so a wrong one is the misclassification nothing corrects. `ts-render` (2483) is the residue of the
same seven rewrites and `mechanism.mjs` says in its own source that it is *not* attributed to tsgo
— probed, `tsc` and `tsgo` agree on the shapes it holds, so which side is wrong is unmeasured.
`completion-is-incomplete` (3894) reads `/isIncomplete:`, a different field from the
`isNewIdentifierLocation` the commit-characters report is about. `completion-commit-characters-value-other`
(2116) is by construction the values that are *not* that report's `(` branch.

## The new checker

`scripts/ci/lsp-hover-terminal-scope-check.mjs` holds the hover report to naming a **set** of
renderings, and holds the nine terminals to being members of it. Its own two-sided self-test is
`scripts/ci/test-lsp-hover-terminal-scope-check.mjs`.

## Checks run on this branch (rebased onto `a4ec3f2c9`)

```
lsp-mechanisms-check.mjs                    EXIT=0
test-lsp-mechanisms-check.mjs               EXIT=0
lsp-hover-terminal-scope-check.mjs          EXIT=0
test-lsp-hover-terminal-scope-check.mjs     EXIT=0
known-failures-md-check.mjs                 EXIT=0
attribution-check.mjs --gate-known          EXIT=0
deliberate-divergences-check.mjs            EXIT=0
check-upstream-issues.mjs                   EXIT=0
test-check-upstream-issues.mjs              EXIT=0
test-attribution-check.mjs                  EXIT=0
```

The prose cites `bf6fe3c63` as the tree its counts were computed on. That citation was checked
after the rebase rather than assumed: `git rev-parse <rev>:compatibility/lsp-mechanisms.json` is
`d0c04f872` at both `bf6fe3c63` and `a4ec3f2c9`, so the counts describe the sidecar this branch
ships. Only the table's `n` column is gated — against the ratchet, by `attribution-check` — so the
prose says to recompute from the sidecar rather than to cite it.
