### PR TITLE
fix(sourcemap): the annotation end survives split coordinates too

### DIFF
--- a/.changeset/annotation-end-in-split-coordinates.md
+++ b/.changeset/annotation-end-in-split-coordinates.md
@@ -1,0 +1,12 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(sourcemap): the annotation end survives split coordinates too
+
+`(binding end, annotation end)` reached only the re-parsed span's end lookup.
+A comment anywhere in the script moves the printer onto split coordinates,
+where an end position is resolved through `loc_map` instead — and the copied
+run carried no override there, so the segment pointed back at the annotation's
+colon. `LocRange` now carries the pair and the end lookup consumes it on both
+routes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.37"
+version = "0.10.38"
 dependencies = [
  "compact_str",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.146", features = ["serialize"] }
 oxc_span = "0.146"
 oxc_diagnostics = "0.146"
 oxc_codegen = "0.146"
-rsvelte_esrap = { version = "=0.10.37", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.38", path = "../rsvelte_esrap" }
 oxc_syntax = "0.146"
 oxc_semantic = "0.146"
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -767,6 +767,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 end: region.1,
                 source: source_offset,
                 linear: false,
+                source_end_override: None,
             });
         } else {
             // The parser's chunk coordinates are retained in comment space, and
@@ -788,6 +789,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                         end: region.0 + start,
                         source: None,
                         linear: false,
+                        source_end_override: None,
                     });
                 }
                 synth.loc_map.push(LocRange {
@@ -795,6 +797,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                     end: region.0 + end,
                     source: Some(span.source.start + (start - span.code.start)),
                     linear: true,
+                    source_end_override: span.source_end_override,
                 });
                 cursor = end;
             }
@@ -804,6 +807,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                     end: region.1,
                     source: None,
                     linear: false,
+                    source_end_override: None,
                 });
             }
         }

--- a/crates/rsvelte_core/tests/binding_annotation_map_end_4319.rs
+++ b/crates/rsvelte_core/tests/binding_annotation_map_end_4319.rs
@@ -223,3 +223,125 @@ fn cell_parameter_with_default() {
         )
     );
 }
+
+/// The `generated line:column -> source line:column` pairs the client map
+/// carries. A position SET cannot see this defect: the annotation end is still
+/// emitted somewhere, just against the wrong generated column.
+fn source_pairs(source: &str) -> BTreeSet<((i64, i64), (i64, i64))> {
+    let map = compile(
+        source,
+        CompileOptions {
+            filename: Some("M.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .map
+    .expect("the client map is on by default");
+
+    let mappings = map
+        .split("\"mappings\":")
+        .nth(1)
+        .and_then(|rest| rest.split('"').nth(1))
+        .expect("mappings field")
+        .to_string();
+
+    let mut out = BTreeSet::new();
+    let mut state = [0i64; 4];
+    for (generated_line, line) in mappings.split(';').enumerate() {
+        state[0] = 0;
+        for segment in line.split(',') {
+            if segment.is_empty() {
+                continue;
+            }
+            let mut fields = Vec::new();
+            let mut value = 0i64;
+            let mut shift = 0u32;
+            for byte in segment.bytes() {
+                let digit = match byte {
+                    b'A'..=b'Z' => i64::from(byte - b'A'),
+                    b'a'..=b'z' => i64::from(byte - b'a') + 26,
+                    b'0'..=b'9' => i64::from(byte - b'0') + 52,
+                    b'+' => 62,
+                    b'/' => 63,
+                    _ => panic!("not a base64 VLQ digit: {byte}"),
+                };
+                value += (digit & 31) << shift;
+                shift += 5;
+                if digit & 32 == 0 {
+                    let negative = value & 1 == 1;
+                    value >>= 1;
+                    fields.push(if negative { -value } else { value });
+                    value = 0;
+                    shift = 0;
+                }
+            }
+            for (index, field) in fields.iter().take(4).enumerate() {
+                state[index] += field;
+            }
+            if fields.len() >= 4 {
+                out.insert(((generated_line as i64, state[0]), (state[2], state[3])));
+            }
+        }
+    }
+    out
+}
+
+fn pairs(spelled: &str) -> BTreeSet<((i64, i64), (i64, i64))> {
+    spelled
+        .split_whitespace()
+        .map(|entry| {
+            let (generated, source) = entry.split_once("->").expect("generated->source");
+            let parse = |text: &str| {
+                let (line, column) = text.split_once(':').expect("line:column");
+                (line.parse().expect("line"), column.parse().expect("column"))
+            };
+            (parse(generated), parse(source))
+        })
+        .collect()
+}
+
+/// Every pair the oracle emits has to be present. rsvelte emits extra pairs of
+/// its own on these inputs, which is a separate divergence and is not pinned
+/// here.
+fn assert_covers_oracle(source: &str, oracle: &str) {
+    let got = source_pairs(source);
+    let missing: Vec<_> = pairs(oracle).difference(&got).copied().collect();
+    assert_eq!(
+        missing,
+        Vec::new(),
+        "pairs the oracle emits and rsvelte does not"
+    );
+}
+
+/// A comment anywhere in the script moves the printer onto split coordinates,
+/// where the end position is resolved through `loc_map` rather than through the
+/// re-parsed span. The annotation end has to survive that route too.
+#[test]
+fn cell_comment_then_annotated_declarator() {
+    assert_covers_oracle(
+        "<script lang=\"ts\">\n\tlet count: number = 0;\n\n\t// c\n\n\tfunction inc() { count++; }\n</script>\n<div>{count}</div>\n",
+        "6:36->0:0 6:37->0:1 7:1->1:1 7:5->1:5 7:10->1:18 7:30->1:21 7:31->1:22
+         10:1->5:1 10:9->5:9 10:10->5:10 10:13->5:13 10:16->5:16 10:17->5:17
+         11:11->5:18 11:16->5:23 12:1->5:27 12:2->5:28
+         14:5->7:1 14:8->7:4 15:20->7:1 15:23->7:4 17:9->7:1 17:12->7:4
+         18:48->7:6 18:53->7:11 19:20->7:1 19:23->7:4 20:0->6:8 20:1->6:9",
+    );
+}
+
+/// The same source with no annotation - a negative control the fix must not
+/// move. `7:10` is the binding's own end on both sides here.
+#[test]
+fn cell_comment_then_plain_declarator() {
+    assert_covers_oracle(
+        "<script lang=\"ts\">\n\tlet count = 0;\n\n\t// c\n\n\tfunction inc() { count++; }\n</script>\n<div>{count}</div>\n",
+        "6:36->0:0 6:37->0:1 7:1->1:1 7:5->1:5 7:10->1:10 7:30->1:13 7:31->1:14
+         10:1->5:1 10:9->5:9 10:10->5:10 10:13->5:13 10:16->5:16 10:17->5:17
+         11:11->5:18 11:16->5:23 12:1->5:27 12:2->5:28
+         14:5->7:1 14:8->7:4 15:20->7:1 15:23->7:4 17:9->7:1 17:12->7:4
+         18:48->7:6 18:53->7:11 19:20->7:1 19:23->7:4 20:0->6:8 20:1->6:9",
+    );
+}

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.37"
+version = "0.10.38"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -143,6 +143,11 @@ pub struct LocRange {
     pub source: Option<u32>,
     /// Whether the range advances through the source byte for byte.
     pub linear: bool,
+    /// `(binding_end, annotation_end)` for a binding whose type annotation was
+    /// erased from the copied text: upstream's parser ends the binding after the
+    /// annotation, so an end position landing on `binding_end` reports
+    /// `annotation_end` instead.
+    pub source_end_override: Option<(u32, u32)>,
 }
 
 /// A block body whose braces map somewhere other than its comment-placement
@@ -900,18 +905,35 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         if !self.loc_map.is_empty() {
             let index = self.loc_map.partition_point(|range| range.end < offset);
             if let Some(range) = self.loc_map.get(index)
-                && range.end == offset
+                && range.start <= offset
                 && range.linear
                 && let Some(source) = range.source
             {
                 let mapped = source + (offset - range.start);
-                let line_starts = self.map_line_starts.as_deref().unwrap_or(&self.line_starts);
-                let line = usize_to_u32(line_starts.partition_point(|&s| s <= mapped));
-                let line_start = line_starts[(line - 1) as usize];
-                return Some((line, mapped.saturating_sub(line_start)));
+                // The annotation is erased from the copied text, so the same
+                // token ends one run earlier here than it does upstream.
+                if let Some((binding_end, annotation_end)) = range.source_end_override
+                    && mapped == binding_end
+                {
+                    return self.source_line_col(annotation_end);
+                }
+                if range.end == offset {
+                    return self.source_line_col(mapped);
+                }
             }
         }
         self.map_position(offset)
+    }
+
+    /// Source-map line and column of a source-space `offset`.
+    fn source_line_col(&self, offset: u32) -> Option<(u32, u32)> {
+        let line_starts = self.map_line_starts.as_deref().unwrap_or(&self.line_starts);
+        if line_starts.is_empty() {
+            return None;
+        }
+        let line = usize_to_u32(line_starts.partition_point(|&s| s <= offset));
+        let line_start = line_starts[(line - 1) as usize];
+        Some((line, offset.saturating_sub(line_start)))
     }
 
     /// esrap's `write_source_keyword`: bracket the literal `keyword` with

--- a/crates/rsvelte_esrap/tests/split_coordinates.rs
+++ b/crates/rsvelte_esrap/tests/split_coordinates.rs
@@ -97,6 +97,7 @@ impl<'a> Assembler<'a> {
             end: base + source_offset(text.len()),
             source: maps_to,
             linear: false,
+            source_end_override: None,
         });
         self.body.extend(program.body);
     }
@@ -118,6 +119,7 @@ impl<'a> Assembler<'a> {
             end: base + source_offset(text.len()),
             source: Some(maps_to),
             linear: true,
+            source_end_override: None,
         });
         self.body.extend(program.body);
     }
@@ -409,12 +411,14 @@ fn linear_range_maps_a_token_end_before_a_generated_suffix() {
         end: base + source_offset(expression.len()),
         source: Some(anchor),
         linear: true,
+        source_end_override: None,
     });
     a.loc_map.push(LocMapEntry {
         start: base + source_offset(expression.len()),
         end: base + source_offset(generated.len()),
         source: None,
         linear: false,
+        source_end_override: None,
     });
     a.body.extend(program.body);
 

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -259,7 +259,6 @@ name = "corsa_core"
 version = "1.12.4"
 dependencies = [
  "base64",
- "bumpalo",
  "compact_str",
  "memchr",
  "rustc-hash",
@@ -1373,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.37"
+version = "0.10.38"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
Continues #4346, which is the same rule on the other route.

## The rule

Upstream parses with acorn-typescript, whose `Identifier` range covers its own type annotation, so esrap stamps the map at the **annotation's** end. rsvelte erases the annotation before re-parsing with oxc, so the binding ends at its own last byte and `ScriptProjection` carries `(binding end, annotation end)` to repair it.

#4346 consumed that pair in `RestoreRawMappedSpans::source_end_offset` — the route a re-parsed AST span takes. There is a second route: **a comment anywhere in the script puts the printer on split coordinates**, where `map_end_position` resolves an end through `loc_map` and never reaches that lookup. `LocRange` carried no override, so the segment pointed back at the annotation's colon.

`LocRange` now carries the pair through `take_chunk_region`, and the `loc_map` branch of `map_end_position` consumes it.

## The cell

```svelte
<script lang="ts">
	let count: number = 0;

	// c

	function inc() { count++; }
</script>
<div>{count}</div>
```

| | `g7:10` |
|---|---|
| oracle | `s1:18` — the byte after `number` |
| rsvelte, before | `s1:10` — the colon |
| rsvelte, after | `s1:18` |

Delete the `// c` and rsvelte was already right, which is what says the axis is the coordinate space and not the annotation.

**A position SET cannot see this class** — the annotation end is still emitted, at the wrong generated column — so the file's existing `source_positions` helper reports these cells as identical. `cell_comment_then_annotated_declarator` therefore compares `generated line:column -> source line:column` **pairs**, asserting that every pair the oracle emits is present. Both expected sets were generated from `submodules/svelte`, never read back out of rsvelte.

`cell_comment_then_plain_declarator` is the negative control: the same source with the annotation removed. Ablating the propagation (`source_end_override: None` at the push site) fails the first and passes the second; restoring it leaves the tree byte-identical.

## Measurement

Two arms, distinct `sha256` (`794a367c…` base at `f8a00afb0`, `4f6e6c59…` head), `corpus_hash` over 33,912 collected components, rows == distinct keys on both:

| | moved |
|---|---|
| `js.code` + `css.code` (no `--map`) | **0** / 33,912 |
| the same with `--map` | **1,618** / 33,912 |

So the change is map-only, and its reach is 1,618 client units. **The direction of those 1,618 is UNMEASURED**: no gate compares a corpus map to the oracle's, and I did not build one for this. What is measured is the fixture oracle:

- On `main`'s population the sourcemaps gate is unchanged — `770/770 official segments, 0 missing, 0 wrong, 0/1634 out of range`, ratchet still `[]`.
- Applied on top of #4291, where `sourcemaps/samples/typescript` becomes byte-identical and its 52 segments enter the comparison for the first time, this fix alone takes it from `46 exact / 2 missing / 4 wrong` to `48 exact / 2 missing / 2 wrong` — both repaired segments are the two annotated bindings in that fixture (`let count: number` and `const clear: ITimeoutDestroyer`), whose script holds a comment.

The two remaining divergences there are a different mechanism (the text aligner's resync after `count++` -> `$.update(count)`) and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyd6xc1EN5Jt4yNWeiWtuy
