### PR TITLE
docs(agents): five rows from one integration window — a stacked PR's silent close, and four instrument failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5306,6 +5306,94 @@ one line comment with a trailing attachment kills the instrument instantly, and 
 ablating the code finds it, because ablation moves the code and holds the cells. Where an
 instrument excludes by name, write the control that carries each *sibling* of the name.
 
+
+### A stacked PR is CLOSED by its parent's merge, and its stale checks still read green
+
+Merging a PR deletes its head branch, and GitHub **closes** every PR whose base was that
+branch — it does not conflict them, and it does not annotate them. Measured to the second:
+`#4306` merged at `14:07:09Z`; `#4308`, based on `#4306`'s branch, has `closedAt`
+`14:07:13Z`. Twenty minutes later its author reported it open and green from a check census
+reading `total=39 received=39 completed=11 bad=[]` — a correct measurement of check-runs that
+are still attached to a **closed** PR. Every check-shaped predicate passes: the count is
+plausible, nothing is failing, the head SHA matches the local branch. `state` is the only
+field that separates them, and a rollup census is exactly the instrument that does not read it.
+
+Recovery has an order, because `gh pr reopen` refuses while the base is missing: push the
+parent's pre-merge head back to the deleted branch name, `reopen`, `--base main`, then delete
+the branch again (the PR stays open once its base is `main` — verified). Two cautions from
+doing it. The parent's pre-merge head is on **no** local ref after a squash-merge, so read it
+from `gh pr view <parent> --json headRefOid` and `git fetch origin <sha>`. And brace the
+refspec: `"$sha:refs/heads/x"` in zsh applies the `:r` modifier to `$sha` and pushes to
+`…efs/heads/x`, inside double quotes too — the recorded `${MB}:AGENTS.md` hazard, reached
+from the push side by someone who had cited it that morning.
+
+So a settle predicate over a PR needs `state == "OPEN"` beside its denominator floor, and a
+stacked branch needs its base checked after every parent merge, not only when a check goes red.
+
+### Two arms answering `false` is two absences agreeing, not an identity
+
+An arm probe must discriminate, and the recorded failure is a probe whose answer predates the
+change. A quieter one: a probe that returns the **same negative** from both arms. `assign_present`
+read `false` on the base arm and `false` on the head arm, and was reported as "the two arms
+agree" — which is true of the two values and says nothing about the two binaries, because a
+probe that finds nothing in either is satisfied by any pair of arms, including two copies of one
+file and two unrelated trees.
+
+It has the same shape as a filter that discards on both sides reading as agreement, one level
+out: there the comparison drops the carrier symmetrically, here the probe never had one. The
+replacement was stronger and needed no binary at all — `git merge-base --is-ancestor` for each
+fix against each arm, plus the negative control that HEAD is **not** an ancestor of the merge
+base. **Where an arm's identity can be settled from its provenance, prefer that to a probe on
+its output**: provenance answers "which tree built this" directly, while a probe answers it only
+through whatever the probe happens to be able to see.
+
+### A control needle written from memory fails the control, and the needle is the fault
+
+The recorded rule is that a control's *name* is a claim nobody checks. Its needle is a second
+claim, and it fails loudly rather than silently — which is what makes it easy to misattribute.
+A corpus census used `$.template(` as its positive control and got **0**; the generated client
+output spells that call `$.from_html(`. The instrument was correct throughout and the reading
+that presented itself was "the instrument is broken".
+
+This is the mirror of the usual advice. When a positive control fails, the standing habit is to
+suspect the instrument — and here suspecting the instrument produces a rewrite of working code,
+while the one-line fix is to take the needle **from the oracle's actual output** rather than from
+memory of the API. The person who hit it also declined to report the numbers from the run whose
+control had failed, which is the other half: those numbers are a measurement taken while
+something known-broken was in the pipeline, whichever component it turned out to be.
+
+### The strongest carrier is the one most likely to belong to a different mechanism
+
+A mechanism was established by reading code (`fits` reads a build-time first line and has no
+`ind` parameter, so it *cannot* rebuild), and a 33,911-file run measured its input error: 19 of
+1,310 eligible sites, all one direction, 10–64 columns of over-charge. The carrier chosen to
+demonstrate an output consequence was the largest and clearest — and reading it settled that the
+printer had rebuilt correctly and the divergence came from **the rebuild's own budget**
+disagreeing with the oracle. A third quantity, in the same branch of the same function.
+
+The reason to expect this rather than be surprised by it: a carrier is selected for the *size* of
+its divergence, and the mechanism you are studying is one of several that can produce a large one.
+So the selection is biased toward whichever mechanism in that region is loudest, which is not
+necessarily yours. The discipline that survived it is stating the three quantities separately —
+mechanism confirmed, input error measured, **output consequence UNMEASURED** — instead of letting
+the confirmed half license the unmeasured one. A change to `fits` made on that evidence would have
+left the demonstrating carrier untouched.
+
+### A sweep that stores hashes cannot be grepped for code, and the ids answer instead
+
+Asked for the denominator behind a `0`, the prescription given was "grep the stage-1 output" —
+wrong, because stage 1 stores `id` plus a 32-hex digest per unit and no generated text at all.
+Run anyway, `grep -c 'assign' s1.ndjson` returns **124**, every hit a *path*
+(`bits-ui/…/icons/assign-to-me.svelte`). Reported as the denominator, `n=124` is the right shape,
+the right order of magnitude, and about filenames. A fixed-string re-grep returns `0` and the
+positive control (`'"id"'` → 34,828) says the file is readable.
+
+Two things generalize. **A zero is suspected and a plausible number is not** — the recorded
+`grep` hazards mostly produce an empty result, and this one produces a figure that would have
+been published. And the fix is not a better pattern: it is a **second pass** over the population
+with the quantity you actually want, which here cost a quarter of one sweep arm and turned the
+`0` into a real absence (`n=64` carriers, none moved) instead of an uninterpretable one.
+
 ### Working with Subagents
 
 Use the `Agent` tool for substantial work — feature implementation, multi-file refactors, broad code exploration, or anything likely to consume meaningful context.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2962,7 +2962,11 @@ absolute-path modifier, so the argument becomes `<abspath>GENTS.md`, git fails t
 and `wc -l` on the empty stdout reports `0` for every tree. Brace the expansion
 (`"${r}:AGENTS.md"`) — quoting alone does **not** help, because the modifier binds to the bare
 parameter name inside double quotes too. The failure was visible only because nothing discarded
