### PR TITLE
test(envelope): compare the parse-envelope writer to the decoder with a golden envelope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1099,6 +1099,15 @@ jobs:
       - name: Run NAPI option-boundary gate
         run: pnpm run test:napi-options
 
+      # Separate process for the same reason, and the only gate that compares
+      # the Rust parse-envelope writer against the JS decoder.
+      - name: Run parse-envelope golden gate
+        run: pnpm run test:parse-envelope-golden
+
+      # The decoder's own bounds checks. Hand-crafted envelopes, no addon.
+      - name: Run parse-envelope decoder validation
+        run: pnpm run test:parse-envelope
+
       # Again a separate process, for the same reason: this one is the only gate
       # that drives the `cssHash` callback across the boundary.
       - name: Run NAPI cssHash gate

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"bootstrap-platform-packages": "node scripts/release/bootstrap-platform-packages.mjs",
 		"test:envelope": "node scripts/dev/test-envelope-validation.mjs",
 		"test:parse-envelope": "node scripts/dev/test-parse-envelope-validation.mjs",
+		"test:parse-envelope-golden": "node scripts/dev/test-parse-envelope-golden.mjs",
 		"test:parse-bom": "node scripts/dev/test-parse-bom.mjs",
 		"test:corpus-verify-flags": "node scripts/dev/test-corpus-verify-baseline-flags.mjs",
 		"test:corpus-parse-gate": "node scripts/dev/test-corpus-parse-gate.mjs",

