### PR TITLE
docs(fmt): attribute the four CSS-engine entries, on a corrected premise

### DIFF
--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -8746,6 +8746,48 @@ measurement above had to be written for this row.
 `pattern/adversarial/css/css-custom-property-values`.
 **Pinned by** `crates/rsvelte_formatter/tests/css_native.rs`.
 
+**Ratchet** `compatibility/fmt-known-failures.json`, four entries over three facets of the same
+choice: whitespace around the column combinator and around a `nth-child(… of <selector>)` clause
+(2), a hex escape's own terminating space before `{` (1), and the continuation depth of a
+comma-separated multi-value declaration (1). **Pinned by** the four tests named below, in the
+same file — each asserts rsvelte's spelling is produced **and** the oracle's is absent, so a
+build that stops printing the construct entirely cannot pass.
+
+#### The four `fmt-known-failures.json` facets, measured on the same bytes
+
+| construct | `oxfmt(svelte: true)` | `rsvelte-fmt` | pin |
+|---|---|---|---|
+| column combinator | `.a\|\|.b {` | `.a \|\| .b {` | `a_column_combinator_keeps_its_spaces` |
+| `nth-child(2n of …)` | `of.important)` | `of .important)` | `an_nth_child_of_clause_keeps_the_space_after_of` |
+| hex escape ending a selector | `#\31\32\33 {` | `#\31\32\33  {` | `a_hex_escape_ending_a_selector_keeps_its_own_separator` |
+| multi-value continuation depth | first at 8, the rest at 10 | every continuation at one depth | `every_continuation_of_a_multi_value_declaration_sits_at_one_depth` |
+
+#### What the official compiler says, and the claim that had to be withdrawn
+
+`fmt-mechanisms.json` justified three of these with *"the official compiler's scoped CSS is
+byte-identical for the two spellings"*. Measured against
+`submodules/svelte/packages/svelte/src/compiler/index.js` (`VERSION=5.56.10`) on the minimal
+construct and again on the five ratchet files, **`css.code` DIFFERS for every one of them**.
+Svelte carries selectors and declarations through scoping close to verbatim, so a moved space
+inside `<style>` always moves `css.code` — the sentence is one **no CSS whitespace divergence can
+satisfy**, which is a stronger statement than "it was measured and was wrong": it is a claim whose
+falsity follows from the mechanism, so it cannot have been measured before it was written.
+
+What holds instead, and what these rows now assert: `js.code` is byte-identical for the two
+spellings, and `css.code` differs **only in whitespace** — the non-whitespace character sequences
+are identical, with the scope hash equal on both sides. Two negative controls separate that from
+an instrument artifact (`color: red` against `color: blue`, and `#\31\32\33` against
+`#\31\32\33\34`, both reporting non-whitespace DIFFER). That still meets this registry's
+criterion — valid CSS, and no change to which elements match or which declarations apply — on a
+premise that had to be replaced to reach it.
+
+**A fifth `fmt-known-failures.json` entry is deliberately not here.** `oxc_formatter_css`
+*rejects* one `<style>` body and `native_style_formatter` returns it verbatim. It passes the same
+output test (`js.code` identical, `css.code` whitespace-only), and it fails the other one: there
+is no code implementing a chosen behaviour, only a fallback for input the engine could not parse.
+Recording it as deliberate would spell an unimplemented case as a decision, so it stays listed in
+the ratchet and is described there as a limitation.
+
 #### Input
 
 One declaration block carrying an empty custom-property value (`--bar:   !important`), a bracket

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -1382,11 +1382,30 @@ their corpus paths — it is the set of rows below rather than one row. Only the
 first is a *reject* path, and its fingerprint is in the output rather than in the
 diff: tabs survive in rsvelte's text while the config says `useTabs: false`, with
 the other three CSS candidates at 0 tab-bearing lines in the same run, so the body
