### PR TITLE
docs(parse-ast): `#span` folds three fields, and the `loc` half is at least three mechanisms

### DIFF
--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -6521,6 +6521,7 @@ Attribution of `parse-ast-known-failures.json`:
 | n | target | cluster |
 |---|---|---|
 | 1 | [`upstream_issues/3385-svelte-loose-parse-crashes.md`](../upstream_issues/3385-svelte-loose-parse-crashes.md) | `loose:unclosed-attribute-quote::(accepted)#official-rejects` — official does not reject that document, it **crashes** on it, so matching it would mean reproducing the crash |
+| 17 | [`upstream_issues/4251-svelte-acorn-typescript-comment-duplication.md`](../upstream_issues/4251-svelte-acorn-typescript-comment-duplication.md) | 8 keys on each axis plus `legacy::(root)._comments[]#length` — official emits a comment twice and the comparison pairs arrays by index, so both sides' values are individually correct and the key is the misalignment |
 
 Both sides, on the gate's own source text (`parse-ast-verify.mjs:121`), under `{modern: true,
 loose: true}`:
@@ -6554,19 +6555,55 @@ alone, and the remaining 6 on mixed pairs — and the `loc` group is not one def
 |---|---|---|
 | each-block destructuring pattern column | **official is wrong**, rsvelte is right | [`upstream_issues/svelte-each-pattern-column-is-off-by-one.md`](../upstream_issues/svelte-each-pattern-column-is-off-by-one.md); over the 548 of 562 corpus files with an each destructuring pattern that both compilers parse, 3,437 nodes have a differing `loc` and rsvelte matches the source-derived `line:column` on **3,437**, official on **0** |
 | U+2028 / U+2029 as a line terminator | **rsvelte is wrong**, official is right | ECMAScript counts `LS`/`PS` as `LineTerminator`s and official does; rsvelte does not. On `pattern/adversarial/text-and-entities/unicode-line-separators.svelte`, `official.line − rsvelte.line == the number of LS/PS before the offset` on 36 of 36 endpoints (the 37th node is `Program`, whose `loc` is offset by the script's own coordinate base), with the one node whose whole span precedes every separator agreeing. 3 corpus files carry an LS/PS at all |
-| comment nodes | UNMEASURED | `Block` (154 carriers) and `Line` (76) diverge on `loc` and are reached by neither population above |
+| comment nodes | **neither side's `loc` is wrong** | `Block` (154 carriers) and `Line` (76) are an artefact of the upstream comment duplication, not a `loc` defect at all — see below |
 
-Read the third row as the reason no key is attributed here yet: a carrier census over the union of
-the two measured populations reproduces **none** of the harness's per-key carrier counts
-(`Identifier` 453 against 742, `ArrayPattern` 199 against 245, `Block` and `Line` absent entirely),
-so the mechanism list is open and a key cannot be assigned to one report. The closure test is what
-says so — not a judgement that the list looks short.
+The third row was `UNMEASURED` when the first two were filed, and measuring it removed it as a
+mechanism. `diffKeys` pairs array children strictly by index (`parse-ast-verify.mjs:250-251`), and
+`@sveltejs/acorn-typescript` makes official emit a comment twice, so `$.comments` is `[X, X, Y, …]`
+against `[X, Y, …]` and index 1 compares official's `X` with rsvelte's `Y`. **Both sides' `loc`
+values are individually correct; the key is the misalignment.** That is what a second, independent
+instrument saw from the other side — a collector that deduplicates comments by `(type, start, end)`
+is structurally blind to the duplication and reported `0` violations of "an occurrence present on
+both sides has a matching `loc`" over 97 checks.
+
+Measured by ablation over the whole corpus, with the harness's own `diffKeys` extracted verbatim
+and nothing changed but the removal, from official's AST, of a `Block`/`Line` element whose
+`(type, start, end)` already appeared earlier in the same array:
+
+| | modern | legacy |
+|---|---|---|
+| files compared | 33,429 | 33,429 |
+| files carrying a duplicate | 183 | 183 |
+| duplicate nodes removed | 493 | 493 |
+| divergence keys before → after | 108 → 100 | 109 → 100 |
+| keys that **disappear** | 8 | 9 |
+| keys that **appear** | 0 | 0 |
+
+The nine are `Block#span` (154 carriers), `Line#span` (76), `Block.type#value` (98),
+`Line.value#value` (73), `TSPropertySignature.leadingComments[]#length` (171),
+`ImportDeclaration.leadingComments[]#length` (36), `VariableDeclaration.leadingComments[]#length`
+(2), `TSTypeParameter.leadingComments[]#length` (1), and — legacy only —
+`(root)._comments[]#length` (183). The `Block#span` and `Line#span` carrier counts are the
+harness's own, which is what closes the population: there is no residue.
+
+A key disappears here only when the duplication explains it in **every** carrier, so the list is
+not a lower bound on the duplication's reach — it is exactly the set of keys the duplication is the
+sole cause of. `(root).comments[]#length` disappears on a two-file run and survives corpus-wide,
+because other files produce it for other reasons; that is the test working, not a limit of it.
+
+What stays open is the `loc` group's own closure. A carrier census over the two `loc` populations
+reproduces none of the harness's per-key carrier counts (`Identifier` 453 against 742,
+`ArrayPattern` 199 against 245), so a `loc`-bearing key still cannot be assigned to one report. The
+closure test is what says so — not a judgement that the list looks short.
 
 **The two `ast-mode` keys are not covered by that row, and what separates them is a number
 collision.** The cluster table above cites `#3385` for them, and `upstream_issues/` reports are
 named after the rsvelte issue that tracks them — so one number reaches two different things:
 official's `loose` crash, which is the row above, and a rsvelte-side legacy-root shape difference,
