### PR TITLE
ci(release): rsvelte_formatter has two publishing dependents in different fixed groups

### DIFF
--- a/scripts/release/check-core-consumer-changesets.mjs
+++ b/scripts/release/check-core-consumer-changesets.mjs
@@ -89,6 +89,14 @@ const RULES = [
     requires: ['@rsvelte/vite-plugin-svelte-native'],
   },
   {
+    prefix: 'crates/rsvelte_formatter/src/',
+    // Two dependents publish artifacts, and they sit in separate `fixed` groups
+    // (`@rsvelte/fmt`, and `@rsvelte/language-server` + `rsvelte-vscode`), so
+    // naming one leaves the other shipping a stale formatter. `rsvelte_fmt_wasm`
+    // is the third dependent and needs no naming for the reason recorded below.
+    requires: ['@rsvelte/fmt', '@rsvelte/language-server'],
+  },
+  {
     prefix: 'crates/rsvelte_fmt/src/',
     requires: ['@rsvelte/fmt'],
   },

--- a/scripts/release/test-core-consumer-changesets.mjs
+++ b/scripts/release/test-core-consumer-changesets.mjs
@@ -71,6 +71,49 @@ for (const [prefix, pkg] of Object.entries(SOLE_ARTIFACT)) {
 	});
 }
 
+// `rsvelte_formatter` is the one crate whose dependents publish into MORE than
+// one fixed group, so its `requires` is derived from the dependency graph rather
+// than transcribed: a fourth dependent, or a dependent moving group, has to fail
+// here rather than silently leave one artifact shipping a stale formatter.
+const CRATE_ARTIFACT = {
+	rsvelte_fmt: '@rsvelte/fmt',
+	rsvelte_language_server: '@rsvelte/language-server',
+	rsvelte_fmt_wasm: null, // published nowhere — absent from release.yml's matrix
+};
+
+check('crates/rsvelte_formatter/src/ requires one package per publishing dependent', () => {
+	const dependents = readdirSync(join(ROOT, 'crates'))
+		.filter((dir) => dir !== 'rsvelte_formatter')
+		.filter((dir) => {
+			const manifest = join(ROOT, 'crates', dir, 'Cargo.toml');
+			return existsSync(manifest) && readFileSync(manifest, 'utf8').includes('rsvelte_formatter');
+		});
+	assert.ok(dependents.length > 0, 'no dependent found — the scan is broken, not the table');
+	const unmapped = dependents.filter((d) => !(d in CRATE_ARTIFACT));
+	assert.deepEqual(unmapped, [], 'a new rsvelte_formatter dependent: map it, then extend the rule');
+	const expected = [...new Set(dependents.map((d) => CRATE_ARTIFACT[d]).filter(Boolean))].sort();
+	const rule = RULES.find((r) => r.prefix === 'crates/rsvelte_formatter/src/');
+	assert.ok(rule, 'no rule for crates/rsvelte_formatter/src/');
+	assert.deepEqual([...rule.requires].sort(), expected);
+});
+
+// The rule is only load-bearing while its packages sit in different fixed groups:
+// two packages in one group cascade, and naming both would be noise.
+check('the formatter rule names packages in distinct fixed groups', () => {
+	const rule = RULES.find((r) => r.prefix === 'crates/rsvelte_formatter/src/');
+	const groupOf = (pkg) => CONFIG.fixed.findIndex((group) => group.includes(pkg));
+	const groups = rule.requires.map(groupOf);
+	assert.ok(!groups.includes(-1), 'a required package is in no fixed group');
+	assert.equal(new Set(groups).size, groups.length, 'two required packages share a fixed group');
+});
+
+// The wasm dependent is exempt because it has no artifact. That is a fact about
+// release.yml, not a preference, so it is asserted rather than commented.
+check('rsvelte_fmt_wasm publishes nothing', () => {
+	const yml = readFileSync(join(ROOT, '.github/workflows/release.yml'), 'utf8');
+	assert.ok(!yml.includes('rsvelte_fmt_wasm'), 'rsvelte_fmt_wasm is in release.yml now — it needs a rule');
+});
+
 // Every package a rule names must be a real workspace package, or the
 // requirement can never be satisfied. Fixed-group membership is NOT the test:
 // `@rsvelte/svelte2tsx` is in no group and is correct there, because it depends


### PR DESCRIPTION
Closes #4298.

`check-core-consumer-changesets.mjs` maps a changed crate path to the npm packages a changeset
must name. `crates/rsvelte_formatter/src/` had no row, so a formatter change could ship with a
changeset naming only one of its publishing dependents — and the two sit in **separate `fixed`
groups**, so naming one does not version the other.

```
crates/rsvelte_formatter/src/   ->  @rsvelte/fmt              (fixed group: @rsvelte/fmt + 5 platform)
                                    @rsvelte/language-server  (fixed group: @rsvelte/language-server
                                                               + 5 platform + rsvelte-vscode)
```

`rsvelte_fmt_wasm` is the third dependent and needs no naming: it publishes no npm artifact of its
own, which the self-test asserts by requiring `release.yml` never to mention it.

## Self-test

`scripts/release/test-core-consumer-changesets.mjs` gains four checks that are **derived** rather
than transcribed, so the table cannot drift from the workspace:

- a `CRATE_ARTIFACT` map, with `rsvelte_fmt_wasm: null` spelled rather than omitted;
- each row's `requires` re-derived from a scan of every `crates/*/Cargo.toml` for dependents, with
  `assert.ok(dependents.length > 0, 'no dependent found — the scan is broken, not the table')` so
  an empty scan fails as an instrument fault instead of passing as agreement;
- an assertion that the two required packages really are in *distinct* `fixed` groups, which is
  the whole reason both must be named;
- an assertion that `release.yml` does not mention `rsvelte_fmt_wasm`.

## Two-sided ablation

```
rule removed entirely            2 FAIL
rule naming only one package     1 FAIL
restored                         cmp IDENTICAL, all checks pass
```

The restored tree was compared byte-for-byte against the pre-ablation file rather than eyeballed.