-was copied rather than printed. None of the five changes the compiled CSS —
-`#\31\32\33` / `.a\5c` and the gradient indent are byte-identical through the
-official compiler after scope-hash normalization, and the other three carry their
-spelling through verbatim with identical scoping — so what a pin here would record
-is the engine choice, not a claim about which side is correct.
+was copied rather than printed.
+
+**The sentence that stood here was false, and it was false by construction rather
+than by drift.** It read "none of the five changes the compiled CSS", with
+`#\31\32\33` / `.a\5c` and the gradient indent called *byte-identical through the
+official compiler after scope-hash normalization*. Measured on 2026-09-04 against
+`submodules/svelte/packages/svelte/src/compiler/index.js` (`VERSION=5.56.10`), on
+the minimal construct and again on the five ratchet files, **`css.code` DIFFERS for
+every one of them** — and no normalization rescues it, because the two sides'
+scope hashes are equal (they are non-whitespace characters, and the non-whitespace
+halves are identical). Svelte carries selectors and declarations through scoping
+close to verbatim, so a moved space inside `<style>` always moves `css.code`:
+**"byte-identical `css.code`" is not a claim that can be true of any CSS
+whitespace divergence**, which is why the mechanism rather than a re-measurement
+is what condemns it.
+
+What survives is weaker and is what the four rows below now say: `js.code` is
+byte-identical for the two spellings, and `css.code` differs **only in
+whitespace** — the non-whitespace character sequences are identical. Two negative
+controls separate that from a fact about the instrument: `color: red` against
+`color: blue`, and `#\31\32\33` against `#\31\32\33\34`, both report
+non-whitespace DIFFER. So a pin here records the engine choice and not a claim
+about which side is correct — the original conclusion, on a premise that had to be
+replaced to reach it.
 
 The remaining entries are one bucket rather than seven because the mechanical
 `20`-`26` split above is recomputed from `compatibility/fmt-report.json`, which is
@@ -1395,13 +1414,43 @@ buckets per entry from the doc would be transcription, not measurement.
 
 | n | mechanism | pinned |
 |---|---|---|
-| 1 | `oxc_formatter_css` rejects the `<style>` body, so `native_style_formatter` returns it verbatim and the source's own indentation survives — measured as 6 tab-bearing lines in rsvelte's output under `useTabs: false`, against 0 in the oracle's own output for the same file and 0 on both sides for three of the four sibling candidates (the fourth reads 1 on both sides, inside a declaration value); the oracle's PostCSS path accepts the same body and reformats it | none — candidate, not pinned for this facet |
-| 2 | the two engines disagree about whitespace around a selector token neither models — the column combinator and a `nth-child(… of <selector>)` clause: rsvelte's `oxc_formatter_css` prints the space, the oracle's PostCSS path closes it up; the official compiler carries either spelling through verbatim and scopes both identically | none — candidate, not pinned for this facet |
-| 1 | a hex escape ending a selector: rsvelte emits the escape's terminating space and the separator before `{` as two spaces where the oracle emits one — the same file's 18 other selectors, including every hex escape followed by more text, agree; the official compiler's scoped CSS is byte-identical for the two spellings | none — candidate, not pinned for this facet |
-| 1 | continuation indent of a comma-separated multi-value declaration: rsvelte's engine prints every continuation at one depth where the oracle's PostCSS path keeps the source's uneven depth; the official compiler's scoped CSS is byte-identical for the two spellings | none — candidate, not pinned for this facet |
+| 1 | `oxc_formatter_css` rejects the `<style>` body, so `native_style_formatter` returns it verbatim and the source's own indentation survives — measured as 6 tab-bearing lines in rsvelte's output under `useTabs: false`, against 0 in the oracle's own output for the same file and 0 on both sides for three of the four sibling candidates (the fourth reads 1 on both sides, inside a declaration value); the oracle's PostCSS path accepts the same body and reformats it. Whitespace-only in `css.code` and byte-identical in `js.code` like its three siblings, but not pinned as deliberate: rsvelte's behaviour here is the fallback for input the engine rejects, not a formatting rule it implements | none — not a formatting choice, so `deliberate-divergences` does not apply |
+| 2 | the two engines disagree about whitespace around a selector token neither models — the column combinator and a `nth-child(… of <selector>)` clause: rsvelte's `oxc_formatter_css` prints the space, the oracle's PostCSS path closes it up; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace | `crates/rsvelte_formatter/tests/css_native.rs` — `a_column_combinator_keeps_its_spaces`, `an_nth_child_of_clause_keeps_the_space_after_of` |
+| 1 | a hex escape ending a selector: rsvelte emits the escape's terminating space and the separator before `{` as two spaces where the oracle emits one — the same file's 18 other selectors, including every hex escape followed by more text, agree; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace | `crates/rsvelte_formatter/tests/css_native.rs` — `a_hex_escape_ending_a_selector_keeps_its_own_separator` |
+| 1 | continuation indent of a comma-separated multi-value declaration: rsvelte's engine prints every continuation at one depth where the oracle's PostCSS path indents the ones following an interleaved comment one level deeper than the first; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace | `crates/rsvelte_formatter/tests/css_native.rs` — `every_continuation_of_a_multi_value_declaration_sits_at_one_depth` |
 | 515 | no upstream report and no pinned deliberate divergence; elimination is the only end state open to these entries | none |
 
 Partition of `fmt-known-failures.json` by mechanism: `1 + 2 + 1 + 1 + 515`
+
+Attribution of `fmt-known-failures.json`:
+
+| n | target | cluster |
+|---|---|---|
+| 4 | `deliberate-divergences` | the CSS engine rsvelte ships is `oxc_formatter_css` and the oracle's embedded-`<style>` path is prettier's PostCSS printer, so three facets of that choice are recorded rather than closed: whitespace around the column combinator and around `nth-child(… of …)` (2 entries), a hex escape's own terminating space before `{` (1), and the continuation depth of a comma-separated multi-value declaration (1). Pinned two-sidedly in `crates/rsvelte_formatter/tests/css_native.rs` — each test asserts rsvelte's spelling is produced **and** the oracle's is absent, so a build that stops printing the construct cannot pass |
+
+This table is **partial**, and its coverage is the sum of its own `n` column against the entry
+count declared above — `attribution-check` prints the two side by side, so neither is repeated
+here. Every entry it does not reach is unattributed rather than attributed to nothing.
+
+**`css-engine-rejects-block` is deliberately not in it, and separating the two questions is what
+that cost.** It satisfies the same output test as its three siblings — measured, `js.code`
+byte-identical and `css.code` whitespace-only — which is the question *does this change runtime
+meaning*. The other question is *is there code implementing the behaviour being chosen*, and
+there is not: rsvelte returns the block verbatim because `oxc_formatter_css` **rejected** it, so
+the behaviour is a fallback for unsupported input rather than a formatting rule. Writing
+`deliberate` for it would spell "we have not implemented this" as "we chose this", which is the
+one misclassification that stops anyone measuring it again. It stays listed.
+
+**One entry carries a shape its single label does not name.** The sidecar's own note says "the
+assignment is one-to-one, so a double count is unwritable" — true of the table's arithmetic, and
+not of the entries: `fmt-region-shapes.snapshot.json` records a **set** of shapes per entry for
+exactly this reason. `layerchart/docs/src/routes/+page.svelte` is labelled
+`css-engine-multi-value-indent` and also diverges on a comment line the oracle leaves
+**tab-indented** under `useTabs: false` while rsvelte reindents it. Both hunks reproduce from one
+minimal input (two comma-separated gradients with a comment between them), so they are one
+PostCSS behaviour seen twice rather than two independent defects — but the entry does not retire
+when the labelled facet is closed, and nothing in the one-to-one sidecar says so. The two files
+describe the same population and disagree about whether an entry has one mechanism or several.
 
 ### The `>`-boundary population — which stage first produces each hunk's final form
 