--- a/scripts/dev/parse-envelope-golden.json
+++ b/scripts/dev/parse-envelope-golden.json
@@ -1,0 +1,1175 @@
+{
+	"source": "<script>\n\tlet items = [1, 2];\n\tlet promise = Promise.resolve(1);\n\tfunction sum(seed = 0, ...rest) {\n\t\treturn rest.reduce((a, b) => a + b, seed);\n\t}\n</script>\n\n<!-- a comment -->\n<div class=\"box\" on:click={() => sum(1, 2)}>\n\t{#each items as item, i}\n\t\t{@const doubled = item * 2}\n\t\t<span>{doubled}{i}</span>\n\t{/each}\n\t{#await promise then value}\n\t\t{value}\n\t{/await}\n</div>\n\n<style>\n\t.box { color: red; }\n</style>\n",
+	"version": 11,
+	"byteLength": 3257,
+	"sha256": "57c5f85a66ebf09f2d720aead0ce78547ac1aa3d595e94bbccc0e46f20123b2e",
+	"ast": {
+		"css": {
+			"type": "StyleSheet",
+			"start": 373,
+			"end": 411,
+			"attributes": [],
+			"children": [
+				{
+					"type": "Rule",
+					"prelude": {
+						"type": "SelectorList",
+						"start": 382,
+						"end": 386,
+						"children": [
+							{
+								"type": "ComplexSelector",
+								"start": 382,
+								"end": 386,
+								"children": [
+									{
+										"type": "RelativeSelector",
+										"combinator": null,
+										"selectors": [
+											{
+												"type": "ClassSelector",
+												"name": "box",
+												"start": 382,
+												"end": 386
+											}
+										],
+										"start": 382,
+										"end": 386
+									}
+								]
+							}
+						]
+					},
+					"block": {
+						"type": "Block",
+						"start": 387,
+						"end": 402,
+						"children": [
+							{
+								"type": "Declaration",
+								"start": 389,
+								"end": 399,
+								"property": "color",
+								"value": "red"
+							}
+						]
+					},
+					"start": 382,
+					"end": 402
+				}
+			],
+			"comments": [],
+			"content": {
+				"start": 380,
+				"end": 403,
+				"styles": "\n\t.box { color: red; }\n",
+				"comment": null
+			}
+		},
+		"js": [],
+		"start": 0,
+		"end": 412,
+		"type": "Root",
+		"fragment": {
+			"type": "Fragment",
+			"nodes": [
+				{
+					"type": "Text",
+					"start": 157,
+					"end": 159,
+					"raw": "\n\n",
+					"data": "\n\n"
+				},
+				{
+					"type": "Comment",
+					"start": 159,
+					"end": 177,
+					"data": " a comment "
+				},
+				{
+					"type": "Text",
+					"start": 177,
+					"end": 178,
+					"raw": "\n",
+					"data": "\n"
+				},
+				{
+					"type": "RegularElement",
+					"start": 178,
+					"end": 371,
+					"name": "div",
+					"attributes": [
+						{
+							"type": "Attribute",
+							"start": 183,
+							"end": 194,
+							"name": "class",
+							"value": [
+								{
+									"type": "Text",
+									"start": 190,
+									"end": 193,
+									"raw": "box",
+									"data": "box"
+								}
+							],
+							"name_loc": {
+								"start": {
+									"line": 10,
+									"column": 5,
+									"character": 183
+								},
+								"end": {
+									"line": 10,
+									"column": 10,
+									"character": 188
+								}
+							}
+						},
+						{
+							"type": "OnDirective",
+							"start": 195,
+							"end": 221,
+							"name": "click",
+							"name_loc": {
+								"start": {
+									"line": 10,
+									"column": 17,
+									"character": 195
+								},
+								"end": {
+									"line": 10,
+									"column": 25,
+									"character": 203
+								}
+							},
+							"expression": {
+								"type": "ArrowFunctionExpression",
+								"start": 205,
+								"end": 220,
+								"loc": {
+									"start": {
+										"line": 10,
+										"column": 27
+									},
+									"end": {
+										"line": 10,
+										"column": 42
+									}
+								},
+								"id": null,
+								"expression": true,
+								"generator": false,
+								"async": false,
+								"params": [],
+								"body": {
+									"type": "CallExpression",
+									"start": 211,
+									"end": 220,
+									"loc": {
+										"start": {
+											"line": 10,
+											"column": 33
+										},
+										"end": {
+											"line": 10,
+											"column": 42
+										}
+									},
+									"callee": {
+										"type": "Identifier",
+										"start": 211,
+										"end": 214,
+										"loc": {
+											"start": {
+												"line": 10,
+												"column": 33
+											},
+											"end": {
+												"line": 10,
+												"column": 36
+											}
+										},
+										"name": "sum"
+									},
+									"arguments": [
+										{
+											"type": "Literal",
+											"start": 215,
+											"end": 216,
+											"loc": {
+												"start": {
+													"line": 10,
+													"column": 37
+												},
+												"end": {
+													"line": 10,
+													"column": 38
+												}
+											},
+											"value": 1,
+											"raw": "1"
+										},
+										{
+											"type": "Literal",
+											"start": 218,
+											"end": 219,
+											"loc": {
+												"start": {
+													"line": 10,
+													"column": 40
+												},
+												"end": {
+													"line": 10,
+													"column": 41
+												}
+											},
+											"value": 2,
+											"raw": "2"
+										}
+									],
+									"optional": false
+								}
+							},
+							"modifiers": []
+						}
+					],
+					"fragment": {
+						"type": "Fragment",
+						"nodes": [
+							{
+								"type": "Text",
+								"start": 222,
+								"end": 224,
+								"raw": "\n\t",
+								"data": "\n\t"
+							},
+							{
+								"type": "EachBlock",
+								"start": 224,
+								"end": 315,
+								"expression": {
+									"type": "Identifier",
+									"start": 231,
+									"end": 236,
+									"loc": {
+										"start": {
+											"line": 11,
+											"column": 8
+										},
+										"end": {
+											"line": 11,
+											"column": 13
+										}
+									},
+									"name": "items"
+								},
+								"body": {
+									"type": "Fragment",
+									"nodes": [
+										{
+											"type": "Text",
+											"start": 248,
+											"end": 251,
+											"raw": "\n\t\t",
+											"data": "\n\t\t"
+										},
+										{
+											"type": "ConstTag",
+											"start": 251,
+											"end": 278,
+											"declaration": {
+												"type": "VariableDeclaration",
+												"start": 253,
+												"end": 277,
+												"declarations": [
+													{
+														"type": "VariableDeclarator",
+														"start": 259,
+														"end": 277,
+														"id": {
+															"type": "Identifier",
+															"start": 259,
+															"end": 266,
+															"loc": {
+																"start": {
+																	"line": 12,
+																	"column": 10,
+																	"character": 259
+																},
+																"end": {
+																	"line": 12,
+																	"column": 17,
+																	"character": 266
+																}
+															},
+															"name": "doubled"
+														},
+														"init": {
+															"type": "BinaryExpression",
+															"start": 269,
+															"end": 277,
+															"loc": {
+																"start": {
+																	"line": 12,
+																	"column": 20
+																},
+																"end": {
+																	"line": 12,
+																	"column": 28
+																}
+															},
+															"left": {
+																"type": "Identifier",
+																"start": 269,
+																"end": 273,
+																"loc": {
+																	"start": {
+																		"line": 12,
+																		"column": 20
+																	},
+																	"end": {
+																		"line": 12,
+																		"column": 24
+																	}
+																},
+																"name": "item"
+															},
+															"operator": "*",
+															"right": {
+																"type": "Literal",
+																"start": 276,
+																"end": 277,
+																"loc": {
+																	"start": {
+																		"line": 12,
+																		"column": 27
+																	},
+																	"end": {
+																		"line": 12,
+																		"column": 28
+																	}
+																},
+																"value": 2,
+																"raw": "2"
+															}
+														}
+													}
+												],
+												"kind": "const"
+											}
+										},
+										{
+											"type": "Text",
+											"start": 278,
+											"end": 281,
+											"raw": "\n\t\t",
+											"data": "\n\t\t"
+										},
+										{
+											"type": "RegularElement",
+											"start": 281,
+											"end": 306,
+											"name": "span",
+											"attributes": [],
+											"fragment": {
+												"type": "Fragment",
+												"nodes": [
+													{
+														"type": "ExpressionTag",
+														"start": 287,
+														"end": 296,
+														"expression": {
+															"type": "Identifier",
+															"start": 288,
+															"end": 295,
+															"loc": {
+																"start": {
+																	"line": 13,
+																	"column": 9
+																},
+																"end": {
+																	"line": 13,
+																	"column": 16
+																}
+															},
+															"name": "doubled"
+														}
+													},
+													{
+														"type": "ExpressionTag",
+														"start": 296,
+														"end": 299,
+														"expression": {
+															"type": "Identifier",
+															"start": 297,
+															"end": 298,
+															"loc": {
+																"start": {
+																	"line": 13,
+																	"column": 18
+																},
+																"end": {
+																	"line": 13,
+																	"column": 19
+																}
+															},
+															"name": "i"
+														}
+													}
+												]
+											},
+											"name_loc": {
+												"start": {
+													"line": 13,
+													"column": 3,
+													"character": 282
+												},
+												"end": {
+													"line": 13,
+													"column": 7,
+													"character": 286
+												}
+											}
+										},
+										{
+											"type": "Text",
+											"start": 306,
+											"end": 308,
+											"raw": "\n\t",
+											"data": "\n\t"
+										}
+									]
+								},
+								"context": {
+									"type": "Identifier",
+									"start": 240,
+									"end": 244,
+									"loc": {
+										"start": {
+											"line": 11,
+											"column": 17,
+											"character": 240
+										},
+										"end": {
+											"line": 11,
+											"column": 21,
+											"character": 244
+										}
+									},
+									"name": "item"
+								},
+								"index": "i"
+							},
+							{
+								"type": "Text",
+								"start": 315,
+								"end": 317,
+								"raw": "\n\t",
+								"data": "\n\t"
+							},
+							{
+								"type": "AwaitBlock",
+								"start": 317,
+								"end": 364,
+								"expression": {
+									"type": "Identifier",
+									"start": 325,
+									"end": 332,
+									"loc": {
+										"start": {
+											"line": 15,
+											"column": 9
+										},
+										"end": {
+											"line": 15,
+											"column": 16
+										}
+									},
+									"name": "promise"
+								},
+								"value": {
+									"type": "Identifier",
+									"start": 338,
+									"end": 343,
+									"loc": {
+										"start": {
+											"line": 15,
+											"column": 22,
+											"character": 338
+										},
+										"end": {
+											"line": 15,
+											"column": 27,
+											"character": 343
+										}
+									},
+									"name": "value"
+								},
+								"error": null,
+								"pending": null,
+								"then": {
+									"type": "Fragment",
+									"nodes": [
+										{
+											"type": "Text",
+											"start": 344,
+											"end": 347,
+											"raw": "\n\t\t",
+											"data": "\n\t\t"
+										},
+										{
+											"type": "ExpressionTag",
+											"start": 347,
+											"end": 354,
+											"expression": {
+												"type": "Identifier",
+												"start": 348,
+												"end": 353,
+												"loc": {
+													"start": {
+														"line": 16,
+														"column": 3
+													},
+													"end": {
+														"line": 16,
+														"column": 8
+													}
+												},
+												"name": "value"
+											}
+										},
+										{
+											"type": "Text",
+											"start": 354,
+											"end": 356,
+											"raw": "\n\t",
+											"data": "\n\t"
+										}
+									]
+								},
+								"catch": null
+							},
+							{
+								"type": "Text",
+								"start": 364,
+								"end": 365,
+								"raw": "\n",
+								"data": "\n"
+							}
+						]
+					},
+					"name_loc": {
+						"start": {
+							"line": 10,
+							"column": 1,
+							"character": 179
+						},
+						"end": {
+							"line": 10,
+							"column": 4,
+							"character": 182
+						}
+					}
+				},
+				{
+					"type": "Text",
+					"start": 371,
+					"end": 373,
+					"raw": "\n\n",
+					"data": "\n\n"
+				}
+			]
+		},
+		"options": null,
+		"instance": {
+			"type": "Script",
+			"start": 0,
+			"end": 157,
+			"context": "default",
+			"content": {
+				"type": "Program",
+				"start": 8,
+				"end": 148,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 0
+					},
+					"end": {
+						"line": 7,
+						"column": 9
+					}
+				},
+				"body": [
+					{
+						"type": "VariableDeclaration",
+						"start": 10,
+						"end": 29,
+						"loc": {
+							"start": {
+								"line": 2,
+								"column": 1
+							},
+							"end": {
+								"line": 2,
+								"column": 20
+							}
+						},
+						"declarations": [
+							{
+								"type": "VariableDeclarator",
+								"start": 14,
+								"end": 28,
+								"loc": {
+									"start": {
+										"line": 2,
+										"column": 5
+									},
+									"end": {
+										"line": 2,
+										"column": 19
+									}
+								},
+								"id": {
+									"type": "Identifier",
+									"start": 14,
+									"end": 19,
+									"loc": {
+										"start": {
+											"line": 2,
+											"column": 5
+										},
+										"end": {
+											"line": 2,
+											"column": 10
+										}
+									},
+									"name": "items"
+								},
+								"init": {
+									"type": "ArrayExpression",
+									"start": 22,
+									"end": 28,
+									"loc": {
+										"start": {
+											"line": 2,
+											"column": 13
+										},
+										"end": {
+											"line": 2,
+											"column": 19
+										}
+									},
+									"elements": [
+										{
+											"type": "Literal",
+											"start": 23,
+											"end": 24,
+											"loc": {
+												"start": {
+													"line": 2,
+													"column": 14
+												},
+												"end": {
+													"line": 2,
+													"column": 15
+												}
+											},
+											"value": 1,
+											"raw": "1"
+										},
+										{
+											"type": "Literal",
+											"start": 26,
+											"end": 27,
+											"loc": {
+												"start": {
+													"line": 2,
+													"column": 17
+												},
+												"end": {
+													"line": 2,
+													"column": 18
+												}
+											},
+											"value": 2,
+											"raw": "2"
+										}
+									]
+								}
+							}
+						],
+						"kind": "let"
+					},
+					{
+						"type": "VariableDeclaration",
+						"start": 31,
+						"end": 64,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 1
+							},
+							"end": {
+								"line": 3,
+								"column": 34
+							}
+						},
+						"declarations": [
+							{
+								"type": "VariableDeclarator",
+								"start": 35,
+								"end": 63,
+								"loc": {
+									"start": {
+										"line": 3,
+										"column": 5
+									},
+									"end": {
+										"line": 3,
+										"column": 33
+									}
+								},
+								"id": {
+									"type": "Identifier",
+									"start": 35,
+									"end": 42,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 5
+										},
+										"end": {
+											"line": 3,
+											"column": 12
+										}
+									},
+									"name": "promise"
+								},
+								"init": {
+									"type": "CallExpression",
+									"start": 45,
+									"end": 63,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 15
+										},
+										"end": {
+											"line": 3,
+											"column": 33
+										}
+									},
+									"callee": {
+										"type": "MemberExpression",
+										"start": 45,
+										"end": 60,
+										"loc": {
+											"start": {
+												"line": 3,
+												"column": 15
+											},
+											"end": {
+												"line": 3,
+												"column": 30
+											}
+										},
+										"object": {
+											"type": "Identifier",
+											"start": 45,
+											"end": 52,
+											"loc": {
+												"start": {
+													"line": 3,
+													"column": 15
+												},
+												"end": {
+													"line": 3,
+													"column": 22
+												}
+											},
+											"name": "Promise"
+										},
+										"property": {
+											"type": "Identifier",
+											"start": 53,
+											"end": 60,
+											"loc": {
+												"start": {
+													"line": 3,
+													"column": 23
+												},
+												"end": {
+													"line": 3,
+													"column": 30
+												}
+											},
+											"name": "resolve"
+										},
+										"computed": false,
+										"optional": false
+									},
+									"arguments": [
+										{
+											"type": "Literal",
+											"start": 61,
+											"end": 62,
+											"loc": {
+												"start": {
+													"line": 3,
+													"column": 31
+												},
+												"end": {
+													"line": 3,
+													"column": 32
+												}
+											},
+											"value": 1,
+											"raw": "1"
+										}
+									],
+									"optional": false
+								}
+							}
+						],
+						"kind": "let"
+					},
+					{
+						"type": "FunctionDeclaration",
+						"start": 66,
+						"end": 147,
+						"loc": {
+							"start": {
+								"line": 4,
+								"column": 1
+							},
+							"end": {
+								"line": 6,
+								"column": 2
+							}
+						},
+						"id": {
+							"type": "Identifier",
+							"start": 75,
+							"end": 78,
+							"loc": {
+								"start": {
+									"line": 4,
+									"column": 10
+								},
+								"end": {
+									"line": 4,
+									"column": 13
+								}
+							},
+							"name": "sum"
+						},
+						"expression": false,
+						"generator": false,
+						"async": false,
+						"params": [
+							{
+								"type": "AssignmentPattern",
+								"start": 79,
+								"end": 87,
+								"loc": {
+									"start": {
+										"line": 4,
+										"column": 14
+									},
+									"end": {
+										"line": 4,
+										"column": 22
+									}
+								},
+								"left": {
+									"type": "Identifier",
+									"start": 79,
+									"end": 83,
+									"loc": {
+										"start": {
+											"line": 4,
+											"column": 14
+										},
+										"end": {
+											"line": 4,
+											"column": 18
+										}
+									},
+									"name": "seed"
+								},
+								"right": {
+									"type": "Literal",
+									"start": 86,
+									"end": 87,
+									"loc": {
+										"start": {
+											"line": 4,
+											"column": 21
+										},
+										"end": {
+											"line": 4,
+											"column": 22
+										}
+									},
+									"value": 0,
+									"raw": "0"
+								}
+							},
+							{
+								"type": "RestElement",
+								"start": 89,
+								"end": 96,
+								"loc": {
+									"start": {
+										"line": 4,
+										"column": 24
+									},
+									"end": {
+										"line": 4,
+										"column": 31
+									}
+								},
+								"argument": {
+									"type": "Identifier",
+									"start": 92,
+									"end": 96,
+									"loc": {
+										"start": {
+											"line": 4,
+											"column": 27
+										},
+										"end": {
+											"line": 4,
+											"column": 31
+										}
+									},
+									"name": "rest"
+								}
+							}
+						],
+						"body": {
+							"type": "BlockStatement",
+							"start": 98,
+							"end": 147,
+							"loc": {
+								"start": {
+									"line": 4,
+									"column": 33
+								},
+								"end": {
+									"line": 6,
+									"column": 2
+								}
+							},
+							"body": [
+								{
+									"type": "ReturnStatement",
+									"start": 102,
+									"end": 144,
+									"loc": {
+										"start": {
+											"line": 5,
+											"column": 2
+										},
+										"end": {
+											"line": 5,
+											"column": 44
+										}
+									},
+									"argument": {
+										"type": "CallExpression",
+										"start": 109,
+										"end": 143,
+										"loc": {
+											"start": {
+												"line": 5,
+												"column": 9
+											},
+											"end": {
+												"line": 5,
+												"column": 43
+											}
+										},
+										"callee": {
+											"type": "MemberExpression",
+											"start": 109,
+											"end": 120,
+											"loc": {
+												"start": {
+													"line": 5,
+													"column": 9
+												},
+												"end": {
+													"line": 5,
+													"column": 20
+												}
+											},
+											"object": {
+												"type": "Identifier",
+												"start": 109,
+												"end": 113,
+												"loc": {
+													"start": {
+														"line": 5,
+														"column": 9
+													},
+													"end": {
+														"line": 5,
+														"column": 13
+													}
+												},
+												"name": "rest"
+											},
+											"property": {
+												"type": "Identifier",
+												"start": 114,
+												"end": 120,
+												"loc": {
+													"start": {
+														"line": 5,
+														"column": 14
+													},
+													"end": {
+														"line": 5,
+														"column": 20
+													}
+												},
+												"name": "reduce"
+											},
+											"computed": false,
+											"optional": false
+										},
+										"arguments": [
+											{
+												"type": "ArrowFunctionExpression",
+												"start": 121,
+												"end": 136,
+												"loc": {
+													"start": {
+														"line": 5,
+														"column": 21
+													},
+													"end": {
+														"line": 5,
+														"column": 36
+													}
+												},
+												"id": null,
+												"expression": true,
+												"generator": false,
+												"async": false,
+												"params": [
+													{
+														"type": "Identifier",
+														"start": 122,
+														"end": 123,
+														"loc": {
+															"start": {
+																"line": 5,
+																"column": 22
+															},
+															"end": {
+																"line": 5,
+																"column": 23
+															}
+														},
+														"name": "a"
+													},
+													{
+														"type": "Identifier",
+														"start": 125,
+														"end": 126,
+														"loc": {
+															"start": {
+																"line": 5,
+																"column": 25
+															},
+															"end": {
+																"line": 5,
+																"column": 26
+															}
+														},
+														"name": "b"
+													}
+												],
+												"body": {
+													"type": "BinaryExpression",
+													"start": 131,
+													"end": 136,
+													"loc": {
+														"start": {
+															"line": 5,
+															"column": 31
+														},
+														"end": {
+															"line": 5,
+															"column": 36
+														}
+													},
+													"left": {
+														"type": "Identifier",
+														"start": 131,
+														"end": 132,
+														"loc": {
+															"start": {
+																"line": 5,
+																"column": 31
+															},
+															"end": {
+																"line": 5,
+																"column": 32
+															}
+														},
+														"name": "a"
+													},
+													"operator": "+",
+													"right": {
+														"type": "Identifier",
+														"start": 135,
+														"end": 136,
+														"loc": {
+															"start": {
+																"line": 5,
+																"column": 35
+															},
+															"end": {
+																"line": 5,
+																"column": 36
+															}
+														},
+														"name": "b"
+													}
+												}
+											},
+											{
+												"type": "Identifier",
+												"start": 138,
+												"end": 142,
+												"loc": {
+													"start": {
+														"line": 5,
+														"column": 38
+													},
+													"end": {
+														"line": 5,
+														"column": 42
+													}
+												},
+												"name": "seed"
+											}
+										],
+										"optional": false
+									}
+								}
+							]
+						}
+					}
+				],
+				"sourceType": "module"
+			},
+			"attributes": []
+		}
+	}
+}