-stderr. The command block above was itself written with `$MB:AGENTS.md` unbraced, four
+stderr. **And the hazard is the modifier SET, not `:A`** — `$sha:refs/heads/x` loses `:r`
+(root) and pushes to `…efs/heads/x`, `$B:scripts/…/mechanism.mjs` loses `:s` (substitute) and
+reads `…suiteshanism.mjs`. Three of them were hit here in one day, on a push refspec, a
+`git show` and a `git diff`, by three people who between them had cited this paragraph. Memorise
+the brace, not the letter. The command block above was itself written with `$MB:AGENTS.md` unbraced, four
 paragraphs above the note describing that exact hazard, and returned an empty set with three
 `fatal:` lines on stderr that a `0 collisions` label was printed over. What caught it was the
 injection control returning `0` where it must return `1` — the result and the broken control
@@ -4010,6 +4014,15 @@ Three quantities, and each was read as the next one by someone: **142** labels d
 (a different job). Before reducing a set-valued key to "which members matter", read the
 consuming predicate for its quantifier — `some` and `every` gave covers differing by 2.3x
 here, and the cheaper one is what you compute by reflex.
+
+**Read the `142` as a reading, not as a fact about the tree.** It is the number of keys in
+`lsp-mechanisms.json`'s `mechanisms`, and that file is primary while every count of it here is
+derived — measured again at `d168231700` it is **141**, with 72 labels carried by an entry of
+which 71 are moved by a terminal (`unclassified` is the one that is not). So of the four
+quantities in the table below, three were re-derived and still hold and one had drifted by one;
+which is which is not visible from the prose, only from the JSON. That figure is spelled twice
+in this section — once in the sentence above and once in the table — and **neither spelling is
+gated**, which is the next row's subject.
 
 ### Before suspecting a function is missing a case, count the population where it is CALLED
 
