### PR TITLE
docs(fmt): which stage first produces each `>`-boundary hunk, and three axes over the ratchet

### DIFF
--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -210,7 +210,7 @@ samples) — see `AGENTS.md` § "Generated shape matrix" and issue #2281.
 | 6 | svelte2tsx TSX text parity | per-component TSX text, oxfmt-normalized | `exportedNames` / `events`; TSX line+column layout; whitespace inside a statement; anything about an error both sides raise; how the port decided a token was code; whether an output it scores `match` is TypeScript at all (6j) | [S] [D] |
 | 7 | svelte2tsx source map | structural invariants and corpus-wide mapped-line coverage on rsvelte's own map | relation between generated text and mapped original text; source index | [D] |
 | 8 | css-prune sweep | `css.code` + `code@line:col` warnings of 1969 generated components | `js.code`; **every element in the grid is a plain `<div>`/`<p>` in one component** | [D] |
-| 9 | Formatter parity (JS corpus) | whole-file bytes vs oxfmt oracle | ids whose oracle file is absent are skipped, uncounted | [D] |
+| 9 | Formatter parity (JS corpus) | whole-file bytes vs oxfmt oracle | ids whose oracle file is absent are skipped, uncounted; it compares **one application per side**, so `format(format(x)) != format(x)` is invisible at any corpus size (9e) | [D] |
 | 10 | Formatter parity (Rust svelte.dev) | whole-file bytes vs generated fixture | exercises `--no-native-css`, not the shipped default | [S] |
 | 11 | Lint output parity | set of `rule\tline:col\tmessage` | `.svelte.(js\|ts)` ungated on **both** sides; autofixes never compared | [D] |
 | 12 | svelte-check Layer 1 (fixtures) | multiset of `SEVERITY file:line code` | column, message, `source`, file-walk counts, every flag but `--tsconfig` | [D] |
@@ -2836,6 +2836,14 @@ That is not a hole in this gate (it does compare `css.code`). It is a fact about
 (`fmt-verify.mjs:102`). No normalization — this is the one gate that compares raw bytes.
 Population: manifest entries with `kind === 'component'` (`fmt.mjs:170`).
 
+**Provenance.** `compatibility/fmt/meta.json` identifies the ORACLE arm (svelte and svelte.dev
+SHAs, the pattern-corpus tree hash, `oxfmt --version`, the config hash) and is rewritten only
+when the oracle regenerates. The rsvelte arm is rebuilt on every run and was identified by
+nothing until `compatibility/fmt/actual-meta.json` was added: it records the binary's
+**sha256** — the identity — plus the repository revision, the two binary paths, and a `partial`
+flag set by `--only`. The revision is a label and the hash is not: a dirty tree, a stale
+`target/`, or `RSVELTE_FMT_BIN` pointing elsewhere all leave the revision looking right.
+
 **The two sides deliberately do not share a CSS engine.** The oracle reaches
 prettier-plugin-svelte's PostCSS path for an embedded `<style>`; rsvelte-fmt's default reaches
 in-process `oxc_formatter_css`. **[D] #3628:** `.card >> .a` is accepted and respaced by
