### PR TITLE
fix(lint-types): re-resolve the out-of-workspace lock after the corsa-bind bump

### DIFF
--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -259,7 +259,6 @@ name = "corsa_core"
 version = "1.12.4"
 dependencies = [
  "base64",
- "bumpalo",
  "compact_str",
  "memchr",
  "rustc-hash",


### PR DESCRIPTION
`main` is red on `Lint-types lockfile` (run 33997284682, job 101389908513). This is one line of `crates/rsvelte_lint_types/Cargo.lock`.

```
error: cannot update the lock file …/crates/rsvelte_lint_types/Cargo.lock because --locked was passed
crates/rsvelte_lint_types/Cargo.lock is out of date — `cargo metadata --locked` above refused to update it.
```

**The carrier is a submodule bump, not the Rust crate bumps.** The diff is `corsa_core` losing its `bumpalo` dependency — `corsa_core` lives at `submodules/corsa-bind/src/core/corsa_core/`, and #4053 bumped that submodule to `da15ba0d4444`. I first attributed it to the batch's `crossbeam-channel` / `smallvec` / `libc` / `string_wizard` bumps because the job's message says "something in the root workspace changed the resolution"; reading the diff rather than the message named the real one.

```diff
 name = "corsa_core"
 dependencies = [
  "base64",
- "bumpalo",
  "compact_str",
```

Measured: `bumpalo` is absent from `corsa_core`'s manifest at the new submodule sha, positive control `memchr` present. Whether the *previous* sha carried it is **UNMEASURED** — that commit is not fetched locally, and I would rather leave the direction unstated than infer it.

Two-sided control on the fix itself:

```
revert the file  -> check-lint-types-lock exits 1
restore it       -> exits 0
```

Produced by the repair the job's own message prescribes (`git submodule update --init submodules/corsa-bind` then `pnpm run fix:lint-types-lock`), not by hand.

**This is the failure mode the job exists to catch, outrun by a batch merge.** `crates/rsvelte_lint_types` is its own Cargo workspace, so the root `cargo test` never re-resolves it; `Lint-types lockfile` runs on every PR precisely so drift fails on the PR that introduces it. Twenty commits landed on `main` together and #4053 was green alone.

The other root cause of today's red `main` — 2 NEW `Formatter parity` failures, both arriving with the svelte.dev and layerchart submodule bumps — is lane C and is with rsvelte-72. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmNuq3boYDqe9CWwSfxi8