@@ -5393,6 +5406,88 @@ Two things generalize. **A zero is suspected and a plausible number is not** —
 been published. And the fix is not a better pattern: it is a **second pass** over the population
 with the quantity you actually want, which here cost a quarter of one sweep arm and turned the
 `0` into a real absence (`n=64` carriers, none moved) instead of an uninterpretable one.
+
+### The same number spelled twice, and only one spelling is gated
+
+The recorded case of a gated half and an ungated half is two *sentences* — a JSON the checker
+reads and prose it does not — drifting apart. Measured on `parse-ast`'s section by injecting one
+edit at a time and reading the checker's verdict, the split runs through **one number**:
+
+| the figure | injected | verdict |
+|---|---|---|
+| `currently **211 entries**` | 212 | **GATED** — names the file, the declared value and the JSON's |
+| partition line `62 + 44 + … + 1` | one term +1 | **GATED** — sum 212 against a population of 211 |
+| the cluster table's `keys` column, `\| span \| 62 \|` | 63 | **UNGATED** |
+| the same table's `bases` column, `33` | 99 | **UNGATED** |
+| prose `**118 distinct bases**` | 119 | **UNGATED** |
+| prose `a 1.79x collapse` | 9.99x | **UNGATED** |
+
+The `keys` column and the partition line are the *same quantity in two spellings*, adjacent on
+the page, and exactly one of them is defended. So "read the gated half" is not a rule you can
+apply by looking: which spelling the checker consumes is invisible in the text, and here the
+ungated one is the one laid out as a table, which reads as more authoritative.
+
+What follows is a working rule rather than a warning. When a section's numbers are revised,
+**recompute every one of them from the artifact instead of subtracting from the old prose** — the
+run that produced this table also corrected `child-count 1.33x → 1.20x` and `0 of 97 → 0 of 93`,
+neither of which is reachable by arithmetic on the numbers that were there.
+
+### Move a constant, then grep its value — the ports are a concept and the value is a string
+
+A wire format's version had two homes anyone would name — the Rust writer
+(`napi_raw_parse.rs`) and the JS reader (`parse-envelope.js`) — and a **third** that only a grep
+finds: `scripts/dev/test-parse-envelope-validation.mjs`, which hand-assembles an envelope and
+carries the number so that forgetting it makes *that test alone* fail. The person who found it
+was not looking for a third port; they had just changed a constant and mechanically searched for
+its value.
+
+That is the transferable form. This file says repeatedly that one upstream rule has two or more
+ports here, and every instance was found by counting *sites*, which needs someone to already
+suspect the count. A constant is a **string**, so "I moved this value, where else does it live"
+is a search rather than an inventory.
+
+It also has a half the search cannot reach, and the same file demonstrates it. That third copy
+hand-writes not only the version but a **record layout**, and the layout it happens to spell is
+`JS_IDENTIFIER` while the change was to `RestElement` — so it did not need updating this time.
+Had it needed it, the grep for the version number would have found the file and told you nothing
+about the layout inside it. A value-grep closes the copies of the value; the copies of the
+*shape* are still an inventory.
+
+### An old arm can fail for a reason that is not the arm
+
+Staging a previous binary as the negative control for a new cell, it refused before reaching the
+cell: `EnvelopeError: parse envelope: unsupported version 9 (expected 10)`. A control that fails
+for a second reason is not a control — it cannot distinguish "this build lacks the fix" from
+"this build cannot be spoken to at all". The recorded rule that a control must traverse the stage
+the measurement dies on is the same statement pointed at arms rather than at commands.
+
+The instance is kept for its other half: the broken control was *informative anyway*, because the
+version mismatch is what revealed that the change under test needed a version bump of its own —
+a record had grown a field, so the layout had moved. A control that fails cleanly, with a message
+naming the incompatibility, is a measurement of something; it is just not a measurement of what
+you asked.
+
+
+### A branch checkout is a silent parameter of every edit that follows it
+
+Five rows were committed to `docs/agents-md-batch-18`, then `git checkout main` was run for an
+unrelated census, and the next three edits — a `python3` heredoc asserting single occurrences, a
+patch that named its anchor, a heading count — all landed on **`main`**. Every one succeeded.
+The assertions passed because the anchors really were unique; the file really did grow; the
+`git diff --numstat` shape was exactly right.
+
+What caught it was arithmetic on a **shape**, not a verdict: the heading count read `192` where
+`189 + 5 + 3 = 197` was expected. A count that must equal a computed value is a different
+instrument from a count that must merely be plausible — `192` is a perfectly plausible number for
+this file, and only the prediction made it wrong.
+
+The recorded sibling is an agent's shell cwd resetting to the main checkout so `cargo` compiles
+someone else's tree. This is the same fact with `git checkout` as the mover and no build to leave
+a `Compiling <crate> (<path>)` line behind: **nothing in an edit's output names the branch it
+landed on.** The recovery is cheap once you know (`git diff > patch`, `git checkout -- .`, switch,
+`git apply --3way`), and the resulting add/add conflict is the good case — two versions of the
+same insertion point, both wanted, resolved by keeping both. Prefix a branch-sensitive edit with
+`git branch --show-current`, or predict a number the edit must produce and check it.
 
 ### Working with Subagents
 