--- a/scripts/dev/test-parse-envelope-golden.mjs
+++ b/scripts/dev/test-parse-envelope-golden.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+// Golden-envelope gate for the binary `parse()` wire format (issue #4284).
+//
+// The format has two implementations that must agree byte for byte:
+// `crates/rsvelte_bindings_support/src/napi_raw_parse.rs` writes it and
+// `apps/npm/vite-plugin-svelte-native/parse-envelope.js` reads it. Both carry a
+// `VERSION` and the decoder throws on a mismatch — but that check only fires
+// when somebody bumps one side. #4249 added two fields to a node's payload and
+// bumped neither, so a writer and a decoder built from different commits read
+// different offsets off the same bytes and produce a SILENT MISREAD rather than
+// the throw the check exists for.
+//
+// Asserting the two `VERSION` literals are equal does NOT catch that: they were
+// equal and consistent throughout. What catches it is encoding a known AST with
+// the real writer and requiring the real decoder to reproduce a frozen JSON —
+// a layout change that only one side made cannot survive it, and a layout change
+// both sides made still fails until the golden is regenerated, which is where
+// the author is looking at the layout and can decide about `VERSION`.
+//
+// The byte hash is asserted as well as the decoded JSON, because the two answer
+// different questions. The JSON catches writer/decoder skew; the hash catches a
+// layout change that happens to decode to the same tree, and makes the diff say
+// so out loud.
+//
+// Regenerate deliberately: `UPDATE_PARSE_ENVELOPE_GOLDEN=1 pnpm run test:parse-envelope-golden`
+// Prereq: `pnpm run build:vps-native`.
+
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+const goldenPath = resolve(here, 'parse-envelope-golden.json');
+const update = process.env.UPDATE_PARSE_ENVELOPE_GOLDEN === '1';
+
+let pass = 0;
+let fail = 0;
+function assert(label, cond, detail) {
+	if (cond) {
+		pass += 1;
+		console.log(`  ok   ${label}`);
+	} else {
+		fail += 1;
+		console.error(`  FAIL ${label}${detail ? `\n       ${detail}` : ''}`);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The input. Deliberately small and boring: every node in it is a shape the
+// parser has emitted the same way for a long time, so this gate goes red for a
+// wire-layout change rather than for parser churn. It still crosses the
+// payload kinds the envelope encodes differently — a script with a function
+// declaration (rest parameter, default), template blocks, an attribute, a
+// directive, an expression tag, a comment, and a `<style>` (which the writer
+// hands to the JSON fallback).
+// ---------------------------------------------------------------------------
+const GOLDEN_SOURCE = [
+	'<script>',
+	'\tlet items = [1, 2];',
+	'\tlet promise = Promise.resolve(1);',
+	'\tfunction sum(seed = 0, ...rest) {',
+	'\t\treturn rest.reduce((a, b) => a + b, seed);',
+	'\t}',
+	'</script>',
+	'',
+	'<!-- a comment -->',
+	'<div class="box" on:click={() => sum(1, 2)}>',
+	'\t{#each items as item, i}',
+	'\t\t{@const doubled = item * 2}',
+	'\t\t<span>{doubled}{i}</span>',
+	'\t{/each}',
+	'\t{#await promise then value}',
+	'\t\t{value}',
+	'\t{/await}',
+	'</div>',
+	'',
+	'<style>',
+	'\t.box { color: red; }',
+	'</style>',
+	'',
+].join('\n');
+
+// ---------------------------------------------------------------------------
+// Load the raw addon. Exactly one addon per process — two rsvelte addons
+// required into the same process have been observed to SIGSEGV.
+// ---------------------------------------------------------------------------
+function resolveTriple() {
+	const { platform, arch } = process;
+	if (platform === 'darwin') {
+		if (arch === 'arm64') return 'darwin-arm64';
+		if (arch === 'x64') return 'darwin-x64';
+	} else if (platform === 'linux') {
+		let isMusl = false;
+		try {
+			isMusl = !process.report.getReport().header.glibcVersionRuntime;
+		} catch {
+			isMusl = false;
+		}
+		const libc = isMusl ? 'musl' : 'gnu';
+		if (arch === 'x64') return `linux-x64-${libc}`;
+		if (arch === 'arm64') return `linux-arm64-${libc}`;
+	} else if (platform === 'win32') {
+		if (arch === 'x64') return 'win32-x64-msvc';
+	}
+	return null;
+}
+
+const triple = resolveTriple();
+if (!triple) {
+	console.error(`[parse-envelope-golden] unsupported platform ${process.platform}/${process.arch}`);
+	process.exit(2);
+}
+const addonPath = resolve(repoRoot, `apps/npm/vite-plugin-svelte-native-${triple}/rsvelte.node`);
+const require_ = createRequire(import.meta.url);
+let napi;
+try {
+	napi = require_(addonPath);
+} catch (e) {
+	console.error(
+		`[parse-envelope-golden] cannot load ${addonPath}\n  run \`pnpm run build:vps-native\` first\n  ${e.message}`
+	);
+	process.exit(2);
+}
+
+const decoderPath = resolve(repoRoot, 'apps/npm/vite-plugin-svelte-native/parse-envelope.js');
+const { decodeParseEnvelope } = require_(decoderPath);
+
+// ---------------------------------------------------------------------------
+// Encode with the real writer.
+// ---------------------------------------------------------------------------
+const buf = Buffer.from(napi.parseEnvelope(GOLDEN_SOURCE));
+const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+const magic = view.getUint32(0, true);
+const version = view.getUint32(4, true);
+const sha256 = createHash('sha256').update(buf).digest('hex');
+
+// The decoder's own literal, read out of its source rather than copied here:
+// a third copy of the number is exactly what this gate exists to make
+// unnecessary.
+const decoderSource = readFileSync(decoderPath, 'utf8');
+const decoderVersionMatch = decoderSource.match(/^const VERSION = (\d+);$/m);
+assert('the decoder declares a VERSION literal this gate can read', decoderVersionMatch !== null);
+const decoderVersion = decoderVersionMatch ? Number(decoderVersionMatch[1]) : null;
+
+assert('the envelope carries the "RPV1" magic', magic === 0x3156_5052, `got 0x${magic.toString(16)}`);
+assert(
+	"the writer's version word equals the decoder's VERSION",
+	version === decoderVersion,
+	`writer ${version} vs decoder ${decoderVersion}`
+);
+
+// ---------------------------------------------------------------------------
+// Decode with the real decoder. This is the half that a one-sided layout
+// change cannot pass.
+// ---------------------------------------------------------------------------
+let decoded = null;
+try {
+	decoded = decodeParseEnvelope(buf);
+	assert('the decoder accepts the writer output', true);
+} catch (e) {
+	assert('the decoder accepts the writer output', false, e.message);
+}
+
+if (update) {
+	writeFileSync(
+		goldenPath,
+		`${JSON.stringify({ source: GOLDEN_SOURCE, version, byteLength: buf.byteLength, sha256, ast: decoded }, null, '\t')}\n`
+	);
+	console.log(`[parse-envelope-golden] wrote ${goldenPath}`);
+	console.log(`  version=${version} byteLength=${buf.byteLength} sha256=${sha256}`);
+	process.exit(0);
+}
+
+let golden;
+try {
+	golden = JSON.parse(readFileSync(goldenPath, 'utf8'));
+} catch (e) {
+	console.error(
+		`[parse-envelope-golden] cannot read ${goldenPath}\n  ${e.message}\n` +
+			'  regenerate with UPDATE_PARSE_ENVELOPE_GOLDEN=1'
+	);
+	process.exit(2);
+}
+
+const REGEN =
+	'the wire layout moved. Bump VERSION in crates/rsvelte_bindings_support/src/napi_raw_parse.rs, ' +
+	'apps/npm/vite-plugin-svelte-native/parse-envelope.js and ' +
+	'scripts/dev/test-parse-envelope-validation.mjs, then regenerate with ' +
+	'UPDATE_PARSE_ENVELOPE_GOLDEN=1 pnpm run test:parse-envelope-golden';
+
+assert(
+	'the golden was generated from this source',
+	golden.source === GOLDEN_SOURCE,
+	'the input changed without the golden being regenerated'
+);
+assert(
+	'the envelope byte length is unchanged',
+	golden.byteLength === buf.byteLength,
+	`golden ${golden.byteLength} vs ${buf.byteLength} — ${REGEN}`
+);
+assert(
+	'the envelope bytes are unchanged',
+	golden.sha256 === sha256,
+	`golden ${golden.sha256} vs ${sha256} — ${REGEN}`
+);
+assert(
+	'the decoded tree is unchanged',
+	JSON.stringify(decoded) === JSON.stringify(golden.ast),
+	`the decoder produced a different tree from the same input — ${REGEN}`
+);
+assert(
+	'the golden records the version it was generated with',
+	golden.version === version,
+	`golden ${golden.version} vs writer ${version}`
+);
+
+console.log(`\n[parse-envelope-golden] ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/scripts/dev/test-parse-envelope-validation.mjs
+++ b/scripts/dev/test-parse-envelope-validation.mjs
@@ -7,6 +7,7 @@
 // variants, and asserts that `decodeParseEnvelope` throws on out-of-range
 // string/JSON windows instead of silently truncating.
 
+import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -17,7 +18,14 @@ const { decodeParseEnvelope } = await import(
 ).then((m) => m.default ?? m);
 
 const MAGIC = 0x3156_5052; // "RPV1"
-const VERSION = 11;
+// Read out of the decoder rather than copied. A third literal is not a gate:
+// this file pins test <-> decoder and can never see the Rust writer, so keeping
+// its own copy only made the number look enforced. What compares the writer to
+// the decoder is `test-parse-envelope-golden.mjs`.
+const VERSION = Number(
+	readFileSync(join(repoRoot, 'apps/npm/vite-plugin-svelte-native/parse-envelope.js'), 'utf8')
+		.match(/^const VERSION = (\d+);$/m)[1]
+);
 const HEADER_LEN = 24;
 const TAG_JSON = 0x00;
 const JS_IDENTIFIER = 0x80;


### PR DESCRIPTION
Closes #4284.

The binary `parse()` wire format has two implementations that must agree byte for byte — `crates/rsvelte_bindings_support/src/napi_raw_parse.rs` writes it, `apps/npm/vite-plugin-svelte-native/parse-envelope.js` reads it — and until now the only thing holding them together was a `VERSION` literal plus a comment asking for a lockstep bump. #4249 added two fields to a node's payload and bumped neither side, so a writer and a decoder built from different commits read different offsets off the same bytes: a **silent misread** rather than the throw the version check exists for.

## Why the cheap check is not the one to land

The issue's central point, and it is measurable rather than rhetorical. Asserting the two `VERSION` literals are equal does not catch #4249 — they were equal and consistent throughout. Ablating this gate reproduces exactly that shape (one extra `write_bool` in the `Identifier` payload, decoder untouched, both literals left at 11):

```
  ok   the writer's version word equals the decoder's VERSION      <- the cheap check, still green
  FAIL the decoder accepts the writer output
       parse envelope: inline JSON out of bounds (offset 1039 + length 655616 exceeds buffer of 3281 bytes)
  FAIL the envelope byte length is unchanged      golden 3257 vs 3281
  FAIL the envelope bytes are unchanged           golden 57c5f85a… vs 5a9e45aa…
  FAIL the decoded tree is unchanged
[parse-envelope-golden] 5 passed, 4 failed
```

Restoring the writer returns it to 9 passed / 0 failed and leaves the tree byte-identical.

## What landed

`scripts/dev/test-parse-envelope-golden.mjs` encodes a fixed source with the real writer (`napi.parseEnvelope`), requires the real decoder (`decodeParseEnvelope`) to reproduce a frozen tree, and pins the envelope's byte length and `sha256`.

The hash and the tree answer different questions and both are asserted: the **tree** catches writer/decoder skew, and the **hash** catches a layout change that happens to decode to the same tree and makes the diff say so out loud. Regeneration is deliberate (`UPDATE_PARSE_ENVELOPE_GOLDEN=1`), and the failure message names the three files to bump.

The input is deliberately small and boring — every node in it is a shape the parser has emitted the same way for a long time — so this goes red for a wire-layout change rather than for parser churn, while still crossing the payload kinds the envelope encodes differently: a `<script>` with a function declaration (default parameter, rest parameter), an each block with an index and a `{@const}`, an await block, an attribute, an `on:` directive, expression tags, a comment, and a `<style>` (which the writer hands to the JSON fallback).

## The third copy of the literal is deleted, not gated

`scripts/dev/test-parse-envelope-validation.mjs` hardcoded `VERSION` so it could hand-craft valid envelopes. That copy pins **test ↔ decoder** and can never see the Rust writer, so having its own number only made the constant look enforced — it caught #4250's bump by accident, and that accident is what this PR replaces with a deliberate gate. It now reads `VERSION` out of the decoder's source, as the golden gate does, so there are two literals rather than three and the golden gate is what compares them.

Adding a checker for the three literals instead would have been the trap the issue names: a file whose name says the envelope version is checked, sitting in front of the question it does not answer.

## Wiring

Both scripts run in `ci.yml`'s **VPS native shim smoke test** job, which already builds the addon, each in its own process (two rsvelte addons in one process have been observed to SIGSEGV). `test:parse-envelope` had a `package.json` script and **no workflow reference at all** — `grep -rn 'test:parse-envelope' .github/workflows/` returned 0 before this change and returns 2 lines after it.

Local: `workflow-trigger-guard`, `step-environment-guard`, `prereq-coverage-guard` and `check-core-consumer-changesets` all exit 0; pre-commit `cargo fmt` + `cargo clippy --all-targets --all-features -D warnings` clean. No crate source changes, so no changeset.

One incidental worth recording: the golden was first written under `scripts/dev/fixtures/`, and `git add -A` silently skipped it — this clone's `.git/info/exclude` carries a bare `fixtures` pattern (the committed `.gitignore` is root-anchored `/fixtures/` and would not have). The file lives at `scripts/dev/parse-envelope-golden.json` instead, so no directory in its path is named `fixtures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj