### PR TITLE
fix(compiler): place an erased-TS comment by the source declarator count

### DIFF
--- a/.changeset/erased-ts-comment-declarator-count.md
+++ b/.changeset/erased-ts-comment-declarator-count.md
@@ -1,0 +1,9 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Place a comment left behind by TypeScript erasure where upstream places it. A
+comment inside an erased `interface` or type alias preceding an `export let` was
+unconditionally flushed after the `let` keyword; upstream only does that when the
+source declaration has more than one declarator, and with a single declarator it
+prints the comment ahead of `let`.

--- a/compatibility/pattern-corpus/README.md
+++ b/compatibility/pattern-corpus/README.md
@@ -31,15 +31,21 @@ Ids are `pattern/issues/<file>`, `pattern/matrix/<axis>/<file>` and
    message or position belongs here too; say so in its row.
 3. **One behaviour per file, minimal.** Delete everything the shape does not
    need.
-4. **Never write provenance in an HTML comment.** Removed comments are
-   themselves a whitespace-sensitive compiler input (see #1975) — a `<!-- from
-   issue N -->` line silently changes what the file tests. Provenance belongs in
-   the table below and nowhere else. (The comments in
-   `matrix/whitespace-comments/` are the *payload*, not provenance.)
+4. **Never write provenance in a comment — HTML or JavaScript.** Removed
+   comments are themselves a whitespace-sensitive compiler input (see #1975), and
+   a comment inside `<script>` is the same input one level down: #4279's first
+   repro carried a `//` line explaining each cell and was green on *both* arms,
+   because a real leading comment ahead of an `export let` changes the very
+   attachment the file exists to pin. Provenance belongs in the table below and
+   nowhere else. (The comments in `matrix/whitespace-comments/` are the
+   *payload*, not provenance.)
 5. **Commit formatted files.** They flow through the fmt gate, so keep them in
    the shape prettier-plugin-svelte would produce; an unformatted file is a
    needless new formatter case, not a compiler case.
-6. **A repro lands with its fix, not before.** Adding a file for a still-open
+6. **Measure a repro on both arms.** A file that matches on the fixed tree is
+   only a repro if it *diverges* on the tree without the fix; a cell that is green
+   either way pins nothing and cannot regress.
+7. **A repro lands with its fix, not before.** Adding a file for a still-open
    divergence would mean seeding a `known-failures` entry, and the seed then has
    to be tracked and burned down separately from the fix. Add the repro in the
    fix PR (or immediately after it merges) so it lands green.
@@ -699,6 +705,7 @@ Ids are `pattern/issues/<file>`, `pattern/matrix/<axis>/<file>` and
 | `template-local-no-outer-name.svelte` | corpus residue | Negative half: no outer binding of the name exists, so nothing may be grafted. Green on all three arms and all four targets; it rejects a resolver that would attach an initializer to whatever record it finds. |
 | `4280-trailing-comment-hosts.svelte` | [#4278](https://github.com/baseballyama/rsvelte/issues/4278), [#4280](https://github.com/baseballyama/rsvelte/issues/4280) | A trailing comment on a legacy prop declaration, on the **client**. The comment was located by scanning the declaration's last source line for `//`, which finds neither a block comment nor a comment on a wrapped line; and `transform_let_with_reexported_props` — the port a `let d = {}; export { d }` reaches — had no trailing-comment handling at all, so the second host was a second defect rather than a second cell. Where the comment goes depends on whether the call the declaration lowers to holds a node esrap can attach to: `a` and `b` have no default and none, `c` has a synthesized thunk, `d` and `e` reach the other port. A line comment inserted before a `)` must carry its own newline or it swallows the rest of the call, which is why the two spellings are crossed with the hosts rather than assumed equivalent. |
 | `block-local-binding-leaks-past-its-block.svelte` | [#4135](https://github.com/baseballyama/rsvelte/issues/4135) | `ScopeRoot` scope 0 is deliberately polluted with every child scope's declarations, so a name-keyed `get_binding` answers with an `{#await}` value or an `{#each}` item/index for a reference nowhere near its block — upstream's scope chain has no such name there at all. Phase 2 wrote that binding into `binding.references`, so the position-keyed `binding_at_reference` inherited the same answer and the outer `{code}` came out inside a `$.template_effect` reading the block-local. One enumeration (`BindingKind::is_block_local`) and one decision (`ScopeRoot::is_block_local_out_of_scope`) are consulted by both phase-2 writers and the phase-3 name fallback; each half was ablated on its own and neither fixes the file alone. The in-block `{code}` / `{idx}` reads are the controls — they must keep resolving to their block binding while the sibling reads outside must not resolve at all. |
+| `4279-erased-ts-comment-declarator-count.svelte` | [#4279](https://github.com/baseballyama/rsvelte/issues/4279) | A comment left inside an erased `interface` body ahead of an `export let`. Where upstream flushes it is decided by the source declaration's **declarator count**, not by the erased host or by where in it the comment sits: one declarator keeps the declaration located and prints the comment ahead of `let`, two or more split into a statement per prop and print it after. rsvelte forced the second shape in both cases. `two, three` is the multi-declarator half, which is what the real corpus carriers are and which must not move; the `client` and `client-dev` targets are the only ones that diverge, because the server does not lower a prop through this path. The corpus output gate cannot see this file move: `ast_equiv_batch` runs under `CommentPolicy::Ignore` (`GATES.md` blind spot 1a), and the two shapes are one `let use = …` declaration either way, so both arms score `match` — measured on `svelte-tweakpane-ui/src/lib/extra/AutoValue.svelte`, which carries the identical splice while `known-failures.client.json` is empty. What pins the placement is `erased_typescript_interface_comment_follows_the_declarator_count` in `3_transform/client/tests.rs`; this file is the reproduction, not the guard. |
 
 ## `matrix/` — the axes around those repros
 

--- a/compatibility/pattern-corpus/issues/4279-erased-ts-comment-declarator-count.svelte
+++ b/compatibility/pattern-corpus/issues/4279-erased-ts-comment-declarator-count.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	interface I {
+		// c
+		a?: number;
+	}
+
+	export let one: I = 1;
+
+	interface J {
+		// d
+		b?: number;
+	}
+
+	export let two: J = 2,
+		three: J = 3;
+</script>
+
+<p>{one}{two}{three}</p>

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -62,14 +62,6 @@ pub(crate) struct ScriptProjection {
     /// speculation covers is a `TSTypeLiteral`'s braces up to the end of its
     /// first member, which is why an `interface` body never doubles.
     pub(crate) repeated_comment_outputs: Vec<Range<u32>>,
-    /// Source ranges of leading comments attached to an erased TypeScript
-    /// declaration when the next surviving statement is an exported prop.
-    ///
-    /// Upstream keeps that attachment through TS erasure. Its generated prop
-    /// declaration therefore prints `let` before advancing to the located
-    /// identifier and flushing the comment. A text projection would otherwise
-    /// reattach the comment to the following `let` declaration.
-    pub(crate) erased_leading_comments_before_export_props: Vec<Range<u32>>,
     /// `(binding end, annotation end)` for every binding whose own type
     /// annotation was erased. Upstream's parser puts the annotation inside the
     /// binding's range, so a node ending at the first is located at the second.
@@ -763,24 +755,6 @@ fn strip_typescript_from_program_impl(
         merged.push((start, end));
     }
 
-    let erased_leading_comments_before_export_props = if include_projection {
-        program
-            .comments
-            .iter()
-            .filter(|comment| comment.is_leading())
-            .filter_map(|comment| {
-                let (_, remove_end) = merged.iter().find(|(start, end)| {
-                    *start <= comment.attached_to && comment.attached_to < *end
-                })?;
-                let after = source.get(*remove_end as usize..)?.trim_start();
-                (after.starts_with("export let ") || after.starts_with("export var "))
-                    .then_some(comment.span.start..comment.span.end)
-            })
-            .collect()
-    } else {
-        Vec::new()
-    };
-
     // Build output by skipping removed regions
     let mut output = String::with_capacity(source.len());
     let mut copied_chunks =
@@ -885,7 +859,6 @@ fn strip_typescript_from_program_impl(
         copied_chunks,
         reemitted_comment_outputs: reemitted_comment_outputs.unwrap_or_default(),
         repeated_comment_outputs: repeated_comment_outputs.unwrap_or_default(),
-        erased_leading_comments_before_export_props,
         binding_annotation_ends: collect_binding_annotation_ends(program),
         source_len: source.len() as u32,
         output_len: output.len() as u32,
@@ -2857,28 +2830,6 @@ const answer: number = 42;
                 .iter()
                 .any(|chunk| chunk.source.start <= declaration_start
                     && declaration_start < chunk.source.end)
-        );
-    }
-
-    #[test]
-    fn projection_records_erased_interface_comment_before_exported_prop() {
-        let source = "\
-interface Props {}
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-interface Events {}
-export let use: string[] = [];
-";
-        let retained = RetainedProgram::parse(source, true);
-        let (_, projection) =
-            strip_typescript_from_program_with_projection(source, retained.program());
-        let projection = projection.expect("interfaces should create a projection");
-
-        let start = source.find("// eslint-disable-next-line").unwrap() as u32;
-        let end =
-            start + "// eslint-disable-next-line @typescript-eslint/no-unused-vars".len() as u32;
-        assert_eq!(
-            projection.erased_leading_comments_before_export_props,
-            vec![start..end]
         );
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -3474,7 +3474,6 @@ fn overlay_lowered_callee_spans(
                     kept.push(RawMappedSpan {
                         code: span.code.start..span.code.start + shared_len,
                         source: span.source.start..span.source.start + shared_len,
-                        erased_comment_before_export_prop: span.erased_comment_before_export_prop,
                         source_end_override: None,
                     });
                 }
@@ -3486,7 +3485,6 @@ fn overlay_lowered_callee_spans(
                     kept.push(RawMappedSpan {
                         code: span.code.end - shared_len..span.code.end,
                         source: span.source.end - shared_len..span.source.end,
-                        erased_comment_before_export_prop: span.erased_comment_before_export_prop,
                         source_end_override: None,
                     });
                 }
@@ -3501,19 +3499,16 @@ fn overlay_lowered_callee_spans(
         kept.push(RawMappedSpan {
             code: start..end,
             source: source_start..source_start + generated_len,
-            erased_comment_before_export_prop: false,
             source_end_override: None,
         });
         kept.push(RawMappedSpan {
             code: end..end,
             source: source_end..source_end,
-            erased_comment_before_export_prop: false,
             source_end_override: None,
         });
         kept.push(RawMappedSpan {
             code: end..delimiter_end,
             source: source_end..source_end + 1,
-            erased_comment_before_export_prop: false,
             source_end_override: None,
         });
         *spans = kept;
@@ -3570,7 +3565,6 @@ fn copied_spans_for_normalized_code(
                     code: start_output as u32..output as u32,
                     source: (original_offset + start_input as u32)
                         ..(original_offset + input as u32),
-                    erased_comment_before_export_prop: false,
                     source_end_override: None,
                 });
                 continue;
@@ -3601,7 +3595,6 @@ fn copied_spans_for_normalized_code(
                         spans.push(RawMappedSpan {
                             code: run_start as u32..code_offset as u32,
                             source: source_start..source_end,
-                            erased_comment_before_export_prop: false,
                             source_end_override: None,
                         });
                     }
@@ -3745,7 +3738,6 @@ fn copied_spans_for_normalized_code(
             spans.push(RawMappedSpan {
                 code: output as u32..output as u32,
                 source: source..source,
-                erased_comment_before_export_prop: false,
                 source_end_override: None,
             });
         }
@@ -3753,15 +3745,6 @@ fn copied_spans_for_normalized_code(
         output += skip_output;
     }
     if let Some(projection) = projection {
-        for comment in &projection.erased_leading_comments_before_export_props {
-            let comment = (original_offset + comment.start)..(original_offset + comment.end);
-            if let Some(span) = spans
-                .iter_mut()
-                .find(|span| span.source.start <= comment.start && comment.end <= span.source.end)
-            {
-                span.erased_comment_before_export_prop = true;
-            }
-        }
         for &(binding_end, annotation_end) in &projection.binding_annotation_ends {
             let binding_end = original_offset + binding_end;
             let annotation_end = original_offset + annotation_end;
@@ -4591,9 +4574,6 @@ fn compose_script_projection(
         // still needed when the retained body contains the following prop.
         reemitted_comment_outputs: Vec::new(),
         repeated_comment_outputs: Vec::new(),
-        erased_leading_comments_before_export_props: source_projection
-            .erased_leading_comments_before_export_props
-            .clone(),
         binding_annotation_ends: source_projection.binding_annotation_ends.clone(),
         source_len: source_projection.source_len,
         output_len: body_len as u32,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -158,33 +158,49 @@ fn first_comment_reemitted_from_a_typescript_declaration_repeats_in_client_outpu
 }
 
 #[test]
-fn erased_typescript_interface_comment_keeps_exported_prop_cursor_position() {
-    let source = r#"<script lang="ts">
+fn erased_typescript_interface_comment_follows_the_declarator_count() {
+    // Where upstream flushes the comment is decided by how many declarators the
+    // source `export let` has, not by where the comment sits in the erased
+    // region: one declarator keeps the declaration located and prints the
+    // comment ahead of `let`, two split into a statement per prop and print it
+    // after. Both expectations are the oracle's own output.
+    let head = r#"<script lang="ts">
         interface $$Props {}
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         interface $$Events {}
-        export let use: string[] = [];
-    </script>"#;
+"#;
+    let cells: &[(&str, &str, &str)] = &[
+        (
+            "one declarator",
+            "        export let use: string[] = [];\n    </script>",
+            "\t// eslint-disable-next-line @typescript-eslint/no-unused-vars\n\tlet use = $.prop",
+        ),
+        (
+            "two declarators",
+            "        export let use: string[] = [],\n            elem: string[] = [];\n    </script>",
+            "\tlet // eslint-disable-next-line @typescript-eslint/no-unused-vars\n\tuse = $.prop",
+        ),
+    ];
 
-    for dev in [false, true] {
-        let output = crate::compiler::compile(
-            source,
-            crate::compiler::CompileOptions {
-                filename: Some("erased-interface-comment-exported-prop.svelte".to_string()),
-                dev,
-                ..Default::default()
-            },
-        )
-        .expect("compiles")
-        .js
-        .code;
+    for (name, tail, expected) in cells {
+        for dev in [false, true] {
+            let output = crate::compiler::compile(
+                &format!("{head}{tail}"),
+                crate::compiler::CompileOptions {
+                    filename: Some("erased-interface-comment-exported-prop.svelte".to_string()),
+                    dev,
+                    ..Default::default()
+                },
+            )
+            .expect("compiles")
+            .js
+            .code;
 
-        assert!(
-            output.contains(
-                "let // eslint-disable-next-line @typescript-eslint/no-unused-vars\n\tuse = $.prop"
-            ),
-            "the erased interface keeps ownership of its leading comment in dev={dev}:\n{output}"
-        );
+            assert!(
+                output.contains(expected),
+                "{name} in dev={dev} must place the comment as upstream does:\n{output}"
+            );
+        }
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
@@ -136,9 +136,6 @@ pub enum JsStatement {
 pub struct RawMappedSpan {
     pub code: Range<u32>,
     pub source: Range<u32>,
-    /// This copied run ends with a comment that upstream keeps attached to an
-    /// erased TS declaration before an exported prop.
-    pub erased_comment_before_export_prop: bool,
     /// `(binding end, annotation end)`: upstream's parser puts a type annotation
     /// inside its binding's range, so a node ending at the first source position
     /// is located at the second. At most one per run, because the annotation is

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -388,33 +388,6 @@ fn restore_raw_mapped_spans(stmts: &mut [Statement<'_>], spans: &[RawMappedSpan]
     }
 }
 
-/// Preserve upstream's comment cursor when TypeScript erasure removed the node
-/// a leading comment was attached to immediately before an exported prop.
-///
-/// The prop lowering keeps the source identifier but rebuilds the declaration.
-/// Leaving the reparsed declaration located makes esrap flush the orphaned
-/// comment before `let`; upstream reaches the identifier first and therefore
-/// emits `let // comment` instead. Only the declaration wrapper is unlocated —
-/// its identifier and initializer retain their copied source spans.
-fn unlocate_prop_declarations_after_erased_comments(
-    stmts: &mut [Statement<'_>],
-    spans: &[RawMappedSpan],
-    code_base: u32,
-) {
-    for comment_end in spans
-        .iter()
-        .filter(|span| span.erased_comment_before_export_prop)
-        .map(|span| code_base + span.code.end)
-    {
-        if let Some(Statement::VariableDeclaration(declaration)) = stmts
-            .iter_mut()
-            .find(|statement| statement.span().start >= comment_end)
-        {
-            declaration.span = SPAN;
-        }
-    }
-}
-
 /// The client transform rebuilds effect calls but retains their callback from
 /// the source AST. Keep that split when a raw chunk is reparsed: the callback
 /// remains located for comment placement while the generated call does not.
@@ -2163,15 +2136,12 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                         .source_comments
                         .insert((*source_offset, *source_offset + len));
                 }
-                let region = self.take_chunk_region(Some(*source_offset), copied_spans);
-                if let Some((region_start, _)) = region {
-                    unlocate_prop_declarations_after_erased_comments(
-                        &mut stmts,
-                        copied_spans,
-                        region_start,
-                    );
-                    // The chunk's own spans are its comment anchors; the source
-                    // offset is carried by the region's `loc_map` entry instead.
+                // The chunk's own spans are its comment anchors; the source
+                // offset is carried by the region's `loc_map` entry instead.
+                if self
+                    .take_chunk_region(Some(*source_offset), copied_spans)
+                    .is_some()
+                {
                     return Some(stmts);
                 }
                 let comment_anchor = self.comment_anchor(comment_anchor.or(Some(*source_offset)));
@@ -2191,7 +2161,6 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 {
                     *statement.span_mut() = comment_anchor;
                 }
-                unlocate_prop_declarations_after_erased_comments(&mut stmts, copied_spans, 0);
                 self.note_span(*source_offset);
                 Some(stmts)
             }
@@ -2203,16 +2172,12 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 copied_spans,
             } => {
                 let mut stmts = self.parse_raw_statements(code, false, &[])?;
-                if effect_spans.is_empty() {
-                    let region = self.take_chunk_region(Some(*source_offset), copied_spans);
-                    if let Some((region_start, _)) = region {
-                        unlocate_prop_declarations_after_erased_comments(
-                            &mut stmts,
-                            copied_spans,
-                            region_start,
-                        );
-                        return Some(stmts);
-                    }
+                if effect_spans.is_empty()
+                    && self
+                        .take_chunk_region(Some(*source_offset), copied_spans)
+                        .is_some()
+                {
+                    return Some(stmts);
                 }
                 restore_raw_mapped_spans(&mut stmts, copied_spans, code);
                 erase_generated_effect_call_locs(&mut stmts, effect_spans);
@@ -2228,7 +2193,6 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 {
                     *statement.span_mut() = comment_anchor;
                 }
-                unlocate_prop_declarations_after_erased_comments(&mut stmts, copied_spans, 0);
                 self.note_span(*source_offset);
                 Some(stmts)
             }
@@ -3221,13 +3185,11 @@ mod tests {
             RawMappedSpan {
                 code: 0..4,
                 source: 100..104,
-                erased_comment_before_export_prop: false,
                 source_end_override: None,
             },
             RawMappedSpan {
                 code: 4..8,
                 source: 300..304,
-                erased_comment_before_export_prop: false,
                 source_end_override: None,
             },
         ];
@@ -3246,13 +3208,11 @@ mod tests {
             RawMappedSpan {
                 code: 0..4,
                 source: 100..104,
-                erased_comment_before_export_prop: false,
                 source_end_override: None,
             },
             RawMappedSpan {
                 code: 4..8,
                 source: 300..304,
-                erased_comment_before_export_prop: false,
                 source_end_override: None,
             },
         ];
@@ -3271,19 +3231,16 @@ mod tests {
             RawMappedSpan {
                 code: 0..4,
                 source: 100..104,
-                erased_comment_before_export_prop: false,
                 source_end_override: None,
             },
             RawMappedSpan {
                 code: 4..4,
                 source: 200..200,
-                erased_comment_before_export_prop: false,
                 source_end_override: None,
             },
             RawMappedSpan {
                 code: 4..8,
                 source: 300..304,
-                erased_comment_before_export_prop: false,
                 source_end_override: None,
             },
         ];


### PR DESCRIPTION
Closes #4279.

## What was wrong

A comment left behind by TypeScript erasure ahead of an `export let` was
unconditionally flushed **after** the `let` keyword. Upstream does that only when
the source declaration has **more than one declarator**: with a single declarator
the declaration keeps its `loc`, esrap's comment cursor reaches it before the
identifier, and the comment prints ahead of `let`.

```svelte
<script lang="ts">
	interface I { /* c */ a?: number }
	export let one: I = 1;
</script>
```

| | official | rsvelte (before) |
|---|---|---|
| one declarator | `/* c */` then `let one = $.prop(...)` | `let /* c */` then `one = $.prop(...)` |
| two declarators | `let /* c */` then `two = $.prop(...)` | same (already correct) |

## The axis is the declarator count, not the erased host

Four hypotheses were falsified before this one held — the erased host
(`interface` vs `type` alias), where in the host the comment sits, the comment
kind, and the `dev` flag all leave the verdict unchanged. Printing official's
**full** output rather than the diff is what named it: upstream itself prints
`let // c` in the `>= 2` case, so the two shapes are both upstream's and the
choice between them is made by the source.

## What is deleted

`unlocate_prop_declarations_after_erased_comments` forced the multi-declarator
shape in both cases, together with the flag it set
(`RawMappedSpan::erased_comment_before_export_prop`), the projection field that
fed it (`Analysis::erased_leading_comments_before_export_props`) and its builder
— 4 call sites, net −149/+51 under `crates/`.

Three things say the whole chain was dead rather than merely wrong:

- Its doc comment asserted the opposite of what upstream does ("upstream reaches
  the identifier first and therefore emits `let // comment`"), and that is false
  on all six erased-host × comment-kind cells, **including the exact spelling it
  names**.
- Its unit test asserted the same wrong string. The svelte pin has not moved
  since that function landed, so the expectation was never oracle-generated.
- It is not load-bearing for the `>= 2` case either. Under a two-sided
  `ABLATE_UNLOCATE` switch on one binary, all 24 grid cells are EQ with it
  disabled and the base arm reproduces `main`'s 6 DIFF with it enabled — and the
  two real corpus files it was originally added for still match on all four
  targets without it.

The one control never taken when it landed was *are the `>= 2` cells already EQ
without this*. They are.

## Measurement

Two arms, one process each, `sha256`-distinct, separated by a live two-sided
probe (base 6/24 DIFF, head 0/24). The arm the sweep ran predates a clippy
`collapsible_if` collapse, so the final tree was swept too and the two agree by
measurement rather than by argument: **MOVED 0** over all 135,560 units, with
base-vs-final reproducing the same ten keys and the same hashes.

```
135,560 units compared (130,586 live, 4,974 dead in both)
MOVED 10
  MISMATCH -> match      8
  MISMATCH -> MISMATCH   2
  match -> MISMATCH      0
```

The two that stay are one file (`svelte-tweakpane-ui/.../AutoValue.svelte`) whose
residual is block-comment continuation indentation. Its head differing-line set
is a **strict subset** of its base one (26 ⊂ 28, 0 lines present in head and
absent from base), and the two non-comment lines it carried on base — the `let //`
splice and the `let`-less `value = $.prop(...)` under it — are gone.

Local: `cargo fmt --all --check` 0, `cargo clippy --workspace --all-targets
--all-features -- -D warnings` 0, and `cargo test --release -p rsvelte_core --lib`
1969 passed / 0 failed (`Running unittests src/lib.rs` present), all re-run after
the rebase.

## Why no gate saw it

The corpus output gate scores all ten units `match` on **both** arms.
`ast_equiv_batch` runs under `CommentPolicy::Ignore` (`GATES.md` blind spot 1a,
already documented with a positive control), and the two shapes are one
`let v = ...` declaration either way — so a comment-placement-only byte
difference is rescued, and retirement and regression are equally invisible.

That is the interesting part rather than a missing gate row: the blind spot **was**
measured, cited by file and line, and carried its own control, and the defect went
in through it anyway. Documenting a blind spot is not closing one.

It also decides what the pattern-corpus file is for. It is the **reproduction**;
the guard is `erased_typescript_interface_comment_follows_the_declarator_count`
in `3_transform/client/tests.rs`, whose two cells are generated from the oracle:

```
one declarator   ->  `// c` then `let use = $.prop(...)`
two declarators  ->  `let // c` then `use = $.prop(...)`
```

## Two pattern-corpus conventions

The first repro I wrote was green on **both** arms. It carried a `//` line
explaining each cell, and a real leading comment ahead of an `export let` changes
the very attachment the file exists to pin — so the convention against provenance
comments is widened from HTML to JavaScript, and a second one is added:

> **Measure a repro on both arms.** A file that matches on the fixed tree is only a
> repro if it *diverges* on the tree without the fix; a cell that is green either
> way pins nothing and cannot regress.

Rule 4 would not have caught it (I was not writing provenance, I was labelling
cells), so they are two rules rather than one.

## Base

Rebased onto `9171df619` (#4376), which touches `2_analyze/scope_builder.rs` —
disjoint from this change's files, no conflict. The sweep above was taken at
merge-base `1512bcdcf`; the merge ref's verdict is CI's corpus gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