### PR DESCRIPTION
Five rows, all from one integration window on 2026-09-04/05, all measured. Each was found by a mechanism other than the one it warns about, which is the property that made them worth writing down.

## 1. A stacked PR is CLOSED by its parent's merge, and its stale checks still read green

Merging `#4306` at `14:07:09Z` deleted its head branch; `#4308`, based on that branch, has `closedAt` `14:07:13Z`. Four seconds. GitHub does not conflict such a PR and does not annotate it — it closes it.

Twenty minutes later its author reported it open and green from `total=39 received=39 completed=11 bad=[]`. That is a **correct** measurement of check-runs still attached to a closed PR. Every check-shaped predicate passes; `state` is the only field that separates them, and a rollup census does not read it.

Recovery has an order, because `gh pr reopen` refuses while the base is missing — the row gives it, including that the parent's pre-merge head sits on no local ref after a squash-merge, and that the refspec needs braces (`"${sha}:refs/heads/x"`; zsh applies `:r` inside double quotes too — the recorded `${MB}:AGENTS.md` hazard reached from the push side, by someone who had cited it that morning).

## 2. Two arms answering `false` is two absences agreeing, not an identity

`assign_present` read `false` on both arms and was reported as "the two arms agree". True of the two values, and satisfied by any pair of arms including two copies of one file. Same shape as a filter that discards on both sides reading as agreement, one level out. The replacement needed no binary: `git merge-base --is-ancestor` per fix per arm, with the negative control that HEAD is not an ancestor of the merge base.

## 3. A control needle written from memory fails the control, and the needle is the fault

A corpus census used `$.template(` as its positive control and got 0; the generated client output spells it `$.from_html(`. When a positive control fails the standing habit is to suspect the instrument — and here that produces a rewrite of working code. The other half: the person declined to report the numbers from the run whose control had failed.

## 4. The strongest carrier is the one most likely to belong to a different mechanism

A mechanism was established by reading code and its input error measured at 19 of 1,310 sites, one direction, 10–64 columns. The carrier chosen to demonstrate an output consequence turned out to be a **third** quantity in the same branch of the same function. A carrier is selected for the *size* of its divergence, so the selection is biased toward whichever mechanism in that region is loudest.

## 5. A sweep that stores hashes cannot be grepped for code, and the ids answer instead

The prescription "grep the stage-1 output" was mine and was wrong: stage 1 stores `id` plus a digest. Run anyway, `grep -c 'assign'` returns **124**, every hit a *path*. Reported as a denominator, `n=124` is the right shape and about filenames. **A zero is suspected and a plausible number is not.** The fix is a second pass over the population, which cost a quarter of one sweep arm and turned the `0` into a real absence (`n=64` carriers, none moved).

## Credit

Rows 2, 3 and 5 come from rsvelte-98's measurements; row 4 from rsvelte-72's. Row 1 is mine, found while recovering #4308.

## Verification

- `git diff --numstat` reports `88 0` — insertions only, the shape that would have caught the `$'` expansion that doubled this file in a previous batch.
- Headings 189 → 194; collision check against `origin/main` returns 0, with an injection control that returns 1 when a known-present heading is added to the candidate set.
- `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` pass (pre-commit hook, 17 crates).