@@ -2898,6 +2906,35 @@ here so it is not mistaken for a blind spot. Its staleness check is `console.war
 (`fmt-verify.mjs:110-126`).
 
 **Tracked:** #2447. **Closing 9a:** assert `matched + failures.length + excluded === included.length`. Cost: trivial.
+
+### Blind spot 9e — it compares ONE application per side, so non-idempotency is invisible [D]
+
+`fmt-verify.mjs:106` compares `oracle(src)` against `rsvelte(src)`. Neither side is ever fed
+its own output, so `format(format(x)) != format(x)` is outside the comparison at any corpus
+size — an entry can be listed, retired, or green while the formatter does not converge.
+
+**[D]** Measured 2026-09-04 over the 520 `fmt-known-failures.json` entries, by formatting each
+side's own first-pass output a second time and comparing bytes: **rsvelte 28 non-idempotent,
+the oxfmt oracle 8, 3 of them shared — so 25 are rsvelte-only.** The gate scored every one of
+those 28 exactly as it scores an idempotent entry. `fmt.mjs:215` already records that oxfmt is
+not idempotent for every input, which is why the oracle's own 8 have to be measured before any
+of the 28 can be read as a defect: the rsvelte-only figure is 25, not 28.
+
+The compiler side of the repository has the gate this one lacks —
+`scripts/compat-corpus/idempotency-verify.mjs` asserts the property directly rather than
+sampling inputs (`AGENTS.md`, *Transform idempotency*) — and the formatter has no counterpart.
+Filed as **#4301**, which enumerates the paths and gives the per-file sign; the sign is
+**3-valued** (more lines / fewer lines / same line count, different bytes — 5 of the 28), which
+a prediction recorded in that issue got wrong by assuming two.
+
+**Not a claim about the ratchet's causes.** #4301 asserts *containment* — the non-idempotent
+set overlaps the listed set — and not that non-idempotency causes any listed entry. The 520
+were chosen because they are the population this gate already writes to disk, not because a
+non-idempotent formatter is where a divergence must come from.
+
+**Closing 9e:** a second application per side on the entries already materialized, as its own
+verdict rather than folded into the byte comparison. Cost: one extra format per compared entry,
+not per corpus component.
 
 ---
 
@@ -6043,6 +6080,7 @@ whose oracle is the other implementation is only as good as its independent expe
 | [28](#28-how-is-an-elements-attribute-list-rendered--d) | How is an element's attribute list rendered? | 2 emitters (+2 copies of `action_arguments`) | **[D]** | 1 defect open |
 | [29](#29-is-a-name-inside-a-named-slots-body-reactive--d) | Is a name inside a named slot's body reactive? | 2 (phase 2 scope fork, phase 3 name lookup) | **[D]** | open |
 | [30](#30-is-this-rule-a-global-block--d) | Is this rule a global block? | 4 predicates, 13 decision sites | **[D]** | 5 defects closed, 1 open |
+| [31](#31-does-this-element-hug-its-content--d) | Does this element hug its content? | 3 | **[D]** | no — ports disagree, output does not |
 
 **Rows 22–27 have bodies below and no line in this table** — measured 2026-09-02 by
 enumerating the `#### <n>.` headings against the table's own `[n]` links. The index is the
@@ -7555,6 +7593,52 @@ lexically nested snippet body, and only `RenderTag` is special-cased. A port tha
 `break` intuition into the descending walker prunes real descendants; one that carries the
 descending intuition upward invents ancestors.
 
