### PR TITLE
fix(fmt): a `{@const}` body's assignment is an expression, not a declarator initializer

### DIFF
--- a/.changeset/fmt-const-tag-assignment-parens.md
+++ b/.changeset/fmt-const-tag-assignment-parens.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/fmt": patch
+"@rsvelte/language-server": patch
+---
+
+Drop the declarator parentheses the JS printer adds around an assignment used as a `{@const}` body.
+
+`{@const y = h = 0}` was printed `{@const y = (h = 0)}`. The tag's body is formatted by wrapping it as `const <body>;` and handing it to the JS printer, which parenthesizes an assignment in declarator-initializer position; the oracle formats the same body as an expression and neither adds the parentheses nor keeps the source's. Measured against `oxfmt(svelte: true)`, both engines print `const y = (a = b);` for the plain JS statement, so this is rsvelte asking the engine a different question rather than an engine divergence.
+
+Only a top-level assignment initializer is affected: `(h = 0) + 1`, `c ? (h = 0) : 2` and `() => (h = 0)` keep the parentheses they need.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -903,7 +903,7 @@ Svelte structure, oxc for embedded JS, and PostCSS for embedded CSS) and require
 embedded CSS by default, so the ratchet intentionally includes CSS-engine parity
 as well as Svelte-structure parity. The ratchet may only shrink.
 
-**Current baseline: `fmt-known-failures.json`, 520 entries.** The 789-entry
+**Current baseline: `fmt-known-failures.json`, 519 entries.** The 789-entry
 split this paragraph used to give (22 pre-enrolment + 766 expanded population + 1
 pattern-corpus repro) no longer holds: 239 entries left the ratchet in the
 2026-09-01 re-baseline, and the CI report the baseline is derived from carries a
@@ -928,17 +928,18 @@ An id that carries two clusters' divergences at once is filed under its dominant
 one (see *Multiple clusters per id*), so the per-cluster counts below remain a
 partition of the ratchet rather than an over-count:
 
-Partition of `fmt-known-failures.json` by cluster: `242 + 212 + 15 + 36 + 13 + 1 + 1`
+Partition of `fmt-known-failures.json` by cluster: `242 + 212 + 15 + 36 + 12 + 1 + 1`
 
 **The partition is now the mechanical rule applied to all 520 entries**, where it
 used to be the hand-diagnosed Clusters 1-12 (23 entries) plus the mechanical
 Clusters 20-27 over the rest. The hand-diagnosed sections below are kept — their
 diagnoses did not stop being true — but their ids are now counted inside the
 mechanical buckets, because the CI report names an entry's first differing line
-and not the cluster a human filed it under. The addends are, in order:
-20 breaks-later 246, 21 breaks-earlier 212, 22 intra-line-ws 15,
-23 indent-only 36, 24 other 13, 25 extra-line 1, 26 missing-line 1;
-27 quote-style is now empty.
+and not the cluster a human filed it under. The addends are, in order: 20 breaks-later,
+21 breaks-earlier, 22 intra-line-ws, 23 indent-only, 24 other, 25 extra-line,
+26 missing-line; 27 quote-style is now empty. Only the order is here — the counts
+are the gated line above, and spelling the distribution twice is what let the
+first term drift out of step with it.
 
 **21 entries left in #4191** — 11 from **20 — breaks-later** and 10 from
 **23 — indent-only** — when a `<script>` body stopped being formatted at a
@@ -1419,9 +1420,9 @@ buckets per entry from the doc would be transcription, not measurement.
 | 2 | the two engines disagree about whitespace around a selector token neither models — the column combinator and a `nth-child(… of <selector>)` clause: rsvelte's `oxc_formatter_css` prints the space, the oracle's PostCSS path closes it up; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace | `crates/rsvelte_formatter/tests/css_native.rs` — `a_column_combinator_keeps_its_spaces`, `an_nth_child_of_clause_keeps_the_space_after_of` |
 | 1 | a hex escape ending a selector: rsvelte emits the escape's terminating space and the separator before `{` as two spaces where the oracle emits one — the same file's 18 other selectors, including every hex escape followed by more text, agree; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace | `crates/rsvelte_formatter/tests/css_native.rs` — `a_hex_escape_ending_a_selector_keeps_its_own_separator` |
 | 1 | continuation indent of a comma-separated multi-value declaration: rsvelte's engine prints every continuation at one depth where the oracle's PostCSS path indents the ones following an interleaved comment one level deeper than the first; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace | `crates/rsvelte_formatter/tests/css_native.rs` — `every_continuation_of_a_multi_value_declaration_sits_at_one_depth` |
