### PR TITLE
perf(lint,check): mimalloc for both CLIs, and an overlay source map nothing reads

### DIFF
--- a/.changeset/check-overlay-map-write.md
+++ b/.changeset/check-overlay-map-write.md
@@ -1,0 +1,22 @@
+---
+'@rsvelte/svelte-check': patch
+---
+
+The overlay stops writing a source map no run can read back.
+
+Each component's shadow is accompanied by a `.svelte.tsx.map` on disk, written so a later
+incremental run can recover the map without re-running svelte2tsx. Reading it back requires
+a manifest entry, and `manifest::save` runs under `incremental` alone — so without
+`--incremental` the write is dead: the map the run itself needs is already in memory on
+`OverlayEntry`, and no later run can trust the file.
+
+The overlay is where a large project's check time goes, and it is syscall-bound rather than
+compute-bound: profiled on the report's own 5,000-component workspace, materialization is
+62% of a `--tsgo` run and 95% of its samples sit in `libsystem_kernel` (`open` 38%,
+`rename` 23%, `write` 14%, `close` 11%). Dropping one of the three files per component takes
+the overlay from 15,006 files to 10,006 and measures 1.73x on overlay materialization and
+**1.38x on the whole `--tsgo` run**, 16/16 pairwise wins each.
+
+Both directions are pinned by artifact: with `--incremental` the maps are still written
+(5,000 of them), without it none are, and `check-verify` reports 0 divergences on both the
+`tsc` and `tsgo` backends.

--- a/.changeset/lint-check-mimalloc.md
+++ b/.changeset/lint-check-mimalloc.md
@@ -1,0 +1,18 @@
+---
+'@rsvelte/lint': patch
+'@rsvelte/svelte-check': patch
+---
+
+`rsvelte-lint` and `rsvelte-check` link the allocator the rest of the tree already uses.
+
+The compiler CLI, the NAPI addon and `rsvelte-fmt` set mimalloc as the global allocator;
+these two binaries were still on the macOS system allocator, which a corpus lint profile
+puts at 22% of self time in `nanov2_*`/`tiny_*` alone. Measured as a two-arm ABBA over the
+33,912-file corpus (one tree, two binaries whose `nm -gU | grep -c mi_malloc` reads 0 and 2),
+lint moves 1.285x single-threaded and 1.674x multi-threaded, 6/6 pairwise wins each; the
+lint output is byte-identical over 73,799 findings on 6,788 real-world sources.
+
+`rsvelte-check` measures on the report's own 5,000-component workspace: 1.19x on the
+Svelte-diagnostics row and null under `--tsgo`, where the type-check backend dominates.
+mimalloc is a CLI-only optional dependency of `rsvelte_lint` so the wasm build does not
+carry it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6567,11 +6567,27 @@ Wave 4 architecture (decided; tsgo ships an LSP server as of TypeScript 7, so th
 `skipLibCheck`, idle machine, 3 runs each): **typecheck is 66-89% of the run**, overlay
 materialization 8-29%, walk + post under 2% together.
 
-**The overlay is not the lever, and a diskless overlay is not available anyway.** A batch
-`tsc -p` reads its program from disk, so the LSP's in-memory projection has no counterpart
-here — and even a free overlay caps the whole run at 1.1-1.4x. It does have a shape worth
-knowing: 500 components materialize **2,005 files** (`.svelte.tsx`, `.svelte.tsx.map`, and two
-byte-identical `.d.ts` bridges each), ~310 ms to rewrite.
+**That split is a property of the PROJECT SIZE, and the sentence that used to stand here —
+"the overlay is not the lever" — was read off the small end of it.** Re-measured on the
+5,000-component workspace the site's own report benchmarks, the order inverts: **overlay 62%,
+typecheck 34%**, walk + compile under 4% together. Typecheck grows sublinearly under
+`skipLibCheck` while the overlay writes three files per component, so the ranking those two
+numbers produce depends entirely on which `n` you picked. The claim that a diskless overlay is
+unavailable still stands — a batch `tsc -p` reads its program from disk — but "even a free
+overlay caps the run at 1.1-1.4x" is a statement about 100-500 components and is 2.9x at 5,000.
+
+**And the overlay is syscall-bound, not compute-bound**, which is what makes the file count the
+lever rather than svelte2tsx. Profiled with `samply` (5,000 components, cold cache): **95% of
+samples are in `libsystem_kernel`** — `open` 38%, `rename` 23%, `write` 14%, `close` 11%,
+`stat`/`lstat`/`unlink` 7% together — against 4.5% in rsvelte's own binary. So the arithmetic
+that predicts a change here is "how many syscalls per component does it remove", and #4342 is
+that arithmetic applied once: a `.svelte.tsx.map` written on every non-incremental run can only
+be read back through a manifest entry, and the manifest is persisted under `incremental` alone.
+Deleting one of the three files per component measured **1.73x on the overlay and 1.38x on the
+whole `--tsgo` run**. What is left after it is below the noise floor — memoizing the per-parent
+`create_dir_all` + `reject_symlink_components` (8 `lstat` per file over 100 distinct parents)
+prices at ~4.7% of the overlay, and dropping `write_atomic`'s `rename` prices at 14% of the
+overlay while giving up the one guard against a concurrent run reading a torn shadow.
 
 **`--incremental` is the largest measured lever and it is off by default.** On the
 500-component project a warm run drops from 1693-2147 ms to 254-319 ms — **5.4-6.7x** — because

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,6 +2530,7 @@ name = "rsvelte_check"
 version = "0.5.25"
 dependencies = [
  "clap",
+ "mimalloc",
  "notify",
  "oxc_allocator",
  "oxc_ast",
@@ -2742,6 +2743,7 @@ dependencies = [
  "fancy-regex",
  "javascript-globals",
  "memchr",
+ "mimalloc",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",

--- a/crates/rsvelte_check/Cargo.toml
+++ b/crates/rsvelte_check/Cargo.toml
@@ -23,6 +23,9 @@ rsvelte_core = { path = "../rsvelte_core", default-features = false, features = 
 rsvelte_diagnostics = { path = "../rsvelte_diagnostics" }
 rsvelte_projection = { path = "../rsvelte_projection" }
 clap = { version = "4.5", features = ["derive"] }
+# rsvelte's production allocator, for the same allocation-bound reason the
+# compiler CLI and the NAPI addon use it.
+mimalloc = { version = "0.1", features = ["local_dynamic_tls"] }
 notify = { version = "8", default-features = false, features = ["macos_kqueue"] }
 oxc_allocator = "0.146"
 oxc_ast = "0.146"

--- a/crates/rsvelte_check/src/main.rs
+++ b/crates/rsvelte_check/src/main.rs
@@ -3,6 +3,11 @@
 //! TypeScript type errors. Type-checking runs by default via `tsc`
 //! (or `tsgo` with `--tsgo`); pass `--no-type-check` for Svelte-only.
 
+// rsvelte's production allocator, for the same allocation-bound reason the
+// compiler CLI and the NAPI addon use it.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 

--- a/crates/rsvelte_check/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_check/src/svelte_check/overlay.rs
@@ -745,12 +745,15 @@ pub fn materialize_overlay_with(
                     if emit_dts_twin {
                         write_atomic(&dts_path, shadow_reexport(&tsx_path).as_bytes())?;
                     }
-                    // Persist the source map so the next incremental run can
-                    // recover it without re-running svelte2tsx.
-                    if let Some(map) = &result.map {
-                        write_atomic(&map_path, map.as_bytes())?;
-                    } else {
-                        remove_if_exists(&map_path)?;
+                    // Only an incremental run can read this back: a cache hit
+                    // needs a manifest entry, and the manifest is persisted
+                    // under `incremental` alone.
+                    if incremental {
+                        if let Some(map) = &result.map {
+                            write_atomic(&map_path, map.as_bytes())?;
+                        } else {
+                            remove_if_exists(&map_path)?;
+                        }
                     }
                     Ok(())
                 };

--- a/crates/rsvelte_lint/Cargo.toml
+++ b/crates/rsvelte_lint/Cargo.toml
@@ -31,7 +31,7 @@ required-features = ["cli"]
 default = ["cli"]
 # The CLI: native compiler backend + ESLint-config import + the bin's runtime
 # deps (clap/walkdir/rayon).
-cli = ["native", "eslint-import", "dep:clap", "dep:walkdir", "dep:rayon"]
+cli = ["dep:mimalloc", "native", "eslint-import", "dep:clap", "dep:walkdir", "dep:rayon"]
 # Native product surface (CLI diagnostics, validation, and source-scan rules).
 # Compiler parallelism is an independent opt-in owned by binary callers.
 native = ["dep:rsvelte_preprocess"]
@@ -59,6 +59,10 @@ serde_json = "1.0"
 
 # CLI-only runtime deps (off in the wasm build).
 clap = { version = "4.5", features = ["derive"], optional = true }
+# rsvelte's production allocator. 22% of a corpus lint run's self time was in the
+# system allocator (`nanov2_*`/`tiny_*`), which is what the compiler CLI and the
+# NAPI addon already avoid.
+mimalloc = { version = "0.1", optional = true, features = ["local_dynamic_tls"] }
 walkdir = { version = "2.5", optional = true }
 rayon = { version = "1.10", optional = true }
 

--- a/crates/rsvelte_lint/src/bin/lint_benchmark_runner.rs
+++ b/crates/rsvelte_lint/src/bin/lint_benchmark_runner.rs
@@ -18,6 +18,11 @@
 //!
 //! Output (stdout): `{"times": [<ms>, ...]}`.
 
+// rsvelte's production allocator: a corpus lint run spends 22% of its self time
+// in the system allocator, which the compiler CLI and NAPI addon already avoid.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use std::env;
 use std::fs;
 use std::io::{self, BufRead};

--- a/crates/rsvelte_lint/src/main.rs
+++ b/crates/rsvelte_lint/src/main.rs
@@ -6,6 +6,11 @@
 //! prints diagnostics through the shared `svelte_check` writers (plus a local
 //! SARIF writer) so the output matches `rsvelte check`.
 
+// rsvelte's production allocator: a corpus lint run spends 22% of its self time
+// in the system allocator, which the compiler CLI and NAPI addon already avoid.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 


### PR DESCRIPTION
Two independent measurements, one branch: the lint CLI and `rsvelte-check` were the two binaries in the tree still on the macOS system allocator, and `rsvelte-check`'s overlay writes a file per component that only an incremental run could ever read back.

## 1. mimalloc for `rsvelte-lint` and `rsvelte-check`

`rsvelte_fmt`, `rsvelte_napi` and `rsvelte_devtools` already declare it; these two did not, and a corpus lint profile puts **22% of self time in `nanov2_*` / `tiny_*`**.

Two-arm ABBA, both binaries built from one tree, separated by a discriminating probe on the artifact (`nm -gU | grep -c mi_malloc` → 0 vs 2) and by `sha256`:

| row | A (system) | B (mimalloc) | speedup | pairwise |
|---|---|---|---|---|
| lint, `RAYON=1`, 33,912 files | 74,885 ms | 58,176 ms | **1.285x** | 6/6, p=0.031 |
| lint, default threads | 34,254 ms | 15,460 ms | **1.674x** | 6/6, p=0.031 |
| check, Svelte diagnostics, `RAYON=1` | 443.6 ms | 374.1 ms | **1.186x** | 15/16, p=0.0003 |
| check, Svelte diagnostics, default | 116.9 ms | 105.7 ms | **1.106x** | 13/16, p=0.011 |
| check, `--tsgo` | 4,339 ms | 4,390 ms | 0.989x | 8/16, p=0.60 — **null** |

The `--tsgo` null is the expected one: the type-check backend owns that run.

`lint-verify` reports **0 divergences over 73,799 findings on 6,788 real-world sources**, so the output is byte-identical.

mimalloc is optional and gated behind `cli` in `rsvelte_lint`, so the wasm build does not link it; both `[[bin]]` targets already carry `required-features = ["cli"]`.

## 2. The overlay writes a source map no run can read back

A `.svelte.tsx.map` is emitted per component so a later incremental run can recover it without re-running svelte2tsx. Recovering it requires a manifest entry, and `manifest::save` runs under `incremental` alone — so on a default run the write is dead. The map the run itself needs never leaves memory (`OverlayEntry::source_map`).

Profiled with `samply` on the report's own 5,000-component workspace: **95% of the overlay's samples are in `libsystem_kernel`** (`open` 38%, `rename` 23%, `write` 14%, `close` 11%), so the file count is the cost, not svelte2tsx. The overlay goes from 15,006 files to 10,006:

| row | before | after | speedup | pairwise |
|---|---|---|---|---|
| overlay materialization | 2,998.8 ms | 1,736.6 ms | **1.73x** | 16/16, p<0.0001 |
| whole `--tsgo` run | 4,423.1 ms | 3,211.7 ms | **1.38x** | 16/16, p<0.0001 |

Both directions are pinned by artifact rather than by intent: with `--incremental` the maps are still written (5,000 of them), without it none are.

## Correctness

- `check-verify` (layer 1, 36 mini-projects): 0 divergences on the `tsc` backend **and** on `--rsvelte-backend tsgo`.
- `cargo test --release -p rsvelte_check`: 268 passed across 11 targets, including 222 lib tests.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean on the workspace.
- `lint-verify`: 0 new divergences.

## AGENTS.md

`### Where rsvelte-check time goes` said "typecheck is 66-89% of the run, overlay 8-29%" and concluded the overlay is not the lever. That was measured at 100 and 500 components; at 5,000 the order **inverts** to overlay 62% / typecheck 34%, because typecheck grows sublinearly under `skipLibCheck` while the overlay writes three files per component. The section now records that the split is a property of `n`, that the overlay is syscall-bound, and what the two remaining candidates cost (~4.7% for memoizing the per-parent `create_dir_all` + `reject_symlink_components`, 14% for dropping `write_atomic`'s `rename` at the price of the only guard against a concurrent run reading a torn shadow) — both below the noise floor of the measurement above, which is why neither is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyd6xc1EN5Jt4yNWeiWtuy