--- a/compatibility/fmt-mechanisms.json
+++ b/compatibility/fmt-mechanisms.json
@@ -2,20 +2,20 @@
 	"$schema-note": "id -> mechanism slug for every entry of fmt-known-failures.json. The `Entries by mechanism` table in KNOWN-FAILURES.md is derived from this file: one row per `mechanisms` key, `n` = how many `entries` name it, and `known-failures-md-check.mjs` compares the table to it. The assignment is one-to-one, so a double count is unwritable.",
 	"mechanisms": {
 		"css-engine-rejects-block": {
-			"description": "`oxc_formatter_css` rejects the `<style>` body, so `native_style_formatter` returns it verbatim and the source's own indentation survives — measured as 6 tab-bearing lines in rsvelte's output under `useTabs: false`, against 0 in the oracle's own output for the same file and 0 on both sides for three of the four sibling candidates (the fourth reads 1 on both sides, inside a declaration value); the oracle's PostCSS path accepts the same body and reformats it",
-			"pinned": "none — candidate, not pinned for this facet"
+			"description": "`oxc_formatter_css` rejects the `<style>` body, so `native_style_formatter` returns it verbatim and the source's own indentation survives — measured as 6 tab-bearing lines in rsvelte's output under `useTabs: false`, against 0 in the oracle's own output for the same file and 0 on both sides for three of the four sibling candidates (the fourth reads 1 on both sides, inside a declaration value); the oracle's PostCSS path accepts the same body and reformats it. Whitespace-only in `css.code` and byte-identical in `js.code` like its three siblings, but not pinned as deliberate: rsvelte's behaviour here is the fallback for input the engine rejects, not a formatting rule it implements",
+			"pinned": "none — not a formatting choice, so `deliberate-divergences` does not apply"
 		},
 		"css-engine-selector-token-spacing": {
-			"description": "the two engines disagree about whitespace around a selector token neither models — the column combinator and a `nth-child(… of <selector>)` clause: rsvelte's `oxc_formatter_css` prints the space, the oracle's PostCSS path closes it up; the official compiler carries either spelling through verbatim and scopes both identically",
-			"pinned": "none — candidate, not pinned for this facet"
+			"description": "the two engines disagree about whitespace around a selector token neither models — the column combinator and a `nth-child(… of <selector>)` clause: rsvelte's `oxc_formatter_css` prints the space, the oracle's PostCSS path closes it up; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace",
+			"pinned": "`crates/rsvelte_formatter/tests/css_native.rs` — `a_column_combinator_keeps_its_spaces`, `an_nth_child_of_clause_keeps_the_space_after_of`"
 		},
 		"css-engine-trailing-escape-space": {
-			"description": "a hex escape ending a selector: rsvelte emits the escape's terminating space and the separator before `{` as two spaces where the oracle emits one — the same file's 18 other selectors, including every hex escape followed by more text, agree; the official compiler's scoped CSS is byte-identical for the two spellings",
-			"pinned": "none — candidate, not pinned for this facet"
+			"description": "a hex escape ending a selector: rsvelte emits the escape's terminating space and the separator before `{` as two spaces where the oracle emits one — the same file's 18 other selectors, including every hex escape followed by more text, agree; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace",
+			"pinned": "`crates/rsvelte_formatter/tests/css_native.rs` — `a_hex_escape_ending_a_selector_keeps_its_own_separator`"
 		},
 		"css-engine-multi-value-indent": {
-			"description": "continuation indent of a comma-separated multi-value declaration: rsvelte's engine prints every continuation at one depth where the oracle's PostCSS path keeps the source's uneven depth; the official compiler's scoped CSS is byte-identical for the two spellings",
-			"pinned": "none — candidate, not pinned for this facet"
+			"description": "continuation indent of a comma-separated multi-value declaration: rsvelte's engine prints every continuation at one depth where the oracle's PostCSS path indents the ones following an interleaved comment one level deeper than the first; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace",
+			"pinned": "`crates/rsvelte_formatter/tests/css_native.rs` — `every_continuation_of_a_multi_value_declaration_sits_at_one_depth`"
 		},
 		"unattributed": {
 			"description": "no upstream report and no pinned deliberate divergence; elimination is the only end state open to these entries",

--- a/crates/rsvelte_formatter/tests/css_native.rs
+++ b/crates/rsvelte_formatter/tests/css_native.rs
@@ -101,3 +101,82 @@ fn a_nested_calc_group_stays_inline_like_the_oxc_engine() {
         "inner group was broken out:\n{out}"
     );
 }
+
+// ── Deliberate divergences from the `oxfmt(svelte: true)` oracle ─────────────
+// These four carry `fmt-known-failures.json` entries. Each asserts BOTH that
+// rsvelte's spelling is produced and that the oracle's is absent, so a build
+// that stops printing the construct entirely cannot pass.
+//
+// Measured, not asserted: the official compiler's `js.code` is byte-identical
+// for the two spellings and its `css.code` differs only in whitespace (the
+// non-whitespace characters are identical). `css.code` byte-identity is not
+// available for any CSS whitespace divergence — Svelte carries selectors and
+// declarations through scoping close to verbatim, so a moved space in `<style>`
+// always moves `css.code`.
+
+#[test]
+fn a_column_combinator_keeps_its_spaces() {
+    let out = fmt(".a||.b { color: red; }\n", CssDialect::Css);
+    assert!(
+        out.contains(".a || .b {"),
+        "column combinator respacing changed:\n{out}"
+    );
+    assert!(
+        !out.contains(".a||.b"),
+        "closed the combinator up like the oracle:\n{out}"
+    );
+}
+
+#[test]
+fn an_nth_child_of_clause_keeps_the_space_after_of() {
+    let out = fmt(
+        "li:nth-child(2n of.important) { color: red; }\n",
+        CssDialect::Css,
+    );
+    assert!(
+        out.contains("(2n of .important)"),
+        "`of` respacing changed:\n{out}"
+    );
+    assert!(
+        !out.contains("of.important"),
+        "closed `of` up like the oracle:\n{out}"
+    );
+}
+
+#[test]
+fn a_hex_escape_ending_a_selector_keeps_its_own_separator() {
+    // The first space terminates the escape; the second separates it from `{`.
+    // The oracle emits one, which is the terminator doing both jobs.
+    let out = fmt("#\\31\\32\\33 { color: red; }\n", CssDialect::Css);
+    assert!(
+        out.contains("#\\31\\32\\33  {"),
+        "escape separator changed:\n{out}"
+    );
+    assert!(
+        !out.contains("#\\31\\32\\33 {"),
+        "merged the two spaces like the oracle:\n{out}"
+    );
+}
+
+#[test]
+fn every_continuation_of_a_multi_value_declaration_sits_at_one_depth() {
+    // The oracle's PostCSS path indents the continuations that follow an
+    // interleaved comment one level deeper than the first, so its own output is
+    // uneven within one declaration.
+    let src = ".g {\n\tbackground-image:\n\t\t/* A */\n\t\trepeating-linear-gradient(to right, var(--a) 0, var(--a) 2px, transparent 2px, transparent var(--size)),\n\t\t/* B */\n\t\trepeating-linear-gradient(to right, var(--b) 0, var(--b) 0.5px, transparent 0.5px, transparent calc(var(--size) / 5));\n}\n";
+    let out = fmt(src, CssDialect::Css);
+    let depths: Vec<usize> = out
+        .lines()
+        .filter(|l| l.trim_start().starts_with("to right,"))
+        .map(|l| l.len() - l.trim_start().len())
+        .collect();
+    assert_eq!(
+        depths.len(),
+        2,
+        "both continuations must be present:\n{out}"
+    );
+    assert_eq!(
+        depths[0], depths[1],
+        "the two continuations sit at different depths:\n{out}"
+    );
+}


### PR DESCRIPTION
Four of the five `fmt-known-failures.json` CSS entries get a terminal
(`deliberate-divergences`), on a premise that had to be replaced first. Stacked on
#4306 — the base flips to `main` when that merges, and I will rebase from
`git rev-parse origin/main` afterwards rather than trusting the automatic base
relabel, which moves the label and not the branch.

## The premise the sidecar was carrying is one no CSS whitespace divergence can satisfy

Three of the four entries were justified with *"the official compiler's scoped CSS is
byte-identical for the two spellings"*. Measured against
`submodules/svelte/packages/svelte/src/compiler/index.js` (`VERSION=5.56.10`) on the
minimal construct and again on the five ratchet files, **`css.code` DIFFERS for every
one of them** — minimally and whole-file, with the scope hashes equal, so no
normalization rescues it.

That is stronger than "it was measured and came out wrong". Svelte carries selectors
and declarations through scoping close to verbatim, so a moved space inside `<style>`
always moves `css.code`: the sentence's falsity follows from the mechanism, which means
it cannot have been measured before it was written.

What survives, and what these rows now assert:

- `js.code` is **byte-identical** for the two spellings;
- `css.code` differs **only in whitespace** — the non-whitespace character sequences are
  identical, scope hash equal on both sides.

Two negative controls separate that from an instrument artifact (`color: red` against
`color: blue`, and `#\31\32\33` against `#\31\32\33\34`, both reporting non-whitespace
DIFFER). The replaced premise still meets the registry's criterion — valid CSS, and no
change to which elements match or which declarations apply.

## The four facets

| construct | `oxfmt(svelte: true)` | `rsvelte-fmt` | pin |
|---|---|---|---|
| column combinator | `.a\|\|.b {` | `.a \|\| .b {` | `a_column_combinator_keeps_its_spaces` |
| `nth-child(2n of …)` | `of.important)` | `of .important)` | `an_nth_child_of_clause_keeps_the_space_after_of` |
| hex escape ending a selector | `#\31\32\33 {` | `#\31\32\33  {` | `a_hex_escape_ending_a_selector_keeps_its_own_separator` |
| multi-value continuation depth | first at 8, the rest at 10 | every continuation at one depth | `every_continuation_of_a_multi_value_declaration_sits_at_one_depth` |

Each pin is **two-sided** — it asserts rsvelte's spelling is produced *and* the oracle's
is absent — so a build that stops printing the construct entirely cannot pass. Ablated
against the oracle's spellings all four fail (`depths [6, 8]` for the last).

`format_css_source` reproduces the three spacing facets exactly, which is what answers
the "point at the code that implements the behaviour being chosen" precondition; the
multi-value half additionally involves the embedding and the CLI options.

## The fifth entry is deliberately NOT here

`css-engine-rejects-block` passes the same output test (`js.code` identical, `css.code`
whitespace-only) and fails the other one: `oxc_formatter_css` **rejects** the `<style>`
body and `native_style_formatter` returns it verbatim. There is no code implementing a
chosen behaviour, only a fallback for input the engine could not parse. Recording it as
deliberate would spell an unimplemented case as a decision, so it stays listed and is
described there as a limitation.

## `render_neutral_divergences.rs` is untouched, and that is the point

Its doc comment states a condition new rows must satisfy. `FormatOptions::default()` has
`style_formatter: None` while the CLI / wasm / LSP install `native_style_formatter(...)`,
so a `<style>` in that file never reaches the native CSS engine — the file structurally
cannot observe this facet. The pins went where the facet is observable instead of
loosening the doc comment to admit them.

## Checks

| checker | result |
|---|---|
| `deliberate-divergences-check.mjs` | EXIT=0 — 25 recorded divergences, each pinned by an existing test |
| `known-failures-md-check.mjs` | 50 declared ratchets across 36 docs match their JSON; 34 cluster partitions add up |
| `attribution-check.mjs` | `fmt-known-failures.json: 4 of 520 entries attributed, 516 carry no target` — **the problem count is unchanged at 4**; fmt moves from "no `Attribution of` block" to a partial one, which is progress the DoD counter does not register |
| `cargo test -p rsvelte_formatter --test css_native` | 12 passed — the four new pins confirmed **by name**, not by the count |

Also records, in `KNOWN-FAILURES.md`, that `fmt-mechanisms.json` (one record per entry)
and `fmt-region-shapes.snapshot.json` (a set) disagree about label granularity, with
`layerchart/docs/src/routes/+page.svelte` as the worked example.