-| 515 | no upstream report and no pinned deliberate divergence; elimination is the only end state open to these entries | none |
+| 514 | no upstream report and no pinned deliberate divergence; elimination is the only end state open to these entries | none |
 
-Partition of `fmt-known-failures.json` by mechanism: `1 + 2 + 1 + 1 + 515`
+Partition of `fmt-known-failures.json` by mechanism: `1 + 2 + 1 + 1 + 514`
 
 Attribution of `fmt-known-failures.json`:
 
@@ -1587,7 +1588,7 @@ this cell is not a hug disagreement: it is a layout pass 1.6 does not have, name
 after the open tag and borrowing the closing tag's `>` onto its own line. How many corpus
 entries carry that shape is **unmeasured**.
 
-**What this population is not.** `fmt-known-failures.json` holds 520 entries; the 72 carriers
+**What this population is not.** `fmt-known-failures.json` holds 519 entries; the 72 carriers
 here are the ones whose *first differing line* is a `>` boundary, so this is a sub-population
 chosen by a signature, not a cluster of the partition above. An entry is retired only when
 every one of its differing regions is repaired.
@@ -1626,7 +1627,7 @@ the four classes come out `27 / 122 / 244 / 127` under the order now printed, an
 ungated half rot separately — `known-failures-md-check` reads the partition line and reads no
 prose, so the line stayed right while the table drifted.
 
-Partition of `fmt-known-failures.json` by diff shape: `244 + 127 + 122 + 27`
+Partition of `fmt-known-failures.json` by diff shape: `244 + 126 + 122 + 27`
 
 **Three of every four entries agree on every token and differ only in layout** — every row above
 except the token one. The placement and line-break rows are separated on purpose: collapsing runs
@@ -1660,7 +1661,7 @@ cluster prose agree where they overlap.
 
 Two things this measurement is not. It is **not** an attribution: a layout difference against an
 oracle whose byte output is the goal is still an entry to eliminate, so the mechanism table's
