### PR TITLE
chore(lsp-gate): the empty-result label carries its method, because the two spellings come from different places

### DIFF
--- a/compatibility/lsp-mechanisms.json
+++ b/compatibility/lsp-mechanisms.json
@@ -613,7 +613,10 @@
 		"inlay-hint-mixed": {
 			"terminal": null
 		},
-		"empty-result-spelling": {
+		"empty-result-spelling-document-highlight": {
+			"terminal": null
+		},
+		"empty-result-spelling-inlay-hint": {
 			"terminal": null
 		},
 		"diagnostic-mixed": {
@@ -213775,22 +213778,22 @@
 			"folding-range-set-missing"
 		],
 		"differential:fixtures/css-smoke-highlight-attribute|textDocument/documentHighlight|0:13|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-document-highlight"
 		],
 		"differential:fixtures/css-smoke-highlight-attribute|textDocument/documentHighlight|0:13|phase=edit|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-document-highlight"
 		],
 		"differential:fixtures/css-smoke-highlight-unsupported|textDocument/documentHighlight|0:24|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-document-highlight"
 		],
 		"differential:fixtures/css-smoke-highlight-unsupported|textDocument/documentHighlight|0:24|phase=edit|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-document-highlight"
 		],
 		"differential:fixtures/css-smoke-highlight|textDocument/documentHighlight|0:9|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-document-highlight"
 		],
 		"differential:fixtures/css-smoke-highlight|textDocument/documentHighlight|0:9|phase=edit|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-document-highlight"
 		],
 		"differential:fixtures/css-smoke-hover-attribute|textDocument/hover|0:13|/contents/value:value-mismatch[official=fd1653666824,rsvelte=fce3ea66547c]": [
 			"css-data"
@@ -213919,10 +213922,10 @@
 			"css-data"
 		],
 		"differential:fixtures/html-document-highlight|textDocument/documentHighlight|0:2|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-document-highlight"
 		],
 		"differential:fixtures/html-document-highlight|textDocument/documentHighlight|0:2|phase=edit|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-document-highlight"
 		],
 		"differential:fixtures/html-smoke-completions|textDocument/completion|0:1|/isIncomplete:value-mismatch[official=b5bea41b6c62,rsvelte=fcbcf165908d]": [
 			"completion-is-incomplete"
@@ -214045,10 +214048,10 @@
 			"completion-item-set-missing-mixed"
 		],
 		"differential:fixtures/html-smoke-word-highlight|textDocument/documentHighlight|1:4|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-document-highlight"
 		],
 		"differential:fixtures/html-smoke-word-highlight|textDocument/documentHighlight|1:4|phase=edit|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-document-highlight"
 		],
 		"differential:fixtures/plugin-diagnostic-error|textDocument/diagnostic|/items:extra-rsvelte[count=1,hash=568ec1805561]": [
 			"diagnostic-item-set-extra-svelte"
@@ -215149,10 +215152,10 @@
 			"diagnostic-item-set-extra-ts"
 		],
 		"differential:upstream-features/union-type-props/input.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-features/union-type-props/input.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/call-hierarchy/another-ref-format-date.svelte|textDocument/documentSymbol|:extra-rsvelte[count=2,hash=2e44da4d6346]": [
 			"document-symbol-mixed-kind-range"
@@ -215329,10 +215332,10 @@
 			"folding-range-character"
 		],
 		"differential:upstream-testfiles/code-actions/codeaction-add-lang-ts.svelte|textDocument/inlayHint|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/code-actions/codeaction-add-lang-ts.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/code-actions/codeaction-checkJs-module.svelte|textDocument/diagnostic|/items:extra-rsvelte[count=1,hash=d501e3466860]": [
 			"diagnostic-identity-source"
@@ -215623,10 +215626,10 @@
 			"folding-range-character"
 		],
 		"differential:upstream-testfiles/code-actions/codeaction-custom-fix-all-component6.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/code-actions/codeaction-custom-fix-all-component6.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/code-actions/codeaction-custom-fix-all-store.svelte|textDocument/diagnostic|/items:extra-rsvelte[count=1,hash=117baaa942cd]": [
 			"diagnostic-item-set-extra-svelte"
@@ -215911,10 +215914,10 @@
 			"document-symbol-mixed-kind-range-set-missing"
 		],
 		"differential:upstream-testfiles/code-actions/organize-imports-snippet.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/code-actions/organize-imports-snippet.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/code-actions/organize-imports-unchanged1.svelte|textDocument/diagnostic|/items:extra-rsvelte[count=2,hash=3eca5eb31d66]": [
 			"diagnostic-mixed"
@@ -216319,10 +216322,10 @@
 			"folding-range-character"
 		],
 		"differential:upstream-testfiles/completions/component-events-completion.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/component-events-completion.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/component-events-event-dispatcher.svelte|textDocument/diagnostic|/items:extra-rsvelte[count=1,hash=4c51009f12d9]": [
 			"diagnostic-item-set-extra-rsvelte"
@@ -216421,10 +216424,10 @@
 			"folding-range-character"
 		],
 		"differential:upstream-testfiles/completions/component-props-completion-rune.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/component-props-completion-rune.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/component-props-rune.svelte|textDocument/diagnostic|/items:extra-rsvelte[count=1,hash=bf79f5766bb2]": [
 			"diagnostic-item-set-extra-ts"
@@ -216451,10 +216454,10 @@
 			"document-symbol-mixed-kind-set-missing"
 		],
 		"differential:upstream-testfiles/completions/component-props-rune.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/component-props-rune.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/custom-element-tag.svelte|textDocument/diagnostic|/items:extra-rsvelte[count=1,hash=bdb6552a8641]": [
 			"diagnostic-identity-code"
@@ -216481,10 +216484,10 @@
 			"document-symbol-range"
 		],
 		"differential:upstream-testfiles/completions/custom-element-tag.svelte|textDocument/inlayHint|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/custom-element-tag.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/editingCompletion.svelte|textDocument/diagnostic|/items:extra-rsvelte[count=18,hash=28f95e3ebdb5]": [
 			"diagnostic-mixed"
@@ -216553,10 +216556,10 @@
 			"document-symbol-mixed-kind-set-missing"
 		],
 		"differential:upstream-testfiles/completions/emptytext-imported.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/emptytext-imported.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/emptytext-importer.svelte|textDocument/documentSymbol|:extra-rsvelte[count=7,hash=92594dc20179]": [
 			"document-symbol-mixed-kind-range-set-extra"
@@ -216865,10 +216868,10 @@
 			"document-symbol-range"
 		],
 		"differential:upstream-testfiles/completions/importcompletions5.svelte|textDocument/inlayHint|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/importcompletions5.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=74234e98afe7,rsvelte=4f53cda18c2b]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/importcompletions6.svelte|textDocument/diagnostic|/items:extra-rsvelte[count=2,hash=a56f1f327987]": [
 			"diagnostic-mixed"
@@ -217129,10 +217132,10 @@
 			"folding-range-set-missing"
 		],
 		"differential:upstream-testfiles/completions/namespaced-v5.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/namespaced-v5.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/completions/namespaced.svelte|textDocument/diagnostic|/items:extra-rsvelte[count=13,hash=1ad9a3872dbe]": [
 			"diagnostic-item-set-extra-mixed"
@@ -217369,10 +217372,10 @@
 			"folding-range-set-missing"
 		],
 		"differential:upstream-testfiles/definition/definition-rune.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/definition/definition-rune.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/definition/imported-rune.svelte|textDocument/documentSymbol|:extra-rsvelte[count=1,hash=c84b9b5b906e]": [
 			"document-symbol-kind"
@@ -217489,10 +217492,10 @@
 			"folding-range-character"
 		],
 		"differential:upstream-testfiles/diagnostics/different-ts-service.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/diagnostics/different-ts-service.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/diagnostics/different-ts-service/different-ts-service.svelte|textDocument/documentSymbol|:extra-rsvelte[count=3,hash=4c363a0c05f6]": [
 			"document-symbol-mixed-kind-range"
@@ -217513,10 +217516,10 @@
 			"folding-range-character"
 		],
 		"differential:upstream-testfiles/diagnostics/different-ts-service/different-ts-service.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/diagnostics/different-ts-service/different-ts-service.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/diagnostics/shared-comp.svelte|textDocument/diagnostic|/items:extra-rsvelte[count=2,hash=7aa343b85919]": [
 			"diagnostic-mixed"
@@ -217585,10 +217588,10 @@
 			"document-symbol-mixed-kind-range"
 		],
 		"differential:upstream-testfiles/diagnostics/unresolvedimport2.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/diagnostics/unresolvedimport2.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/document-highlight/document-highlight.svelte|textDocument/documentSymbol|:extra-rsvelte[count=1,hash=0b19fa6828f8]": [
 			"document-symbol-kind"
@@ -217777,10 +217780,10 @@
 			"document-symbol-mixed-kind-range"
 		],
 		"differential:upstream-testfiles/find-component-references-parent2.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/find-component-references-parent2.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/find-file-references-child.svelte|textDocument/documentSymbol|:extra-rsvelte[count=2,hash=50653c9f64c5]": [
 			"document-symbol-kind"
@@ -218041,10 +218044,10 @@
 			"folding-range-character"
 		],
 		"differential:upstream-testfiles/implementation/implementation.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/implementation/implementation.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/imported-file.svelte|textDocument/diagnostic|/items/@diagnostic-69decdbf90ec/range/end/character:value-mismatch[official=3d914f9348c9,rsvelte=c6f3ac57944a]": [
 			"diagnostic-item-range-end"
@@ -218065,10 +218068,10 @@
 			"document-symbol-mixed-kind-set-missing"
 		],
 		"differential:upstream-testfiles/imported-file.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/imported-file.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/performance.svelte|textDocument/diagnostic|/items:extra-rsvelte[count=3,hash=f289e14cc69a]": [
 			"diagnostic-item-set-extra-ts"
@@ -218311,10 +218314,10 @@
 			"folding-range-set-missing"
 		],
 		"differential:upstream-testfiles/rename/rename-runes.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/rename/rename-runes.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/rename/rename-shorthand.svelte|textDocument/documentSymbol|:extra-rsvelte[count=22,hash=5e46c8b5b8eb]": [
 			"document-symbol-mixed-kind-range-set-extra"
@@ -218443,10 +218446,10 @@
 			"folding-range-character"
 		],
 		"differential:upstream-testfiles/rename/rename2.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/rename/rename2.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"differential:upstream-testfiles/rename/rename3.svelte|textDocument/documentSymbol|:extra-rsvelte[count=1,hash=8cf91711bdef]": [
 			"document-symbol-kind"
