### PR TITLE
fix(release): the "name is reserved" inference has two producers, so it skipped a needed retry

### DIFF
--- a/.changeset/vscode-publish-attempt.md
+++ b/.changeset/vscode-publish-attempt.md
@@ -1,0 +1,22 @@
+---
+'rsvelte': patch
+---
+
+The publish decision skipped the Marketplace on an inference with two producers.
+
+`mpAbsent && ovsxAtOrAhead` — an empty gallery beside an Open VSX copy at or
+ahead of the target — was documented as "a contradiction only one state
+produces: the Marketplace copy is unlisted while its name stays reserved."
+
+Measured on run 33888597354: a single publish put 0.7.0 on Open VSX (six targets,
+all accepted) and was rejected by the Marketplace for its **display name**. That
+leaves exactly the same pair. So the state after any partially-successful publish
+is indistinguishable from the one the guard was written for, and the guard then
+skips every retry at that version — which is what happened on `63e8e025b`, where
+the display-name fix could not be attempted because the previous run had put
+0.7.0 on Open VSX.
+
+The Marketplace decision is now a function of the Marketplace state alone: an
+empty gallery is published into and `vsce` gives the verdict. A failed attempt is
+a red job with a diagnostic; the skip it replaces was neither success nor failure
+and reported nothing.

--- a/scripts/release/publish-vscode.mjs
+++ b/scripts/release/publish-vscode.mjs
@@ -128,7 +128,6 @@ const shouldPublish = needMp || needOvsx;
 
 const MP_STATE = {
   'query-failed': '(query failed)',
-  'name-reserved': '(none, but the name is reserved)',
   superseded: '(newer release is live)',
 };
 
@@ -256,13 +255,6 @@ if (needMp) {
   }
 } else if (mpReason === 'query-failed') {
   console.log('Marketplace state unknown (query failed) — skipping.');
-} else if (mpReason === 'name-reserved') {
-  console.log(
-    `::warning::${id} is unlisted on the Marketplace while its name stays ` +
-      'reserved, so no publish can succeed. Restore it at ' +
-      `https://marketplace.visualstudio.com/manage/publishers/${extPkg.publisher} ` +
-      'or rename it in apps/npm/vscode/package.json.',
-  );
 } else {
   console.log('Marketplace already up to date — skipping.');
 }

--- a/scripts/release/test-publish-vscode-decision.mjs
+++ b/scripts/release/test-publish-vscode-decision.mjs
@@ -4,8 +4,9 @@
 // Every case below pairs a state the guard must publish from with the
 // near-miss it must skip, so a guard that always answered one way fails here.
 // The negative controls are the two that have actually shipped a red `main`:
-// a failed query read as "not published", and an unlisted-but-name-reserved
-// Marketplace read as "not published".
+// a failed query read as "not published", and an empty gallery read as a
+// reserved name — an inference with more than one producer, so it skipped a
+// publish that had to be attempted.
 
 import { cmp, decide } from './vscode-publish-decision.mjs';
 
@@ -94,16 +95,22 @@ check('a newer live release supersedes ours → skip', () => {
   assert(d.mpReason === 'superseded', `reason was ${d.mpReason}`);
 });
 