+
+### 31. Does this element hug its content? [D]
+
+Upstream (prettier-plugin-svelte, `printChildren` / `shouldHugStart` / `shouldHugEnd`) answers
+once, from the **children**: an inline, non-empty element hugs its start unless its first child
+is a text node beginning with whitespace. rsvelte answers it in **three** places, and they do
+not take the same input.
+
+| port | file | what it reads |
+|---|---|---|
+| Doc builder | `crates/rsvelte_formatter/src/children.rs` — `should_hug_start` / `should_hug_end` | the child **nodes**: `children.first()`, is it text, does that text start with whitespace |
+| markup text printer | `crates/rsvelte_formatter/src/markup/open_tag.rs` — `open_tag_layout` | the **byte after `>`** in the source, plus a `component` test when that byte is `<` |
+| collapse post-pass | `crates/rsvelte_formatter/src/collapse/{hug,doc_build,collect,children_port}.rs` | string edits over already-printed text; two of these files carry comments saying they "Mirror `build_element_doc`" |
+
+**Demonstrated.** Both ports were instrumented to print their own answer and run on the same
+24 inputs — first-child kind (element / comment / `{expr}` / `{#if}` / text / whitespace-leading
+text) × host (`<span>` / `<Comp>`) × content width (fits / overflows). They disagree on exactly
+one shape:
+
+```svelte
+<span><b>bold</b> tail</span>
+```
+
+`children.rs` answers `hug_start = true` (the first child is not text, so the
+whitespace-leading-text exclusion does not apply — which is upstream's rule). `open_tag.rs`
+answers `hug_open = false`, because the byte after `>` is `<` and its extra `component`
+condition is not met. Upstream has no such condition.
+
+**And the divergence does not reach the output on any of those 24 cells** — every one is
+byte-identical to the `oxfmt(svelte: true)` oracle, at both widths. So this row is a real
+inventory entry and **not** a burndown candidate: "two ports answer differently" and "the
+difference is observable in the output" are separate claims, and only the first is established.
+Whether making `open_tag.rs` agree would *break* the two currently-passing cells is
+**unmeasured** — it needs a build, and none was taken.
+
+**Not [M].** The 24 inputs are constructed, not collected. A measured comparison over real
+files needs the two traces paired by **element identity**, which neither probe emits — they
+print a tag name, and a file with four `<span>`s gives four unpaired lines per port. Over the
+72 `>`-boundary carriers the Doc port fires 1,120 times in 51 files and the markup port 5,616
+times in all 72, so the population exists; the pairing does not.
+
+**A third reader of the same decision, in the same file set.** `collapse/mod.rs`'s pass 8 is
+`collapse`'s own invocation of the children port, so the Doc rule is consulted both inside the
+base render and again after it. That is why the `>`-boundary attribution in
+[`fmt-known-failures.md`](KNOWN-FAILURES.md#fmt-known-failures) reports the children-port pass
+as its own stage (15 hunks) rather than folding it into either neighbour.
 
 ### Adding a row, and closing one
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -1403,6 +1403,145 @@ buckets per entry from the doc would be transcription, not measurement.
 
 Partition of `fmt-known-failures.json` by mechanism: `1 + 2 + 1 + 1 + 515`
 
+### The `>`-boundary population — which stage first produces each hunk's final form
+
+**Read the double derivation before the table.** Two instruments, built on different arm
+pairs, were asked which `>`-boundary hunks the markup base render produces without any
+`collapse` post-pass. They agree exactly, including the per-sign split:
+
+| derivation | arms compared | base render | breaks-later | breaks-earlier | indent-only |
+|---|---|---|---|---|---|
+| positional ablation | collapse **on** vs collapse **off** | 77 | 65 | 9 | 3 |
+| prefix ladder, `k=0` | prefix-`k` vs the **full** pipeline | 77 | 65 | 9 | 3 |
+
+That agreement is the reason the split below is quotable; the table's tidiness is not. It is
+the shape `AGENTS.md` names as the thing that actually fires these rules — one quantity
+produced twice by derivations that share no stage.
+
+**Population.** The 72 ratchet carriers holding at least one `>`-boundary hunk, and the 213
+such hunks in them. A hunk is a `>`-boundary hunk when the first differing line's two sides
+are in a prefix relation **in either direction** and the remainder, after its leading
+whitespace, starts with `>`; plus an `indent-only` hunk whose trimmed line starts with `>`.
+The sign is recorded and never summed away: `breaks-later` is rsvelte's line being the longer
+one, `breaks-earlier` the oracle's.
+
+**Instrument.** `crates/rsvelte_formatter/src/collapse/mod.rs`'s post-pass was made
+prefix-abortable behind an environment variable (not committed — it is a measurement, and a
+flag the tree does not implement reads as absence rather than as error). Arm `k` applies
+collapse passes 1..k and no more; `k=0` applies none. For each hunk, the smallest `k` whose
+output already agrees with the full pipeline **at that line's position** is the stage at which
+the hunk's final form first appears.
+
+Three things were fixed before the ladder was read, because a mis-scaled ladder returns a
+plausible monotone curve with every arm alive:
+
+| end fix | result |
+|---|---|
+| no variable set == the gate's own `compatibility/fmt/actual/` | 72/72 |
+| `k=10` (all passes) == the same | 72/72 |
+| `k=0` == the independently built collapse-off arm | 72/72 |
+
+The third read **71/72** first, and the cause was not the ladder: a probe run to count which
+passes the collapse-off arm reaches had been pointed at the stored arm itself, and
+`rsvelte-fmt` **rewrites its argument in place**, so the probe overwrote the artifact it was
+verifying. Rebuilding all 72 off-arms located the one file; after restoring it the whole
+attribution was recomputed rather than assumed unaffected, and every number below is unchanged.
+
+**Negative control.** 8.9% of all lines in these files (2,174 of 24,351) sit inside a region
+`collapse` changes at all. The 136 hunks below that need `collapse` are 63.8% of 213 — a 7.2x
+enrichment, so the classification is discriminating rather than an artefact of how much of a
+file `collapse` touches. An earlier version of this instrument asked instead whether the line's
+*text* occurs anywhere in the collapse-off output; its background is **92.5%**, which makes its
+"base render" column an upper bound contaminated by coincidental matching, and it was discarded
+rather than reported.
+
+**The split.**
+
+| stage | hunks | breaks-later | breaks-earlier | indent-only |
+|---|---|---|---|---|
+| `k=0` before any collapse pass — the markup base render | 77 | 65 | 9 | 3 |
+| `k=2` pass 1.6 `try_collapse_only` | 49 | 24 | 25 | 0 |
+| `k=4` pass 1.8 block prefix | 4 | 4 | 0 | 0 |
+| `k=6` pass 1.95 recollapse open tag | 2 | 0 | 2 | 0 |
+| `k=8` the children-port final pass | 15 | 15 | 0 | 0 |
+| `k=9` pass 3 `<pre>` / `<textarea>` | 2 | 2 | 0 | 0 |
+| `k=10` pass 4 trim edge whitespace | 64 | 45 | 2 | 17 |
+
+**These are the stages at which a hunk's final form FIRST appears, not the stages that
+uniquely wrote it.** A later pass rewriting the same text to the same bytes leaves the minimal
+`k` where it is, so the table cannot say a stage is the only writer. What it does support is
+the conclusion below, and that rests on exclusion in both directions rather than on the row
+count.
+
+**No single repair closes this population.** The 77 at `k=0` do not move under any change to
+`collapse` — measured directly, they are the hunks whose line is outside every region the
+collapse-off comparison marks as changed. The 136 at `k≥2` do not move under any change to the
+base render alone — they do not exist in the collapse-off output at their final form. Neither
+direction is an inference from the ladder; each is its own comparison.
+
+**Monotonicity was measured, not assumed: 3 of 213 hunks are non-monotone.** A hunk settled at
+one prefix and unsettled at a larger one means two stages are contending over one line, and
+the "minimal prefix" quantity does not apply to it. All three are `breaks-later`, and in all
+three a later pass restores what an earlier one had already reached:
+
+```
+settled at k=0..10      sign            file
+00111111011             breaks-later    appwrite-console/…/commandCenter/panels/ai.svelte
+11000000011             breaks-later    huly/plugins/lead-resources/…/LeadsPresenter.svelte
+11111111011             breaks-later    appwrite-console/…/commandCenter/panels/template.svelte
+```
+
+Two are un-settled by the children-port pass and one by pass 1.6; pass 3 or pass 4 restores
+each. Read those three as the names of the two contending stages rather than as a minimal
+prefix.
+
+**How much of the base-render half is the children port.** `children.rs::build_element_doc` is
+reached in 51 of the 72 carriers (1,120 calls; the markup port's own probe fires 5,616 times,
+which is the positive control that the counter is live). A file-level reach label is useless in
+the positive direction and decisive in the negative one, so it is used only that way:
+
+| | hunks | |
+|---|---|---|
+| base render, in a carrier the Doc port never reaches | **20** | markup alone — settled |
+| base render, in a carrier the Doc port does reach | **57** | markup or Doc — **unmeasured** |
+| the children-port final pass (`k=8`) | 15 | the children port — settled |
+
+There is no environment switch that disables the Doc port alone, so the 57 stay unmeasured
+rather than being apportioned by inference. The 15 at `k=8` are separated because that pass is
+`collapse`'s own invocation of the children port, which the on/off ablation folds into
+`collapse` and the ladder does not.
+
+**A three-line reproduction of the family, found while probing something else.** An inline
+element whose first child is text beginning with whitespace, with content wider than the print
+width:
+
+```svelte
+<div>
+	<span> plain This is a deliberately long run of prose that will not fit inside the print width at all</span>
+</div>
+```
+
+```
+oracle                                    rsvelte
+  <span>                                    <span> plain This is a … the
+    plain This is a … the                   print width at all</span>
+    print width at all</span
+  >
+```
+
+Trimmed, the two sides are `…at all</span` and `…at all</span>`, so this is a `breaks-later`
+`>`-boundary hunk by the rule above. Walked up the ladder it settles at **`k=2`, pass 1.6**,
+and both hug ports answer `hug_start = false` for it — as does upstream's `shouldHugStart`,
+whose rule is that an element whose first child is whitespace-leading text is not hugged. So
+this cell is not a hug disagreement: it is a layout pass 1.6 does not have, namely breaking
+after the open tag and borrowing the closing tag's `>` onto its own line. How many corpus
+entries carry that shape is **unmeasured**.
+
+**What this population is not.** `fmt-known-failures.json` holds 520 entries; the 72 carriers
+here are the ones whose *first differing line* is a `>` boundary, so this is a sub-population
+chosen by a signature, not a cluster of the partition above. An entry is retired only when
+every one of its differing regions is repaired.
+
 ### Entries by DIFF SHAPE — a second axis, and 3 in 4 are layout alone
 
 The table above partitions by **attribution target**. This one partitions the same entries by
@@ -1416,15 +1555,26 @@ artifact. That objection is right about the report and does not reach this axis:
 trees are regenerable by `pnpm run generate-fmt-corpus` and the classification below is a
 measurement of them, not a transcription of a doc.
 
-Each entry is placed by the first of these tests that passes, so the classes are disjoint and
-exhaustive:
+Each entry is placed by the first of these tests that passes, **in the order printed** — which
+is most-specific first, because each test's normalization is strictly weaker than the one above
+it. Read in any other order the classes are still exhaustive and no longer disjoint: deleting
+every whitespace byte subsumes both of the tests below it, so evaluating that one first puts
+393 entries in it and empties the other two.
 
 | n | class | test |
 |---|---|---|
-| 247 | whitespace **placement** only | equal once every whitespace byte is deleted from both |
-| 127 | a real token difference | none of the below |
-| 123 | line breaks only, whitespace-preserving | equal once whitespace runs collapse to one space |
 | 27 | horizontal whitespace only | equal once spaces/tabs collapse and trailing ones are dropped |
+| 122 | line breaks only, whitespace-preserving | equal once whitespace runs collapse to one space |
+| 244 | whitespace **placement** only | equal once every whitespace byte is deleted from both |
+| 127 | a real token difference | none of the above |
+
+The `n` column above disagreed with the partition line below it by 4 (`247`/`123` against
+`244`/`122`) and listed the tests in an order that cannot produce either set of numbers. It was
+re-derived from `compatibility/fmt/{oracle,actual}` rather than copied from the partition line:
+the four classes come out `27 / 122 / 244 / 127` under the order now printed, and `393 / 0 / 0 /
+127` under the order that was printed. This is the recorded shape where a gated half and an
+ungated half rot separately — `known-failures-md-check` reads the partition line and reads no
+prose, so the line stayed right while the table drifted.
 
 Partition of `fmt-known-failures.json` by diff shape: `244 + 127 + 122 + 27`
 
@@ -1468,6 +1618,50 @@ against a locally regenerated corpus), so recompute them rather than citing them
 confirms what the two-sided ratchet asserts and was taken without running the gate.
 
 
+
+### Entries by REGION — a third axis, and CSS diverges in one direction only
+
+The two axes above ask *who owns this* and *what do the outputs disagree about*. This one asks
+**where in the file the disagreement starts**, which is the axis that separates the three
+formatting engines: markup (rsvelte's own printer), embedded JS (oxc) and embedded CSS.
+
+Each entry is placed by the region of the **oracle** line its first hunk starts on. A `<script>`
+or `<style>` delimiter line is counted as **markup**, because the tag itself is emitted by the
+markup printer whatever formats its interior.
+
+| n | region of the first differing line |
+|---|---|
+| 487 | markup |
+| 28 | embedded CSS |
+| 5 | embedded JS |
+
+**The boundary rule decides exactly 3 entries, and both readings were taken.** A first
+derivation counting a delimiter line as belonging to the block it closes gave `5 / 31 / 484`; the
+rule above gives `5 / 28 / 487`. The difference is a set, not a rounding — `open-webui/…
+/VoiceRecording.svelte` and two `sparrow-app` icons, each of whose first differing line is a
+`</style>` inside an **SVG**. Both totals are 520; neither is more measured than the other, and
+the rule is stated here so the number can be recomputed under either.
+
+**And this is a positional attribution, not an engine attribution.** It says which region of the
+oracle text the hunk begins in. It does not say which engine wrote the line — an SVG `<style>`
+element is markup that happens to contain CSS, and whether its interior reaches the CSS engine at
+all is **UNMEASURED**.
+
+Crossed with the diff-shape labels, CSS is the one region whose divergences run in a single
+direction:
+
+| region | breaks-later | breaks-earlier |
+|---|---|---|
+| markup | 233 | 214 |
+| embedded CSS | **11** | **0** |
+| embedded JS | 0 | 0 |
+
+Markup is near-symmetric, and every CSS entry in the prefix-relation class has rsvelte producing
+the **longer** line. **The zero is a measured zero, not an instrument zero**: `breaks-earlier` is
+representable by the same classifier that emits 214 of them in the markup region, and the CSS
+entries reach the same decision point — they simply come out the other way. The remaining 17 CSS
+entries carry labels for which direction is not defined (`intra-line-ws` 11, `indent-only` 4,
+`other` 2).
 
 ### Cluster 1 — close-tag-dangle / open-tag hugging for inline & void children (3)
 

--- a/scripts/compat-corpus/fmt.mjs
+++ b/scripts/compat-corpus/fmt.mjs
@@ -57,6 +57,7 @@ const SOURCES = path.join(CORPUS, 'sources');
 const FMT = path.join(CORPUS, 'fmt');
 const ORACLE = path.join(FMT, 'oracle');
 const ACTUAL = path.join(FMT, 'actual');
+const ACTUAL_META_PATH = path.join(FMT, 'actual-meta.json');
 const META_PATH = path.join(FMT, 'meta.json');
 
 const OXFMT_BIN = process.env.OXFMT_BIN || path.join(ROOT, 'node_modules/.bin/oxfmt');
@@ -323,6 +324,27 @@ async function main() {
 				fs.rmSync(stage, { recursive: true, force: true });
 			}
 		}
+		// meta.json is the ORACLE cache key and is not rewritten when only the
+		// binary changes, so the arm's identity has to live beside it.
+		fs.mkdirSync(FMT, { recursive: true });
+		fs.writeFileSync(
+			ACTUAL_META_PATH,
+			JSON.stringify(
+				{
+					rsvelteRevision: await gitSha(ROOT),
+					rsvelteFmtBin: path.relative(ROOT, RSVELTE_FMT_BIN),
+					rsvelteFmtSha256: createHash('sha256')
+						.update(fs.readFileSync(RSVELTE_FMT_BIN))
+						.digest('hex'),
+					oxfmtBin: path.relative(ROOT, OXFMT_BIN),
+					generatedAt: new Date().toISOString(),
+					targets: targets.length,
+					partial: Boolean(ONLY_FILE),
+				},
+				null,
+				'\t',
+			) + '\n',
+		);
 	}
 }
 


