### PR TITLE
fix(vscode): the extension is `baseballyama.rsvelte`, because the old name is reserved and unlisted

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -43,7 +43,7 @@
       "@rsvelte/language-server-linux-arm64-gnu",
       "@rsvelte/language-server-linux-x64-gnu",
       "@rsvelte/language-server-win32-x64-msvc",
-      "rsvelte-vscode"
+      "rsvelte"
     ]
   ],
   "linked": [],

--- a/.changeset/vscode-extension-rename.md
+++ b/.changeset/vscode-extension-rename.md
@@ -1,0 +1,14 @@
+---
+'rsvelte': minor
+---
+
+The VS Code extension is published as `baseballyama.rsvelte`, not `baseballyama.rsvelte-vscode`.
+
+The old identifier is unlisted on the Marketplace while its name stays reserved — a
+publisher-account state that no retry moves — so every release commit failed its
+`Publish to Marketplace` step while Open VSX published fine. The extension's `name` is
+what the Marketplace keys on, so the rename is the identifier change.
+
+Anyone who installed `baseballyama.rsvelte-vscode` from Open VSX keeps that extension; it
+does not update to this one. Install `baseballyama.rsvelte` instead, and set
+`"editor.defaultFormatter": "baseballyama.rsvelte"` if you had pinned the old id.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -822,9 +822,9 @@ jobs:
 
       - name: Typecheck + bundle VS Code extension
         run: |
-          pnpm --filter rsvelte-vscode run test
-          pnpm --filter rsvelte-vscode run typecheck
-          pnpm --filter rsvelte-vscode run build
+          pnpm --filter rsvelte run test
+          pnpm --filter rsvelte run typecheck
+          pnpm --filter rsvelte run build
 
   # Single required status check that fans the sharded `Test` matrix and the
   # dedicated heavy-test jobs back into one signal: branch protection can require

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -1,6 +1,6 @@
 name: Publish VS Code Extension
 
-# Publishes `rsvelte-vscode` to the VS Code Marketplace (+ Open VSX). The
+# Publishes `rsvelte` to the VS Code Marketplace (+ Open VSX). The
 # extension version follows `@rsvelte/language-server` (kept in lockstep by the
 # changesets `fixed` group), so a normal release — merging the "Version
 # Packages" PR — bumps both and pushes to main, which triggers this workflow.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ limitations.
 | Standalone linting                                 | [`@rsvelte/lint`](apps/npm/lint/README.md)                                           |
 | Svelte diagnostics in oxlint                       | [`@rsvelte/oxlint-plugin`](apps/npm/oxlint-plugin/README.md)                         |
 | Language server                                    | [`@rsvelte/language-server`](apps/npm/language-server/README.md)                     |
-| VS Code                                            | [`rsvelte-vscode`](apps/npm/vscode/README.md)                                        |
+| VS Code                                            | [`rsvelte`](apps/npm/vscode/README.md)                                        |
 | Neovim, Sublime Text, Helix, and Emacs             | [Editor setup](editors/README.md)                                                    |
 | Zed                                                | [`rsvelte` Zed extension](apps/zed/README.md)                                        |
 | Rust API                                           | [`rsvelte`](crates/rsvelte/README.md)                                                |

--- a/apps/npm/lint/README.md
+++ b/apps/npm/lint/README.md
@@ -132,7 +132,7 @@ and whether it's autofixable; rules with an options schema are marked
 `(options)`.
 
 The same file drives editor diagnostics: `@rsvelte/language-server` and the