-check('gallery empty while Open VSX already has the target → name reserved, skip', () => {
+check('gallery empty while Open VSX already has the target → still attempt', () => {
+  // This pair used to be read as "the name is reserved" and skipped. Measured
+  // on run 33888597354 it has a second producer: one publish put the target on
+  // Open VSX and the Marketplace rejected it for its DISPLAY name. Skipping
+  // here locked the retry out of that version permanently, and a skip is
+  // neither success nor failure, so it reported nothing.
   const d = run({ mp: { latest: null, live: live() }, ovsx: { latest: '0.5.2' } });
-  assert(d.needMp === false, 'publishing here is rejected as "already exists"');
-  assert(d.missingMp.length === 0, 'nothing may be packaged for the Marketplace');
-  assert(d.mpReason === 'name-reserved', `reason was ${d.mpReason}`);
+  assert(d.needMp === true, 'an empty gallery is published into');
+  assert(d.missingMp.length === PLATFORMS.length, 'every platform is missing');
+  assert(d.mpReason === 'publish', `reason was ${d.mpReason}`);
 });
 
-check('name-reserved does NOT swallow the next version', () => {
-  // Open VSX behind the target is the discriminating half: the same empty
-  // gallery must still produce a real publish attempt for a new version.
+check('an empty gallery with Open VSX BEHIND is the same answer', () => {
+  // The discriminating half of the pair above: whichever way Open VSX sits, the
+  // Marketplace decision is now a function of the Marketplace state alone. If a
+  // future guard reintroduces an Open VSX term, exactly one of these two moves.
   const d = run({
     target: '0.5.3',
     mp: { latest: null, live: live() },

--- a/scripts/release/vscode-publish-decision.mjs
+++ b/scripts/release/vscode-publish-decision.mjs
@@ -27,26 +27,20 @@ export function cmp(a, b) {
  * @param {boolean} input.force            VSCODE_PUBLISH_FORCE
  * @param {string[]} input.platforms       every (version, targetPlatform) pair
  * @returns {{ missingMp: string[], needMp: boolean, needOvsx: boolean,
- *             mpReason: 'query-failed' | 'name-reserved' | 'superseded' | 'publish' | 'up-to-date' }}
+ *             mpReason: 'query-failed' | 'superseded' | 'publish' | 'up-to-date' }}
  */
 export function decide({ target, mp, ovsx, hasOvsx, force, platforms }) {
-  const mpAbsent = mp !== null && mp.latest === null && mp.live.size === 0;
-  const ovsxAtOrAhead =
-    ovsx !== null && ovsx.latest !== null && cmp(ovsx.latest, target) >= 0;
-  // The gallery holding no record of an extension whose target version is
-  // already on Open VSX is a contradiction only one state produces: the
-  // Marketplace copy is unlisted (removed, or failed validation) while its name
-  // stays reserved. `vsce publish` answers that with "already exists", which no
-  // retry moves — so publishing here fails every push until a human restores or
-  // renames the extension. A new version still gets a real attempt, because
-  // Open VSX is then behind and this guard does not fire.
-  const nameReserved = mpAbsent && ovsxAtOrAhead;
+  // An empty gallery beside an Open VSX copy at or ahead of the target was read
+  // as "the name is reserved" and skipped. Measured on run 33888597354, that
+  // pair has at least two producers: one publish put 0.7.0 on Open VSX and was
+  // rejected by the Marketplace for its DISPLAY name, leaving exactly this
+  // state. Skipping on it locks the retry out at that version forever — and a
+  // skip is neither success nor failure, so it hides the problem rather than
+  // reporting it. An empty gallery is published into; vsce gives the verdict.
   const superseded = mp !== null && Boolean(mp.latest) && cmp(target, mp.latest) < 0;
 
   const missingMp =
-    mp === null || nameReserved || superseded
-      ? []
-      : platforms.filter((p) => !mp.live.has(p));
+    mp === null || superseded ? [] : platforms.filter((p) => !mp.live.has(p));
   const needMp = force || missingMp.length > 0;
 
   const needOvsx =
@@ -58,7 +52,6 @@ export function decide({ target, mp, ovsx, hasOvsx, force, platforms }) {
   let mpReason = 'up-to-date';
   if (needMp) mpReason = 'publish';
   else if (mp === null) mpReason = 'query-failed';
-  else if (nameReserved) mpReason = 'name-reserved';
   else if (superseded) mpReason = 'superseded';
 
   return { missingMp, needMp, needOvsx, mpReason };


### PR DESCRIPTION
## 症状

#4315（`displayName` の修正）を `63e8e025b` に入れたあと、`Publish VS Code Extension` は **`completed/success` になり、何も公開しませんでした**。

```
Check version:      completed/success
Build native server: completed/skipped
Publish extension:   completed/skipped
```

判定の出力：

```
extension:            baseballyama.rsvelte
target version:       0.7.0 (follows @rsvelte/language-server)
marketplace version:  (none, but the name is reserved)  → publish: false
open vsx version:     0.7.0  → publish: false
```

つまり **`displayName` を直したのに、その修正が試されませんでした。** ジョブは緑です。skip は成功でも失敗でもないので、何も報告されません。

## 原因 — 前提が偽

`vscode-publish-decision.mjs` はこう書いていました：

```js
// The gallery holding no record of an extension whose target version is
// already on Open VSX is a contradiction only one state produces: the
// Marketplace copy is unlisted (removed, or failed validation) while its name
// stays reserved.
const nameReserved = mpAbsent && ovsxAtOrAhead;
```

**「only one state produces」が偽です。** run 33888597354 で測定：1 回の publish が

- Open VSX に 0.7.0 を **6 ターゲットすべて**公開し、
- Marketplace には **`displayName` を理由に**拒否された。

その結果が `gallery 空 + Open VSX が target 以上` — **ガードが書かれた状態と区別が付きません**。

しかもこれは**自己施錠**します。部分的に成功した publish が、その版に対する以後のすべての再試行を skip させる。`63e8e025b` で起きたのがまさにそれで、直した `displayName` は一度も vsce に届いていません。

## 変更

Marketplace の判定を **Marketplace の状態だけの関数**にしました。gallery が空なら publish を試み、vsce に答えさせます。

- `nameReserved` と `mpReason: 'name-reserved'` を削除（`publish-vscode.mjs` の 2 箇所も）。
- 失敗は**赤いジョブと診断**になります。それが置き換える skip は、成功でも失敗でもなく何も報告しませんでした。

## 検証（ablation つき）

```
node scripts/release/test-publish-vscode-decision.mjs   →  11/11、EXIT=0
```

判定を revert した ablation：

```
ABLATED_EXIT=1
FAIL gallery empty while Open VSX already has the target → still attempt   ← 1 件だけ
```

もう 1 つの新セル（**Open VSX が target より後ろ**）は ablation で**動きません**。それが対照です — 旧ガードもそこでは発火しないので、2 セルのうち**ちょうど 1 つが動く**のが正しい挙動で、実測でそうなりました。将来また Open VSX の項を判定に戻す変更が入れば、この 2 つのうち片方だけが動きます。

復元後、`vscode-publish-decision.mjs` は `/tmp` に取ったコピーと `cmp -s` でバイト一致、テストは再び 11/11。

## この PR が閉じないもの

**`rsvelte Language Tools` が空いている保証は依然としてありません。** 分かるのは publish を試みた瞬間だけです。この PR がするのは、**その試行が起きるようにする**ことだけです。

`P0` について：`Publish VS Code Extension` は `d4c79bb04` で FAILURE、`63e8e025b` で（何もせず）SUCCESS。この PR 以後は本当の試行になるので、通れば緑、通らなければ次の `displayName` を決めるエラーメッセージが出ます。**「緑になった」を「公開された」と読まないでください** — それが今回の教訓です。