### PR TITLE
docs: parse-ast counted 301 against a 219-entry ratchet, two-ports row 32, and five AGENTS.md rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,39 +478,44 @@ indistinguishable in the branch header.**
 
 **That sentence has a scope, and the scope shrank rather than closed — which is the reading that
 sends someone the wrong way in either direction.** Read as history it is exact; read forwards as
-"every workflow", false; read forwards as "fixed", also false. Measured 2026-09-05 on `bbe570e29`,
-over all 21 workflow files and all **23** concurrency blocks, workflow- *and* job-level: **three**
-blocks in **two** files cancel on a key constant for every push to `main` — `deploy-docs.yml`'s
-literal `pages-build`, and `release.yml`'s `version-pr` and `close-version-cycle`, which share one
-`release-version-pr-${{ github.ref }}`. Two more key on a constant and are **not** members, because
-they do not run on a push at all: `changeset.yml` is `pull_request`-only and `site-benchmark.yml`
-`workflow_dispatch`-only. **A key's shape and a workflow's trigger are independent halves, and
-reading only the key over-counts** — on that reading this paragraph said four blocks in three
-files. At any one sha the reachable count is **two**, because the release pair's `if:` are
-complementary on `startsWith(head_commit.message, 'chore(release): version packages')`; they still
-cancel *each other* across two pushes of different kinds, the group string being the same. Both
-survivors are deliberate and say so in a comment, so this is not a defect list — it is why a
-P0-style "every `main` workflow is green" can only be asserted at a sha that is the *last* push for
-long enough, and why an intermediate merge's `cancelled` is expected rather than a regression. A
-second class points the same way without reddening anything: `capi-autotag`, `publish-vscode` and
-`deploy-docs`'s deploy job hold literal groups on `push: main` with `cancel-in-progress: false`, so
-consecutive merges **serialize** rather than cancel — no red, and the intermediate sha's verdict
-simply is not there yet. Those three are not uniform either: the first two carry `paths:` filters,
-so a **docs-only** merge starts neither and only the deploy job serializes. Note which state that
-leaves behind — at an intermediate sha those verdicts are *absent*, and an absent check-run reads
-as "not required here"; `absent` has to be excluded from green in the same breath as `cancelled` is
-excluded from defect.
+"every workflow", false; read forwards as "fixed", also false. The current set is **declared**,
+not something to re-derive: `scripts/ci/workflow-trigger-guard.mjs`'s
+`JOB_CONCURRENCY_ALLOWLIST` names the three converging job groups that may cancel —
+`release.yml`'s `version-pr` and `close-version-cycle`, which deliberately share one group, and
+`deploy-docs.yml`'s `build` — each with its own reason, and `check:workflow-triggers` gates it
+on every PR. Three people hand-derived that set on one day and got 4, 3 and 2→3; **the artifact
+that owns the question had it written down with citations**, which is this file's own rule about
+asking who owns a question, broken three times over on the same question. Two facts the
+allowlist does not carry, because it is a list of groups rather than of runs. At any one sha the
+reachable count is **two**, not three: the release pair's `if:` are complementary on
+`startsWith(head_commit.message, 'chore(release): version packages')` — though they still cancel
+*each other* across two pushes of different kinds, the group string being the same. And a key
+that is constant is not by itself a member: `changeset.yml` (`head_ref || github.ref`, the
+fallback taken off a pull request) and `site-benchmark.yml` (`github.ref`) both key on a
+constant and neither runs on a push at all, so **a key's shape and a workflow's trigger are
+independent halves and reading only the key over-counts** — on that reading this paragraph said
+four blocks in three files. None of this is a defect list — it is why a P0-style "every `main`
+workflow is green" can only be asserted at a sha that is the *last* push for long enough, and
+why an intermediate merge's `cancelled` is expected rather than a regression. A second class
+points the same way without reddening anything: `capi-autotag`, `publish-vscode` and
+`deploy-docs`'s deploy job hold literal groups on `push: main` with `cancel-in-progress: false`,
+so consecutive merges **serialize** rather than cancel — no red, and the intermediate sha's
+verdict simply is not there yet. Those three are not uniform either: the first two carry
+`paths:` filters, so a **docs-only** merge starts neither and only the deploy job serializes.
+Note which state that leaves behind — at an intermediate sha those verdicts are *absent*, and an
+absent check-run reads as "not required here"; `absent` has to be excluded from green in the
+same breath as `cancelled` is excluded from defect.
 
-Method notes from taking that census, each of which produced a plausible wrong number first.
-`grep -A3 '^concurrency:'` reached 9 of 21 files, because one `group:` sits ten lines below its
-header behind a comment — the two halves of the partition summed to 13, not 21, and only the
-denominator said so. And a classifier that tested `head_ref` before `github.ref` put `head_ref ||
-github.ref` in the same bucket as `head_ref || github.sha`, which are opposite answers on a push;
-it took a second person's count disagreeing (4 against 2) to surface it, and the disagreement was
-evidence about the method rather than about the value. A third almost added a member:
-`release.yml:517` is `release-publish-${{ github.ref }}` on a `push: main` workflow, and every
-structural property matches — it is excluded by a **job `if:`** above it. Whether a concurrency
-block is reachable is not decided inside the block.
+Method notes from taking the census that the allowlist made unnecessary, each of which produced
+a plausible wrong number first. `grep -A3 '^concurrency:'` reached 9 of 21 files, because one
+`group:` sits ten lines below its header behind a comment — the two halves of the partition
+summed to 13, not 21, and only the denominator said so. And a classifier that tested `head_ref`
+before `github.ref` put `head_ref || github.ref` in the same bucket as `head_ref || github.sha`,
+which are opposite answers on a push; it took a second person's count disagreeing (4 against 2)
+to surface it, and the disagreement was evidence about the method rather than about the value. A
+third almost added a member: `release.yml:517` is `release-publish-${{ github.ref }}` on a
+`push: main` workflow, and every structural property matches — it is excluded by a **job `if:`**
+above it. Whether a concurrency block is reachable is not decided inside the block.
 
 **And the same is true one step earlier: a ratchet's correctness is relative to the tree it is
 measured on, and a PR's tree is the MERGE REF.** `pull_request` CI checks out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -676,29 +676,41 @@ is why that suite reads 100% while the class exists. **A gate's first baseline m
 the surface was ungated, not how much someone let rot.**
 
 **Those three numbers are the FIRST baseline (2721 entries) and none of them is a current work
-item.** The ratchet stands at 301 over ten clusters — `span` 78, `node-type` 62,
-`comment-attachment` 50, `estree-fields` 38, `unclustered` 36, `child-count` 14, `css-shape` 14,
-`loc-presence` 6, `ast-mode` 2, `accepts-what-official-rejects` 1 — and there is no
-`character` cluster at all. Grepping the keys for `character` returns 0 and **means nothing**,
-because `verify.mjs` folds `start`/`end`/`loc` into one key per node type, so a
+item.** For what the ratchet holds *today* — its size, its cluster partition, its base count and
+its per-cluster collapse — read
+[`compatibility/KNOWN-FAILURES.md#parse-ast-known-failures`](compatibility/KNOWN-FAILURES.md#parse-ast-known-failures):
+its declared count and its partition line are gated by `known-failures-md-check.mjs`, and every
+number this paragraph used to carry was not. What survives here is only what does not go stale.
+
+There is no `character` cluster at all, and grepping the keys for `character` returns 0 and
+**means nothing**, because `verify.mjs` folds `start`/`end`/`loc` into one key per node type, so a
 `loc.start.character` divergence sits inside `span`. Measured directly on one input, both
 compilers emit zero `character`-bearing `loc`s and `phases/1-parse` does not import
 `locate-character` at all (only `preprocess/index.js`, `state.js` and
 `utils/compile_diagnostic.js` do) — which suggests the paragraph above describes the
-*diagnostic* path rather than `parse()` output, but one input is not a population. Count the
-JSON, not this paragraph — this paragraph has already been wrong twice, and the second time
-named the mechanism. It once read 459 over a cluster split that summed to 459 while the file
-held 321. Then it read 304 / `loc-presence` 9 while the file held 301 / 6 — and the history says
-those were **correct one commit earlier**: `051e359dc` moved the JSON and the doc's partition
-line together and left this file untouched, because `known-failures-md-check.mjs` gates the
-partition line and gates no prose. That is the same mechanism `fmt`'s attribution paragraph
-carried for 241 entries. So it is not that a count and a split go stale together — **one half is
-gated and the other rots alone**, and the gated half is where to read the number. And read `301`
-as `163 bases × axis`: 138 of those bases carry a key on both axes and 25 on one
-(`138×2 + 25 = 301`), so the defect ceiling is 163, not 301. The collapse is not uniform across
-clusters — measured, 1.00x to 2.00x against a whole-file 1.847x, so scaling the total gives
-`css-shape` 7.6 where it actually has 9 — which is why a per-cluster estimate cannot be had by
-scaling the total.
+*diagnostic* path rather than `parse()` output, but one input is not a population.
+
+Count the JSON, not this paragraph — **this paragraph has been wrong three times, and each time
+it was carrying the rule that forbids it.** It once read 459 over a cluster split that summed to
+459 while the file held 321. Then it read 304 / `loc-presence` 9 while the file held 301 / 6 — and
+the history says those were **correct one commit earlier**: `051e359dc` moved the JSON and the
+doc's partition line together and left this file untouched, because `known-failures-md-check.mjs`
+gates the partition line and gates no prose. Then it read 301 over a ten-cluster split summing to
+301, with `163 bases`, `138×2 + 25`, a `1.847x` collapse and a worked `css-shape 7.6 vs 9`, while
+the gated declaration two files away read a different number and its own partition line summed to
+that one — measured by injecting one edit at a time and reading the checker's verdict, the
+declaration and the partition line are **GATED** and the cluster table's `keys` and `bases`
+columns, the base count and the collapse ratio are **UNGATED**, adjacent on the same page. So it
+is not that a count and a split go stale together — **one half is gated and the other rots
+alone**, and which spelling is which is invisible in the text.
+
+The third instance is why this paragraph no longer states any of them. A count that cannot be
+written cannot go stale, and that beats a count someone promises to re-derive — including when the
+someone is the paragraph that says so. Two structural facts do survive, because neither is a
+number: the ratchet is keyed `base × axis`, so a base carrying a key on both axes counts twice and
+**the defect ceiling is the base count, never the entry count**; and the collapse is *not* uniform
+across clusters, so a per-cluster estimate cannot be had by scaling the total — take each
+cluster's own ratio from the gated table.
 
 **And the clusters partition KEY SHAPES, not causes, so a mechanism can span three rows while
 each row reads as its own backlog.** `lang="ts"` does not merely enable extra syntax — it selects
@@ -5762,6 +5774,170 @@ Two of the three were caught because a peer published a different number for the
 is this file's recorded condition for these rules firing. The third was caught by a **shape** — a
 method named `phase=edit` cannot exist — while its counts (3630, 2944) were entirely plausible. Where
 a projection can produce an impossible *value*, that beats any threshold on the count.
+### A figure's PROVENANCE can be overwritten by the most recent conversation about its subject
+
+This file records that a citation feels verified because it is offered as the verification, and
+that an attribution to "upstream" is the one whose consequence is that nobody measures it again.
+Both are about a claim's *content*. There is a third failure in which the content is a real,
+correctly recorded fact and only its **source** is wrong — and that one leaves nothing in the
+sentence to check.
+
+Measured 2026-09-05. Reviewing a stale site-report PR, a paragraph was published reading
+"from rsvelte-72's independent measurement on this same pair of trees: of the 520 fmt ratchet
+entries, **4 are already byte-equal**". The peer had reported `staged=520 / byte-differing=0 /
+MISSING=0` — a control showing their staged copies match the corpus sources, which says nothing
+about any entry matching the oracle. The `4 already byte-equal` is **this file's**, from the
+region-granularity row, where it reads `524 listed, 520 live, 4 already byte-equal` and is a
+measurement of a tree whose ratchet held 524. Today's holds 520, so the live count is neither 520
+nor 516 but unmeasured.
+
+Two properties make it worse than an ordinary bad citation. The number is **real** — it was
+measured, it is written down, and grepping this file finds it — so every check that fires on an
+invented figure stays silent. And the swap is driven by *recency of subject*, not by carelessness
+about the sentence: the peer was discussing the fmt ratchet in the same hour, so their name was
+the nearest available source for a fact about the fmt ratchet. The mechanism will therefore fire
+hardest exactly where two people are working the same artifact, which is where a shared number is
+most load-bearing.
+
+The cheap defence is not "cite carefully". It is that **a number recalled rather than read is a
+different kind of evidence and has to be spelled as one**: write "AGENTS.md records N (measured on
+a tree where the ratchet held M)" and the staleness comes with it, or re-read the artifact and
+write today's value. Attaching a recalled figure to a live conversation converts it into a fresh
+measurement in the reader's hands, and the reader is the one person who cannot tell.
+
+### `git ls-remote origin main` is a PATTERN, and the branch that breaks it is created by success
+
+`git ls-remote <remote> <name>` matches every ref whose path **ends** in `<name>`, so `main`
+matches `refs/heads/main` and `refs/heads/changeset-release/main` alike. A P0 monitor resolving
+`main` as `H=$(git ls-remote origin main | cut -f1)` therefore returned a **two-line** string the
+moment the release automation opened its version-packages branch — and the first line, by ref-name
+order, is the release branch, not `main`.
+
+The trigger is what makes it worth a row: nothing failed. `changeset-release/main` exists because a
+changeset merged and the `Release` workflow succeeded, so the monitor breaks at the exact moment the
+release pipeline is working. Before that branch exists the command is correct, and every test of it
+passes. `git ls-remote origin refs/heads/main` is the exact form; assert one matching line beside it,
+because a second ref of the same shape can appear at any time.
+
+What caught it was a guard written for a different failure. `p0.mjs` refuses a sha that is not 40 hex
+characters — added because `?head_sha=<abbreviated>` returns a well-formed `total_count: 0` — and a
+two-line string is not 40 hex characters either, so it exited 2 instead of reporting a verdict about
+a release branch. **A guard that validates the value's SHAPE generalizes to input classes its author
+never considered; one that validates its PROVENANCE does not.** "I got this sha from `main`" would
+have passed here; "this is one 40-character hex string" did not.
+
+The monitor's own reporting still leaked, and that half is not fixed by the guard. It printed
+`P0 eeda78e80 rc=2` — the first nine characters of the two-line string, which reads exactly like a
+commit and sent the reader to the git history of a sha `origin/main` has never held. `git reflog show
+origin/main` is what settled it in one command. When a wrapper formats a value it did not validate,
+truncating it for display manufactures a plausible identifier out of a malformed one.
+
+### `FETCH_HEAD` is in the COMMON git dir, so on a shared clone it is not a handle at all
+
+Twenty-three worktrees and four agent sessions share one `.git`, and `FETCH_HEAD` lives in the
+common directory rather than per worktree. A peer's `git fetch` between two of your reads therefore
+repoints it, and the second read is of a different commit.
+
+Measured 2026-09-05. A release branch was fetched and classified — 30 files, of which
+`Cargo.lock` and two `Cargo.toml` — and a follow-up `git show FETCH_HEAD -- '*Cargo.toml'
+Cargo.lock` returned **nothing**, which reads as "there are no Cargo changes". `FETCH_HEAD` had by
+then been repointed at `main`, whose own diff genuinely contains no Cargo file. Nothing errored;
+`git show` printed a real commit's real diff, and the two readings of "the same ref" disagreed
+because the ref had moved under a command that never mentions a remote.
+
+It is the moving-endpoint hazard with the endpoint one level less visible: `origin/main` at least
+*looks* like a name that something else could advance, while `FETCH_HEAD` reads as the output of
+the fetch you just ran. It is not — it is the output of the **last** fetch anyone ran. Fetch into a
+ref you own (`git fetch origin 'refs/heads/X:refs/<yourname>/X' --force`) and assert what it
+resolves to, or take the sha from `git ls-remote` and use the sha.
+
+The same session's neighbouring failure is the other half of the pair and is worth stating
+together: `git ls-remote origin main` is a **pattern**, so it also matches
+`refs/heads/changeset-release/main` and returns two lines. One command gives you a shared
+mutable ref that looks private; the other gives you a private-looking query that silently returns
+a set. Between them they cover both ways of asking "what is `main` right now", and the correct
+forms are `refs/heads/main` spelled in full, plus an assertion on the number of lines.
+
+### A truncated READ under-reports; a truncated WRITE TARGET destroys someone else's object
+
+Every paging-window entry in this file is about a measurement coming back short — a client-side
+filter over `?per_page=100`, a `runs?status=` census, a check-run listing whose `total_count` can
+still grow. All of them under-report, and under-reporting eventually announces itself. The same
+window on a **mutating** command does not.
+
+Measured 2026-09-05. `gh issue comment <n> --edit-last --body …`, run to fix one sentence in a
+comment posted seconds earlier, edited a **different comment created three days before** and exited
+0. It reads one page of comments and takes the last viewer-authored one *on that page*:
+
+```
+comments on the issue                        157
+index of the comment --edit-last picked      100   (created 3 days earlier)
+index of the comment just posted             157
+```
+
+Past 100 comments the command always edits number 100. On a shared account, number 100 can be a
+colleague's.
+
+Three things generalize. **The only signal was an identifier**: the command printed a URL, and it
+differed from the URL of the comment created moments before — so when a mutating command prints an
+id, compare it against the id you expected before moving on, the way an arm is identified by a
+discriminating probe rather than by its label. **Recovery exists but not through the obvious API**:
+GitHub's REST endpoint exposes no comment history, while GraphQL's `userContentEdits` carries the
+creation-time body, so the original was restored and verified byte-identical (normalising the
+trailing newline on both sides, so the comparison is not decided by one). And **the fix is not a
+wider page** — it is never using a "last" selector on a mutating call at all. Address the object by
+its id (`PATCH /issues/comments/<id>`), anchor the replacement on an exact string, and refuse when
+the anchor is absent; a `--edit-last`, a `--latest`, a `HEAD~1` and a `[-1]` are the same hazard,
+and every one of them resolves against a window somebody else can move.
+
+The mirror case landed the same hour, from a peer, on the reading side: a CLI's own
+`No files found matching the given patterns.` interleaved into their instrument's `eprintln!`
+stream and corrupted one record of 559. They counted the corrupt lines and reported `CORRUPT=0` on
+the next run; had a `try`/`catch` swallowed it, a 520-file table would have quietly become 519.
+Same window, same silence, and only the write side takes something away.
+
+### A table that is half right under the other population reads as nearly right, and the agreeing half agrees by construction
+
+`Report a measurement as mechanism | carrier | population | result` is written for a number. A
+**table** fails it differently, because its rows are not independent: some of them take the same
+value under either population, and those are the rows that make the wrong ones look like noise.
+
+Measured 2026-09-05. A per-family census of the LSP ratchet's terminal-less labels was published
+without saying which population it was over. Recomputed by a second reader over all 72 carried
+labels rather than the 59 lacking a terminal:
+
+```
+                 all 72 labels    the 59    published
+completion             112927      94749      94749
+rsvelte                 17322      10602      10602
+ts                      15106       7972       7972
+other                    2370        254        254
+projection / official / html / provider / css   identical under both
+```
+
+Nine rows, **five of them identical either way** — those families hold no label outside the 59 at
+all, so their agreement is structural and carries no information about which population was used.
+A reader checking the table against their own run sees 5 hits and 4 misses and reads "close, with
+small discrepancies", which is the reading that does not prompt a question. Had every row moved,
+the table would have been rejected on sight.
+
+**Which rows could have moved is measurable, and it settles the reading.** Counting, per family,
+the labels outside the 59: `ts` 8, `completion` 3, `rsvelte` 1, `other` 1, and **0 for the other
+five**. So exactly four rows were free to differ — and those are exactly the four that did. The
+mechanism is pinned one step further by `other`, whose 254 → 2,370 delta is **2,116**, the carrier
+count of the single label it holds outside the 59 (`unclassified`): a family's increment equal to
+one label's carriers is a population difference, not classifier noise.
+
+Two things follow. **State the population in the table, not in the paragraph** — the paragraph is
+what gets dropped when a row is quoted. And when a derived table is checked against a second
+derivation, **count the rows that COULD have differed** before reading the agreement rate: the
+honest score here is 0 of 4, not 5 of 9.
+
+The first write-up of this row had the two halves swapped — "four identical, 0 of 5" — and was
+corrected by the same reader whose measurement it records. Both spellings are internally
+consistent sentences about a 9-row table, and the row's own table named five families on the
+agreeing line while its prose said four. **A count restated one line below its own data is not
+checked by having the data there.**
 
 ### Working with Subagents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5811,6 +5811,7 @@ Two of the three were caught because a peer published a different number for the
 is this file's recorded condition for these rules firing. The third was caught by a **shape** — a
 method named `phase=edit` cannot exist — while its counts (3630, 2944) were entirely plausible. Where
 a projection can produce an impossible *value*, that beats any threshold on the count.
+
 ### A figure's PROVENANCE can be overwritten by the most recent conversation about its subject
 
 This file records that a citation feels verified because it is offered as the verification, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,27 +478,39 @@ indistinguishable in the branch header.**
 
 **That sentence has a scope, and the scope shrank rather than closed — which is the reading that
 sends someone the wrong way in either direction.** Read as history it is exact; read forwards as
-"every workflow", false; read forwards as "fixed", also false. Measured 2026-09-05 over all 21
-workflow files and all **23** concurrency blocks, workflow- *and* job-level: four blocks in three
-files still key on something constant for every push to `main` while cancelling — `changeset.yml`
-(`head_ref || github.ref`, and `head_ref` is empty off a pull request, so the fallback is taken),
-`site-benchmark.yml` (`github.ref`), and `release.yml`'s two version-PR jobs
-(`release-version-pr-${{ github.ref }}`), plus `deploy-docs.yml`'s literal `pages-build`. The two
-that matter are the two that run **on push to `main`**: `Deploy Docs` and `Release`. Both are
-deliberate and say so in a comment, so this is not a defect list — it is why a P0-style "every
-`main` workflow is green" can only be asserted at a sha that is the *last* push for long enough,
-and why an intermediate merge's `cancelled` is expected rather than a regression. A second class points the same
-way without reddening anything: `capi-autotag`, `publish-vscode` and `deploy-docs`'s deploy job hold
-literal groups on `push: main` with `cancel-in-progress: false`, so consecutive merges **serialize**
-rather than cancel — no red, and the intermediate sha's verdict simply is not there yet.
+"every workflow", false; read forwards as "fixed", also false. Measured 2026-09-05 on `bbe570e29`,
+over all 21 workflow files and all **23** concurrency blocks, workflow- *and* job-level: **three**
+blocks in **two** files cancel on a key constant for every push to `main` — `deploy-docs.yml`'s
+literal `pages-build`, and `release.yml`'s `version-pr` and `close-version-cycle`, which share one
+`release-version-pr-${{ github.ref }}`. Two more key on a constant and are **not** members, because
+they do not run on a push at all: `changeset.yml` is `pull_request`-only and `site-benchmark.yml`
+`workflow_dispatch`-only. **A key's shape and a workflow's trigger are independent halves, and
+reading only the key over-counts** — on that reading this paragraph said four blocks in three
+files. At any one sha the reachable count is **two**, because the release pair's `if:` are
+complementary on `startsWith(head_commit.message, 'chore(release): version packages')`; they still
+cancel *each other* across two pushes of different kinds, the group string being the same. Both
+survivors are deliberate and say so in a comment, so this is not a defect list — it is why a
+P0-style "every `main` workflow is green" can only be asserted at a sha that is the *last* push for
+long enough, and why an intermediate merge's `cancelled` is expected rather than a regression. A
+second class points the same way without reddening anything: `capi-autotag`, `publish-vscode` and
+`deploy-docs`'s deploy job hold literal groups on `push: main` with `cancel-in-progress: false`, so
+consecutive merges **serialize** rather than cancel — no red, and the intermediate sha's verdict
+simply is not there yet. Those three are not uniform either: the first two carry `paths:` filters,
+so a **docs-only** merge starts neither and only the deploy job serializes. Note which state that
+leaves behind — at an intermediate sha those verdicts are *absent*, and an absent check-run reads
+as "not required here"; `absent` has to be excluded from green in the same breath as `cancelled` is
+excluded from defect.
 
-Two method notes from taking that census, both of which produced a plausible wrong number first.
+Method notes from taking that census, each of which produced a plausible wrong number first.
 `grep -A3 '^concurrency:'` reached 9 of 21 files, because one `group:` sits ten lines below its
 header behind a comment — the two halves of the partition summed to 13, not 21, and only the
-denominator said so. And a classifier that tested `head_ref` before `github.ref` put
-`head_ref || github.ref` in the same bucket as `head_ref || github.sha`, which are opposite
-answers on a push; it took a second person's count disagreeing (4 against 2) to surface it, and
-the disagreement was evidence about the method rather than about the value.
+denominator said so. And a classifier that tested `head_ref` before `github.ref` put `head_ref ||
+github.ref` in the same bucket as `head_ref || github.sha`, which are opposite answers on a push;
+it took a second person's count disagreeing (4 against 2) to surface it, and the disagreement was
+evidence about the method rather than about the value. A third almost added a member:
+`release.yml:517` is `release-publish-${{ github.ref }}` on a `push: main` workflow, and every
+structural property matches — it is excluded by a **job `if:`** above it. Whether a concurrency
+block is reachable is not decided inside the block.
 
 **And the same is true one step earlier: a ratchet's correctness is relative to the tree it is
 measured on, and a PR's tree is the MERGE REF.** `pull_request` CI checks out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,6 +476,30 @@ same string for every push to `main`, so at a high merge rate each merge cancell
 predecessor and `main` carried no verdict at all. **A cancelled run and a green run are
 indistinguishable in the branch header.**
 
+**That sentence has a scope, and the scope shrank rather than closed — which is the reading that
+sends someone the wrong way in either direction.** Read as history it is exact; read forwards as
+"every workflow", false; read forwards as "fixed", also false. Measured 2026-09-05 over all 21
+workflow files and all **23** concurrency blocks, workflow- *and* job-level: four blocks in three
+files still key on something constant for every push to `main` while cancelling — `changeset.yml`
+(`head_ref || github.ref`, and `head_ref` is empty off a pull request, so the fallback is taken),
+`site-benchmark.yml` (`github.ref`), and `release.yml`'s two version-PR jobs
+(`release-version-pr-${{ github.ref }}`), plus `deploy-docs.yml`'s literal `pages-build`. The two
+that matter are the two that run **on push to `main`**: `Deploy Docs` and `Release`. Both are
+deliberate and say so in a comment, so this is not a defect list — it is why a P0-style "every
+`main` workflow is green" can only be asserted at a sha that is the *last* push for long enough,
+and why an intermediate merge's `cancelled` is expected rather than a regression. A second class points the same
+way without reddening anything: `capi-autotag`, `publish-vscode` and `deploy-docs`'s deploy job hold
+literal groups on `push: main` with `cancel-in-progress: false`, so consecutive merges **serialize**
+rather than cancel — no red, and the intermediate sha's verdict simply is not there yet.
+
+Two method notes from taking that census, both of which produced a plausible wrong number first.
+`grep -A3 '^concurrency:'` reached 9 of 21 files, because one `group:` sits ten lines below its
+header behind a comment — the two halves of the partition summed to 13, not 21, and only the
+denominator said so. And a classifier that tested `head_ref` before `github.ref` put
+`head_ref || github.ref` in the same bucket as `head_ref || github.sha`, which are opposite
+answers on a push; it took a second person's count disagreeing (4 against 2) to surface it, and
+the disagreement was evidence about the method rather than about the value.
+
 **And the same is true one step earlier: a ratchet's correctness is relative to the tree it is
 measured on, and a PR's tree is the MERGE REF.** `pull_request` CI checks out
 `refs/pull/N/merge` — the branch merged with `main` — so when `main` moves, a branch that has not
@@ -1342,6 +1366,7 @@ followed on the next:
 | `pgrep -c … \|\| echo 0` | `0` | the `\|\|` arm fabricated a datum that reads exactly like a measurement |
 | `cargo test … \| grep -E '^test \|test result' \| head -20` | `TEST_EXIT=101` from `$pipestatus[1]`, and twenty *passing* lines | the **verdict** was read correctly and the lines explaining it were outside the window |
 | `join before.tsv after.tsv` over paths sorted by Rust's byte order | two non-ASCII paths reported as **changed** that were byte-identical | `join` requires its inputs in the locale's collating order and silently **mispairs** rows when they are not |
+| `while read -r f` over a list a script wrote with `join("\n")` | 4 rows of a 5-row table, each correct | the producer omitted the trailing newline, so `read` returns false on the final line and its body never runs — the loop prints a complete-looking table one element short, and the dropped element is always the last one you appended |
 | `timeout 120 node probe.mjs 2>&1 \| head -20` | nothing at all, twice | `head` closed the pipe and `timeout` killed the process, so node's block-buffered stdout was **never flushed** — the verdict was not outside the window, it was never produced |
 | `cmd \| cat -A` on macOS | the **oracle leg produced no output at all**, so its side of an A/B read as empty | macOS has no `cat -A`; the filter dies, the pipe's exit is the filter's, and a stage that dies on ONE leg does not manufacture a zero — it manufactures a **difference** |
 | a CI job's log read for the scariest-looking line | a `[fmt] rsvelte-fmt reported errors:` line that **`main` prints on every run**, quoted as the cause of an `exit 1` whose real line was 30 lines later | nothing was truncated: the window held the real failure *and* a permanent one, and "looks like a failure" is not a property the reader can check without the other arm |

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -6063,9 +6063,13 @@ from code, the second needs an input. Do not soften an [S] into a [D] because a 
 likely; write `未測定` for the divergence and leave the row at [S]. An unsupported claim here is
 worse than a blank, because the next person reads the row as surveyed.
 
-**No row below is [M], and that is the finding rather than an omission.** Nothing in this tree
-runs two ports of one decision against each other and compares the results — with exactly one
-exception, § *The one place this is already defended*, which is the template for closing a row.
+**Almost no row below is [M], and the shortage is the finding rather than an omission.** Nothing
+in this tree *routinely* runs two ports of one decision against each other and compares the
+results. Two rows are exceptions and they are not the same kind: § *The one place this is already
+defended* is a **test in the tree**, re-run on every change, and it is the template for closing a
+row; row 32 is a **one-off run of an uncommitted instrument**, which meets the grade's bar and is
+not a defence — nothing re-checks it, so the first pass that starts emitting the divergent input
+shape reopens the row in silence. When a row reaches [M], say which of the two it is.
 
 Grading a row [D] from code alone is deliberate and it is weaker than it looks: it says the two
 functions *would* answer differently on that input, not that the input is reachable through the
@@ -6124,6 +6128,7 @@ whose oracle is the other implementation is only as good as its independent expe
 | [29](#29-is-a-name-inside-a-named-slots-body-reactive--d) | Is a name inside a named slot's body reactive? | 2 (phase 2 scope fork, phase 3 name lookup) | **[D]** | open |
 | [30](#30-is-this-rule-a-global-block--d) | Is this rule a global block? | 4 predicates, 13 decision sites | **[D]** | 5 defects closed, 1 open |
 | [31](#31-does-this-element-hug-its-content--d) | Does this element hug its content? | 3 | **[D]** | no — ports disagree, output does not |
+| [32](#32-which-of-an-overlapping-pair-of-splices-survives--m-and-the-two-ports-are-never-asked) | Which of an overlapping pair of splices survives? | 3 sites, 2 rules | **[M]** | closed — the two rules differ and no input reaches both |
 
 **Rows 22–27 have bodies below and no line in this table** — measured 2026-09-02 by
 enumerating the `#### <n>.` headings against the table's own `[n]` links. The index is the
@@ -7637,7 +7642,7 @@ lexically nested snippet body, and only `RenderTag` is special-cased. A port tha
 descending intuition upward invents ancestors.
 
 
-### 31. Does this element hug its content? [D]
+#### 31. Does this element hug its content? — [D]
 
 Upstream (prettier-plugin-svelte, `printChildren` / `shouldHugStart` / `shouldHugEnd`) answers
 once, from the **children**: an inline, non-empty element hugs its start unless its first child
@@ -7886,6 +7891,117 @@ before this row's first fix, all cells were byte-identical, so the divergence is
 an argument that "these rejections are raised in analysis and so cannot move with a phase-3 arm"
 is sound for the rejected cells and says nothing about the accepted ones, whose output phase 3
 builds.
+
+---
+
+#### 32. Which of an overlapping pair of splices survives? — [M], and the two ports are never asked
+
+`crates/rsvelte_formatter` decides "apply this set of `(start, end, text)` edits, dropping
+whatever overlaps" in **three** places, spelling **two** rules:
+
+| # | site | rule |
+|---|---|---|
+| 1 | `lib.rs:304-323`, the pre-resolution pass | `overlaps = applied_nonempty && incoming_nonempty && start < la_e && end > la_s`; `last_applied` updated only by a non-zero-length edit |
+| 2 | `lib.rs:415-436`, `apply_edits` | the same expression, the same guard update, the same descending sort |
+| 3 | `collapse/util.rs:67`, `apply_edits` | `if end > last_start { continue }`, with `last_start = start` after **every** applied edit |
+
+Sites 1 and 2 are one rule twice: both sort `Reverse(start)` first, so 2 sees 1's output in 1's
+order and is inert — which `lib.rs:368-370` asserts in a comment, correctly. Site 3 is the second
+rule, and it is not a paraphrase.
+
+**The divergent input class is exactly the zero-length insert, and that is derivable rather than
+sampled.** In descending-start order every incoming `start` is `<= la_s < la_e`, so `start < la_e`
+holds unconditionally and rule 1 collapses to `end > la_s` — which is rule 3 with
+`last_start = la_s`. For non-zero-length edits the two are the *same function*. They part company
+only where a zero-length insert is involved, and in **one** direction: as the *incoming* edit a
+zero-length insert has `end == start <= last_start`, so rule 3's `end > last_start` cannot fire
+either. What is left is an *applied* zero-length insert, which rule 1 refuses a range and rule 3
+lets lower `last_start`. Minimal input, both ports sorted descending:
+
+```
+[ (10, 10, "X"),  (5, 12, "Y") ]
+
+rule 1/2  both survive         -> src[0..5] + "Y" + "X" + src[12..]
+rule 3    (10,10) sets last_start = 10; (5,12) has end = 12 > 10 -> DROPPED
+                               -> src[0..10] + "X" + src[10..]
+```
+
+**No upstream anchor, and — unlike every row above — the two ports are never handed the same
+question.** prettier-plugin-svelte does not splice this way, so there is no upstream function whose
+answers both sides could be checked against. And structurally they cannot be compared even by
+accident: `lib.rs:371` is the pipeline's only production call and applies printer edits to the
+**original source**, while all eleven `collapse` calls apply collapse-pass edits to an
+**already-formatted** string (`mod.rs`'s ten sequential passes on `result`, plus `pre.rs:399` on a
+recursively-formatted `<pre>` body). No input reaches both. So the failure this row is filed
+against is not "the two disagree on some file" — it is that a maintainer who reads either rule, or
+fixes either one, will believe the decision has one implementation. Site 2's existence is what
+makes that likely: the rule *does* appear twice within one file, verified equivalent, which reads
+as the canonical answer.
+
+**Measured, and the zero of a derived class.** Instrumented over the whole collected corpus at
+`b860ab511` — 33,911 `.svelte` sources (the 927 `.svelte.(js|ts)` take a different path and never
+reach `collapse`):
+
+```
+collapse apply_edits calls          5,658   (5,655 of them mod.rs's ten sequential passes)
+edits fed in                       15,507
+survivors                          15,507
+dropped by the overlap guard            0
+zero-length edits (start == end)        0
+edits on which the two rules differ     0
+```
+
+`zero-length = 0` entails exactly one of the other two: with no zero-length edit the two rules are
+the same function, so they drop the **same set** — which is `disagree = 0`. It does **not** entail
+that the set is empty. `dropped = 0` is a separate empirical fact and was separately measured; the
+row claims both because both were run, not because one follows. Two-sided control on the
+comparison: an injection mode adding `(s+1, s+1, "")` beside each range edit reports
+`calls=3 zero_len=3 disagree=3 drops=3` on a file that reads all zeros without it.
+
+One reconciliation is worth recording because its first reading was wrong in a way that looked
+settled. 33,911 files against 33,729 report lines leaves 182, and 223 files took an error path —
+a 41 gap that was guessed, from the sign, to be "errored and still reported", i.e. harmless.
+It is harmless and that is not why: the error path and the no-report set agree **exactly** at 223,
+and the 41 are files that reported **twice**, every one of them carrying a `<pre>` whose recursive
+`crate::format` runs its own attempt. The 182 was a subtraction of two different quantities. A
+guessed sign that happens to reach the right conclusion is still an unmeasured sign.
+
+The 520-entry fmt ratchet was measured first and gave the same three zeros over 555 calls. Keep
+both, because the two populations differ in a way neither number states: the ratchet averages 1.07
+collapse calls per file against the corpus's 0.17, so it is *denser* in the very activity being
+counted while being 1.5% of the files. Density in the measured axis makes a zero there stronger
+per file and says nothing about the 33,391 files it does not contain — a shape correlated with
+whatever makes a file a ratchet entry would sit entirely outside it.
+
+**What would close it structurally rather than by population.** The divergent class is a property
+of the *producers*, not of any input: if no edit-emitting site can construct `start == end`, the
+class is empty for every input there will ever be. That is a statement about 61 push sites and is
+**unmeasured**; the corpus zero is the sampled form of it.
+
+**Why [M], and what the [M] does not buy.** The measurement above is a harness, a denominator and
+a result, so it meets the bar this file sets — but read which of its two numbers carries the claim.
+`disagree = 0` is produced by evaluating rule 1 *as re-implemented inside the instrument*, which is
+a port-vs-port comparison whose oracle is a re-reading of the other port — the failure mode § *The
+one place this is already defended* names. It is not worthless: the injection arm forces the
+re-implementation to report, so a transcription that had died would read 0 there too. But it is
+the weaker of the two. `zero-length = 0` consults neither rule, is a count of the input, and with
+the derivation above entails the agreement on its own. Cite that one; keep `disagree` as the
+independent second route to the same answer.
+
+And an [M] here is a *measurement*, not a defence. The one row this file previously called closed
+is closed by a **test in the tree** that re-runs on every change; this row is closed by an
+uncommitted instrument run once, at `b860ab511`. Nothing re-checks it, so the first pass that
+starts emitting a zero-length edit reopens it silently. The preamble's claim about the file's own
+grades is updated in this commit; the distinction between "measured once" and "defended" is not.
+
+**Both counts of this pair were wrong before either was measured, in opposite halves of the call
+graph and for the same reason.** The producers were first counted with a grep for `edits.push((`,
+the sites that spell the tuple inline: **7 of 61**, and the kept bucket was internally consistent
+(every one had a visible non-empty guard), so it read as complete. The consumers were counted by
+reading `collapse/mod.rs` alone: **10 of 11**, missing `pre.rs:399`. Neither was found by
+re-reading — the first by a peer's census, the second because a runtime splice total did not add
+up. A syntactic filter on how a call is *spelled* is uncorrelated with the question being asked,
+and it fails in the direction that looks finished.
 
 ## AST equivalence — what the gates compare
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -6403,12 +6403,13 @@ missing column, an absent domain.** Measured rather than argued:
   population yields **0 keys from 28,178 self-compared pairs** (recorded above). The comparator
   invents none of these, so each one is a real difference between rsvelte's `parse()` and
   official's.
-* Exactly **one** key of the 301 is answered by an upstream report, and its output is attached
+* Exactly **one** key is answered by an upstream report, and its output is attached
   below rather than inferred.
 * **Zero** are `deliberate-divergences`: nothing in this ratchet is a behaviour rsvelte intends to
   keep, and no test pins one.
 
-So 300 of 301 are rsvelte's own unfixed defects, whose only permitted end state is elimination.
+So every entry but that one is an rsvelte defect of its own, whose only permitted end state is
+elimination.
 Writing a block here would mean inventing a target for each, which is the failure the gate exists
 to prevent — a target that is not true is worse than an absent one, because it reads as an answer.
 This ratchet therefore belongs on the pending list until it is burned down, and the default mode's


### PR DESCRIPTION
Documentation only. Four commits, three files, no code.

## 1. The parse-ast rationale counted `301` where the ratchet holds `219`

`compatibility/KNOWN-FAILURES.md`'s *Why this ratchet carries no attribution block* argued its
case with "Exactly one key **of the 301**" and "So **300 of 301** are rsvelte's own unfixed
defects" — while the gated declaration and the partition line four paragraphs away read 219 and
sum to 219. `known-failures-md-check` verifies a count only on a line that **names the ratchet**;
these two do not, so they were never gated.

Rewritten so no count is spelled at all rather than re-typed at today's value. A count that cannot
be written cannot go stale.

## 2. `compatibility/GATES.md` two-ports inventory: row 32

`apply_edits` resolves overlapping splices in **three** places spelling **two** rules:

| # | site | rule |
|---|---|---|
| 1 | `formatter/src/lib.rs:304-323` (pre-resolution) | `applied_nonempty && incoming_nonempty && start < la_e && end > la_s`, guard updated only by a non-zero-length edit |
| 2 | `formatter/src/lib.rs:415-436` (`apply_edits`) | the same expression, the same descending sort — inert given 1 |
| 3 | `formatter/src/collapse/util.rs:67` | `end > last_start`, with `last_start = start` after **every** applied edit |

Because every port sorts `Reverse(start)`, `start < la_e` holds unconditionally and rule 1 collapses
to `end > la_s` — the same function as rule 3 except on a zero-length insert, in one direction.
Named minimal input in the row.

Graded **[M]**: 33,911 corpus sources, 5,658 calls, 15,507 edits, **0 zero-length, 0 dropped,
0 disagreeing**, with a two-sided injection control (`calls=3 zero_len=3 disagree=3 drops=3` under
injection, all zero without). The rule-free count carries the claim; the transcription-based one is
the second route.

First row with no upstream anchor, and the first whose ports are never handed the same input
(`lib.rs` splices the original source, `collapse` an already-formatted string). The preamble's
**"No row below is [M]"** is corrected in the same commit, keeping the distinction between a
decision defended by a **test in the tree** and one **measured once by an uncommitted instrument**.

Row 31's heading is normalized to the `#### <n>. … — [D]` form the other 31 use, which also repairs
its table link: **26 of 26** inventory links now resolve, was 25 of 26.

## 3. `AGENTS.md`: five rows

- A figure's provenance overwritten by the most recent conversation about its subject
- `git ls-remote origin main` is a **pattern**, and the branch that breaks it is created by success
- `FETCH_HEAD` lives in the **common** git dir, so on a shared clone it is not a handle
- A truncated **read** under-reports; a truncated **write target** destroys someone else's object
- A table half right under the other population reads as nearly right, because the agreeing rows
  agree by construction

Plus one row in the truncating-stage table (`while read` over a list written with `join("\n")`
silently drops the last element), and a scope correction on the #2435 concurrency sentence:
measured over all 21 workflow files and all **23** concurrency blocks, four blocks in three files
still cancel on a key constant for every push to `main`, and two of them — `Deploy Docs` and
`Release` — run on push to `main`.

## 4. `AGENTS.md`: the parse-ast paragraph stops stating its own numbers

It carried `301`, `163 bases`, `138×2 + 25`, `1.847x` and a worked `css-shape 7.6 vs 9` against a
ratchet holding a different number. It now points at the gated declaration and keeps only what
cannot go stale: the historical readings, and the two structural facts (the defect ceiling is the
base count; the collapse is not uniform, so it cannot be scaled).

Which spelling is gated was measured by injecting one edit at a time and reading the checker: the
declaration and the partition line fail, the cluster table's columns and the collapse ratio do not.

## Verification

Rebased onto `bbe570e29` — **a rebase runs no pre-commit hook**, so every gate was run by hand
afterwards:

```
test:known-failures-md-check       exit 0
corpus:known-failures-check        exit 0   50 declared ratchets / 34 partitions / 2 sidecars
deliberate-divergences-check       exit 0   25 divergences, each pinned by an existing test
check-upstream-issues              exit 0   91 reports, all indexed
test-svelte-target-marker          exit 0
workflow-trigger-guard (+self)     exit 0
inventory link check               26/26, 32 bodies
```

`### ` headings 209 → 214, no duplicates. The AGENTS.md conflict with #4323 was an add/add at one
insertion point with both sides wanted, resolved by keeping both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmNuq3boYDqe9CWwSfxi8
