### PR TITLE
chore(report): the performance report's group ids are derived, not four stale literals

### DIFF
--- a/scripts/reports/run-performance.mjs
+++ b/scripts/reports/run-performance.mjs
@@ -455,7 +455,7 @@ for (const target of targets) {
     dev: target.dev,
     comparisonClasses: [
       {
-        id: "svelte-5.56.8",
+        id: `svelte-${officialVersion}`,
         files: currentEligible.length,
         excludedFiles: files.length - currentEligible.length,
         bytes: currentBytes,
@@ -500,7 +500,7 @@ for (const target of targets) {
         ],
       },
       {
-        id: "svelte-5.56.4",
+        id: `svelte-${referenceVersion}-mrwaip`,
         files: mrwaipEligible.length,
         excludedFiles: files.length - mrwaipEligible.length,
         bytes: mrwaipBytes,
@@ -539,7 +539,7 @@ for (const target of targets) {
         ],
       },
       {
-        id: "svelte-5.56.8-verter",
+        id: `svelte-${officialVersion}-verter`,
         files: currentEligible.length,
         excludedFiles: files.length - currentEligible.length,
         bytes: currentBytes,
@@ -863,7 +863,7 @@ const result = {
       `@typescript/native (npm:typescript@${tsgoVersion.replace(/^TypeScript | \(native\)$/g, "")})`,
       `oxvelte@${OXVELTE_VERSION}+${OXVELTE_REV}`,
     ],
-    competitorReferences: ["svelte@5.56.4", "svelte@5.56.8"],
+    competitorReferences: [`svelte@${referenceVersion}`, `svelte@${officialVersion}`],
   },
   commit: {
     rsvelte: git("rev-parse", "HEAD"),


### PR DESCRIPTION
Four of the six version strings in the performance report were string literals, and a competitor bump left them naming versions nothing in the run was using. `id: "svelte-5.56.8"` sat three lines above `version: officialVersion`, so one group's own two fields disagreed.

Measured on this tree, with each arm asked what it reports rather than what it is called:

| what the report said | what the arm reports |
|---|---|
| `id: "svelte-5.56.8"` | built `compiler/index.js` `VERSION` = **5.56.10** |
| `id: "svelte-5.56.4"` (the mrwaip reference) | `svelte-mrwaip-reference` `VERSION` = **5.56.10** |
| `id: "svelte-5.56.8-verter"` | same built compiler = **5.56.10** |
| `competitorReferences: ["svelte@5.56.4", "svelte@5.56.8"]` | **5.56.10** and **5.56.10** |

All four now read the same variables the sibling `version:` fields already read, which are assigned once at `run-performance.mjs:64-65`. No other behaviour changes; the group ids are labels in the emitted JSON.

Two notes on why the values are taken this way. The two Svelte compilers export `VERSION` and the two competitors do not, so the competitors keep reading their installed manifest — a version has to be read off the arm, and the arm decides which source can answer. And the entry point matters: this script imports `submodules/svelte/packages/svelte/compiler/index.js`, the **built** compiler, which can report a different `VERSION` from the source tree the corpus gates use. Reading it from the module the run actually loaded is the point of the change, so it stays that import.

The `id` is a label, and this repository already records that an arm's label is not its identity. What makes a stale label worse than a missing one here is that it is emitted into the shipped artifact, where a reader has no way to tell it apart from a measured field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyd6xc1EN5Jt4yNWeiWtuy