-`515 unattributed` stands unchanged. And the counts are a measurement of a tree (`ac2908043`,
+`514 unattributed` stands unchanged. And the counts are a measurement of a tree (`ac2908043`,
 against a locally regenerated corpus), so recompute them rather than citing them.
 
 **One control came for free: `0` entries are byte-equal now.** The classifier's first test is

--- a/compatibility/fmt-known-failures.json
+++ b/compatibility/fmt-known-failures.json
@@ -484,7 +484,6 @@
 	"svelte-ux/packages/svelte-ux/src/lib/components/Collapse.svelte",
 	"svelte-ux/packages/svelte-ux/src/routes/+error.svelte",
 	"svelte-ux/packages/svelte-ux/src/routes/docs/components/Gooey/+page.svelte",
-	"svelte/packages/svelte/tests/parser-modern/samples/const-tag-parenthesized-init/input.svelte",
 	"svelte/packages/svelte/tests/parser-modern/samples/css-nth-of-minified/input.svelte",
 	"svelte/packages/svelte/tests/print/samples/css-escape-sequences/input.svelte",
 	"sveltekit/packages/enhanced-img/test/Output.svelte",

--- a/compatibility/fmt-mechanisms.json
+++ b/compatibility/fmt-mechanisms.json
@@ -508,7 +508,6 @@
 		"svelte-ux/packages/svelte-ux/src/lib/components/Collapse.svelte": "unattributed",
 		"svelte-ux/packages/svelte-ux/src/routes/+error.svelte": "unattributed",
 		"svelte-ux/packages/svelte-ux/src/routes/docs/components/Gooey/+page.svelte": "unattributed",
-		"svelte/packages/svelte/tests/parser-modern/samples/const-tag-parenthesized-init/input.svelte": "unattributed",
 		"svelte/packages/svelte/tests/parser-modern/samples/css-nth-of-minified/input.svelte": "css-engine-selector-token-spacing",
 		"svelte/packages/svelte/tests/print/samples/css-escape-sequences/input.svelte": "css-engine-trailing-escape-space",
 		"sveltekit/packages/enhanced-img/test/Output.svelte": "unattributed",

--- a/crates/rsvelte_formatter/src/expression/declaration.rs
+++ b/crates/rsvelte_formatter/src/expression/declaration.rs
@@ -16,6 +16,93 @@ use crate::width::{VisualWidth, tab_width};
 /// mirrors [`format_content_expression`]: the body is formatted at indent 0 and
 /// the wrap width narrowed by the markup `depth`, then continuation lines are
 /// re-indented to that depth.
+/// Drop the parens the JS printer puts around a declarator initializer that is
+/// an assignment. Only a single-line body is touched: once the declaration has
+/// broken, the parens are the break anchor and removing them would move the wrap.
+fn strip_initializer_parens(s: &str) -> String {
+    if s.contains('\n') || !s.ends_with(')') {
+        return s.to_string();
+    }
+    let Some(eq) = top_level_declarator_eq(s) else {
+        return s.to_string();
+    };
+    let (head, tail) = s.split_at(eq + 1);
+    let init = tail.trim_start();
+    if !init.starts_with('(') {
+        return s.to_string();
+    }
+    let mut depth = 0usize;
+    for (i, c) in init.char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                // A pair closing before the end wraps only a prefix of the init.
+                if depth == 0 && i + 1 != init.len() {
+                    return s.to_string();
+                }
+            }
+            _ => {}
+        }
+    }
+    format!("{head} {}", &init[1..init.len() - 1])
+}
+
+/// Byte offset of the `=` separating a declarator's binding from its
+/// initializer: the first one outside a string, template or bracket that is not
+/// part of `==`, `=>`, or a compound assignment.
+fn top_level_declarator_eq(s: &str) -> Option<usize> {
+    let b = s.as_bytes();
+    let mut depth = 0usize;
+    let mut quote: Option<u8> = None;
+    let mut i = 0usize;
+    while i < b.len() {
+        let c = b[i];
+        if let Some(q) = quote {
+            if c == b'\\' {
+                i += 2;
+                continue;
+            }
+            if c == q {
+                quote = None;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'"' | b'\'' | b'`' => quote = Some(c),
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth = depth.saturating_sub(1),
+            b'=' if depth == 0 => {
+                let next = b.get(i + 1).copied();
+                let prev = if i == 0 { None } else { Some(b[i - 1]) };
+                let compound = matches!(
+                    prev,
+                    Some(
+                        b'=' | b'!'
+                            | b'<'
+                            | b'>'
+                            | b'+'
+                            | b'-'
+                            | b'*'
+                            | b'/'
+                            | b'%'
+                            | b'&'
+                            | b'|'
+                            | b'^'
+                    )
+                );
+                if next != Some(b'=') && next != Some(b'>') && !compound {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
 pub(super) fn format_const_declaration(
     decl_source: &str,
     options: &FormatOptions,
@@ -40,6 +127,20 @@ pub(super) fn format_const_declaration(
         )));
     }
 
+    // The JS printer parenthesizes an assignment used as a declarator
+    // initializer; the oracle formats a const tag's body as an expression, so it
+    // never adds them and strips the source's.
+    let init_is_assignment = parser_ret
+        .program
+        .body
+        .first()
+        .and_then(|st| match st {
+            oxc_ast::ast::Statement::VariableDeclaration(d) => d.declarations.first(),
+            _ => None,
+        })
+        .and_then(|d| d.init.as_ref())
+        .is_some_and(|e| matches!(e, oxc_ast::ast::Expression::AssignmentExpression(_)));
+
     let indent_width = options.js.indent_width.value() as usize;
     let lead = depth * indent_width;
     let full_width = options.js.line_width.value() as usize;
@@ -62,7 +163,12 @@ pub(super) fn format_const_declaration(
         let s = formatted.trim_end();
         let s = s.strip_prefix("const ").unwrap_or(s);
         let s = s.strip_suffix(';').unwrap_or(s);
-        Ok(s.trim_end().to_string())
+        let s = s.trim_end();
+        Ok(if init_is_assignment {
+            strip_initializer_parens(s)
+        } else {
+            s.to_string()
+        })
     };
 
     // The JS formatter measures the body as `const <body>;` at indent 0. Two

--- a/crates/rsvelte_formatter/tests/expression.rs
+++ b/crates/rsvelte_formatter/tests/expression.rs
@@ -100,3 +100,35 @@ fn declaration_tag_let_normalises_quotes() {
         "single quotes should become double: {out}"
     );
 }
+
+#[test]
+fn an_assignment_used_as_a_const_body_loses_the_declarator_parens() {
+    // The JS printer parenthesizes an assignment used as a declarator
+    // initializer; the oracle formats a const tag's body as an expression and so
+    // does not, and strips the source's.
+    for src in [
+        "{#if x}{@const y = h = 0}{/if}\n",
+        "{#if x}{@const y = (h = 0)}{/if}\n",
+    ] {
+        let out = fmt(src);
+        assert!(out.contains("{@const y = h = 0}"), "{src:?} -> {out}");
+        assert!(!out.contains("(h = 0)"), "{src:?} -> {out}");
+    }
+}
+
+#[test]
+fn a_nested_assignment_in_a_const_body_keeps_the_parens_it_needs() {
+    // Only a top-level assignment initializer is affected: these parens are the
+    // JS printer's and are load-bearing.
+    for (src, want) in [
+        ("{#if x}{@const y = (h = 0) + 1}{/if}\n", "(h = 0) + 1"),
+        (
+            "{#if x}{@const y = c ? (h = 0) : 2}{/if}\n",
+            "c ? (h = 0) : 2",
+        ),
+        ("{#if x}{@const f = () => (h = 0)}{/if}\n", "() => (h = 0)"),
+    ] {
+        let out = fmt(src);
+        assert!(out.contains(want), "{src:?} -> {out}");
+    }
+}

--- a/crates/rsvelte_formatter/tests/render_neutral_divergences.rs
+++ b/crates/rsvelte_formatter/tests/render_neutral_divergences.rs
@@ -25,16 +25,6 @@ fn an_array_elision_carries_no_space() {
 }
 
 #[test]
-fn an_assignment_used_as_a_const_body_keeps_its_parentheses() {
-    // The oracle drops them; both forms are the same expression.
-    let out = fmt("{#if x}{@const y = h = 0}{/if}\n");
-    assert!(
-        out.contains("{@const y = (h = 0)}"),
-        "parentheses around the assignment were dropped:\n{out}"
-    );
-}
-
-#[test]
 fn a_script_close_tag_keeps_its_internal_whitespace() {
     // The oracle rewrites `</script   \n\n>` to `</script>`. Svelte accepts both
     // and the compiled output is identical, so the source form is preserved.


### PR DESCRIPTION
## What

`{@const y = h = 0}` was printed `{@const y = (h = 0)}`. The tag's body is formatted by
wrapping it as `const <body>;` and handing that to the JS printer, which parenthesizes an
assignment in **declarator-initializer** position. The oracle formats the same body as an
**expression** and neither adds the parentheses nor keeps the source's.

Both engines print `const y = (a = b);` for the plain JS statement, so this is rsvelte asking
the engine a different question — not an engine divergence.

## Why this reverses a pin

This removes the `render_neutral_divergences.rs` pin added in #4052
(`an_assignment_used_as_a_const_body_keeps_its_parentheses`).

The criterion is AGENTS.md's: *reproduce the oracle unless the bytes are invalid JavaScript or
the program's runtime meaning changes.* rsvelte is the diverging side, both forms compile to the
same program, and the oracle's spelling is measured and clean — so the criterion points at
reproducing. The pin's own comment ("both forms are the same expression") asserts
*harmlessness*, which is the premise of a deliberate divergence rather than a reason for one.

## Pre-measurement of the reversal's blast radius

Measured on `origin/main` by the integrator, independently of the author:

| quantity | value |
|---|---|
| pins in `render_neutral_divergences.rs` | 5 |
| pins this PR removes | 1 |
| pins left untouched | 4 |

So the reversal is scoped to the one pin it names; it does not thin the file's other four.

Ratchet movement: `fmt-known-failures.json` −1 entry, `fmt-mechanisms.json` −1 record (they
must move together — the sidecar checker is two-sided).

## Numbers from the author, not re-derived here

Attributed rather than restated as measured by me: the 12-cell rule grid + 3-cell same-file
control + the original 8-cell grid at 23/23 EQ, and a corpus reach of 2 units predicted by an
independent source scan before the output sweep observed the same two.

## The reversal is recorded, not silent

Two tests in `expression.rs` assert `(h = 0)` is no longer emitted, from both the parenthesised
and the bare source. Three further cells assert the parentheses a **nested** assignment still
needs are kept — `(h = 0) + 1`, `c ? (h = 0) : 2`, `() => (h = 0)` — so a fix that simply
stopped parenthesising assignments everywhere would fail here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmNuq3boYDqe9CWwSfxi8
