### PR TITLE
fix(vscode): the Marketplace rejected the display name, not the id

### DIFF
--- a/.changeset/vscode-display-name.md
+++ b/.changeset/vscode-display-name.md
@@ -1,0 +1,18 @@
+---
+'rsvelte': patch
+---
+
+The Marketplace rejected `baseballyama.rsvelte` for its **display name**, not its id.
+
+Measured on the 0.7.0 publish: `marketplace version: (none) → publish: true`, vsce
+packaged and uploaded, and the rejection was `This extension display name is taken.`
+Open VSX accepted the same artifact for all six targets. So the id freed by the
+previous rename is fine and `displayName: "rsvelte"` is the collision.
+
+`displayName` is now `rsvelte Language Tools`. The extension id, the publisher and
+every documented setting value (`baseballyama.rsvelte`) are unchanged.
+
+The failure handler in `scripts/release/publish-vscode.mjs` asserted the other cause
+— it inferred "the name is reserved" from an empty gallery query without reading
+vsce's message, which is written to the job log rather than to the error object. It
+now enumerates both causes and points at the line above it.

--- a/apps/npm/vscode/package.json
+++ b/apps/npm/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsvelte",
-  "displayName": "rsvelte",
+  "displayName": "rsvelte Language Tools",
   "version": "0.7.0",
   "private": true,
   "description": "Rust-powered Svelte language support with formatting, linting and TypeScript 7 features",

--- a/scripts/release/publish-vscode.mjs
+++ b/scripts/release/publish-vscode.mjs
@@ -231,17 +231,22 @@ if (needMp) {
         { cwd: extDir, stdio: 'inherit' },
       );
     } catch (error) {
-      // The gallery query above found NO live version, yet the Marketplace
-      // rejects the name as taken: the two only agree if the extension is
-      // unlisted (removed / unpublished) while its name stays reserved. No
-      // amount of retrying moves that, so say what has to happen instead.
+      // vsce writes its reason to this job's log (stdio is inherited), not to
+      // `error`, so this branch cannot read it — enumerate the causes instead of
+      // asserting one. Measured 2026-09-04: with `mp.latest === null` the real
+      // reason was `displayName`, and the earlier wording named `name`.
       if (mp && mp.latest === null) {
         console.error(
-          `\nThe Marketplace gallery reports NO live version of ${id}, but the\n` +
-            'publish was rejected. That pair means the extension is unlisted while its\n' +
-            'name is still reserved — a publisher-account state, not a build problem.\n' +
-            `Check https://marketplace.visualstudio.com/manage/publishers/${extPkg.publisher}\n` +
-            'and either restore the extension or rename it in apps/npm/vscode/package.json.',
+          `\nThe Marketplace gallery reports NO live version of ${id}, yet the publish\n` +
+            'was rejected. vsce printed the reason directly above this line; it is one of:\n' +
+            `  "extension display name is taken"  -> \`displayName\` collides with another\n` +
+            '     publisher. Change `displayName` in apps/npm/vscode/package.json. The\n' +
+            '     extension id is not the problem.\n' +
+            `  "extension name is taken" / 403     -> \`${id}\` is unlisted while its name\n` +
+            '     stays reserved on this account. Restore it at\n' +
+            `     https://marketplace.visualstudio.com/manage/publishers/${extPkg.publisher}\n` +
+            '     or change `name` in apps/npm/vscode/package.json.\n' +
+            'Neither is a build problem and neither is fixed by retrying.',
         );
       }
       marketplaceError = error;


### PR DESCRIPTION
## 測定

`d4c79bb04` の `Publish VS Code Extension`（run 33888597354）が、リネーム後の id で初めて publish まで到達しました。

```
extension:            baseballyama.rsvelte
target version:       0.7.0 (follows @rsvelte/language-server)
marketplace version:  (none)  → publish: true
  missing:            universal, darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-x64
open vsx version:     0.6.0  → publish: true

Packaged: rsvelte-0.7.0-win32-x64.vsix (26 files, 15.73 MB)
Publishing 'baseballyama.rsvelte v0.7.0'...
##[error]This extension display name is taken. Please try a different one.
```

**id は空いていました。** 決定は `publish: true` を出し、vsce はパッケージングとアップロードまで進み、拒否されたのは `displayName` です。同じアーティファクトを Open VSX は 6 ターゲットすべて受け付けました：

```
🚀 Published baseballyama.rsvelte v0.7.0            ✓ universal
🚀 Published baseballyama.rsvelte v0.7.0@darwin-arm64  ✓
🚀 Published baseballyama.rsvelte v0.7.0@darwin-x64    ✓
🚀 Published baseballyama.rsvelte v0.7.0@linux-arm64   ✓
🚀 Published baseballyama.rsvelte v0.7.0@linux-x64     ✓
🚀 Published baseballyama.rsvelte v0.7.0@win32-x64     ✓
```

（`❌ Namespace already exists: baseballyama` は ovsx の通常出力で、その直後に 6 件すべてが成功しています。ジョブが赤いのは vsce の側だけです。）

## 変更

1. `displayName`: `"rsvelte"` → `"rsvelte Language Tools"`。**id・publisher・設定値は不変**です（`"editor.defaultFormatter": "baseballyama.rsvelte"` はそのまま）。
2. `scripts/release/publish-vscode.mjs` の失敗ハンドラ。

## 2 番目のほうが重要です — ハンドラは読んでいない原因を断定していました

旧コードはこう書いていました：

```js
// The gallery query above found NO live version, yet the Marketplace
// rejects the name as taken: the two only agree if the extension is
// unlisted (removed / unpublished) while its name stays reserved.
if (mp && mp.latest === null) { … 'name is still reserved' … }
```

推論自体はもっともらしく、**そして実測では原因は `displayName` でした**。ハンドラは `error` から理由を読んでいません — 読めません。`stdio: 'inherit'` なので vsce のメッセージはジョブのログに行き、`error.stderr` は `null` です（今回のログにも `stderr: null` が出ています）。

つまり **「gallery が空 + 拒否された」という 2 つの観測から、3 つ目の観測（実際のメッセージ）を読まずに機構を 1 つ選んでいた**。もっともらしい機構は原因ではない、の実例です。しかもその断定は「publisher アカウントの状態なので、まず Marketplace の管理画面を見ろ」と指示していて、**実際に必要な作業（`displayName` を変える）から遠ざけます**。

新しいハンドラは 2 つの原因を列挙し、「vsce がすぐ上の行に理由を出している」と指す形にしました。読めない情報について断定しない、という以上のことはこの分岐からはできません。

## 検証

- `node --check scripts/release/publish-vscode.mjs` — 通過
- `node scripts/release/test-publish-vscode-decision.mjs` — 11 ケース全通過（判定ロジックは未変更）
- `node scripts/release/check-core-consumer-changesets.mjs` — EXIT 0

## この PR が閉じないもの

**`rsvelte Language Tools` が空いている保証はありません。** 分かるのは publish を試みた瞬間だけで、gallery query は「空き」と「予約済み」を区別できません（実測済み：予約済みだった旧 id も、実際は空いていた新 id も、ともに 0 件を返しました）。この PR は**次の 1 回の試行**を用意するだけです。

`P0` の観点では、`Publish VS Code Extension` は現在 `main` で FAILURE です。この PR が入り、次のリリースで publish が通れば緑になります。通らなければ、そのときのエラーメッセージが次の `displayName` を決めます。