@@ -219007,10 +219010,10 @@
 			"diagnostic-item-set-missing-ts"
 		],
 		"expected:upstream-features/$$slots/input.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"expected:upstream-features/$$slots/input.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"expected:upstream-features/$store-bind/input.svelte|textDocument/diagnostic|/items:extra-rsvelte[count=12,hash=29fb0b74b6df]": [
 			"diagnostic-item-set-extra-mixed"
@@ -219037,10 +219040,10 @@
 			"diagnostic-item-set-missing-ts"
 		],
 		"expected:upstream-features/$store/input.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"expected:upstream-features/$store/input.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"expected:upstream-features/accessors-customElement-configs/input.svelte|textDocument/diagnostic|/items:extra-rsvelte[count=1,hash=85c871d26c93]": [
 			"diagnostic-item-set-extra-ts"
@@ -219829,10 +219832,10 @@
 			"diagnostic-item-set-extra-ts"
 		],
 		"expected:upstream-features/union-type-props/input.svelte|textDocument/inlayHint|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		],
 		"expected:upstream-features/union-type-props/input.svelte|textDocument/inlayHint|phase=edit|/:value-mismatch[official=4f53cda18c2b,rsvelte=74234e98afe7]": [
-			"empty-result-spelling"
+			"empty-result-spelling-inlay-hint"
 		]
 	}
 }