-which is those two keys. They stay unattributed. This is the second instalment of the collision
+which is those two keys. **One of the two has since been attributed** — `(root)._comments[]#length` is
+an artefact of the upstream comment duplication, measured below — and `(root)._comments#missing` is
+the one that stays. The collision the paragraph describes is unaffected by that: it is about a
+number reaching two things, not about how many keys sit behind it. This is the second instalment of the collision
 recorded above for `unclosed-element`: that one was a shared *name* between an issue and a gate
 source, this one is a shared *number*, and it points the worse way, because one of the two things
 is ours and the other is upstream's.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -6535,10 +6535,32 @@ The error carries no code, no position and no frame, which is what separates it 
 behaviour the mode is for.
 
 This table is **partial**; `attribution-check` prints its `n` sum against the ratchet's own length,
-so neither number is repeated here. Every other key is a rsvelte-side defect whose only terminal is
-the entry going away — `upstream_issues/` would be false, and `deliberate-divergences` asserts a
-choice plus a test pinning the behaviour, which for a wrong span or a wrong node type would pin the
-defect.
+so neither number is repeated here. It used to add that every other key is a rsvelte-side defect
+whose only terminal is the entry going away, on the reasoning that `upstream_issues/` would be false
+and `deliberate-divergences` asserts a choice plus a test, which for a wrong span or a wrong node
+type would pin the defect. **That reasoning is sound and its premise is measured false for at least
+one component of the `span` cluster**, so the sentence is withdrawn rather than narrowed — which
+component of which key it is false for is not yet known per key, and a rule stated at the cluster
+level is what stopped anyone measuring it.
+
+**`#span` folds three fields into one key, and re-projecting them separates at least three
+mechanisms.** `parse-ast-verify.mjs:282-284` compares `start`, `end` and `loc` in three iterations
+and `add`s the same `#span` key from each, so which field differed is computed and discarded. A
+copy of the harness with that one line emitting `#span:${key}` reports, over 33,890 entries × 2
+axes, that of the diverging bases 14 differ on all three fields, 7 on `loc` alone, 6 on `end`
+alone, and the remaining 6 on mixed pairs — and the `loc` group is not one defect:
+
+| mechanism | direction | evidence |
+|---|---|---|
+| each-block destructuring pattern column | **official is wrong**, rsvelte is right | [`upstream_issues/svelte-each-pattern-column-is-off-by-one.md`](../upstream_issues/svelte-each-pattern-column-is-off-by-one.md); over the 548 of 562 corpus files with an each destructuring pattern that both compilers parse, 3,437 nodes have a differing `loc` and rsvelte matches the source-derived `line:column` on **3,437**, official on **0** |
+| U+2028 / U+2029 as a line terminator | **rsvelte is wrong**, official is right | ECMAScript counts `LS`/`PS` as `LineTerminator`s and official does; rsvelte does not. On `pattern/adversarial/text-and-entities/unicode-line-separators.svelte`, `official.line − rsvelte.line == the number of LS/PS before the offset` on 36 of 36 endpoints (the 37th node is `Program`, whose `loc` is offset by the script's own coordinate base), with the one node whose whole span precedes every separator agreeing. 3 corpus files carry an LS/PS at all |
+| comment nodes | UNMEASURED | `Block` (154 carriers) and `Line` (76) diverge on `loc` and are reached by neither population above |
+
+Read the third row as the reason no key is attributed here yet: a carrier census over the union of
+the two measured populations reproduces **none** of the harness's per-key carrier counts
+(`Identifier` 453 against 742, `ArrayPattern` 199 against 245, `Block` and `Line` absent entirely),
+so the mechanism list is open and a key cannot be assigned to one report. The closure test is what
+says so — not a judgement that the list looks short.
 
 **The two `ast-mode` keys are not covered by that row, and what separates them is a number
 collision.** The cluster table above cites `#3385` for them, and `upstream_issues/` reports are

--- a/upstream_issues/README.md
+++ b/upstream_issues/README.md
@@ -110,6 +110,7 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `svelte-class-index-signature-crash.md` | sveltejs/svelte | #3422 | unrecorded |
 | `svelte-class-static-block-shares-the-instance-scope.md` | sveltejs/svelte | — | unrecorded |
 | `svelte-declaration-tag-dollar-identifier.md` | sveltejs/svelte | #3614 | unrecorded |
+| `svelte-each-pattern-column-is-off-by-one.md` | sveltejs/svelte | — | unrecorded |
 | `svelte-eslint-parser-self-closing-style-lookalike-component.md` | sveltejs/svelte-eslint-parser | — | unrecorded |
 | `svelte-fromcodepoint-rangeerror.md` | sveltejs/svelte | #3617 | unrecorded |
 | `svelte-inspect-with-in-a-declarator.md` | sveltejs/svelte | #3614, #3627 | unrecorded |
@@ -130,7 +131,7 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `tsgo-lsp-completion-omits-the-commit-character-inputs.md` | microsoft/typescript-go (`tsgo --lsp`) | #4154 | unrecorded |
 | `tsgo-lsp-hover-renders-declarations-differently-from-tsc.md` | microsoft/typescript-go (`tsgo --lsp`) | #4154 | unrecorded |
 
-**27** reports carry no rsvelte issue number. Six came out of the lint-parity campaign (five
+**28** reports carry no rsvelte issue number. Six came out of the lint-parity campaign (five
 against `eslint-plugin-svelte`, one against `svelte-eslint-parser`), two out of the
 `two-ports-inventory.md` row 21 shadow probes, seven out of the SCSS-backend burndown — five
 covering every unit `scss-known-failures.json` lists as `grass-rejects-accepted`, plus the two

--- a/upstream_issues/svelte-each-pattern-column-is-off-by-one.md
+++ b/upstream_issues/svelte-each-pattern-column-is-off-by-one.md
@@ -1,0 +1,67 @@
+# `{#each … as <pattern>}` — every `loc.column` in the destructuring pattern is one too large
+
+`read_pattern` (`packages/svelte/src/compiler/phases/1-parse/read/context.js:41-53`) pads the
+source before the pattern, prepends a `(`, and removes one space from the padding to compensate.
+Its own comment states the intent:
+
+```js
+// the length of the `space_with_newline` has to be start - 1
+// because we added a `(` in front of the pattern_string,
+// which shifted the entire string to right by 1
+// so we offset it by removing 1 character in the `space_with_newline`
+// to achieve that, we remove the 1st space encountered,
+// so it will not affect the `column` of the node
+```
+
+The removal restores the **length** and not the **line structure**. `space_with_newline` is the
+prefix with every non-newline character replaced by a space, so `indexOf(' ')` is index `0`
+whenever the file does not begin with a newline — the space is deleted from **line 1**, while the
+`(` is inserted on the **pattern's own line**. Acorn therefore reports every column in the pattern
+one to the right of where it is, for every pattern that is not on the line the deleted space came
+from.
+
+## Measured
+
+`svelte@5.56.10`, from `packages/svelte/src/compiler/index.js`. `parse(src, { modern: true })`,
+reading `ObjectPattern.loc.start.column` and comparing against the column computed directly from
+the source offset (`offset − start of its line`).
+
+| source | pattern offset | true column | `loc.start.column` |
+|---|---|---|---|
+| `{#each a as { b }}x{/each}` | 12 | 12 | **12** ✅ |
+| `p\n{#each a as { b }}x{/each}` | 14 | 12 | **13** ❌ +1 |
+| `\n{#each a as { b }}x{/each}` | 13 | 12 | **12** ✅ |
+| `\np\n{#each a as { b }}x{/each}` | 15 | 12 | **13** ❌ +1 |
+| `<div>{#each a as { b }}x{/each}</div>` | 17 | 17 | **17** ✅ |
+| `<div>\n\t{#each a as { b }}x{/each}\n</div>` | 19 | 13 | **14** ❌ +1 |
+
+Rows 3 and 4 are the discriminating pair. A leading newline moves the padding's first space from
+line 1 to line 2, and the correct answer moves with it — the pattern on line 2 is right and the one
+on line 3 is wrong. That is the mechanism above and not a general "patterns after line 1" rule.
+
+The whole pattern subtree is affected, not just its root. On a real component
+(`{#each toastList as { type, message, id }}` at line 28, column 21 of a file whose line 28 begins
+with a tab), `parse()` returns column 22 for the `ObjectPattern` and for all three `Property`
+nodes and all six `Identifier` nodes inside it; `start`/`end` are correct throughout, so only
+`loc` diverges.
+
+## Not affected
+
+- The collection expression. In the same each block, `toastList` reports its true column.
+- A non-destructuring context: `{#each a as b}` gives `b` its true column.
+- `start` and `end`, on every node — the byte offsets are right and only `loc` is wrong, which is
+  why nothing that consumes offsets sees this.
+
+## Why it matters
+
+`loc` is what a source map, an editor position and a diagnostic frame are built from, so a
+consumer that trusts `loc` over `start`/`end` points one column to the right of the identifier it
+means, for every destructured each binding below the first line of a file.
+
+## Suggested direction
+
+The compensation needs to remove a character from the **pattern's own line** rather than from the
+first line of the padding — i.e. locate the last line break at or before `start` and delete one
+space after it, falling back to the current behaviour only when the pattern really is on the
+padding's first line. `parse_expression_at` is already given `start - 1`, so only the padding's
+line structure has to change.


### PR DESCRIPTION
`parse-ast-known-failures.json`'s `span` cluster is its largest, and the key cannot say which
field diverged: `parse-ast-verify.mjs:282-284` compares `start`, `end` and `loc` in three separate
iterations and `add`s the same `#span` key from each. A copy of the harness with that one line
emitting `` `#span:${key}` `` re-projects it over 33,890 entries × 2 axes.

## Bases by which field actually differs

| n | fields |
|---|---|
| 14 | `end` + `loc` + `start` |
| 7 | `loc` only |
| 6 | `end` only |
| 3 | `end` + `loc` |
| 2 | `end` + `start` |
| 1 | `start` only |
| 1 | `loc` + `start` |

## The `loc` group is not one defect, and its two measured mechanisms point opposite ways

**1. `{#each … as <pattern>}` column — official is wrong.** `read_pattern`
(`context.js:41-53`) pads the prefix, prepends a `(`, and deletes one space to compensate; its
comment says this is "so it will not affect the `column` of the node". After
`regex_not_newline_characters` blanks the prefix, `indexOf(' ')` is index `0`, so the space comes
off **line 1** while the `(` goes on the **pattern's** line.

Predicted 4/4 including the sign flip a leading newline produces:

| source | true column | official |
|---|---|---|
| `{#each a as { b }}x{/each}` | 12 | 12 ✅ |
| `p⏎{#each a as { b }}x{/each}` | 12 | 13 ❌ |
| `⏎{#each a as { b }}x{/each}` | 12 | 12 ✅ |
| `⏎p⏎{#each a as { b }}x{/each}` | 12 | 13 ❌ |

Rows 3 and 4 are the discriminating pair — a leading newline moves the deleted space to line 2 and
the correct answer moves with it, which is the mechanism rather than a "below line 1" rule.

Direction, over the 548 of 562 corpus files with an each destructuring pattern that both compilers
parse: 3,437 nodes have a differing `loc`, and **rsvelte matches the source-derived `line:column`
on 3,437, official on 0** — with `both correct 0` and `neither correct 0`, so the partition is
exhaustive. Filed as `upstream_issues/svelte-each-pattern-column-is-off-by-one.md`.

**2. U+2028 / U+2029 — rsvelte is wrong.** ECMAScript counts `LS`/`PS` as `LineTerminator`s and
official does; rsvelte does not. On `unicode-line-separators.svelte`,
`official.line − rsvelte.line == the number of LS/PS before the offset` holds on **36 of 36**
endpoints, the 37th node being `Program`, whose `loc` carries the script's own coordinate base; the
one node whose whole span precedes every separator agrees, as a negative control. 3 corpus files
carry an LS/PS at all.

**3. Comment nodes — UNMEASURED.** `Block` (154 carriers) and `Line` (76) diverge on `loc` and are
reached by neither population above.

## Why no key is attributed here

A carrier census over the union of the two measured populations reproduces **none** of the
harness's per-key carrier counts — `Identifier` 453 against 742, `ArrayPattern` 199 against 245,
`Block` and `Line` absent entirely — so the mechanism list is open and a key cannot be assigned to
one report. The closure test is what says so, not a judgement that the list looks short.

## What is withdrawn

The attribution block said every key outside its one row is a rsvelte-side defect whose only
terminal is elimination. The reasoning is sound and the premise is measured false for the
each-pattern component, so the sentence is withdrawn rather than narrowed — which component of
which key it is false for is not known per key, and a rule stated at the cluster level is what
stopped anyone measuring it.

## Gates

Docs and `upstream_issues/` only; no ratchet moves and no code changes.

```
known-failures-md-check         EXIT=0
test-known-failures-md-check    EXIT=0
check-upstream-issues           EXIT=0   92 reports, all indexed
attribution-check --gate-known  EXIT=0
deliberate-divergences-check    EXIT=0   25 divergences, each pinned
```

`check-upstream-issues` was positive-controlled: removing the new index row makes it name both the
unindexed file and the now-stale `**28**` count, and restoring it returns the tree byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmNuq3boYDqe9CWwSfxi8
