### PR TITLE
ci: a concurrency group is keyed by the EVENT too, or the nightly cancels the merge

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,7 +37,7 @@ concurrency:
   # never produced a verdict. The cost is one run per merge instead of one per
   # burst; a branch with no verdict reads exactly like a green one, which is
   # how a stale ratchet reached `main` unnoticed (#2435/#2593).
-  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}
   # CodSpeed compares a PR against `main`'s run for the merge base, so a `main`
   # branch with no run makes it fall back to an older commit and report every
   # PR as a large regression.

--- a/.github/workflows/capi.yml
+++ b/.github/workflows/capi.yml
@@ -40,7 +40,7 @@ concurrency:
   # `github.sha`, not `github.ref`: every push to `main` shares one ref, so a
   # ref-keyed group cancels each merge's run as the next merge starts and `main`
   # carries no verdict — which reads exactly like a green one (#2435/#2593).
-  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -16,7 +16,7 @@ concurrency:
   # never produced a verdict. The cost is one run per merge instead of one per
   # burst; a branch with no verdict reads exactly like a green one, which is
   # how a stale ratchet reached `main` unnoticed (#2435/#2593).
-  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -75,15 +75,24 @@ on:
       - '.github/actions/**'
 
 concurrency:
-  # Keyed by the head branch on a PR (a new push supersedes the old run) and by
-  # the commit otherwise, so a push to `main` shares a group with nothing and
-  # cannot be cancelled. The previous guard — `cancel-in-progress:
-  # ${{ github.ref != 'refs/heads/main' }}` — did not hold: every `main` run
-  # under it was still cancelled the instant the next merge started, so `main`
-  # never produced a verdict. The cost is one run per merge instead of one per
-  # burst; a branch with no verdict reads exactly like a green one, which is
-  # how a stale ratchet reached `main` unnoticed (#2435/#2593).
-  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  # Keyed by the event, the head branch on a PR (a new push supersedes the old
+  # run) and the commit otherwise. Two runs should supersede each other only
+  # when they answer the same question about the same target, and the event is
+  # part of that: without it a `schedule` and a `push` on `main` both resolve
+  # `github.head_ref || github.sha` to the same commit and land in one group.
+  # Measured 2026-09-04 — the nightly firing at 20:33:28Z killed the merge's own
+  # run at 20:33:47Z with 11 of its 12 jobs already green and `Compiler parity`
+  # 17 minutes in. The comment this replaces asserted that a push to `main`
+  # "shares a group with nothing and cannot be cancelled"; that was the claim,
+  # not the behaviour.
+  #
+  # The earlier guard — `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`
+  # — did not hold either: every `main` run under it was still cancelled the
+  # instant the next merge started, so `main` never produced a verdict. The cost
+  # is one run per event instead of one per burst; a run with no verdict reads
+  # exactly like a green one, which is how a stale ratchet reached `main`
+  # unnoticed (#2435/#2593).
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ concurrency:
   # never produced a verdict. The cost is one run per merge instead of one per
   # burst; a branch with no verdict reads exactly like a green one, which is
   # how a stale ratchet reached `main` unnoticed (#2435/#2593).
-  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}
   # Without this the coverage trend line records only whichever merge was last.
   cancel-in-progress: true
 

--- a/.github/workflows/crates-io-packages.yml
+++ b/.github/workflows/crates-io-packages.yml
@@ -49,7 +49,7 @@ concurrency:
   # `github.sha`, not `github.ref`: every push to `main` shares one ref, so a
   # ref-keyed group cancels each merge's run as the next merge starts and `main`
   # carries no verdict — which reads exactly like a green one (#2435/#2593).