### PR DESCRIPTION
Report, not a fix. No compiler or formatter behaviour changes; the one code change records an arm's identity.

## The double derivation agrees exactly

Two independent methods split the 213 `>`-boundary hunks over the 72 carriers, and they agree at the base render to the breakdown:

| derivation | base-render hunks | breaks-later | breaks-earlier | indent-only |
|---|---|---|---|---|
| prefix ablation, `k=0` (collapse off) | **77** | 65 | 9 | 3 |
| positional attribution, first-hunk line | **77** | 65 | 9 | 3 |

The prefix ladder over `collapse_pure_text_elements`' ten `apply_edits` sites:

| k | first settles here | n |
|---|---|---|
| 0 | base markup render | 77 |
| 2 | pass 1.6 `try_collapse_only` | 49 |
| 4 | | 4 |
| 6 | | 2 |
| 8 | the children port (`collapse`'s own `build_element_doc` call) | 15 |
| 9 | | 2 |
| 10 | pass 4, trim edge whitespace | 64 |

Top three cover **190/213 = 89%**.

**What the ladder gives is the earliest stage at which a hunk's final form appears, not the only writer of it.** A later pass can rewrite the same text and restore it; three hunks are measured non-monotone (bitmaps in the section), which is why that was measured rather than assumed to be 0. The "≥2 stages are involved" conclusion rests on the two-directional exclusion, not on the seven rows.

Ends are fixed on both sides: `k=9`/`k=10` are byte-identical to a **no-op arm** (an arm carrying the instrumentation with the guard never firing), and `k=0` is byte-identical to collapse-off — each 72/72.

Background: an ablation says **pass N is necessary**, never "pass N wrote it". For the 46 hunks the containment rule leaves unattributed the *negative* side is the strong reading — did not move ⇒ base.

## Three axes over the 520-entry ratchet

**Region** (which region of the oracle text the first differing line falls in) — 487 markup / 28 embedded CSS / 5 embedded JS. The delimiter-line rule is stated in the section because it decides exactly 3 entries: counting `</style>` as CSS gives 5/31/484, and the difference is a named set of 3 SVG `<style>` closers. Crossed with the diff-shape labels, CSS runs one direction only:

| region | breaks-later | breaks-earlier |
|---|---|---|
| markup | 233 | 214 |
| embedded CSS | **11** | **0** |

That zero is measured, not forced — the same classifier emits 214 `breaks-earlier` in the markup region, so the label is representable and the CSS entries reach the same decision point.

**Diff shape, corrected.** The existing table's counts disagreed with the gated partition line below it by 4 (`247`/`123` against `244`/`122`) and its stated ordering could produce neither set. Re-derived from `compatibility/fmt/{oracle,actual}`: `27 / 122 / 244 / 127`. This is the recorded shape where a gated half and an ungated half rot separately — `known-failures-md-check` reads the partition line and reads no prose.

**Doc-port lower bound, no new arm.** Of the 77 base-render hunks, 20 are in carriers where the Doc port never fires (markup alone), 15 are causally the children port (ladder `k=8`), and **57 are UNMEASURED** — there is no Doc-only env switch, and raising the bound needs per-hunk element identity the traces do not carry.

## GATES.md

- **Blind spot 9e** — the gate compares one application per side, so `format(format(x)) != format(x)` is invisible at any corpus size. Measured over the 520 entries: rsvelte **28** non-idempotent, the oxfmt oracle **8**, 3 shared, so **25 rsvelte-only**. `fmt.mjs:215` already records that oxfmt is not idempotent for every input, which is why the oracle's own 8 have to be measured before any of the 28 reads as a defect. Filed as #4301. (The `(9a)` marker first written for this was already taken by an existing blind spot.)
- **Two-ports inventory row 31** — three ports of "does this element hug its content" (`children.rs` Doc builder, `markup/open_tag.rs` text printer, the `collapse` post-pass). The ports **demonstrably disagree** on `<span><b>bold</b> tail</span>`: `children.rs` answers hug, `open_tag.rs` does not because of an extra `component` condition upstream has no counterpart for. **All 24 constructed cells are byte-equal to the oracle**, so this is an inventory entry and not a burndown candidate — "two ports answer differently" and "the difference is observable" are separate claims and only the first is established. Graded **[D]**, with why it is not [M].
- **Gate 9 provenance** — see below.

## `actual-meta.json` (the one code change)

`compatibility/fmt/meta.json` identifies the **oracle** arm and is rewritten only when the oracle regenerates. The rsvelte arm is rebuilt every run and was identified by nothing. `fmt.mjs` now writes `compatibility/fmt/actual-meta.json` on every `actual/` build with the binary's **sha256** — the identity — plus the revision, both binary paths, and a `partial` flag set by `--only`. The revision is a label and the hash is not: a dirty tree, a stale `target/`, or `RSVELTE_FMT_BIN` pointing elsewhere all leave the revision looking right.

Verified against two controls on a real run: `rsvelteFmtSha256` equals `shasum -a 256 target/release/rsvelte-fmt`, `rsvelteRevision` equals `git rev-parse HEAD`, and `partial` reads `true` under `--only`. Both files are gitignored.

## What this PR does not do

`attribution-check` is unaffected — still 4 problems, and `fmt-known-failures.json` still has no `Attribution of` block. That needs targets for the 515 entries `fmt-mechanisms.json` marks `unattributed`, which is elimination work rather than a report. The 4 CSS-engine facets (5 entries) are the next cheap terminal and are deliberately not in this PR: they need a pin, and a pin needs a two-sided cell.

## Notes on method

- The region numbers were re-derived after an oracle regeneration (`patternHash` moved from `925c9fdf19d4fcc7` to `99c9f6f7c084680e`) and are **unchanged**, with all 520 ids live under both trees.
- One arm was corrupted mid-run and it is worth naming the shape: a pass-reach control ran `rsvelte-fmt` against a stored arm file, and **`rsvelte-fmt` rewrites its argument in place** — so the probe overwrote the artifact it was reading. END-FIX C read 71/72 until every off-arm was rebuilt. The downstream tables were *recomputed* rather than assumed unaffected; they were unchanged.
- `known-failures-md-check` passes: 50 declared ratchets across 36 docs match their JSON, 34 cluster partitions add up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrgGJ3k8oYjSkWY1RNKgND