-[rsvelte VS Code extension](https://marketplace.visualstudio.com/items?itemName=baseballyama.rsvelte-vscode)
+[rsvelte VS Code extension](https://marketplace.visualstudio.com/items?itemName=baseballyama.rsvelte)
 discover it by walking up from the file being linted, so the editor and CI agree
 on the rule set. `files` / `ignores` stay CLI-only — an editor lints the
 document it is handed.

--- a/apps/npm/oxlint-plugin/README.md
+++ b/apps/npm/oxlint-plugin/README.md
@@ -136,7 +136,7 @@ will lift as it matures:
 
 For pixel-accurate markup positions and full scriptless coverage today, use
 [`rsvelte-check`](https://www.npmjs.com/package/@rsvelte/svelte-check) or the
-[rsvelte VS Code extension](https://marketplace.visualstudio.com/items?itemName=baseballyama.rsvelte-vscode)
+[rsvelte VS Code extension](https://marketplace.visualstudio.com/items?itemName=baseballyama.rsvelte)
 directly; this plugin is about folding Svelte diagnostics into an existing oxlint
 pass.
 

--- a/apps/npm/vscode/CHANGELOG.md
+++ b/apps/npm/vscode/CHANGELOG.md
@@ -1,4 +1,4 @@
-# rsvelte-vscode
+# rsvelte
 
 ## 0.6.0
 

--- a/apps/npm/vscode/README.md
+++ b/apps/npm/vscode/README.md
@@ -86,7 +86,7 @@ doesn't conflict with the official Svelte extension):
 // .vscode/settings.json
 {
   "[svelte]": {
-    "editor.defaultFormatter": "rsvelte.rsvelte-vscode",
+    "editor.defaultFormatter": "baseballyama.rsvelte",
   },
 }
 ```

--- a/apps/npm/vscode/package.json
+++ b/apps/npm/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rsvelte-vscode",
+  "name": "rsvelte",
   "displayName": "rsvelte",
   "version": "0.6.0",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"build:wasm:core": "wasm-pack build crates/rsvelte_lint_bindings --out-dir ../../pkg --target web --release -- --features wasm --no-default-features",
 		"build:wasm:lint-node": "wasm-pack build crates/rsvelte_lint_bindings --out-dir ../../apps/npm/language-server/vendor --target nodejs --release -- --features wasm --no-default-features",
 		"build:language-server": "pnpm run build:wasm:lint-node && pnpm --filter @rsvelte/language-server run build",
-		"build:vscode": "pnpm run build:language-server && pnpm --filter rsvelte-vscode run build",
+		"build:vscode": "pnpm run build:language-server && pnpm --filter rsvelte run build",
 		"build:wasm:fmt": "wasm-pack build crates/rsvelte_fmt_wasm --out-dir ../../pkg-fmt --target web --release",
 		"build:wasm:clean": "cargo clean && pnpm run build:wasm",
 		"clean:cache": "rm -rf apps/playground/node_modules/.vite",

--- a/scripts/dev/test-release-comment.mjs
+++ b/scripts/dev/test-release-comment.mjs
@@ -117,6 +117,17 @@ check(
 );
 check('packageUrl for a non-npm package', packageUrl('some-private-thing', '1.0.0', true), null);
 
+// The extension is the ONE private package with a URL, and the branch that
+// builds it was untested: the two cells above pass whether it returns the
+// Marketplace link or null. Its name is also the name the Marketplace publish
+// is keyed on, so a rename that misses `packageUrl` reports a dead link.
+check(
+	'packageUrl for the VS Code extension',
+	packageUrl('rsvelte', '0.6.0', true),
+	'https://marketplace.visualstudio.com/items?itemName=baseballyama.rsvelte',
+);
+check('packageUrl still refuses the extension\'s old name', packageUrl('rsvelte-vscode', '0.6.0', true), null);
+
 {
 	const body = commentBody([{ name: '@rsvelte/compiler', version: '0.10.9', private: false }], 2666);
 	check('commentBody carries the marker', body.includes(MARKER), true);

--- a/scripts/release/check-core-consumer-changesets.mjs
+++ b/scripts/release/check-core-consumer-changesets.mjs
@@ -91,7 +91,7 @@ const RULES = [
   {
     prefix: 'crates/rsvelte_formatter/src/',
     // Two dependents publish artifacts, and they sit in separate `fixed` groups
-    // (`@rsvelte/fmt`, and `@rsvelte/language-server` + `rsvelte-vscode`), so
+    // (`@rsvelte/fmt`, and `@rsvelte/language-server` + `rsvelte`), so
     // naming one leaves the other shipping a stale formatter. `rsvelte_fmt_wasm`
     // is the third dependent and needs no naming for the reason recorded below.
     requires: ['@rsvelte/fmt', '@rsvelte/language-server'],

--- a/scripts/release/comment-released-versions.mjs
+++ b/scripts/release/comment-released-versions.mjs
@@ -69,7 +69,7 @@ export function prNumberFromSubject(subject) {
 /** Where a released package can be read about. */
 export function packageUrl(name, version, isPrivate) {
 	if (isPrivate) {
-		return name === 'rsvelte-vscode'
+		return name === 'rsvelte'
 			? `https://marketplace.visualstudio.com/items?itemName=baseballyama.${name}`
 			: null;
 	}

--- a/scripts/release/publish-vscode.mjs
+++ b/scripts/release/publish-vscode.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Publish the `rsvelte-vscode` extension to the VS Code Marketplace and Open VSX.
+// Publish the `rsvelte` extension to the VS Code Marketplace and Open VSX.
 // The extension version follows `@rsvelte/language-server` (kept in lockstep by
 // the changesets `fixed` group).
 //

--- a/scripts/release/vscode-publish-decision.mjs
+++ b/scripts/release/vscode-publish-decision.mjs
@@ -1,4 +1,4 @@
-// The publish decision for `rsvelte-vscode`, as a pure function of the two
+// The publish decision for `rsvelte`, as a pure function of the two
 // registry states, so it can be tested without a network or a token.
 //
 // Three answers have to stay distinguishable per registry, because two of them


### PR DESCRIPTION
The VS Code extension's `name` becomes `rsvelte`, so its Marketplace identifier becomes
`baseballyama.rsvelte`.

## Why

Every release commit fails `Publish VS Code Extension`. Measured at `60dda100f`
([run 33860988169](https://github.com/baseballyama/rsvelte/actions/runs/33860988169)): all five
platform builds succeed, **all six Open VSX publishes succeed**, and the Marketplace publish is
rejected with

```
The extension 'rsvelte-vscode' already exists in the Marketplace.
Please use a different 'name' in the package.json file
```

while the gallery reports **no live version**:

```
POST /_apis/public/gallery/extensionquery  filterType 7 = baseballyama.rsvelte-vscode
-> 0 extensions
```

`publish-vscode.mjs` already diagnoses that pair correctly and printed its message in the same
log: the extension is *unlisted while its name stays reserved* — a publisher-account state, not
a build problem. No retry moves it. The two ways out are restoring it from the publisher
dashboard or renaming; this PR is the rename.

## What the gallery query can and cannot say

`baseballyama.rsvelte` also returns **0 extensions** — and that is not evidence it is free,
because `baseballyama.rsvelte-vscode` returns 0 too *while being reserved*. That is a live
negative control on the instrument: the query cannot distinguish "free" from "reserved and
unlisted", so **the publish attempt on the next release commit is the only test.** If the new
name is also rejected, the log will say so in the same words and the remaining option is the
dashboard.

## What changes

`name` is the only field the Marketplace keys on, and it is also the pnpm workspace package
name, so the rename reaches the `--filter` invocations, the changesets `fixed` group, and the
release-comment URL builder. Fifteen edits, each applied with an assertion that the string it
replaces occurs **exactly once** in its file (a script that replaced 0 or 2 would have failed
rather than silently doing the wrong thing).

Deliberately **not** rewritten: the two `apps/npm/language-server/CHANGELOG.md` lines naming
`rsvelte-vscode`. They record what shipped under that name and are not claims about today.

Corrected while here: `apps/npm/vscode/README.md` told readers to set
`"editor.defaultFormatter": "rsvelte.rsvelte-vscode"` — publisher `rsvelte`, which this
extension has never had. It now reads `baseballyama.rsvelte`.

## Test added, and its ablation

`packageUrl` has one branch that returns a Marketplace link, and it was **untested**: the two
existing cells (`@rsvelte/compiler` → npm, `some-private-thing` → null) both pass whether that
branch returns the link or null. Two cells now pin it two-sidedly — the extension's name gets
the URL, its old name gets `null`.

```
ablated (packageUrl still keyed on the old name)   2 FAIL, both new cells
restored                                           all pass, and the file is
                                                   byte-identical to the pre-ablation copy
```

## Checks run

```
test-release-comment.mjs             EXIT=0   (with the ablation above)
test-publish-vscode-decision.mjs     EXIT=0
test-core-consumer-changesets.mjs    EXIT=0
workflow-trigger-guard.mjs           EXIT=0
test-workflow-trigger-guard.mjs      EXIT=0
known-failures-md-check.mjs          EXIT=0
attribution-check.mjs --gate-known   EXIT=0
```

## For users

Anyone who installed `baseballyama.rsvelte-vscode` from Open VSX keeps that extension and it
will not update to this one; Open VSX will carry both, with only `baseballyama.rsvelte` moving
forward. The changeset says so.