--- a/compatibility/lsp-mechanisms.json
+++ b/compatibility/lsp-mechanisms.json
@@ -656,19 +656,19 @@
 			"terminal": null
 		},
 		"initialize-capability-diagnosticProvider": {
-			"terminal": null
+			"terminal": "deliberate-divergences"
 		},
 		"initialize-capability-executeCommandProvider": {
 			"terminal": null
 		},
 		"initialize-capability-positionEncoding": {
-			"terminal": null
+			"terminal": "deliberate-divergences"
 		},
 		"initialize-capability-semanticTokensProvider": {
 			"terminal": null
 		},
 		"initialize-capability-workspace": {
-			"terminal": null
+			"terminal": "deliberate-divergences"
 		},
 		"initialize-capability-other": {
 			"terminal": null

--- a/scripts/ci/lsp-mechanisms-check.mjs
+++ b/scripts/ci/lsp-mechanisms-check.mjs
@@ -96,6 +96,33 @@ for (const [label, value] of Object.entries(declared)) {
     fail(`${label} names ${terminal}, which does not exist`);
 }
 
+// A label that carries a method has to carry the one in its own key. The sidecar
+// is generated, so this normally holds by construction — it is checked because
+// the split that introduced these labels was applied to the generated file by
+// hand, and a hand edit the generator would not reproduce reverts on the next
+// regeneration with nothing to say it did.
+const EMPTY_SPELLING = /^empty-result-spelling-(.+)$/;
+const slugOf = (method) =>
+  method
+    .replace(/^textDocument\//, "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase();
+const mismatched = [];
+for (const [id, labels] of Object.entries(entries)) {
+  if (!Array.isArray(labels)) continue;
+  for (const label of labels) {
+    const suffix = EMPTY_SPELLING.exec(label)?.[1];
+    if (suffix === undefined) continue;
+    const method = id.split("|")[1];
+    if (!method || slugOf(method) !== suffix)
+      mismatched.push(`${id} carries ${label}`);
+  }
+}
+if (mismatched.length)
+  fail(
+    `${mismatched.length} empty-result-spelling label(s) name a method their key does not: ${cap(mismatched)}`,
+  );
+
 // The count the attribution table can actually reach today. Reported whether or
 // not it is zero: a table that cannot be written yet must say so with a number,
 // because a missing row and a zero row render the same.

--- a/scripts/compat-lsp/capability-hashes.test.mjs
+++ b/scripts/compat-lsp/capability-hashes.test.mjs
@@ -109,6 +109,47 @@ const OFFICIAL_TOKEN_MODIFIERS = [
   "declaration", "static", "async", "readonly", "defaultLibrary", "local",
 ];
 
+// Three scalar fields rsvelte advertises and upstream omits. The differ spells a
+// scalar as `extra-rsvelte-field[hash=digest(right[key])]`, so unlike the array
+// pointers above the digest is of the VALUE and has a preimage: reproducing it
+// from each declaration ties the ratchet entry to the source, which is what a
+// `deliberate-divergences` pin needs and a path-existence check cannot give.
+const recordedField = (pointer) => {
+  const prefix = `differential:fixtures/capabilities|initialize|${pointer}:extra-rsvelte[hash=`;
+  const hit = baseline.filter((key) => key.startsWith(prefix));
+  assert.equal(hit.length, 1, `expected exactly one baseline entry for ${pointer}`);
+  return hit[0].slice(prefix.length, -1);
+};
+
+test("the three advertised scalars reproduce their recorded digests from source", () => {
+  // crates/rsvelte_language_server/src/server.rs:192
+  assert.equal(digest("utf-16"), recordedField("/capabilities/positionEncoding"));
+  // src/server.rs:80 SERVER_NAME, set at :284
+  assert.equal(
+    digest("rsvelte-language-server"),
+    recordedField("/capabilities/diagnosticProvider/identifier"),
+  );
+  // src/server.rs:292-298, serialised in `lsp_types` field order.
+  assert.equal(
+    digest({ workspaceFolders: { changeNotifications: true, supported: true } }),
+    recordedField("/capabilities/workspace"),
+  );
+});
+
+test("the scalar digests are of the value, not of some neighbouring shape", () => {
+  // Negative controls: each is a plausible reading of the same declaration and
+  // none of them reproduces the entry, so the equalities above identify a value
+  // rather than merely finding something that hashes to twelve hex characters.
+  const encoding = recordedField("/capabilities/positionEncoding");
+  assert.notEqual(digest("utf16"), encoding);
+  assert.notEqual(digest("UTF-16"), encoding);
+  const workspace = recordedField("/capabilities/workspace");
+  assert.notEqual(digest({ workspaceFolders: { supported: true, changeNotifications: true } }), workspace);
+  assert.notEqual(digest({ workspaceFolders: { supported: true } }), workspace);
+  assert.notEqual(digest({ supported: true, changeNotifications: true }), workspace);
+  assert.notEqual(digest("rsvelte"), recordedField("/capabilities/diagnosticProvider/identifier"));
+});
+
 test("the duplicate `@` and the extra space reproduce the recorded trigger-character digests", () => {
   const { missing, extra } = arrayDiff(
     "initialize",

--- a/scripts/compat-lsp/mechanism.mjs
+++ b/scripts/compat-lsp/mechanism.mjs
@@ -88,6 +88,31 @@ function pairingKeyLabelSpace() {
 // Spelled once so a caller outside this file cannot drift from it.
 export const UNCLASSIFIED = "unclassified";
 
+// `textDocument/inlayHint` -> `inlay-hint`. A label is read by people and keyed
+// on by the sidecar, so the method is spelled the way every other label is.
+const methodSlug = (method) =>
+  method
+    .replace(/^textDocument\//, "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase();
+
+// The methods whose dispatch in `classifyDivergence` actually reaches
+// `classifyEmptySpelling` -- measured, not the two that carry the label today
+// and not every method the ratchet holds: `hover`, `definition`, `completion`,
+// `diagnostic`, `documentSymbol` and `foldingRange` have classifiers of their
+// own that never fall through to `classifyGeneric`, so declaring them would put
+// labels in the vocabulary no input can produce. The cross-product test drives
+// every member, so adding one that cannot be reached fails there rather than
+// sitting in the vocabulary unreachable.
+const EMPTY_SPELLING_METHODS = [
+  "initialize",
+  "textDocument/codeAction",
+  "textDocument/documentHighlight",
+  "textDocument/formatting",
+  "textDocument/inlayHint",
+  "textDocument/selectionRange",
+];
+
 export const MECHANISMS = [
   // Architectural: rsvelte proxies tsgo, official bundles `typescript`.
   "ts-lib-copy",
@@ -234,8 +259,14 @@ export const MECHANISMS = [
   "inlay-hint-kind",
   "inlay-hint-mixed",
   // Both sides say "nothing here" and spell it differently -- `null` against `[]`.
-  // Neither side is wrong, so it must not sit inside `rsvelte-empty`.
-  "empty-result-spelling",
+  // Neither side is wrong, so it must not sit inside `rsvelte-empty`. The method
+  // is in the label because the two sides' spellings come from different places
+  // per method -- a forwarded response carries its backend's spelling and a
+  // native one carries ours -- so one terminal over every method would attribute
+  // whichever half is larger. `EMPTY_SPELLING_METHODS` is the closed list; a
+  // method outside it throws in `classifyDivergence` rather than widening a
+  // label nobody enumerated.
+  ...EMPTY_SPELLING_METHODS.map((method) => `empty-result-spelling-${methodSlug(method)}`),
   // A renaming and a genuine set difference in one response: two mechanisms, and
   // the label has to say so rather than inherit whichever the first item carried.
   "diagnostic-mixed",
@@ -928,7 +959,7 @@ const inlayHintKind = (hint) => INLAY_HINT_KIND_BY_CODE[hint?.kind] ?? "other";
 function classifyInlayHint(official, rsvelte, difference) {
   // `null` on one side and `[]` on the other is both sides answering "no hints".
   if (/value-mismatch/.test(difference))
-    return classifyEmptySpelling(official, rsvelte) ?? UNCLASSIFIED;
+    return classifyEmptySpelling("textDocument/inlayHint", official, rsvelte) ?? UNCLASSIFIED;
   if (!/:(missing|extra)-rsvelte/.test(difference)) return UNCLASSIFIED;
   const { direction, items, otherSide } = unpairedItems(
     "textDocument/inlayHint",
@@ -957,8 +988,9 @@ function classifyInlayHint(official, rsvelte, difference) {
 // Both sides answering "nothing" in two spellings is not specific to inlay hints,
 // so it is asked of every list-valued method before that method's own rules. An
 // empty side reaches the differ as an element difference, not only as a mismatch.
-function classifyEmptySpelling(official, rsvelte) {
-  if (isEmptyResult(official) && isEmptyResult(rsvelte)) return "empty-result-spelling";
+function classifyEmptySpelling(method, official, rsvelte) {
+  if (isEmptyResult(official) && isEmptyResult(rsvelte))
+    return `empty-result-spelling-${methodSlug(method)}`;
   if (isEmptyResult(official)) return "official-empty";
   if (isEmptyResult(rsvelte)) return "rsvelte-empty";
   return null;
@@ -982,7 +1014,7 @@ function classifySelectionRange(official, rsvelte) {
 }
 
 function classifyGeneric(method, official, rsvelte, difference) {
-  const empty = classifyEmptySpelling(official, rsvelte);
+  const empty = classifyEmptySpelling(method, official, rsvelte);
   if (empty) return empty;
   if (method === "initialize") {
     const capability = /^\/capabilities\/([^/:]+)/.exec(difference)?.[1];

--- a/scripts/compat-lsp/mechanism.test.mjs
+++ b/scripts/compat-lsp/mechanism.test.mjs
@@ -848,7 +848,29 @@ test("inlayHint: the hint kind is in the set-difference label, and a paired hint
 });
 
 test("an empty side is the same answer however it is spelled", () => {
-  assert.equal(classify("textDocument/inlayHint", null, [], "/:value-mismatch"), "empty-result-spelling");
+  // The method is in the label: a forwarded response carries its TypeScript
+  // backend's spelling and a native one carries ours, so one terminal over both
+  // would attribute whichever half is larger.
+  assert.equal(
+    classify("textDocument/inlayHint", null, [], "/:value-mismatch"),
+    "empty-result-spelling-inlay-hint",
+  );
+  assert.equal(
+    classify("textDocument/documentHighlight", null, [], "/:value-mismatch"),
+    "empty-result-spelling-document-highlight",
+  );
+  // Both directions are one label: which side spells it `null` is a property of
+  // the request, not of a rule either side holds.
+  assert.equal(
+    classify("textDocument/inlayHint", [], null, "/:value-mismatch"),
+    "empty-result-spelling-inlay-hint",
+  );
+  // A method the classifier has never seen is a defect in this module, not a
+  // new class -- the vocabulary check is what says so.
+  assert.throws(
+    () => classify("textDocument/rename", null, [], "/:value-mismatch"),
+    /not in the declared vocabulary/,
+  );
   assert.equal(classify("textDocument/inlayHint", null, [hint(0)], "/:value-mismatch"), "official-empty");
   assert.equal(classify("textDocument/inlayHint", [hint(0)], null, "/:value-mismatch"), "rsvelte-empty");
   // A method with no rules of its own reaches the same test through an element
@@ -960,6 +982,25 @@ test("every declared label in a hand-written cross product is reachable", () => 
       classify("textDocument/diagnostic", left, right, "/items" + (direction === "missing" ? MISSING : EXTRA)),
       label,
     );
+    seen.push(label);
+  }
+
+  // The label carries a method, so the cross product is over the methods whose
+  // dispatch reaches the both-empty test. A member that cannot be reached fails
+  // here rather than sitting in the vocabulary as a label no input produces.
+  const EMPTY_METHOD_BY_SLUG = {
+    initialize: "initialize",
+    "code-action": "textDocument/codeAction",
+    "document-highlight": "textDocument/documentHighlight",
+    formatting: "textDocument/formatting",
+    "inlay-hint": "textDocument/inlayHint",
+    "selection-range": "textDocument/selectionRange",
+  };
+  for (const [label, slug] of declared(/^empty-result-spelling-(.+)$/)) {
+    const method = EMPTY_METHOD_BY_SLUG[slug];
+    assert.ok(method, `no input is declared for ${label}`);
+    assert.equal(classify(method, null, [], "/:value-mismatch"), label);
+    assert.equal(classify(method, [], null, "/:value-mismatch"), label);
     seen.push(label);
   }
 

--- a/scripts/dev/test-lsp-mechanisms-check.mjs
+++ b/scripts/dev/test-lsp-mechanisms-check.mjs
@@ -67,6 +67,38 @@ const cases = [
     /the ratchet does not list/,
   ],
   [
+    "a method-carrying label that names a method its key does not fails",
+    {
+      ratchet: ["differential:fixtures/a|textDocument/inlayHint|0:0|/:value-mismatch"],
+      sidecar: {
+        mechanisms: { "empty-result-spelling-document-highlight": { terminal: null } },
+        entries: {
+          "differential:fixtures/a|textDocument/inlayHint|0:0|/:value-mismatch": [
+            "empty-result-spelling-document-highlight",
+          ],
+        },
+      },
+    },
+    1,
+    /name a method their key does not/,
+  ],
+  [
+    "the same label on the key its method matches passes",
+    {
+      ratchet: ["differential:fixtures/a|textDocument/inlayHint|0:0|/:value-mismatch"],
+      sidecar: {
+        mechanisms: { "empty-result-spelling-inlay-hint": { terminal: null } },
+        entries: {
+          "differential:fixtures/a|textDocument/inlayHint|0:0|/:value-mismatch": [
+            "empty-result-spelling-inlay-hint",
+          ],
+        },
+      },
+    },
+    0,
+    /1 ratchet entries/,
+  ],
+  [
     "an empty mechanism set fails",
     {
       ...wellFormed,


### PR DESCRIPTION
`empty-result-spelling` is one label over 56 ratchet entries. A terminal written on it attributes two mechanisms at once, so it is split by method first.

## What the 56 entries are

Measured on the ratchet's own digests. `digest(v) = sha256(v).hex.slice(0,12)`, identified against five candidates so the two that appear are pinned rather than guessed:

```
74234e98afe7  <- JSON null       (appears)
4f53cda18c2b  <- JSON []         (appears)
12ae32cb1ec0  <- JSON ""         (does not)
44136fa355b3  <- JSON {}         (does not)
eb045d78d273  <- JSON undefined  (does not)
```

```
entries 56 / bases 28   (phase=edit doubles each)

  34  textDocument/inlayHint          official=[]    rsvelte=null
   6  textDocument/inlayHint          official=null  rsvelte=[]
   6  textDocument/inlayHint          official=[]    rsvelte=null   [expected suite]
  10  textDocument/documentHighlight  official=null  rsvelte=[]
```

The two methods are not the same mechanism. `textDocument/inlayHint` has **no native handler** — it is in `forward_tsgo_request`'s arm at `server.rs:711`, and `fn on_inlay_hint` does not exist (grep returns 0; positive control: `document_highlight` returns 4 hits in the same file). `textDocument/documentHighlight` is answered by rsvelte's own provider at `server.rs:1245`.

## `EMPTY_SPELLING_METHODS` is measured, not listed

Two wrong lists were considered and rejected by measurement:

- **the two methods that carry the label today** — a third method answering "nothing" on both sides would throw, and a gate that crashes on a real measurement is worse than one emitting an unexpected label;
- **every method the ratchet holds (12)** — driving all twelve through `classifyDivergence` shows `hover`, `definition`, `completion`, `diagnostic`, `documentSymbol` and `foldingRange` have classifiers of their own that never fall through to `classifyGeneric`, so those six labels would be in the vocabulary with no input able to produce them.

The list is the **six that reach it**, and `mechanism.test.mjs`'s cross-product test now drives every member in both directions, so adding an unreachable one fails there.

## The sidecar edit is machine-checked

`lsp-mechanisms.json` is generated from the complete 17-artifact set of one `lsp-corpus` run, and this re-label was applied to it by hand — which is safe only because the new label is a pure function of the method already in the entry's key. `lsp-mechanisms-check.mjs` now verifies exactly that, so a hand edit the generator would not reproduce cannot sit there silently.

## Controls

| control | result |
|---|---|
| inject one mismatched label into the real sidecar | `rc=1`, names the exact entry |
| restore | `rc=0`, `cmp` byte-identical |
| add an unreachable method (`hover`) to the vocabulary | that test alone reddens |
| restore | 35/35, `cmp` byte-identical |
| `test:lsp-mechanisms-check` | 11 cases, both directions of the new check |

## Both terminals stay `null`

The inlay-hint half is **not** settled as upstream, and that was the first reading. `InlayHintProvider.getInlayHints` (language-tools) returns `null` when inlay hints are **disabled by preference** and `[]` when they are on with nothing to report; `ExecuteMode.FirstNonNull` passes `[]` through unchanged (`PluginHost.ts:970-977`). So official's two spellings carry a distinction rsvelte does not make, because it forwards tsgo's answer verbatim. Which of the two produced each entry is **unmeasured** — it needs both servers running.

`empty-result-spelling-document-highlight` additionally contains #4331, where rsvelte's own two ports disagree on one fixture. That is a defect, not a spelling, and it must not be closed by a terminal written for the other nine entries.

Refs #4048, #4248, #4331