-  group: crates-io-packages-${{ github.head_ref || github.sha }}
+  group: crates-io-packages-${{ github.event_name }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/type-aware-lint.yml
+++ b/.github/workflows/type-aware-lint.yml
@@ -43,7 +43,7 @@ concurrency:
   # `github.sha`, not `github.ref`: every push to `main` shares one ref, so a
   # ref-keyed group cancels each merge's run as the next merge starts and `main`
   # carries no verdict — which reads exactly like a green one (#2435/#2593).
-  group: type-aware-lint-${{ github.head_ref || github.sha }}
+  group: type-aware-lint-${{ github.event_name }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/scripts/ci/test-workflow-trigger-guard.mjs
+++ b/scripts/ci/test-workflow-trigger-guard.mjs
@@ -255,6 +255,56 @@ check('a ref-keyed cancelling group without a push trigger is accepted', () => {
 	);
 });
 
+// --- Concurrency: a cancelling group that cannot distinguish two EVENTS. ---
+//
+// The four cases above vary the group KEY against one event. These vary the
+// EVENT against a key that is already per-push, which is the axis that let a
+// nightly `schedule` cancel a `push` run at the same commit: `github.head_ref`
+// is empty for both, so both fall through to `github.sha`.
+
+const SHA_KEY = 'a-${{ github.head_ref || github.sha }}';
+const EVENT_KEY = 'a-${{ github.event_name }}-${{ github.head_ref || github.sha }}';
+const on = (...triggers) => `\non:\n${triggers.map((t) => `  ${t}:\n`).join('')}`;
+const wf = (triggers, group, cancels = 'true') =>
+	`name: a${triggers}\nconcurrency:\n  group: ${group}\n  cancel-in-progress: ${cancels}\n${JOBS}`;
+
+check('a per-push group is still rejected when two events share it', () => {
+	withDir({ 'a.yml': wf(on('push', 'schedule'), SHA_KEY) }, (dir) => {
+		const { violations } = checkWorkflows(dir, {}, {});
+		assert(violations.length === 1, `expected 1 violation, got ${JSON.stringify(violations)}`);
+		assert(/github\.event_name/.test(violations[0].message), 'expected the event wording');
+	});
+});
+
+check('adding github.event_name to that group accepts it', () => {
+	withDir({ 'a.yml': wf(on('push', 'schedule'), EVENT_KEY) }, (dir) => {
+		const { violations } = checkWorkflows(dir, {}, {});
+		assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
+	});
+});
+
+check('one non-pull_request trigger cannot collide, so the key is not required', () => {
+	withDir({ 'a.yml': wf(on('push', 'pull_request'), SHA_KEY) }, (dir) => {
+		const { violations } = checkWorkflows(dir, {}, {});
+		assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
+	});
+});
+
+check('cancel-in-progress: false makes the event key irrelevant too', () => {
+	withDir({ 'a.yml': wf(on('push', 'schedule'), SHA_KEY, 'false') }, (dir) => {
+		const { violations } = checkWorkflows(dir, {}, {});
+		assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
+	});
+});
+
+check('two non-push events collide with each other, with no push in sight', () => {
+	withDir({ 'a.yml': wf(on('schedule', 'workflow_dispatch'), SHA_KEY) }, (dir) => {
+		const { violations } = checkWorkflows(dir, {}, {});
+		assert(violations.length === 1, `expected 1 violation, got ${JSON.stringify(violations)}`);
+		assert(/github\.event_name/.test(violations[0].message), 'expected the event wording');
+	});
+});
+
 // --- The same mechanism one level down: a job-level cancelling group. ---
 
 /** A push workflow whose single job `publish` carries `group` and `cancels`. */

--- a/scripts/ci/workflow-trigger-guard.mjs
+++ b/scripts/ci/workflow-trigger-guard.mjs
@@ -46,6 +46,12 @@ const BRANCH_FILTER_KEYS = ['branches', 'branches-ignore'];
 // merge, so a ref-keyed cancelling group makes each merge kill its predecessor.
 const PER_PUSH_CONTEXTS = ['github.sha', 'github.run_id'];
 
+// A cancelling group must also contain this to vary between two EVENTS at one
+// commit. `github.head_ref || github.sha` does not: on `main` a `push` and a
+// `schedule` both fall through to the same `github.sha`, so the nightly kills
+// the merge's own run and the merge commit carries a `cancelled` verdict.
+const EVENT_CONTEXT = 'github.event_name';
+
 /**
  * Workflows permitted to filter their PR trigger by base branch, each with the
  * reason. The reason is the point of the list: without it the intent survives
@@ -180,6 +186,13 @@ export function analyzeWorkflow(source, { name = '<source>' } = {}) {
 		return { triggers: [] };
 	}
 
+	// Every trigger under `on:`, not only the PR ones. The per-push rule below
+	// asks whether one event can collide with itself; this list is what says
+	// whether two DIFFERENT events can, which no amount of per-push keying fixes.
+	const nonPrTriggers = directChildren(lines, onIndex + 1, 0)
+		.map((c) => c.key)
+		.filter((k) => !PR_TRIGGERS.includes(k));
+
 	const triggers = [];
 	for (const trigger of directChildren(lines, onIndex + 1, 0)) {
 		if (!PR_TRIGGERS.includes(trigger.key)) continue;
@@ -212,7 +225,7 @@ export function analyzeWorkflow(source, { name = '<source>' } = {}) {
 		}
 	}
 
-	return { triggers, pushes, concurrency, jobs };
+	return { triggers, nonPrTriggers, pushes, concurrency, jobs };
 }
 
 /** True when two pushes to one branch would share this cancelling group. */
@@ -222,6 +235,27 @@ function collidesAcrossPushes(concurrency) {
 		!PER_PUSH_CONTEXTS.some((ctx) => concurrency.group.includes(ctx))
 	);
 }
