### PR TITLE
chore(fmt-gate): a keyframes block stopped diverging, so its exclusion goes — 25 → 24

### DIFF
--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -8817,23 +8817,28 @@ that comparison would show the divergence is the oracle's inconsistency and not 
 
 ### The formatter declines an input its own parser rejects
 
-**Ratchet** `compatibility/fmt-oracle-excluded.json`, the four `invalid-input` entries and the
+**Ratchet** `compatibility/fmt-oracle-excluded.json`, the three `invalid-input` entries and the
 two `migrate` entries.
 **Pinned by** `compatibility/pattern-corpus/adversarial/css/rejected-global-keyframes-selector.svelte`
 and `crates/rsvelte_formatter/tests/style_block.rs`.
 
 #### Input
 
-Four inputs no compiler accepts — a snippet parameter written `c?: number = 5` (TS1015),
-snippet rest parameters (`snippet_invalid_rest_parameter`), `h1:nth-of-type(+12)` and
-`:global(@keyframes shared)` (`css_expected_identifier`, #3120) — and two Svelte 4→5 **migrator
-outputs**, which use `let:` directives and `slot=` attributes.
+Three inputs no compiler accepts — a snippet parameter written `c?: number = 5` (TS1015),
+snippet rest parameters (`snippet_invalid_rest_parameter`) and `h1:nth-of-type(+12)` — and two
+Svelte 4→5 **migrator outputs**, which use `let:` directives and `slot=` attributes. A fourth,
+`:global(@keyframes shared)` (`css_expected_identifier`, #3120), takes the same path and is no
+longer excluded: reindentation is the only thing the oracle does to that block, and the fallback
+reindents too, so the two agree byte-for-byte and the id is scored like any other.
 
 #### Both outputs
 
-`prettier-plugin-svelte` formats all six: it validates nothing beyond its own parse. `rsvelte-fmt`
-reports the parse error, or falls back to emitting the block verbatim where the CSS parser is the
-one that refuses.
+`prettier-plugin-svelte` formats all five: it validates nothing beyond its own parse. `rsvelte-fmt`
+reports the parse error, or — where the CSS parser is the one that refuses — reindents the block
+to its nesting depth without reformatting the CSS inside it, which
+`crates/rsvelte_formatter/tests/style_block.rs` pins two-sidedly
+(`a_tab_indented_body_never_mixes_tabs_into_the_block_indent`,
+`tab_and_space_indented_bodies_format_identically`).
 
 #### Why rsvelte's form is the correct one
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -3180,7 +3180,7 @@ entirely (neither matched nor failed). Each entry carries a `"class"`
 (`oracle-bug` | `invalid-input` | `migrate` | `engine-divergence`) and a
 `"reason"`; this file records the class-level rationale.
 
-**Current baseline: `fmt-oracle-excluded.json`, 25 entries.**
+**Current baseline: `fmt-oracle-excluded.json`, 24 entries.**
 
 `fmt-verify.mjs` warns if an excluded id is no longer in the parity set (can be
 deleted) and notices if an excluded id now matches byte-for-byte (the oracle bug
@@ -3196,14 +3196,14 @@ Attribution of `fmt-oracle-excluded.json`:
 |---|---|---|
 | 3 | [`deliberate-divergences`](#deliberate-divergences) | the `$props()` comment slot the #3515 repros depend on |
 | 3 | [`deliberate-divergences`](#deliberate-divergences) | `engine-divergence` — oxc's line-breaking, not prettier's |
-| 5 | [`deliberate-divergences`](#deliberate-divergences) | `invalid-input` and `migrate` — inputs no compiler accepts, and Svelte 4 migrator output |
+| 4 | [`deliberate-divergences`](#deliberate-divergences) | `invalid-input` and `migrate` — inputs no compiler accepts, and Svelte 4 migrator output |
 | 5 | [`deliberate-divergences`](#deliberate-divergences) | both texts compile to byte-identical client and server `js` **and** `css` |
 | 3 | [`deliberate-divergences`](#deliberate-divergences) | rsvelte reproduces `oxfmt <file>.css` byte-for-byte; the oracle's Svelte path disagrees with oxfmt itself |
 | 2 | [`upstream_issues/3035-prettier-plugin-svelte-drops-a-nested-pattern-key-in-each.md`](../upstream_issues/3035-prettier-plugin-svelte-drops-a-nested-pattern-key-in-each.md) | `oracle-bug` — the `{#each}` head drops a nested pattern's property key |
 | 1 | [`upstream_issues/oxfmt-svelte-css-eats-a-css-escape-terminator-space.md`](../upstream_issues/oxfmt-svelte-css-eats-a-css-escape-terminator-space.md) | `oracle-bug` — a CSS escape's terminator space is eaten, and a live rule becomes dead |
 | 3 | [`upstream_issues/oxfmt-svelte-css-keeps-source-tabs-around-a-selector-comment.md`](../upstream_issues/oxfmt-svelte-css-keeps-source-tabs-around-a-selector-comment.md) | `oracle-bug` — source tabs survive on a comment-bearing selector under `useTabs: false` |
 
-**Every one of the 25 entries now carries a target.** The last one that did not —
+**Every one of the 24 entries now carries a target.** The last one that did not —
 `shadcn-svelte/.../theme-customizer-code.svelte` — was not an oracle bug at all, and it left
 this file for `fmt-known-failures.json`; the measurement is under *A second stated reason was
 falsified* below. The control that decides it is one character wide: replace the `<pre>` with a
@@ -3369,9 +3369,6 @@ correct; file upstream at `oxformatter/oxfmt` or `prettier/prettier-plugin-svelt
   `snippet-rest-args`.
 - **Genuinely-invalid Svelte-specific CSS** — a parser-modern edge `<style>` block
   with invalid `:nth` syntax. — `css-nth-syntax`.
-- **At-rule inside `:global()`** — `:global(@keyframes shared)` is rejected by both
-  compilers (`css_expected_identifier`, #3120); rsvelte-fmt leaves a stylesheet its
-  parser rejects untouched. — `rejected-global-keyframes-selector`.
 
 ### migrate — Svelte 4→5 migrator output (out of scope per AGENTS.md)
 

--- a/compatibility/fmt-oracle-excluded.json
+++ b/compatibility/fmt-oracle-excluded.json
@@ -105,11 +105,6 @@
 		"reason": "oxfmt formats the SAME custom-property value two ways depending on the host file: given `--arr: [1, 2]` and `--sel: a > b ~ c`, `oxfmt x.css` prints `[1 , 2]` / `a > b ~ c` (the oxc CSS engine, which is what rsvelte-fmt uses in-process and reproduces byte-for-byte), while `oxfmt --svelte` prints `[1, 2]` / `a > b ~c` (prettier's CSS printer, which also drops the space after `~` and so changes the token stream the value substitutes). The two oxfmt paths disagree with each other, so parity with the svelte path is undefined for these values."
 	},
 	{
-		"id": "pattern/adversarial/css/rejected-global-keyframes-selector.svelte",
-		"class": "invalid-input",
-		"reason": "`:global(@keyframes shared)` is rejected by both compilers (css_expected_identifier, #3120); rsvelte-fmt falls back to raw passthrough for a stylesheet its CSS parser rejects, so the block keeps its source indentation while the oracle formats it anyway without validating"
-	},
-	{
 		"id": "pattern/issues/3515-props-default-line-comment.svelte",
 		"class": "engine-divergence",
 		"reason": "prettier preserves a line comment between a destructuring assignment and its `$props()` initializer as a leading separator (and inserts a blank line), while oxc attaches the same valid comment after the initializer expression; compiler parity needs the original separator slot to distinguish #3515"


### PR DESCRIPTION
**Ratchet** `compatibility/fmt-oracle-excluded.json` 25 → 24.

`fmt-verify.mjs` が「除外 id がオラクルと byte 一致するようになった」と NOTICE を出し、パリティ木上の集合差（`excluded ∖ differing`）が独立に同じ id を指した。

削除前に**理由を測定**した:

```
src != oracle    DIFFER
src != actual    DIFFER      ← ここ
oracle == actual IDENTICAL
```

エントリの reason（"falls back to raw passthrough … so the block keeps its source indentation"）は **今日では偽**。`src != actual` なので raw passthrough ではない。CSS パーサが拒否した stylesheet に対する fallback は「そのまま出す」ではなく「**CSS を整形せずブロックを入れ子深さに再インデントする**」で、`crates/rsvelte_formatter/tests/style_block.rs` の 2 本が両側から pin している（`a_tab_indented_body_never_mixes_tabs_into_the_block_indent` :122 / `tab_and_space_indented_bodies_format_identically` :143）。

この入力に対してオラクルがやることも**再インデントだけ**なので両者が一致し、この id は乖離の担い手でなくなった。**乖離が消えたのであって、rsvelte が上流バグを再現し始めたのではない**（NOTICE が警告している方の危険は該当しない）。

**deliberate divergence 自体は不変で、記録も残す** — 動いたのは機構の記述と担い手の数だけ。`:global(@keyframes shared)` が担い手でなくなったことは GATES.md 本文に残してある(知識を落とさないため)。

### 同時に直した散文（`deliberate-divergences-check` は終始緑だった）

同チェッカは pin の**存在**は見るが、pin された散文の**真偽**は見ない（`AGENTS.md` の
*A checker gates a pin's EXISTENCE, not the pin's TRUTH*）。そのため GATES.md 側の記述が古いまま生きていた:

- `the four \`invalid-input\` entries` → `three`
- `Four inputs no compiler accepts` → `Three inputs`
- `formats all six` → `all five`
- `falls back to emitting the block verbatim` → 再インデントの正確な記述に置換し、pin している 2 テスト名を併記

### 測定

```
[fmt-verify] included 33666 | excluded 24 | matched 33122 | failed 520   rc=0
                                            ↑ 33121 から +1。failed は不変
known-failures-md-check / test-known-failures-md-check /
deliberate-divergences-check / check-upstream-issues              全部 rc=0

リベース後の再検証（main が GATES.md を 124 行、KNOWN-FAILURES.md を 18 行動かしているため、
「きれいに当たったこと」を根拠にせず測り直した）:
  JSON entries 24 / declared in doc 24 / attribution n-sum 24   3 つとも一致
```
