### PR TITLE
fix(fmt): do not forward the child oxfmt's stdout in write mode

### DIFF
--- a/.changeset/oxfmt-write-stdout-leak.md
+++ b/.changeset/oxfmt-write-stdout-leak.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/fmt': patch
+---
+
+A directory run no longer forwards the child `oxfmt`'s stdout in write mode, where it reported a scope the caller never chose

--- a/crates/rsvelte_fmt/src/oxfmt.rs
+++ b/crates/rsvelte_fmt/src/oxfmt.rs
@@ -187,10 +187,15 @@ pub fn run_oxfmt(
         .output()
         .with_context(|| format!("failed to run `{}` — is oxfmt installed?", oxfmt.display()))?;
 
-    // Forward oxfmt's captured stdout (its own summary / check listing).
     let stdout = String::from_utf8_lossy(&out.stdout);
-    print!("{stdout}");
-    let _ = io::stdout().flush();
+    // Check mode's listing names the files that would be reformatted, so it is
+    // the answer; write mode's is a summary of a run whose scope the caller
+    // never chose — on a Svelte-only tree it reads `No files found matching the
+    // given patterns.` / `on 0 files`, contradicting our own summary line.
+    if matches!(mode, Mode::Check) {
+        print!("{stdout}");
+        let _ = io::stdout().flush();
+    }
 
     let (files_total, issues) = parse_oxfmt_counts(&stdout);
     let code = out.status.code();

--- a/crates/rsvelte_fmt/tests/cli/main.rs
+++ b/crates/rsvelte_fmt/tests/cli/main.rs
@@ -11,6 +11,7 @@ mod daemon;
 mod deep_nesting;
 mod delegation;
 mod native;
+mod oxfmt_stdout;
 mod stdin;
 mod style;
 mod tailwind;

--- a/crates/rsvelte_fmt/tests/cli/oxfmt_stdout.rs
+++ b/crates/rsvelte_fmt/tests/cli/oxfmt_stdout.rs
@@ -1,0 +1,69 @@
+use std::process::Command;
+
+use crate::common::{bin, tempdir};
+
+/// A fake oxfmt that writes one recognisable line to stdout and exits 0 —
+/// standing in for the real summary (`Finished in 2ms on 0 files …`) and the
+/// real check listing, which are the same stream.
+const CHATTY_OXFMT: &str = "console.log('FAKE-OXFMT-STDOUT');\n";
+
+fn run(dir: &std::path::Path, extra: &[&str]) -> (String, String, i32) {
+    let fake = dir.join("fake-oxfmt.cjs");
+    std::fs::write(&fake, CHATTY_OXFMT).unwrap();
+    let mut args = vec![
+        dir.to_str().unwrap().to_string(),
+        "--oxfmt-bin".to_string(),
+        fake.to_str().unwrap().to_string(),
+    ];
+    args.extend(extra.iter().map(|s| (*s).to_string()));
+    let out = Command::new(bin()).args(&args).output().unwrap();
+    (
+        String::from_utf8(out.stdout).unwrap(),
+        String::from_utf8(out.stderr).unwrap(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// #4302: a directory run invokes `oxfmt` for the non-`.svelte` share even when
+/// the tree holds only `.svelte` files, and forwarding that invocation's stdout
+/// printed a `No files found matching the given patterns.` / `on 0 files` pair
+/// above our own `formatted 1 / 1 files`. The two describe different scopes and
+/// the first reads exactly like a failure.
+#[test]
+fn write_mode_does_not_forward_the_child_oxfmt_stdout() {
+    let dir = tempdir();
+    std::fs::write(dir.join("App.svelte"), "<script>let x=1+2</script>").unwrap();
+
+    let (stdout, stderr, code) = run(&dir, &["--write"]);
+    assert_eq!(code, 0, "stdout:\n{stdout}");
+    assert!(
+        !stdout.contains("FAKE-OXFMT-STDOUT"),
+        "write mode should not forward oxfmt's stdout; got:\n{stdout}"
+    );
+    // The run still did its own work and still reports it — the assertion above
+    // is satisfied by a command that prints nothing at all, so this one is what
+    // separates "suppressed the child" from "suppressed everything". Our summary
+    // goes to stderr (`run.rs`'s `eprintln!`), which is also why the leak was
+    // the only thing a caller reading stdout ever saw.
+    assert!(
+        stderr.contains("formatted"),
+        "our own summary should survive; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let after = std::fs::read_to_string(dir.join("App.svelte")).unwrap();
+    assert!(after.contains("let x = 1 + 2;"), "{after}");
+}
+
+/// The other direction: in check mode the child's stdout is the listing of what
+/// would be reformatted, so it must still reach the user. Without this cell the
+/// fix above is passed by deleting the forward outright.
+#[test]
+fn check_mode_still_forwards_the_child_oxfmt_stdout() {
+    let dir = tempdir();
+    std::fs::write(dir.join("App.svelte"), "<script>let x = 1 + 2;</script>\n").unwrap();
+
+    let (stdout, _stderr, _code) = run(&dir, &["--check"]);
+    assert!(
+        stdout.contains("FAKE-OXFMT-STDOUT"),
+        "check mode should forward oxfmt's listing; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Closes #4302.

## What

`rsvelte-fmt <directory>` delegates the non-`.svelte` share to a single `oxfmt`
invocation, and that invocation runs even when the tree holds only `.svelte` files —
where it legitimately matches nothing. Forwarding its stdout printed

```
No files found matching the given patterns.
No config found, using defaults. Please add a config file or try `oxfmt --init` if needed.
Finished in 2ms on 0 files using 10 threads.
```

above `rsvelte-fmt: formatted 1 / 1 files`. `on 0 files` and the summary describe
different scopes, the first line reads exactly like a failure, and it fires on **every**
directory run rather than on an unusual input.

Check mode keeps the forward: there the child's stdout is the listing of files that
*would* be reformatted, which is the answer and not a summary.

## The two streams

Our own summary is an `eprintln!` (`run.rs:237`), so it never shared a stream with the
leak — a caller reading stdout alone got the child's three lines and none of ours. That
is not in the issue and is the reason the fix is "suppress" rather than "reword".

## Controls

`crates/rsvelte_fmt/tests/cli/oxfmt_stdout.rs`, two cells that run opposite ways against
a fake `oxfmt` that writes one recognisable line to stdout:

| cell | asserts |
|---|---|
| `write_mode_does_not_forward_the_child_oxfmt_stdout` | the line is **absent** from stdout — and, separately, that our own summary is still on stderr, so the test is not satisfied by a command that prints nothing at all |
| `check_mode_still_forwards_the_child_oxfmt_stdout` | the line is **present** — without this cell the fix is passed by deleting the forward outright |

Ablated (`if matches!(mode, Mode::Check)` → `if true`), the first fails and the second
still passes; restored, `git diff` is empty and both pass.

`cargo test --release -p rsvelte_fmt --test cli` — 66 passed, 0 failed (64 + these two).

## Not addressed

The issue's second, separately-recorded observation — a directory run exits **2** when
`oxfmt` is absent, after the `.svelte` files have already been rewritten, with no message
naming which file needed `oxfmt` — is untouched here. It is a different decision (what a
partial failure should report), not the leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj