### PR TITLE
fix(lsp): css diagnostics read declarations, not the first colon on a line

### DIFF
--- a/.changeset/css-diagnostics-declaration-scan.md
+++ b/.changeset/css-diagnostics-declaration-scan.md
@@ -1,0 +1,12 @@
+---
+'@rsvelte/language-server': patch
+---
+
+fix(lsp): css diagnostics read declarations, not the first colon on a line
+
+`css::diagnostics` took the first `:` on each line of a `<style>` body, so a
+selector's own pseudo-class was reported as an unknown property (`a:hover` on
+its own line reports `a`) and every declaration after the first `;` on a line
+was invisible. It now walks the body tracking brace depth, comments and string
+literals, and reads a property only from a chunk that sits inside a block —
+which is what `vscode-css-languageservice` gets from a parsed stylesheet.

--- a/crates/rsvelte_language_server/src/css.rs
+++ b/crates/rsvelte_language_server/src/css.rs
@@ -48,29 +48,8 @@ pub fn diagnostics(text: &str) -> Vec<Diagnostic> {
         let end = text[start..]
             .find("</style")
             .map_or(text.len(), |at| start + at);
-        let body = &text[start..end];
-        let mut line_offset = 0;
-        for line in body.split_inclusive('\n') {
-            let current_line_offset = line_offset;
-            line_offset += line.len();
-            let Some(colon) = line.find(':') else {
-                continue;
-            };
-            let property = line[..colon]
-                .rsplit(['{', '}', ';'])
-                .next()
-                .unwrap_or("")
-                .trim();
-            if property.is_empty()
-                || property.starts_with("--")
-                || !property
-                    .bytes()
-                    .all(|byte| byte.is_ascii_alphabetic() || byte == b'-')
-                || KNOWN_CSS_PROPERTIES.contains(&property)
-            {
-                continue;
-            }
-            let property_start = start + current_line_offset + line.find(property).unwrap_or(0);
+        for (property_start, property) in unknown_properties(&text[start..end]) {
+            let property_start = start + property_start;
             diagnostics.push(Diagnostic {
                 range: Range::new(
                     index.position(text, property_start),
@@ -86,6 +65,86 @@ pub fn diagnostics(text: &str) -> Vec<Diagnostic> {
         from = end.saturating_add(8);
     }
     diagnostics
+}
+
+/// Every unknown property name in a `<style>` body, as `(offset, name)`.
+///
+/// `vscode-css-languageservice` asks a parsed stylesheet (`lint.js:355,369`
+/// consult `decl.getProperty()`), so a declaration is what sits between two
+/// declaration boundaries *inside a block* — never a selector, and never only
+/// the first one on a line.
+fn unknown_properties(body: &str) -> Vec<(usize, &str)> {
+    let bytes = body.as_bytes();
+    let mut found = Vec::new();
+    let mut depth = 0usize;
+    let mut chunk_start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i = body[i + 2..]
+                    .find("*/")
+                    .map_or(bytes.len(), |at| i + 2 + at + 2);
+                continue;
+            }
+            quote @ (b'"' | b'\'') => {
+                i += 1;
+                while i < bytes.len() && bytes[i] != quote {
+                    i += if bytes[i] == b'\\' { 2 } else { 1 };
+                }
+                i += 1;
+                continue;
+            }
+            b'{' => {
+                depth += 1;
+                chunk_start = i + 1;
+            }
+            b'}' => {
+                if depth > 0 {
+                    push_declaration(body, chunk_start, i, depth, &mut found);
+                }
+                depth = depth.saturating_sub(1);
+                chunk_start = i + 1;
+            }
+            b';' => {
+                push_declaration(body, chunk_start, i, depth, &mut found);
+                chunk_start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    // An unterminated final declaration is still one the user is typing.
+    push_declaration(body, chunk_start, bytes.len(), depth, &mut found);
+    found
+}
+
+fn push_declaration<'a>(
+    body: &'a str,
+    start: usize,
+    end: usize,
+    depth: usize,
+    found: &mut Vec<(usize, &'a str)>,
+) {
+    if depth == 0 || start >= end {
+        return;
+    }
+    let chunk = &body[start..end];
+    let Some(colon) = chunk.find(':') else {
+        return;
+    };
+    let name = chunk[..colon].trim();
+    if name.is_empty()
+        || name.starts_with("--")
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphabetic() || byte == b'-')
+        || KNOWN_CSS_PROPERTIES.contains(&name)
+    {
+        return;
+    }
+    let offset = start + (name.as_ptr() as usize - chunk.as_ptr() as usize);
+    found.push((offset, name));
 }
 
 #[must_use]
@@ -381,6 +440,7 @@ fn values(prefix: &str) -> Vec<CompletionItem> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lsp_types::Position;
 
     fn labels(text: &str) -> Vec<String> {
         completions(text, text.len())
@@ -475,6 +535,13 @@ mod tests {
         );
     }
 
+    fn messages(text: &str) -> Vec<String> {
+        diagnostics(text)
+            .into_iter()
+            .map(|diagnostic| diagnostic.message)
+            .collect()
+    }
+
     #[test]
     fn reports_unknown_css_properties() {
         let typo = diagnostics("<style>a { colro: red; --theme: blue }</style>");
@@ -483,8 +550,51 @@ mod tests {
             typo[0].code,
             Some(NumberOrString::String("css_unknown_property".to_string()))
         );
-        // The scan stops at the first `:` on a line, so the `--theme` above is
-        // never read and the custom-property guard decides nothing there.
         assert!(diagnostics("<style>a {\n  --theme: blue;\n}</style>").is_empty());
+    }
+
+    #[test]
+    fn a_selector_colon_is_not_a_declaration() {
+        for selector in [
+            "a:hover",
+            "input:focus",
+            "li:nth-child(2)",
+            "::selection",
+            "a:hover, b:focus",
+        ] {
+            assert!(
+                messages(&format!("<style>\n{selector} {{ color: red }}\n</style>")).is_empty(),
+                "{selector}"
+            );
+        }
+        assert!(
+            messages("<style>\n@media (min-width: 700px) {\n  a { color: red }\n}\n</style>")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn every_declaration_on_a_line_is_read() {
+        assert_eq!(
+            messages("<style>\na { colro: red; badprop: blue }\n</style>"),
+            [
+                "Unknown CSS property `colro`.".to_string(),
+                "Unknown CSS property `badprop`.".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn declaration_range_covers_the_property_name() {
+        let text = "<style>\na { colro: red }\n</style>";
+        let range = diagnostics(text)[0].range;
+        assert_eq!(range.start, Position::new(1, 4));
+        assert_eq!(range.end, Position::new(1, 9));
+    }
+
+    #[test]
+    fn comments_and_strings_are_not_declarations() {
+        assert!(messages("<style>\na { /* colro: red */ color: blue }\n</style>").is_empty());
+        assert!(messages("<style>\na::before { content: \"badprop: x\" }\n</style>").is_empty());
     }
 }


### PR DESCRIPTION
Closes #4267.

## What

`css::diagnostics` (`crates/rsvelte_language_server/src/css.rs`) found unknown CSS
properties by scanning the `<style>` body **one line at a time** and taking the
**first `:` on the line**. Both failure directions reproduce on the running server.

Measured with two release binaries built from this worktree (base
`4df5a065dfe8…`, fixed `6e8187c87a22…`, distinct `sha256`), driven over stdio,
one document `<style>⏎a:hover { color: red }⏎b { colro: red; badprop: blue }⏎</style>`,
filtering `textDocument/diagnostic` items to `source == "rsvelte-css"`:

| arm | items |
|---|---|
| base | `Unknown CSS property \`a\`.` @1:0, `Unknown CSS property \`colro\`.` @2:4 |
| fixed | `Unknown CSS property \`colro\`.` @2:4, `Unknown CSS property \`badprop\`.` @2:16 |

The false positive is the serious one: any selector whose first colon precedes
the first declaration reports the selector's element name.

## Fix

The scan walks the body tracking brace depth, block comments and string
literals, and reads a property name only from a chunk terminated by `;`, `}`
or the body's end **inside a block**. A prelude — a selector, an `@media`
condition — is discarded at the `{` that closes it. That is what
`vscode-css-languageservice` gets from a parsed stylesheet: `lint.js:355,369`
ask `cssDataManager.isKnownProperty(decl.getProperty())`.

## Tests

Four new unit tests, and the existing one is now honest. The old test's
`--theme` cell was the **second** colon on its line, so the custom-property
guard was exercised by nothing; under the new scan it is reached and skipped,
and `len() == 1` still holds for the right reason.

- `a_selector_colon_is_not_a_declaration` — `a:hover`, `input:focus`,
  `li:nth-child(2)`, `::selection`, a selector list, and an `@media` prelude.
- `every_declaration_on_a_line_is_read` — both `colro` and `badprop`.
- `declaration_range_covers_the_property_name`.
- `comments_and_strings_are_not_declarations`.

`cargo test --release -p rsvelte_language_server --lib --test robustness --test upstream_fixture_manifest`:
351 + 7 + 6 pass. The `css-smoke-diagnostics-{ok,sass,stylus}` and
`css-unknown-property` fixture assertions are unchanged.

## Gate

The LSP differential fixtures suite was run on both arms with the same official
oracle (`submodules/language-tools` @ `092af3826`, svelte 5.56.10) and the same
tsgo: **224 known divergences, 0 added, 0 removed** on each. The baseline was
re-run three times unpatched and reported 0/0 every time, so the environment
reproduces CI's fixture population exactly.

Not measured: the corpus half of the LSP gate, which runs on a schedule and
needs corpus submodules this worktree does not carry. Corpus `diagnostic` keys
carry no digest (`/items:extra-rsvelte` / `missing-rsvelte`), so a content
change moves a key only when a file's extra set empties or a file gains its
first extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSuCFoDV9gDHEVPQjPFDmH