### PR TITLE
fix(client): a `<script module>` reassignment resolves its value through the binding's initializer

### DIFF
--- a/.changeset/module-state-reassign-non-proxy.md
+++ b/.changeset/module-state-reassign-non-proxy.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A `<script module>` reassignment resolves its value through the binding's initializer, so a module local initialised to `undefined` or a primitive is no longer proxied

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -6170,12 +6170,17 @@ fn transform_module_script_runes_with_target(
             .cloned()
             .collect();
 
+        // Upstream's `AssignmentExpression` proxy decision resolves an Identifier
+        // through `binding.initial` exactly as the `$state(x)` initializer does, so
+        // the reassignment site takes the same list. A module script has no props,
+        // which is the one thing the instance path's `reassign_non_proxy_vars` adds
+        // to its own `non_proxy_vars`.
         result = state_pipeline_ast::transform_state_pipeline_ast(
             &result,
             &pipeline_state_vars,
             &derived_vars,
             analysis.runes,
-            &[],
+            &module_non_proxy_vars,
             &pipeline_non_reactive_vars,
         )
         .unwrap_or(result);

--- a/crates/rsvelte_core/tests/state_proxy_module_host.rs
+++ b/crates/rsvelte_core/tests/state_proxy_module_host.rs
@@ -1,0 +1,123 @@
+//! `state_proxy_undefined_initial.rs` is the same grid on the **instance**
+//! host, where both compilers already agreed. rsvelte keeps the module
+//! script's `$state` lowering in its own port with its own pair of lists —
+//! one for the `$state(x)` **initializer** and one for a **reassignment**
+//! `s = x` — mirroring the instance path's `non_proxy_vars` /
+//! `reassign_non_proxy_vars`. The initializer list was built from
+//! `is_non_proxy_node_type`; the reassignment list was the empty slice, so
+//! every value written into a module `$state` was proxied.
+//!
+//! One cell per list is the point: with only the initializer rows the grid is
+//! green on a tree where the reassignment list is still empty. Every expected
+//! value was read out of the official compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`), and both
+//! directions are present — a predicate that always proxies passes every
+//! `true` row and one that never proxies passes every `false` row.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[derive(Clone, Copy)]
+enum Site {
+    /// `let s = $state(a)`. `s` is reassigned elsewhere on purpose: upstream's
+    /// `is_state_source` demotes a never-reassigned `$state` to a plain value,
+    /// and then there is no `$.state(...)` to read the decision off.
+    Initializer,
+    /// `s = a` inside an exported function.
+    Reassignment,
+}
+
+fn source(site: Site, declaration: &str) -> String {
+    match site {
+        Site::Initializer => format!(
+            "<script module>\n\t{declaration}\n\tlet s = $state(a);\n\texport function bump() {{ s = 1; }}\n</script>\n{{1}}\n"
+        ),
+        Site::Reassignment => format!(
+            "<script module>\n\t{declaration}\n\tlet s = $state(0);\n\texport function go() {{ s = a; }}\n</script>\n{{1}}\n"
+        ),
+    }
+}
+
+/// The `(` … `)` of the first call whose text starts with `needle`, plus how
+/// many top-level commas it holds. Read off the whole call rather than a line:
+/// both compilers break a call across lines when the value is multi-line.
+fn call_at(code: &str, needle: &str) -> Option<(String, usize)> {
+    let at = code.find(needle)?;
+    let open = at + code[at..].find('(')?;
+    let mut depth = 0usize;
+    let mut commas = 0usize;
+    for (i, b) in code.as_bytes()[open..].iter().enumerate() {
+        match b {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((code[at..open + i + 1].to_string(), commas));
+                }
+            }
+            b',' if depth == 1 => commas += 1,
+            _ => {}
+        }
+    }
+    None
+}
+
+fn is_proxied(site: Site, declaration: &str, dev: bool) -> bool {
+    let src = source(site, declaration);
+    let js = compile(
+        &src,
+        CompileOptions {
+            filename: Some("C.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    match site {
+        Site::Initializer => {
+            let (text, _) = call_at(&js, "$.state(")
+                .unwrap_or_else(|| panic!("no `$.state(` for `{declaration}` in:\n{js}"));
+            text.contains("$.proxy(")
+        }
+        Site::Reassignment => {
+            let (_, commas) = call_at(&js, "$.set(s,")
+                .unwrap_or_else(|| panic!("no `$.set(s,` for `{declaration}` in:\n{js}"));
+            commas >= 2
+        }
+    }
+}
+
+/// `(declaration, official proxies the value)` — the same answer at both sites.
+const CELLS: &[(&str, bool)] = &[
+    ("let a = undefined;", false),
+    ("let a = 1;", false),
+    ("let a = 'x';", false),
+    ("let a = null;", false),
+    ("let a = () => 1;", false),
+    ("let a = {};", true),
+    ("let a = [];", true),
+    ("let a;", true),
+];
+
+#[test]
+fn a_module_state_takes_the_same_proxy_decision_at_both_sites() {
+    for &(declaration, expected) in CELLS {
+        for site in [Site::Initializer, Site::Reassignment] {
+            for dev in [false, true] {
+                let site_name = match site {
+                    Site::Initializer => "initializer",
+                    Site::Reassignment => "reassignment",
+                };
+                assert_eq!(
+                    is_proxied(site, declaration, dev),
+                    expected,
+                    "`{declaration}` at the {site_name} site (dev={dev})"
+                );
+            }
+        }
+    }
+    assert!(CELLS.iter().any(|c| c.1), "no cell expects a proxy");
+    assert!(CELLS.iter().any(|c| !c.1), "no cell expects no proxy");
+}


### PR DESCRIPTION
Closes #4264.

## What

Upstream's `should_proxy` (`3-transform/client/utils.js:133-163`) resolves an
`Identifier` through `binding.initial` and recurses, and it is the **same** question at
the `$state(x)` initializer and at an `AssignmentExpression`. rsvelte keeps the module
script's lowering in its own port with its own **pair** of lists, mirroring the instance
path's `non_proxy_vars` / `reassign_non_proxy_vars`:

| list | consumer | state before |
|---|---|---|
| `module_non_proxy_vars` | `transform_module_state_runes_ast` (the `$state(x)` initializer) | built from `is_non_proxy_node_type` — correct |
| the `non_proxy_vars` argument of `transform_state_pipeline_ast` (a reassignment `s = x`) | `state_assigns_combined_ast` | **`&[]`** |

So the reassignment site had no notion of the rule at all and proxied everything. A module
script has no props, which is the one thing the instance path's `reassign_non_proxy_vars`
adds on top of its own `non_proxy_vars`, so the module path can pass the list it already has.

## Measured — one cell per list, both directions

Grid: 8 declarations x {initializer, reassignment} x {prod, dev} = 32 cells, each expectation
read out of `submodules/svelte/packages/svelte/src/compiler/index.js` rather than inferred
from rsvelte's own output.

| arm | EQ | DIFF |
|---|---|---|
| `main` (`c1a13247…`) | 22 | **10** |
| this branch (`df4b3e70…`) | **32** | 0 |

All 10 diverging cells were at the **reassignment** site — `undefined`, `1`, `'x'`, `null`,
`() => 1` in both modes — and the initializer site was already 16/16. That is why the grid
crosses declaration x **site**: with only the initializer rows it is green on a tree where
the reassignment list is still empty, which is the failure mode the issue asked for.

Both directions are present and asserted rather than restated as counts: `{}`, `[]` and a
declaration with **no** initializer must proxy at both sites, and do.

## Blast radius — zero, with the population stated

Two arms, one process per arm (loading two addons in one process segfaults), `sha256`
distinct, arm identity probed **two-sidedly**: the arm must *contain* #4264 (32/32 grid,
vs 22/32 on `main`) and must *lack* #4110's esrap shorthand change (`const { a: a }` still
prints the alias here, and prints shorthand on my #4368 arm — so the probe separates arms,
not runs).

`git diff 8057104f8..origin/main -- crates/` is empty, so the stored `main` arm is a valid
base for this comparison.

| population | rows | distinct keys | live | moved |
|---|---|---|---|---|
| `.svelte`, client prod | 34,882 | 34,882 | 33,623 | **0** |
| `.svelte`, client dev | 34,882 | 34,882 | 33,623 | **0** |
| `.svelte.(js\|ts)`, client prod | 843 | 843 | 735 | **0** |
| `.svelte.(js\|ts)`, client dev | 843 | 843 | 735 | **0** |

The module rows are run through the gate's own preparation (`esbuild.transformSync({loader:
'ts'})`, 667 files stripped). Without it the live population is **120**, and a sweep over the
dead 723 is arithmetically forced to report zero — that is `AGENTS.md`'s "an instrument dead
on the carrying population" case, so the number above is the stripped one.

Read the zero as a statement about the corpus, not about the fix: #4264 measured **0**
carriers over 33,545 files (1,981 with a module script and 3,425 containing `= undefined`
are its two positive controls, so the zero is a conjunction's zero). The grid is the
detector here; the sweep only says nothing else moved.

## Relationship to #4212

#4212's **OVER-proxy** rows (`const c = undefined` / `const c = 1` written into a module
`$state`) are this defect and are closed by this change. Its **UNDER-proxy** half — the text
sniff being an allow-list where upstream is a deny-list, so `(0, {})` and `` x`t` `` lose
their proxy — is untouched and stays open.

## Verification

- `cargo test --release -p rsvelte_core --test state_proxy_module_host --test state_proxy_undefined_initial` — 2 passed, 0 failed (the instance-host grid is the unchanged-host control)
- `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` via the pre-commit hook — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj