### PR TITLE
docs(compatibility): the fmt section's stale 549 becomes "the ratchet"

### DIFF
--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -1029,10 +1029,10 @@ equal after swapping quote characters → **quote-style**; equal after removing 
 whitespace → **intra-line-ws**; anything else → **other**.
 
 **The table below is the wave-2 enrolment measurement, over a population of 765 —
-it is NOT a partition of the current 549.** Its `n` column sums to **766**, one
+it is NOT a partition of the current ratchet.** Its `n` column sums to **766**, one
 more than the 765 the paragraph above claims, so it was already inconsistent with
 its own stated population before this ratchet shrank. What each of its rows would
-be against the current 549 is **unmeasured**: re-deriving it needs every entry's
+be against the current ratchet is **unmeasured**: re-deriving it needs every entry's
 first differing line, which lives only in the CI report. The live partition is the
 `Partition of …` line above, which `known-failures-md-check.mjs` verifies; this
 table is kept for the per-cluster descriptions, not for its counts.
@@ -1205,10 +1205,11 @@ false: the sweep held the expression at 75 columns and varied only the indent, a
 indent 0 — where an indentation-blind budget and a correct one are the same budget —
 the two sides agree with the content run out to 111 columns, both breaking at the
 `&&`. **The axis the rule turns on is the content width, and it was the sweep's held
-constant.** The corpus says so independently: of the 524 entries, 207 have a first
-differing line wider than `printWidth` and 171 of those have the oracle's line as a
-proper prefix of rsvelte's, but only 103 of the 171 would fit with the indentation
-removed — and three sit at indent 0, where rsvelte emits 87 and 93 columns against an
+constant.** The corpus says so independently: of the 524 entries the
+ratchet then held, 207 have a first differing line wider than `printWidth`
+and 171 of those have the oracle's line as a proper prefix of rsvelte's,
+but only 103 of the 171 would fit with the indentation removed — and three
+sit at indent 0, where rsvelte emits 87 and 93 columns against an
 oracle that breaks. The pre-registered prediction's other half was false too:
 **the oracle overflows `printWidth` on 42,871 lines in 12,134 files**, because a
 construct with no break point in it overflows on any printer, so rsvelte's own 43,366


### PR DESCRIPTION
The `fmt` section of `KNOWN-FAILURES.md` carried, in two places, a count from when the ratchet held
549 entries. `known-failures-md-check` gates the declared value and the partition line and does not
read prose, so those two spellings rotted on their own.

They are not renumbered to today's value — the number is **removed** (`the current ratchet`), because
a count that cannot be written cannot go stale. A third site, `207 of 524`, is a real historical
reading, so its subject is made explicit (`the 524 entries the ratchet then held`) rather than
rescaled.

`7+/6-`, three of the added lines being a reflow of a line that reached 104 columns.

Authored by rsvelte-72; opened by the integrator, whose session runs `gh`.

## Attribution

This PR moves **0** attributions: `attribution-check` stays red on the same three files (`fmt` 516,
`lsp` 22,518, `parse-ast` 218). It corrects prose that `known-failures-md-check` does not gate — the
declared count and the partition line are gated, the surrounding sentences are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmNuq3boYDqe9CWwSfxi8

