### PR TITLE
chore(fmt): `RawExpr`'s doc comment says `fits` never forces a break, and both halves of that are false

### DIFF
--- a/crates/rsvelte_formatter/src/doc.rs
+++ b/crates/rsvelte_formatter/src/doc.rs
@@ -55,13 +55,18 @@ pub enum Doc {
     Concat(Vec<Self>),
     /// A pre-formatted embedded expression (`{expr}`) whose JS was formatted by
     /// the external engine (oxc) into a string, not a Doc. In `Flat` mode it
-    /// prints `flat`; in `Break` mode it prints `broken` — the multi-line form,
-    /// one entry per line, the first line bare and each continuation carrying its
-    /// own relative indent (as produced at column 0) plus the current indent
-    /// level. This lets an oxc-formatted interpolation participate in a `Fill`:
-    /// the fill keeps it on one line when its `flat` form fits at the current
-    /// column, else places it broken with continuation lines indented under the
-    /// attribute. `fits` measures it by `flat` width (it never forces a break).
+    /// prints `flat`; in `Break` mode it prints the multi-line form, one entry
+    /// per line, the first line bare and each continuation carrying its own
+    /// relative indent (as produced at column 0) plus the current indent level —
+    /// rebuilt from `src` at the indent being printed, with `broken` as the
+    /// fallback when there is no `src` or the rebuild fails. This lets an
+    /// oxc-formatted interpolation participate in a `Fill`: the fill keeps it on
+    /// one line when its `flat` form fits at the current column, else places it
+    /// broken with continuation lines indented under the attribute. `fits`
+    /// measures it by `flat` width in `Flat` mode; in `Break` mode a breakable
+    /// one charges `broken[0]` and ends the measurement there, so it does force
+    /// a break. `broken` is column-unaware, so that charge can exceed the line
+    /// `print` rebuilds — no corpus input reaches the two apart.
     RawExpr {
         flat: String,
         broken: Vec<String>,


### PR DESCRIPTION
Doc comment only — no behaviour change, one file, +12/-7.

`Doc::RawExpr`'s comment read:

> `fits` measures it by `flat` width (it never forces a break).

Both halves are false. In `Break` mode a breakable `RawExpr` charges `broken[0]` and **ends the measurement there**, so it does force a break; and `broken` is built at `usize::MAX` (`doc_build.rs:289`) while `print` rebuilds from `src` at the indent being printed, so the two are measured at different widths.

The comment was the starting point for a hypothesis that the charge is systematically too large and causes eager breaks. That hypothesis was **falsified** on the corpus:

```
stage 0  FITS_HEAD total=432 differ=0 flipped=0 nosrc=269 norebuild=0   (33,666 units)
stage 1  moved units = 0 / 33,666      rows 33666 = distinct keys 33666
stage 2  compared=33,642  base-match=33,122  head-match=33,122  flips=0
         free control  stage1 >= stage2: true;  33,642 - 33,122 = 520 = the ratchet's size
```

269 of the 432 `Break`-mode measurements have no `src`, so `print` cannot rebuild either and the two agree by construction; the remaining 163 rebuild successfully and are byte-identical to `built`. The patch is dropped — a change that moves 0 bytes over 33,666 units does not earn a per-`fits` rebuild.

What ships is the comment, because a comment asserting fidelity is where this class hides: it is what sent one session into two release builds, and it would send the next one there too.

The comment states the falsification in its own last clause (`no corpus input reaches the two apart`) rather than only the mechanism, so a reader gets the measured bound with the description.