### PR TITLE
fix(parse): read the legacy html fragment's span after `svelte:options` is spliced back

### DIFF
--- a/.changeset/legacy-fragment-span-after-options-splice.md
+++ b/.changeset/legacy-fragment-span-after-options-splice.md
@@ -1,0 +1,12 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(parse): the legacy `html` fragment's span is read after `svelte:options` is spliced back
+
+Upstream's `convert_to_legacy` splices the extracted `<svelte:options>` node back
+into `fragment.nodes` and only then reads `first.start` / `last.end`. rsvelte
+computed the span from the pre-splice vector while building `children` from the
+post-splice one, so a component whose first or last node is `<svelte:options>`
+reported a fragment starting after it — and a component holding nothing else
+reported `start`/`end` of `null` beside a `children` array of length 1.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -6373,7 +6373,7 @@ Ids are `<corpus id with __m<n>__<kind> before the extension> [verdict] (target)
 ## Public `parse()` AST parity ratchet
 
 Gate: `scripts/compat-corpus/parse-ast-verify.mjs`.
-Ratchet: `parse-ast-known-failures.json`, currently **209 entries**.
+Ratchet: `parse-ast-known-failures.json`, currently **208 entries**.
 
 ### The question it asks
 
@@ -6489,11 +6489,11 @@ ratchet at all. So `loose:unclosed-element::RegularElement#span` is an ordinary 
 defect. Reading the issue and the gate as sharing a vocabulary would have attributed an rsvelte
 defect upstream.
 
-Partition of `parse-ast-known-failures.json` by cluster: `62 + 44 + 30 + 30 + 14 + 14 + 6 + 6 + 2 + 1`
+Partition of `parse-ast-known-failures.json` by cluster: `61 + 44 + 30 + 30 + 14 + 14 + 6 + 6 + 2 + 1`
 
 | cluster | keys | bases | what it is |
 |---|---|---|---|
-| `span` | 62 | 33 | `start` / `end` / `loc` disagree on a node type. Merged into one key per node type on purpose: they are derived from the same offsets, and split by field they were 672 keys for the same defects. |
+| `span` | 61 | 32 | `start` / `end` / `loc` disagree on a node type. Merged into one key per node type on purpose: they are derived from the same offsets, and split by field they were 672 keys for the same defects. |
 | `node-type` | 14 | 8 | rsvelte labels a node with a different `type` than acorn/acorn-typescript does. Almost all are TypeScript nodes; the walk stops at a `type` mismatch, so each is one key rather than a spray of derived field keys. |
 | `estree-fields` | 30 | 15 | ESTree fields rsvelte's serializer omits or adds: `typeAnnotation`, `returnType`, `optional`, `readonly`. The lint gates found some of these from the other side. |
 | `unclustered` | 30 | 19 | keys nobody has classified. The cluster exists so an unclassified key reads as unclassified instead of joining someone else's row. |
@@ -6506,8 +6506,8 @@ Partition of `parse-ast-known-failures.json` by cluster: `62 + 44 + 30 + 30 + 14
 
 **Read the `keys` column as `bases x axis`, not as work.** A key is
 `<axis>::<NodeType>.<field>#<kind>` and most node types diverge identically under `modern` and
-`legacy`, so 209 keys are **117 distinct bases**: 92 appear on both axes and 25 on one
-(92x2 + 25 = 209, a 1.79x collapse). The defect ceiling is 117. The per-cluster collapse is not
+`legacy`, so 208 keys are **116 distinct bases**: 92 appear on both axes and 24 on one
+(92x2 + 24 = 208, a 1.79x collapse). The defect ceiling is 116. The per-cluster collapse is not
 uniform — `estree-fields`, `comment-attachment` and `loc-presence` are 2.00x (every base is on
 both axes), `css-shape` 1.56x and `child-count` 1.20x (legacy-only shapes), `ast-mode` and
 `accepts-what-official-rejects` 1.00x by construction.

--- a/compatibility/parse-ast-known-failures.json
+++ b/compatibility/parse-ast-known-failures.json
@@ -37,7 +37,6 @@
 	"legacy::Decorator.expression#missing": "unclustered",
 	"legacy::Decorator.loc#missing": "loc-presence",
 	"legacy::ExpressionStatement.directive#missing": "unclustered",
-	"legacy::Fragment#span": "span",
 	"legacy::Fragment.children[]#length": "child-count",
 	"legacy::FunctionExpression#span": "span",
 	"legacy::FunctionExpression.returnType#missing": "estree-fields",

--- a/crates/rsvelte_core/src/compiler/legacy.rs
+++ b/crates/rsvelte_core/src/compiler/legacy.rs
@@ -531,10 +531,35 @@ fn convert_to_legacy_inner(source: &str, ast: &Root) -> Value {
     let pos_conv = Utf8ToUtf16::for_legacy(source, ast.skip_expression_loc);
     let mut result = Map::new();
 
-    // Calculate html fragment start/end
-    let (start, end) = if !ast.fragment.nodes.is_empty() {
-        let first_start = get_node_start(&ast.fragment.nodes[0]);
-        let last_end = get_node_end(ast.fragment.nodes.last().unwrap());
+    // Convert fragment nodes, inserting svelte:options back if needed
+    let mut fragment_nodes = ast.fragment.nodes.clone();
+    if let Some(ref options) = ast.options {
+        // Find the correct position to insert options
+        let idx = fragment_nodes
+            .iter()
+            .position(|node| options.end <= get_node_start(node))
+            .unwrap_or(fragment_nodes.len());
+
+        // Create a SvelteOptions node to insert
+        let options_node = TemplateNode::SvelteOptions(SvelteElement {
+            start: options.start,
+            end: options.end,
+            name: "svelte:options".into(),
+            name_loc: None,
+            attributes: options
+                .attributes
+                .iter()
+                .map(|a| Attribute::Attribute(a.clone()))
+                .collect(),
+            fragment: Fragment::default(),
+        });
+        fragment_nodes.insert(idx, options_node);
+    }
+
+    // Upstream splices `svelte:options` back in before reading first/last, so the span must follow it.
+    let (start, end) = if !fragment_nodes.is_empty() {
+        let first_start = get_node_start(&fragment_nodes[0]);
+        let last_end = get_node_end(fragment_nodes.last().unwrap());
 
         // Trim whitespace from start and end
         let mut start = first_start as usize;
@@ -560,31 +585,6 @@ fn convert_to_legacy_inner(source: &str, ast: &Root) -> Value {
     } else {
         (None, None)
     };
-
-    // Convert fragment nodes, inserting svelte:options back if needed
-    let mut fragment_nodes = ast.fragment.nodes.clone();
-    if let Some(ref options) = ast.options {
-        // Find the correct position to insert options
-        let idx = fragment_nodes
-            .iter()
-            .position(|node| options.end <= get_node_start(node))
-            .unwrap_or(fragment_nodes.len());
-
-        // Create a SvelteOptions node to insert
-        let options_node = TemplateNode::SvelteOptions(SvelteElement {
-            start: options.start,
-            end: options.end,
-            name: "svelte:options".into(),
-            name_loc: None,
-            attributes: options
-                .attributes
-                .iter()
-                .map(|a| Attribute::Attribute(a.clone()))
-                .collect(),
-            fragment: Fragment::default(),
-        });
-        fragment_nodes.insert(idx, options_node);
-    }
 
     // Build html fragment
     let html = estree_obj! {

--- a/crates/rsvelte_core/tests/legacy_fragment_span_options.rs
+++ b/crates/rsvelte_core/tests/legacy_fragment_span_options.rs
@@ -1,0 +1,116 @@
+//! Upstream's `convert_to_legacy` splices the extracted `<svelte:options>` node
+//! back into `fragment.nodes` and only then reads `first.start` / `last.end`
+//! (`compiler/legacy.js:58-82`), so the html fragment's span covers the options
+//! tag. Expected values are generated through this same entry point —
+//! `svelte.compile(src, { filename: 'main.svelte', generate: 'client' }).ast.html`
+//! on the pinned submodule — rather than inferred from `parse()`.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+use serde_json::Value;
+
+const OPT: &str = "<svelte:options runes={false} />";
+
+fn html_of(source: &str) -> Value {
+    let options = CompileOptions {
+        filename: Some("main.svelte".to_string()),
+        generate: GenerateMode::Client,
+        dev: false,
+        ..Default::default()
+    };
+    let result = compile(source, options).expect("compiles");
+    let text = result.ast.get().expect("compile() must fill `ast`");
+    let ast: Value = serde_json::from_str(text).expect("`ast` is JSON");
+    ast.get("html").expect("legacy ast has `html`").clone()
+}
+
+/// `(name, source, start, end, children)`. A `None` child count is a cell whose
+/// child set diverges for a reason this span rule cannot reach.
+fn cells() -> Vec<(&'static str, String, u64, u64, Option<usize>)> {
+    vec![
+        (
+            "options_first",
+            format!("{OPT}\n<div>x</div>"),
+            0,
+            45,
+            Some(3),
+        ),
+        ("options_only", OPT.to_string(), 0, 32, Some(1)),
+        ("options_only_nl", format!("{OPT}\n"), 0, 32, Some(1)),
+        (
+            "options_middle",
+            format!("<div>a</div>\n{OPT}\n<div>b</div>"),
+            0,
+            58,
+            Some(5),
+        ),
+        // The trailing `Text` between `</div>` and the options tag is dropped
+        // from `children` on the modern axis too, so it is not this rule's.
+        ("options_last", format!("<div>a</div>\n{OPT}"), 0, 45, None),
+        (
+            "leading_ws_options",
+            format!("\n\n  {OPT}\n<div>x</div>"),
+            4,
+            49,
+            Some(4),
+        ),
+        (
+            "options_after_script",
+            format!("<script>\n\tlet a = 1;\n</script>\n{OPT}\n<div>{{a}}</div>"),
+            31,
+            78,
+            Some(4),
+        ),
+        (
+            "negctl_no_options",
+            "<div>x</div>".to_string(),
+            0,
+            12,
+            Some(1),
+        ),
+        (
+            "negctl_ws_div",
+            "\n\n  <div>x</div>\n".to_string(),
+            4,
+            16,
+            Some(2),
+        ),
+        (
+            "negctl_script_div",
+            "<script>\n\tlet a = 1;\n</script>\n<div>{a}</div>".to_string(),
+            31,
+            45,
+            Some(2),
+        ),
+    ]
+}
+
+#[test]
+fn legacy_html_fragment_span_covers_svelte_options() {
+    let mut failures = Vec::new();
+    for (name, source, start, end, children) in cells() {
+        let html = html_of(&source);
+        let got_start = html.get("start").and_then(Value::as_u64);
+        let got_end = html.get("end").and_then(Value::as_u64);
+        if got_start != Some(start) || got_end != Some(end) {
+            failures.push(format!(
+                "{name}: span {got_start:?}..{got_end:?}, official {start}..{end}"
+            ));
+        }
+        if let Some(expected) = children {
+            let got = html.get("children").and_then(Value::as_array).map(Vec::len);
+            if got != Some(expected) {
+                failures.push(format!("{name}: {got:?} children, official {expected}"));
+            }
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Half the cells carry no `<svelte:options>` and must be unaffected; without
+/// them a rule that spans the whole source passes every positive cell.
+#[test]
+fn cells_cover_both_sides_of_the_options_axis() {
+    let (with, without): (Vec<_>, Vec<_>) = cells().into_iter().partition(|c| c.1.contains(OPT));
+    assert!(with.len() >= 5, "{} cells carry svelte:options", with.len());
+    assert!(without.len() >= 3, "{} cells do not", without.len());
+}


### PR DESCRIPTION
## What

Upstream's `convert_to_legacy` splices the extracted `<svelte:options>` node back into
`fragment.nodes` and **only then** reads `first.start` / `last.end`
(`submodules/svelte/packages/svelte/src/compiler/legacy.js:58-82`).

rsvelte computed the html fragment's span from the **pre-splice** vector
(`ast.fragment.nodes`) while building `children` from the **post-splice** one
(`fragment_nodes`) — two readings of one fact inside one function. So a component whose
first or last node is `<svelte:options>` reported a span that excludes it, while its
`children` included it.

The fix is a pure reordering: build the spliced vector first, then read the endpoints from it.

## Carrier

`compatibility/sources/animotion/src/lib/components/slides.svelte` — official `0..842`,
rsvelte `26..842` before this change.

## Ratchet

**This PR drops exactly one id: `legacy::Fragment#span`.** No other ratchet is touched.

`parse-ast-known-failures.json` 209 → 208 entries. `compatibility/KNOWN-FAILURES.md`'s gated
declaration and partition line move with it (`62 + 44 + …` → `61 + 44 + …`), and the ungated
cluster table / base count / collapse ratio were **recomputed from the JSON** rather than
subtracted from the old prose (`span` 62/33 → 61/32; 117 → 116 bases; `92×2 + 24 = 208`;
1.79x collapse unchanged; `0 of 92` cross-cluster bases unchanged).

## Gate verdict

`parse-ast-verify.mjs --report-only`, arm `.corpus-cache/rsvelte.node`
(`builtFromCommit aecb1739f5f6…`, dirty = this fix only):

```
33901 component entries x 2 axes + 7 loose sources — 66,887 compared pairs
STALE (listed but no longer diverging): 1   legacy::Fragment#span
NEW  (diverging but not listed):        0
match -> MISMATCH:                      0
```

`--report-only` exits before the ratchet comparison, so that verdict is a reconstruction of
the gate's three checks (`parse-ast-verify.mjs:607` new / `:613` stale / `:609` cluster drift).
The cluster-drift check was **not run**; it cannot fire here because `clusterOf` is a pure
function of the key string, the `CLUSTERS` table is untouched by this diff, and the new key set
is a subset of the old. Positive control on the key extraction: the report's own header says
`208 divergence keys` and the parse recovered 208.

## Tests

`crates/rsvelte_core/tests/legacy_fragment_span_options.rs` — 10 cells, expected values
generated through the same entry point (`compile(src, {generate:'client'}).ast.html`) on the
pinned submodule, not inferred from `parse()`. A second test asserts the cell set carries
`<svelte:options>` on at least 5 cells and lacks it on at least 3, so a rule that spans the
whole source cannot pass.

## Known and NOT in scope

`<div>a</div>\n<svelte:options …/>` also diverges on the **child set** — official
`[Element, Text, Options]`, rsvelte `[Element, Options]` — and it reproduces on the `modern`
axis too, so it is outside `convert_to_legacy_inner` and is a separate defect. That cell
asserts the span only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ayf2LfKqP7yEEtWjunZ7DF