+
+/**
+ * True when two DIFFERENT events at one commit would share this cancelling
+ * group. Only a workflow with two or more non-`pull_request` triggers can reach
+ * it: a `pull_request` keys on `github.head_ref`, which no other event sets.
+ */
+function collidesAcrossEvents(concurrency, nonPrTriggers) {
+	return (
+		concurrency?.cancels === true &&
+		(nonPrTriggers ?? []).length > 1 &&
+		!concurrency.group.includes(EVENT_CONTEXT)
+	);
+}
+
+const EVENT_EXPLANATION =
+	'`github.head_ref` is empty for every event but a pull request, so `${{ github.head_ref || ' +
+	'github.sha }}` resolves to the same commit for a `push`, a `schedule` and a ' +
+	'`workflow_dispatch` on one ref — one group, and the later event cancels the earlier run. ' +
+	'Measured 2026-09-04: the nightly `Corpus Compat` firing at 20:33:28Z cancelled the merge\'s ' +
+	'own run at 20:33:47Z, leaving `main` with a `cancelled` verdict that reads exactly like a ' +
+	'red one. Add `${{ github.event_name }}` to the group, or set `cancel-in-progress: false`.';
 
 const VERDICT_EXPLANATION =
 	'Every push to a branch shares one `github.ref`, so each merge cancels its predecessor and the ' +
@@ -250,7 +284,18 @@ export function checkWorkflows(
 
 	for (const file of files) {
 		const source = readFileSync(join(dir, file), 'utf8');
-		const { triggers, pushes, concurrency, jobs } = analyzeWorkflow(source, { name: file });
+		const { triggers, nonPrTriggers, pushes, concurrency, jobs } = analyzeWorkflow(source, {
+			name: file,
+		});
+
+		if (collidesAcrossEvents(concurrency, nonPrTriggers)) {
+			violations.push({
+				file,
+				message:
+					`\`concurrency.group\` is \`${concurrency.group}\` with \`cancel-in-progress: true\`, ` +
+					`but this workflow runs on \`${(nonPrTriggers ?? []).join('`, `')}\`. ${EVENT_EXPLANATION}`,
+			});
+		}
 
 		if (pushes && collidesAcrossPushes(concurrency)) {
 			violations.push({


### PR DESCRIPTION
`github.head_ref` is empty for every event but a pull request, so
`${{ github.head_ref || github.sha }}` resolves to the same commit for a `push`, a
`schedule` and a `workflow_dispatch` on one ref — **one group**, and with
`cancel-in-progress: true` the later event kills the earlier run.

## Measured

`main = 64fa49231`, 2026-09-04:

```
2026-09-04T20:15:25Z  push      Corpus Compat  completed/cancelled  run=33915315776
2026-09-04T20:33:28Z  schedule  Corpus Compat  queued               run=33916817559
                                push run updated_at = 20:33:47Z     (19s after the schedule was created)
```

The push run's jobs at the moment it was killed:

```
completed/cancelled  started 20:16:52Z  Compiler parity        ← 17 minutes in
completed/success    ×9   (Affected gates, Shape matrix, SCSS, Formatter, Lint,
                           svelte-check ×3, LSP fixture parity current)
completed/skipped    ×2   (LSP real-world shards, LSP full-population ratchet)
```

Eleven of twelve jobs were already green. `main` is left carrying a `cancelled`
verdict — which under this repository's own recorded rule reads exactly like a red
one, and is not a success under the campaign's P0.

## The comment asserted the opposite

`corpus-compat.yml` said, above the very line that produced this:

> Keyed by the head branch on a PR … and by the commit otherwise, **so a push to
> `main` shares a group with nothing and cannot be cancelled.**

That was the claim, not the behaviour. It is replaced with what was measured, in
the same commit, because a comment asserting fidelity is where this class hides.

## Scope: 7 workflows, chosen by measurement

A collision needs two or more **non-`pull_request`** triggers plus a cancelling
group — a `pull_request` keys on `github.head_ref`, which no other event sets.
Censused over all 21 workflow files (the denominator is printed because a
`grep -A3` over `^concurrency:` silently dropped 8 of them on the first pass —
`corpus-compat.yml`'s `group:` is 10 lines below its `concurrency:`):

| | triggers |
|---|---|
| **benchmark.yml** | push, pull_request, workflow_dispatch |
| **capi.yml** | push, pull_request, workflow_dispatch |
| **codspeed.yml** | push, pull_request, workflow_dispatch |
| **corpus-compat.yml** | workflow_dispatch, schedule, push, pull_request |
| **coverage.yml** | push, pull_request, workflow_dispatch |
| **crates-io-packages.yml** | pull_request, push, workflow_dispatch |
| **type-aware-lint.yml** | workflow_dispatch, push, pull_request, schedule |
| ci.yml / changeset.yml / differential-corpus.yml / site-benchmark.yml | ≤1 non-PR trigger — cannot collide |

The last row is a **negative control**, not an exemption: those four keep the old
shape and the guard stays silent for them, while the seven above each make the
guard fire when reverted.

## The fix is in the guard, not only in the files

`workflow-trigger-guard` already asked *can one event collide with itself* and
required `github.sha`/`github.run_id`. That rule is satisfied by every one of
these seven. The new predicate asks *can two **different** events collide*, which
no amount of per-push keying answers.

Controls, run and restored byte-identically:

```
POSITIVE  revert each of the 7 in turn      → exit 2, and the message names that file   (7/7)
NEGATIVE  the 4 with ≤1 non-PR trigger      → silent
ABLATION  force the predicate false         → exactly the 2 must-fire self-tests go red
SELF-TEST 34 ok / 0 FAIL, exit 0
```

Five new self-test cases pin both directions, including a workflow with
`schedule` + `workflow_dispatch` and **no push at all** — the existing rule's
`pushes &&` guard cannot reach that case.

## Cost

`corpus-compat-job-filter` on this diff emits `lsp-corpus=true, lsp-ratchet=false`,
and `lsp-corpus`'s `if` is a conjunction whose first disjunct requires a schedule,
a dispatch, or `lsp-ratchet` — so the 950-job-minute job does **not** run here.

The change means a `push` and a `schedule` at one commit now both run instead of
one cancelling the other. That is the intended cost: a run with no verdict is
indistinguishable from a green one, which is how a stale ratchet reached `main`
unnoticed (#2435/#2593).