### PR TITLE
fix(esrap): derive a pattern property's shorthand from key/value name equality

### DIFF
--- a/.changeset/esrap-redundant-binding-alias-shorthand.md
+++ b/.changeset/esrap-redundant-binding-alias-shorthand.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A redundant object-pattern alias collapses to shorthand, as esrap derives it from name equality

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.38"
+version = "0.10.39"
 dependencies = [
  "compact_str",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.146", features = ["serialize"] }
 oxc_span = "0.146"
 oxc_diagnostics = "0.146"
 oxc_codegen = "0.146"
-rsvelte_esrap = { version = "=0.10.38", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.39", path = "../rsvelte_esrap" }
 oxc_syntax = "0.146"
 oxc_semantic = "0.146"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.38"
+version = "0.10.39"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -668,6 +668,22 @@ fn child_binary_op(expr: &Expression) -> &'static str {
     }
 }
 
+/// esrap derives a pattern property's shorthand from key/value name equality, not
+/// from the parsed flag, unwrapping an `AssignmentPattern` default before comparing.
+fn binding_property_is_shorthand(node: &BindingProperty) -> bool {
+    if node.computed {
+        return false;
+    }
+    let PropertyKey::StaticIdentifier(key) = &node.key else {
+        return false;
+    };
+    let mut value = &node.value;
+    if let BindingPattern::AssignmentPattern(assign) = value {
+        value = &assign.left;
+    }
+    matches!(value, BindingPattern::BindingIdentifier(id) if id.name == key.name)
+}
+
 /// Whether a concise arrow body must be wrapped in parens (esrap's
 /// `arrow_concise_body_needs_wrap`). A body that is an object literal — or a
 /// compound whose leftmost token would otherwise be `{` — is ambiguous with a
@@ -3093,7 +3109,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     }
 
     fn binding_property(&mut self, node: &BindingProperty, ctx: &mut Context<DIRECT>) {
-        if node.shorthand {
+        if node.shorthand || binding_property_is_shorthand(node) {
             self.binding_pattern(&node.value, ctx);
             return;
         }
@@ -6160,6 +6176,38 @@ mod tests {
             print_ok("function f({ a = 1 }) {}"),
             "function f({ a = 1 }) {}"
         );
+    }
+
+    /// Every expectation is esrap 2.2.12's own output for the same source
+    /// (`submodules/svelte/node_modules/.pnpm/esrap@*/node_modules/esrap`), which
+    /// derives shorthand from key/value name equality rather than from the parsed
+    /// flag. The last four rows are the controls: a real alias, a string key and a
+    /// computed key must NOT collapse, and an already-shorthand property must not
+    /// change.
+    #[test]
+    fn redundant_binding_alias_collapses_to_shorthand() {
+        assert_eq!(print_ok("const { a: a } = o;"), "const { a } = o;");
+        assert_eq!(print_ok("const { a: a = 1 } = o;"), "const { a = 1 } = o;");
+        assert_eq!(
+            print_ok("const { a: a, ...rest } = o;"),
+            "const { a, ...rest } = o;"
+        );
+        assert_eq!(
+            print_ok("const { a: { b: b } } = o;"),
+            "const { a: { b } } = o;"
+        );
+        assert_eq!(
+            print_ok("function f({ a: a = 1 }) {}"),
+            "function f({ a = 1 }) {}"
+        );
+
+        assert_eq!(print_ok("const { a: b } = o;"), "const { a: b } = o;");
+        assert_eq!(
+            print_ok("const { \"a\": a } = o;"),
+            "const { \"a\": a } = o;"
+        );
+        assert_eq!(print_ok("const { [k]: k } = o;"), "const { [k]: k } = o;");
+        assert_eq!(print_ok("const { a } = o;"), "const { a } = o;");
     }
 
     #[test]

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.38"
+version = "0.10.39"
 dependencies = [
  "compact_str",
  "memchr",

--- a/scripts/release/check-core-consumer-changesets.mjs
+++ b/scripts/release/check-core-consumer-changesets.mjs
@@ -68,6 +68,13 @@ const RULES = [
     requires: ['@rsvelte/compiler', '@rsvelte/svelte2tsx', '@rsvelte/svelte-check'],
   },
   {
+    prefix: 'crates/rsvelte_esrap/src/',
+    // Only `rsvelte_core` links it, so a change here reaches every artifact the
+    // core reaches while matching none of the `crates/rsvelte_core/src/` prefix
+    // below — the printer can ship a different output shape with no changeset.
+    requires: ['@rsvelte/compiler'],
+  },
+  {
     prefix: 'crates/rsvelte_check/src/',
     requires: ['@rsvelte/svelte-check'],
   },


### PR DESCRIPTION
Closes #4110.

## What

esrap has **one** `Property` visitor for object literals and object patterns, and it
re-derives shorthand from key/value **name equality** rather than reading the parsed
`shorthand` flag — unwrapping an `AssignmentPattern` default before comparing
(`esrap@2.2.12`). `rsvelte_esrap`'s `binding_property` read the parsed flag, so a
redundant alias spelled out in the source (`const { a: a } = o`) survived into the
output where official collapses it to `const { a } = o`.

The defect is in the **printer**, not in a transform, so it is shared by every
`ObjectPattern` printed through `rsvelte_esrap` on either target.

## Expectations came from the oracle, not from rsvelte

Every row of the new unit test is esrap 2.2.12's own output for the same source,
read out of `submodules/svelte/node_modules/.pnpm/esrap@2.2.12_*/node_modules/esrap`
rather than inferred from a few of our own outputs.

The last four rows are the controls and they run the other way: a real alias
(`{ a: b }`), a string key (`{ "a": a }`) and a computed key (`{ [k]: k }`) must
**not** collapse, and an already-shorthand property must not change. A rule that
always collapses passes the first five rows and fails these.

## Blast radius — measured, both directions

Two arms, one process each, `sha256` distinct
(`main` `c1a13247…`, `fix` `5fbf2672…`), identified by a discriminating probe on
output (#4110's own repro moves `DIFF -> EQ` on the fix arm; #4264's repro stays
`DIFF` on **both**, so the probe separates the arms rather than the runs).

Over the collected corpus, 34,885 `.svelte` sources per target:

| target | units moved | `MISMATCH -> match` | `match -> MISMATCH` |
|---|---|---|---|
| server | 7 | **6** | **0** |
| client | 4 | **3** | **0** |

The moved-but-not-flipped units changed their bytes without changing their verdict
against the oracle — reported separately rather than folded into the repaired count.

## Changeset guard

`scripts/release/check-core-consumer-changesets.mjs` gains a
`crates/rsvelte_esrap/src/` rule. Only `rsvelte_core` links the printer, so a change
here reaches every artifact the core reaches while matching **none** of the existing
`crates/rsvelte_core/src/` prefix — the printer could ship a different output shape
with no changeset. `node scripts/release/test-core-consumer-changesets.mjs` passes.

## Verification

- `cargo test --release -p rsvelte_esrap --lib` — 57 passed, 0 failed (56 + the new one)
- `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings`
  via the pre-commit hook — clean
- The heavy `rsvelte_core` fixture suites are left to CI; the local evidence for them is
  the 34,885-file × 2-target sweep above, which is a superset of their shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj