### PR TITLE
fix(analyze): record a function declaration's own span as its initializer

### DIFF
--- a/.changeset/function-declaration-binding-initial.md
+++ b/.changeset/function-declaration-binding-initial.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+A name bound by a `function` declaration folds to a known function, so the dev-mode `$.assign` wrap is skipped for it as it already is for an arrow

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -818,7 +818,12 @@ impl<'a> ScopeBuilder<'a> {
                 }
             }
             JsNode::FunctionDeclaration {
-                id, params, body, ..
+                id,
+                params,
+                body,
+                start: decl_start,
+                end: decl_end,
+                ..
             } => {
                 if let Some(id_ref) = id {
                     let id_node = self.arena.get_js_node(*id_ref);
@@ -841,6 +846,12 @@ impl<'a> ScopeBuilder<'a> {
                         self.bindings[idx].initial_is_function = true;
                         self.bindings[idx].is_function_implementation = has_body;
                         self.bindings[idx].declaration_start = Some(*start);
+                        // Upstream's `declare` passes the FunctionDeclaration itself
+                        // as `binding.initial` (`scope.js:673`) and `evaluate` folds
+                        // it in the same arm as an arrow (`scope.js:560-563`), so a
+                        // name bound by `function h() {}` resolves exactly like one
+                        // bound by `const h = () => {}`.
+                        self.bindings[idx].initial_span = Some((*decl_start, *decl_end));
                     }
                 }
                 let params = *params;

--- a/crates/rsvelte_core/tests/assign_dev_function_declaration_initial.rs
+++ b/crates/rsvelte_core/tests/assign_dev_function_declaration_initial.rs
@@ -1,0 +1,116 @@
+//! Upstream's `scope.evaluate` resolves an Identifier through its binding's own
+//! initializer (`phases/scope.js:303`), and `declare` passes the
+//! **FunctionDeclaration node itself** as that initializer (`scope.js:673`).
+//! `evaluate` then folds it in the same arm as an arrow or a function
+//! expression (`scope.js:560-563`), so a name bound by `function h() {}` is a
+//! known function exactly as one bound by `const h = () => {}` is, and the
+//! dev-mode `$.assign` wrap is skipped for both.
+//!
+//! The enumeration is closed from the oracle's own `switch` rather than from
+//! the shapes a report happened to name: the arm above is the only one that
+//! separates a declaration kind from "no initializer at all". `ClassDeclaration`
+//! and `ImportDeclaration` are also passed as `initial` upstream, and both fall
+//! to `default` → `UNKNOWN` — the same answer a missing initializer gives — so
+//! they need nothing here. The class row below is that control, and it expects
+//! a **wrap**, which is what stops the table being satisfied by a predicate
+//! that never wraps.
+
+use rsvelte_core::{CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_module};
+
+/// `(label, declarations, right-hand side, official wraps)`.
+const CELLS: &[(&str, &str, &str, bool)] = &[
+    ("inline fn-decl ref", "function h() {}", "h", false),
+    (
+        "binding <- fn decl",
+        "function h() {}\nconst g = h;",
+        "g",
+        false,
+    ),
+    (
+        "binding <- const arrow",
+        "const h = () => {};\nconst g = h;",
+        "g",
+        false,
+    ),
+    (
+        "binding <- const fnexpr",
+        "const h = function () {};\nconst g = h;",
+        "g",
+        false,
+    ),
+    (
+        "binding <- let arrow",
+        "let h = () => {};\nconst g = h;",
+        "g",
+        false,
+    ),
+    ("inline arrow", "", "() => {}", false),
+    ("binding <- literal", "const g = 1;", "g", false),
+    (
+        "binding <- class decl",
+        "class C {}\nconst g = C;",
+        "g",
+        true,
+    ),
+    ("binding <- object", "const g = {};", "g", true),
+];
+
+fn client_dev(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("C.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn module_dev(source: &str) -> String {
+    compile_module(
+        source,
+        ModuleCompileOptions {
+            filename: Some("m.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile_module")
+    .js
+    .code
+}
+
+#[test]
+fn a_function_declaration_binding_folds_like_an_arrow() {
+    for &(label, declarations, rhs, expected) in CELLS {
+        let indented = declarations.replace('\n', "\n\t");
+        let instance = format!(
+            "<script lang=\"ts\">\n\tlet o = $state({{ a: 0, b: 0 }});\n\t{indented}\n\texport function go() {{ o.a = o.b = {rhs}; }}\n</script>\n{{o.a}}\n"
+        );
+        let module_block = format!(
+            "<script module>\n\tlet o = $state({{ a: 0, b: 0 }});\n\t{indented}\n\texport function go() {{ o.a = o.b = {rhs}; }}\n</script>\n{{1}}\n"
+        );
+        let module_file = format!(
+            "let o = $state({{ a: 0, b: 0 }});\n{declarations}\nexport function go() {{ o.a = o.b = {rhs}; }}\n"
+        );
+
+        for (host, code) in [
+            ("instance script", client_dev(&instance)),
+            ("<script module>", client_dev(&module_block)),
+            (".svelte.js", module_dev(&module_file)),
+        ] {
+            assert_eq!(
+                code.contains("$.assign("),
+                expected,
+                "`{label}` in the {host} host:\n{code}"
+            );
+        }
+    }
+    assert!(CELLS.iter().any(|c| c.3), "no cell expects a wrap");
+    assert!(CELLS.iter().any(|c| !c.3), "no cell expects no wrap");
+}


### PR DESCRIPTION
Closes #4294.

## What

Upstream's `declare` passes the **FunctionDeclaration node itself** as
`binding.initial` (`phases/scope.js:673`), and `evaluate` folds it in the same arm as an
arrow or a function expression (`scope.js:560-563`). So a name bound by `function h() {}`
is a known function exactly as one bound by `const h = () => {}` is, and the dev-mode
`$.assign` wrap is skipped for both.

rsvelte wrote `initial_span` from the variable-declarator visitor only, so a function
declaration's binding carried no initializer at all and the resolver failed one level
*before* the node-type dispatch.

## The enumeration is closed from the oracle, not from the report

#4294 asks for this explicitly. Upstream's `initial` can also be a `ClassDeclaration` or
an `ImportDeclaration`, and `evaluate` has **no arm** for either — both fall to `default`
→ `UNKNOWN`, which is the same answer a *missing* initializer already gives. So
`FunctionDeclaration` is the only member of that set that separates a declaration kind
from "no initializer", and neither neighbour needs a writer. `EachBlock` and
`SnippetBlock` are tested by `binding.initial?.type` **before** the recursion and are not
this path.

The grid's `binding <- class decl` row is that control, and it expects a **wrap** — which
is what stops the table being satisfied by a predicate that never wraps.

## Measured — 9 declarations x 3 hosts, expectations from the oracle

`crates/rsvelte_core/tests/assign_dev_function_declaration_initial.rs`. Every expected
value is the official compiler's answer for the same source, not rsvelte's.

| row | official | `main` | this branch |
|---|---|---|---|
| inline fn-decl ref (`h`) | plain | **WRAP** | plain |
| binding <- fn decl | plain | **WRAP** | plain |
| binding <- const arrow | plain | plain | plain |
| binding <- const fnexpr | plain | plain | plain |
| binding <- let arrow | plain | plain | plain |
| inline arrow | plain | plain | plain |
| binding <- literal | plain | plain | plain |
| binding <- class decl | **WRAP** | WRAP | WRAP |
| binding <- object | **WRAP** | WRAP | WRAP |

All three hosts move together: the instance script, `<script module>`, and a
`.svelte.js` through `compileModule`.

## Three declaration sites, and only one is on this path

`initial_span` is not the only thing with more than one writer — a *function* binding is
declared in three places (`Statement::FunctionDeclaration`, `Declaration::FunctionDeclaration`,
and the typed `JsNode::FunctionDeclaration`). I patched all three first and the grid did
**not** move; patching the typed one alone moves every cell in all three hosts. Measured
one arm per subset:

| arm | two oxc sites | typed site | grid |
|---|---|---|---|
| `dfabdc70…` | ✓ | ✗ | unchanged (2 DIFF) |
| `2a83bd9f…` | ✓ | ✓ | 9/9 EQ |
| `7069a41d…` | ✗ | ✓ | 9/9 EQ |

So the shipping change is the typed site only. The two oxc-AST sites are left alone
rather than changed speculatively — an unchanged grid and an unreached port are the same
observation, and here the ablation separates them.

## Blast radius — zero, with the population stated

Two arms, one process each, `sha256` distinct (`main` `c1a13247…`, this branch
`7cc43f7d…`), arm identity probed two-sidedly (this branch *contains* the grid's fix and
*lacks* #4110's esrap change, which the `main` arm also lacks and my #4368 arm has).

| population | rows | distinct keys | live | moved |
|---|---|---|---|---|
| `.svelte`, client prod / dev | 34,882 | 34,882 | 33,623 | **0 / 0** |
| `.svelte`, server prod / dev | 34,882 | 34,882 | 33,624 | **0 / 0** |
| `.svelte.(js\|ts)`, client prod / dev | 843 | 843 | 735 | **0 / 0** |

The module rows go through the gate's own `esbuild` TS strip (667 files); without it the
live population is 120 and the zero would be forced.

#4294 records its reach as unmeasured, and this is that measurement: **0 carriers**. The
shape needs an assignment *chain* whose innermost value is a function-declaration name in
dev mode, and no corpus file has one — so the grid is the detector here and the sweep only
says nothing else moved.

## Verification

- `cargo test --release -p rsvelte_core --test assign_dev_function_declaration_initial` — 1 passed
- `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` via the pre-commit hook — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj