### PR TITLE
fix(fmt): repair the two formatter gates the submodule bumps left red on main

### DIFF
--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -8911,7 +8911,7 @@ measurement above had to be written for this row.
 ### The formatter's CSS engine is oxc, not prettier's PostCSS
 
 **Ratchet** `compatibility/fmt-oracle-excluded.json`, three `oracle-bug` entries: `css-vars`,
-`svelte.dev .../docs/[topic]/[...path]/+layout.svelte`, and
+`svelte.dev .../docs/[topic]/[...path=documentation]/+layout.svelte`, and
 `pattern/adversarial/css/css-custom-property-values`.
 **Pinned by** `crates/rsvelte_formatter/tests/css_native.rs`.
 

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -3341,7 +3341,7 @@ correct; file upstream at `oxformatter/oxfmt` or `prettier/prettier-plugin-svelt
 - **`--svelte` CSS path defects.** Double-spaces an empty custom-property value
   (`css-vars`); emits a single space before `{` after an escaped-unicode selector
   (`unicode-identifier`); wraps a deeply-nested `calc(...)` differently
-  (`svelte.dev .../docs/[topic]/[...path]/+layout.svelte`).
+  (`svelte.dev .../docs/[topic]/[...path=documentation]/+layout.svelte`).
 - **oxfmt formats embedded CSS differently from standalone CSS.** For
   `--arr: [1, 2]` / `--sel: a > b ~ c`, `oxfmt x.css` prints `[1 , 2]` /
   `a > b ~ c` while `oxfmt --svelte` prints `[1, 2]` / `a > b ~c` — the same tool

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -903,7 +903,7 @@ Svelte structure, oxc for embedded JS, and PostCSS for embedded CSS) and require
 embedded CSS by default, so the ratchet intentionally includes CSS-engine parity
 as well as Svelte-structure parity. The ratchet may only shrink.
 
-**Current baseline: `fmt-known-failures.json`, 519 entries.** The 789-entry
+**Current baseline: `fmt-known-failures.json`, 520 entries.** The 789-entry
 split this paragraph used to give (22 pre-enrolment + 766 expanded population + 1
 pattern-corpus repro) no longer holds: 239 entries left the ratchet in the
 2026-09-01 re-baseline, and the CI report the baseline is derived from carries a
@@ -928,7 +928,7 @@ An id that carries two clusters' divergences at once is filed under its dominant
 one (see *Multiple clusters per id*), so the per-cluster counts below remain a
 partition of the ratchet rather than an over-count:
 
-Partition of `fmt-known-failures.json` by cluster: `242 + 212 + 15 + 36 + 12 + 1 + 1`
+Partition of `fmt-known-failures.json` by cluster: `243 + 212 + 15 + 36 + 12 + 1 + 1`
 
 **The partition is now the mechanical rule applied to all 520 entries**, where it
 used to be the hand-diagnosed Clusters 1-12 (23 entries) plus the mechanical
@@ -1420,9 +1420,9 @@ buckets per entry from the doc would be transcription, not measurement.
 | 2 | the two engines disagree about whitespace around a selector token neither models — the column combinator and a `nth-child(… of <selector>)` clause: rsvelte's `oxc_formatter_css` prints the space, the oracle's PostCSS path closes it up; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace | `crates/rsvelte_formatter/tests/css_native.rs` — `a_column_combinator_keeps_its_spaces`, `an_nth_child_of_clause_keeps_the_space_after_of` |
 | 1 | a hex escape ending a selector: rsvelte emits the escape's terminating space and the separator before `{` as two spaces where the oracle emits one — the same file's 18 other selectors, including every hex escape followed by more text, agree; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace | `crates/rsvelte_formatter/tests/css_native.rs` — `a_hex_escape_ending_a_selector_keeps_its_own_separator` |
 | 1 | continuation indent of a comma-separated multi-value declaration: rsvelte's engine prints every continuation at one depth where the oracle's PostCSS path indents the ones following an interleaved comment one level deeper than the first; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace | `crates/rsvelte_formatter/tests/css_native.rs` — `every_continuation_of_a_multi_value_declaration_sits_at_one_depth` |
-| 514 | no upstream report and no pinned deliberate divergence; elimination is the only end state open to these entries | none |
+| 515 | no upstream report and no pinned deliberate divergence; elimination is the only end state open to these entries | none |
 
-Partition of `fmt-known-failures.json` by mechanism: `1 + 2 + 1 + 1 + 514`
+Partition of `fmt-known-failures.json` by mechanism: `1 + 2 + 1 + 1 + 515`
 
 Attribution of `fmt-known-failures.json`:
 
@@ -1588,7 +1588,7 @@ this cell is not a hug disagreement: it is a layout pass 1.6 does not have, name
 after the open tag and borrowing the closing tag's `>` onto its own line. How many corpus
 entries carry that shape is **unmeasured**.
 
-**What this population is not.** `fmt-known-failures.json` holds 519 entries; the 72 carriers
+**What this population is not.** `fmt-known-failures.json` holds 520 entries; the 72 carriers
 here are the ones whose *first differing line* is a `>` boundary, so this is a sub-population
 chosen by a signature, not a cluster of the partition above. An entry is retired only when
 every one of its differing regions is repaired.
@@ -1627,7 +1627,7 @@ the four classes come out `27 / 122 / 244 / 127` under the order now printed, an
 ungated half rot separately — `known-failures-md-check` reads the partition line and reads no
 prose, so the line stayed right while the table drifted.
 
-Partition of `fmt-known-failures.json` by diff shape: `244 + 126 + 122 + 27`
+Partition of `fmt-known-failures.json` by diff shape: `244 + 127 + 122 + 27`
 
 **Three of every four entries agree on every token and differ only in layout** — every row above
 except the token one. The placement and line-break rows are separated on purpose: collapsing runs

--- a/compatibility/fmt-known-failures.json
+++ b/compatibility/fmt-known-failures.json
@@ -181,6 +181,7 @@
 	"kite-public/src/lib/components/story/StoryQuote.svelte",
 	"layercake/src/_components/AxisY.percent-range.html.svelte",
 	"layercake/src/_components/AxisYRight.percent-range.html.svelte",
+	"layerchart/docs/src/examples/components/Chart/facet-click.svelte",
 	"layerchart/docs/src/examples/components/Chart/facet-wrap.svelte",
 	"layerchart/docs/src/routes/+page.svelte",
 	"layerchart/packages/layerchart/src/lib/components/Labels/Labels.base.svelte",

--- a/compatibility/fmt-mechanisms.json
+++ b/compatibility/fmt-mechanisms.json
@@ -205,6 +205,7 @@
 		"kite-public/src/lib/components/story/StoryQuote.svelte": "unattributed",
 		"layercake/src/_components/AxisY.percent-range.html.svelte": "unattributed",
 		"layercake/src/_components/AxisYRight.percent-range.html.svelte": "unattributed",
+		"layerchart/docs/src/examples/components/Chart/facet-click.svelte": "unattributed",
 		"layerchart/docs/src/examples/components/Chart/facet-wrap.svelte": "unattributed",
 		"layerchart/docs/src/routes/+page.svelte": "css-engine-multi-value-indent",
 		"layerchart/packages/layerchart/src/lib/components/Labels/Labels.base.svelte": "unattributed",

--- a/compatibility/fmt-oracle-excluded.json
+++ b/compatibility/fmt-oracle-excluded.json
@@ -80,7 +80,7 @@
 		"reason": "oxfmt's `--svelte` CSS path emits a single space before `{` after an escaped-unicode selector (`#\\31\\32\\33 {`), while its OWN raw-CSS path emits two (`#\\31\\32\\33  {`) — the same text rsvelte produces under --no-native-css. Oracle is internally inconsistent between its svelte-embedded and standalone CSS formatters; rsvelte matches the raw-CSS path."
 	},
 	{
-		"id": "svelte.dev/apps/svelte.dev/src/routes/docs/[topic]/[...path]/+layout.svelte",
+		"id": "svelte.dev/apps/svelte.dev/src/routes/docs/[topic]/[...path=documentation]/+layout.svelte",
 		"class": "oracle-bug",
 		"reason": "oxfmt's `--svelte` CSS path wraps a deeply-nested `calc((100vw - ... ) )` value differently (opens `(` on its own line) than its OWN raw-CSS path, which rsvelte drives under --no-native-css. This is the 'long CSS-value wrapping differs' inconsistency the corpus fmt.mjs header documents between oxfmt's two CSS code paths; rsvelte is self-consistent with the raw-CSS path."
 	},

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -259,7 +259,6 @@ name = "corsa_core"
 version = "1.12.4"
 dependencies = [
  "base64",
- "bumpalo",
  "compact_str",
  "memchr",
  "rustc-hash",

--- a/scripts/fixtures/generate-fmt-corpus.mjs
+++ b/scripts/fixtures/generate-fmt-corpus.mjs
@@ -241,6 +241,22 @@ async function main() {
   const configSrc = fs.readFileSync(OXFMT_CONFIG, 'utf8');
   const configHash = createHash('sha256').update(configSrc).digest('hex').slice(0, 16);
 
+  // An exclusion whose path no longer exists silently stops excluding anything,
+  // and the byte-exact gate then fails on whatever upstream renamed the file to.
+  const stale = [...EXCLUDED_REL].filter(
+    (rel) => !fs.existsSync(path.join(SVELTE_DEV, rel)),
+  );
+  if (stale.length > 0) {
+    console.error(
+      `[generate-fmt-corpus] compatibility/fmt-oracle-excluded.json names ` +
+        `${stale.length} svelte.dev path(s) this checkout does not have:\n` +
+        stale.map((rel) => `  svelte.dev/${rel}`).join('\n') +
+        `\n\nUpstream renamed or deleted them. Point each entry at the new path, ` +
+        `or drop it if the divergence is gone.`,
+    );
+    process.exit(1);
+  }
+
   const svelteFiles = [...walkFiles(SVELTE_DEV, (n) => n.endsWith('.svelte'))].sort();
   const mdFiles = [
     ...walkFiles(SVELTE_DEV, (n) => MARKDOWN_EXTS.has(path.extname(n))),


### PR DESCRIPTION
`main` has been red on **`Test fmt corpus`** and **`Formatter parity`** since 83b6af78a. Two independent causes, both from the submodule bumps merged earlier today, neither of which is a compiler regression.

## 1. The svelte.dev exclusion went stale (#4055)

`compatibility/fmt-oracle-excluded.json` carries exactly one `svelte.dev/`-prefixed id. Upstream renamed the route, so the id stopped matching anything:

```
docs/[topic]/[...path]/+layout.svelte          -> gone
docs/[topic]/[...path=documentation]/+layout.svelte  -> the same file, new name
```

An exclusion whose path no longer exists **silently stops excluding**, and the byte-exact svelte.dev gate then fails on the file it was meant to skip. `fmt-verify` says so out loud (`WARNING: excluded id not in parity set (stale?)`) and the Rust gate does not.

The renamed file carries the **same** divergence the entry records ("opens `(` on its own line"), so re-pointing the id restores the intended exclusion rather than hiding a new one — reproduced on it directly:

```diff
         calc(
           0.5 *
-            (
-              100vw - var(--sk-page-content-width) -
-                var(--sk-page-padding-side) - var(--sk-page-padding-side)
-            )
+            (100vw - var(--sk-page-content-width) -
+              var(--sk-page-padding-side) - var(--sk-page-padding-side))
         )
```

Fixed: the id, the two prose references in `GATES.md` / `KNOWN-FAILURES.md`, and a guard in `generate-fmt-corpus.mjs` that refuses to run when any `svelte.dev/` exclusion names a path this checkout does not have. The class cannot recur silently.

## 2. The layerchart bump adds a component (#4057)

`layerchart/docs/src/examples/components/Chart/facet-click.svelte` does not exist at `a3c51c5` and does exist at `6941212` — corpus growth, not a regression. Its sibling `facet-wrap.svelte` in the same directory is already listed.

Reproduced locally with the gate's own oracle and binary (`oxfmt -c scripts/fixtures/fmt-corpus.oxfmtrc.json --stdin-filepath …`, then `rsvelte-fmt . -c … --oxfmt-bin …` over a staged copy). rsvelte's first differing line is byte-identical to the one CI reports, which is what says the reproduction is the gate's:

```
-    Clicked <b>{selected.party}</b> in {selected.row.year} — {(
-      selected.row.percent * 100
-    ).toFixed(1)}%
+    Clicked <b>{selected.party}</b> in {selected.row.year} — {(selected.row.percent * 100).toFixed(
+      1,
+    )}%
```

Classified by measurement rather than by eye:

- **cluster 20 — breaks-later**, by the stated rule (rsvelte's line is the longer): 99 chars against 63.
- **diff shape: a real token difference.** All three whitespace normalizations still differ, because rsvelte writes a **trailing comma**. Reading this as a pure line-break entry would have been wrong.

Doc numbers were not typed — `known-failures-md-check` named all six, they were corrected one at a time, and it is green. Incidentally the two disagreeing populations reconcile: the ungated diff-shape table already read `27 / 122 / 244 / 127 = 520` while the gated partition line read `519`; the token addend moving `126 -> 127` makes them agree per class.

## What is not here

`[fmt-verify] NOTICE: excluded id now matches oracle — consider un-excluding: svelte/…/block-expression-assign/main.svelte` is a notice, not a failure, and predates these bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyd6xc1EN5Jt4yNWeiWtuy
