### PR TITLE
fix(lsp): give an inherited `paths` alias a shadow-tree candidate (#4100)

### DIFF
--- a/.changeset/tsgo-overlay-paths-alias.md
+++ b/.changeset/tsgo-overlay-paths-alias.md
@@ -1,0 +1,17 @@
+---
+"@rsvelte/language-server": patch
+---
+
+Resolve a `tsconfig` `paths` alias that names a `.svelte` module.
+
+The tsgo overlay inherited `paths` through `extends`, so an alias resolved
+against the source tree — where a component's `.svelte.tsx` shadow does not
+exist, because the shadow is served from memory under the cache directory.
+`rootDirs` lists both trees but governs relative resolution only, so
+`import Widget from '$lib/Widget.svelte'` had no type at all: hover returned
+`null` and the symbol was `any`, with no diagnostic to say so.
+
+The overlay now re-declares every mapping with its shadow-tree twin beside the
+original, the original first so nothing that resolves today moves. This covers
+SvelteKit's generated `"$lib/*": ["../src/lib/*"]`, which is the alias most
+projects import components through.

--- a/crates/rsvelte_language_server/src/tsgo_overlay.rs
+++ b/crates/rsvelte_language_server/src/tsgo_overlay.rs
@@ -960,6 +960,46 @@ impl TsgoOverlay {
         self.write_tsconfig()
     }
 
+    /// tsgo resolves `paths` against the config that declares them, so an
+    /// inherited alias points into the source tree — where a component's
+    /// `.svelte.tsx` shadow does not exist, because it is served from memory
+    /// under `shadow_dir`. `rootDirs` covers relative resolution only, so every
+    /// mapping needs its shadow-tree twin spelled out beside the original.
+    fn overlay_paths(&self) -> Option<serde_json::Value> {
+        let source = self.source_tsconfig.as_deref()?;
+        let config_dir = source.parent().unwrap_or_else(|| Path::new("."));
+        let (value, base) = resolve_config_value_with_base(source, "paths")?;
+        let mut mappings = serde_json::Map::new();
+        for (pattern, targets) in value.as_object()? {
+            let mut candidates = Vec::new();
+            for target in targets
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(serde_json::Value::as_str)
+            {
+                let absolute = rebase_config_spec(target, &base, config_dir);
+                // The source target stays first, so nothing that resolves today
+                // can start resolving somewhere else.
+                candidates.push(json!(absolute));
+                if let Ok(relative) = Path::new(&absolute).strip_prefix(&self.workspace) {
+                    candidates.push(json!(path_for_tsconfig(&self.shadow_dir.join(relative))));
+                }
+            }
+            // The override is total, so a pattern this loop cannot rewrite is a
+            // pattern the project would lose; pass an unrecognised shape through.
+            mappings.insert(
+                pattern.clone(),
+                if candidates.is_empty() {
+                    targets.clone()
+                } else {
+                    serde_json::Value::Array(candidates)
+                },
+            );
+        }
+        (!mappings.is_empty()).then(|| serde_json::Value::Object(mappings))
+    }
+
     fn write_tsconfig(&self) -> Result<(), TsgoOverlayError> {
         let specs = self
             .source_tsconfig
@@ -1001,6 +1041,9 @@ impl TsgoOverlay {
         });
         if let Some(target) = overlay_target(self.source_tsconfig.as_deref()) {
             config["compilerOptions"]["target"] = json!(target);
+        }
+        if let Some(paths) = self.overlay_paths() {
+            config["compilerOptions"]["paths"] = paths;
         }
         if let Some(source) = &self.source_tsconfig {
             config["extends"] = json!(path_for_tsconfig(source));
@@ -1254,6 +1297,16 @@ fn resolve_config_specs(tsconfig: &Path, key: &str) -> Option<(Vec<String>, Path
 }
 
 fn resolve_config_value(tsconfig: &Path, key: &str) -> Option<serde_json::Value> {
+    resolve_config_value_with_base(tsconfig, key).map(|(value, _)| value)
+}
+
+/// The declaring config's directory comes back too: a relative `paths` target
+/// is resolved against the config that spelled it, not against the one that
+/// inherits it.
+fn resolve_config_value_with_base(
+    tsconfig: &Path,
+    key: &str,
+) -> Option<(serde_json::Value, PathBuf)> {
     let mut pending = vec![absolute_normalized(tsconfig)];
     let mut seen = BTreeSet::new();
     let mut visited = 0usize;
@@ -1268,16 +1321,16 @@ fn resolve_config_value(tsconfig: &Path, key: &str) -> Option<serde_json::Value>
         let Some(parsed) = parse_jsonc(&raw) else {
             continue;
         };
-        if let Some(value) = parsed
-            .get("compilerOptions")
-            .and_then(|options| options.get(key))
-        {
-            return Some(value.clone());
-        }
         let base = path
             .parent()
             .unwrap_or_else(|| Path::new("."))
             .to_path_buf();
+        if let Some(value) = parsed
+            .get("compilerOptions")
+            .and_then(|options| options.get(key))
+        {
+            return Some((value.clone(), base));
+        }
         let parents = match parsed.get("extends") {
             Some(serde_json::Value::String(parent)) => vec![parent.as_str()],
             Some(serde_json::Value::Array(parents)) => parents
@@ -2285,6 +2338,114 @@ mod tests {
                 &overlay.workspace().join("src/generated/**")
             )])
         );
+    }
+
+    #[test]
+    fn a_paths_alias_gains_a_shadow_tree_candidate() {
+        // SvelteKit's real layout: the generated config declares the alias and
+        // the root config extends it, so the targets are relative to
+        // `.svelte-kit/` and not to the config the overlay is handed.
+        let workspace = TestWorkspace::new("paths-shadow");
+        write(
+            &workspace.0.join(".svelte-kit/tsconfig.json"),
+            r#"{ "compilerOptions": { "paths": { "$lib": ["../src/lib"], "$lib/*": ["../src/lib/*"] } } }"#,
+        );
+        write(
+            &workspace.0.join("tsconfig.json"),
+            r#"{ "extends": "./.svelte-kit/tsconfig.json" }"#,
+        );
+        write(&workspace.0.join("src/lib/Widget.svelte"), "<p />");
+
+        let overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(overlay.tsconfig_path()).unwrap()).unwrap();
+        let source = path_for_tsconfig(&overlay.workspace().join("src/lib/*"));
+        let shadow = path_for_tsconfig(&overlay.shadow_dir.join("src/lib/*"));
+        // The source target stays first: anything resolving today keeps resolving
+        // to the same file, and the shadow is only reached as a fallback.
+        assert_eq!(
+            config["compilerOptions"]["paths"]["$lib/*"],
+            json!([source, shadow])
+        );
+        assert_eq!(
+            config["compilerOptions"]["paths"]["$lib"],
+            json!([
+                path_for_tsconfig(&overlay.workspace().join("src/lib")),
+                path_for_tsconfig(&overlay.shadow_dir.join("src/lib"))
+            ])
+        );
+    }
+
+    #[test]
+    fn a_project_without_paths_declares_none() {
+        let workspace = TestWorkspace::new("paths-absent");
+        write(
+            &workspace.0.join("tsconfig.json"),
+            r#"{ "compilerOptions": { "strict": true } }"#,
+        );
+        write(&workspace.0.join("src/App.svelte"), "<p />");
+
+        let config = overlay_config_of(&workspace.0);
+        assert!(config["compilerOptions"].get("paths").is_none());
+    }
+
+    #[test]
+    fn a_paths_target_outside_the_workspace_gets_no_shadow_twin() {
+        // `strip_prefix` is what decides this, so a target that escapes the
+        // workspace must carry one candidate rather than a shadow path that
+        // could never hold a component.
+        let workspace = TestWorkspace::new("paths-outside");
+        write(
+            &workspace.0.join("tsconfig.json"),
+            r#"{ "compilerOptions": { "paths": { "@out/*": ["../outside/*"], "@in/*": ["./src/*"] } } }"#,
+        );
+        write(&workspace.0.join("src/App.svelte"), "<p />");
+
+        let overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(overlay.tsconfig_path()).unwrap()).unwrap();
+        assert_eq!(
+            config["compilerOptions"]["paths"]["@out/*"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            config["compilerOptions"]["paths"]["@in/*"],
+            json!([
+                path_for_tsconfig(&overlay.workspace().join("src/*")),
+                path_for_tsconfig(&overlay.shadow_dir.join("src/*"))
+            ])
+        );
+    }
+
+    #[test]
+    fn a_paths_pattern_that_cannot_be_rewritten_is_preserved_verbatim() {
+        // Overriding `paths` replaces the inherited map wholesale, so a shape
+        // this rewrite does not understand has to survive rather than vanish.
+        let workspace = TestWorkspace::new("paths-verbatim");
+        write(
+            &workspace.0.join("tsconfig.json"),
+            r#"{ "compilerOptions": { "paths": { "@ok/*": ["./src/*"], "@weird/*": "not-an-array", "@empty/*": [] } } }"#,
+        );
+        write(&workspace.0.join("src/App.svelte"), "<p />");
+
+        let overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(overlay.tsconfig_path()).unwrap()).unwrap();
+        let paths = &config["compilerOptions"]["paths"];
+        // Live control: the rewritable pattern still gains its shadow twin, so a
+        // rule that preserved everything verbatim would fail here.
+        assert_eq!(
+            paths["@ok/*"],
+            json!([
+                path_for_tsconfig(&overlay.workspace().join("src/*")),
+                path_for_tsconfig(&overlay.shadow_dir.join("src/*"))
+            ])
+        );
+        assert_eq!(paths["@weird/*"], json!("not-an-array"));
+        assert_eq!(paths["@empty/*"], json!([]));
     }
 
     fn overlay_config_of(workspace: &Path) -> serde_json::Value {


### PR DESCRIPTION
Closes #4100.

## What was wrong

`TsgoOverlay` serves each component's `.svelte.tsx` shadow from memory under
`<workspace>/.rsvelte-language-server/tsgo/svelte/`, and materialises only the
parent directories on disk. Its tsconfig inherited `paths` through `extends`,
and tsgo resolves a `paths` target against the config that **declares** it — so
an alias landed in the source tree, where the shadow does not exist.
`rootDirs` lists both trees but governs *relative* resolution only, so a
relative import of the same component was fine and the alias was not.

`import Widget from '$lib/Widget.svelte'` therefore had no type at all: hover
returned `null`, the symbol was `any`, and **no diagnostic said so**.

`overlay_paths` now re-declares every mapping with its shadow-tree twin beside
the original. The original stays first, so nothing that resolves today can start
resolving somewhere else; a target that escapes the workspace gets no twin.
`resolve_config_value` grew a variant returning the declaring config's directory,
because SvelteKit puts the alias in `.svelte-kit/tsconfig.json` and the root
config only extends it.

## What this is not

#4100's *Scale* section attributes 97 melt-ui hover divergences to this. Measured,
they are a **different mechanism** and this PR moves none of them — filed as
#4391. The discriminating cell is a `.ts` alias:

| | `.ts` alias | `.svelte` alias | relative |
|---|---|---|---|
| this defect | answers | **null** | answers |
| #4391 (overlay reads only the workspace-root tsconfig) | **null** | **null** | answers |
| #4392 (tsgo removed `baseUrl`) | **null** via `baseUrl` | **null** via `baseUrl` | answers |

melt-ui's root config declares no `paths` at all — the alias is in
`docs/tsconfig.json`, which the overlay never reads.

## Verification

Two arms, distinct binaries: base `2918de53db7f8221…` and fixed
`65e61db9332bacd9…`, the latter reproduced byte-for-byte by a second clean
rebuild. Positions derived from the source text; a timeout is printed as
`NO-RESPONSE` rather than folded into `null`; workspace roots are `realpath`ed,
because `TsgoOverlay::build` canonicalizes and an un-canonicalized root makes the
probe silently miss.

Six cells, and the cells that must **not** move are the informative half:

```
cell                          base                         fixed                        verdict
1 .ts     relative            (alias) const helper: 1      (alias) const helper: 1      unchanged
2 .ts     paths               (alias) const helper: 1      (alias) const helper: 1      unchanged
3 .svelte relative            (alias) const fromSvelte: 1  (alias) const fromSvelte: 1  unchanged
4 .svelte paths   REPORTED    null                         (alias) const fromSvelte: 1  MOVED
5 .ts     baseUrl  (#4392)    null                         null                         unchanged
6 .svelte baseUrl  (#4392)    null                         null                         unchanged
moved = 1, and it is cell 4
```

SvelteKit layout (root config extending `./.svelte-kit/tsconfig.json`, which
declares `"$lib/*": ["../src/lib/*"]`): `$lib/Widget.svelte` goes `null` ->
`(alias) const fromWidget: 1`, with `$lib/util` and `../lib/Widget.svelte`
unchanged.

The mechanism was separately confirmed on a plain tsgo project with no rsvelte in
the loop — two trees, an alias, the importing file in the shadow tree:

```
before  App.svelte.tsx(2,46): TS2307 Cannot find module '@components/Other.svelte.tsx'
        no error on '@components/other'   (paths does reach the program)
        no error on './Other.svelte.tsx'  (rootDirs/relative works)
after   rc=0, 0 bytes
        + one unresolvable import -> rc=1, TS2307 named   (control live)
        restored                  -> rc=0, 0 bytes
```

Four unit tests: the SvelteKit two-config shape (asserting the order), a project
with no `paths` (must emit no `paths` key), an out-of-workspace target (one
candidate, with an in-workspace sibling in the same config as the live control),
and a pattern this rewrite cannot express.

That fourth one is about the shape of the override rather than about the bug.
`compilerOptions.paths` is replaced wholesale, so every pattern the loop declines
to reproduce is a pattern the project loses — and a non-array value or an array of
non-strings would have been dropped. Both are malformed per the tsconfig schema
and TS rejects them either way, so the blast radius is an error message; an
override that *can* lose a key is still the worse shape, and it costs three lines
not to. The test carries a rewritable pattern beside the two unrewritable ones, so
a rule that preserved everything verbatim fails it.

## The ratchet does not move, and that is measured rather than assumed

`overlay_paths` returns `None` unless the workspace-root config resolves a
`paths` map, in which case `write_tsconfig`'s output is byte-identical. Every
workspace root the LSP gate registers:

```
scripts/compat-lsp/positive                          no root config
compatibility/lsp-fixtures/tsconfig.json             paths = 0
.../typescript/features                              no root config
.../features/diagnostics/fixtures/style-directive    no root config
.../typescript/testfiles/tsconfig.json               paths = 0
bits-ui                                              no root config
shadcn-svelte                                        no root config
melt-ui/tsconfig.json                                paths = 0
flowbite-svelte/tsconfig.json                        extends ./.svelte-kit/tsconfig.json — ABSENT
```

The three upstream test configs that do declare `paths` are nested below a
registered root, and the fixture manifest's four `root` values touch none of
them. `.svelte-kit/` is generated by `svelte-kit sync` and gitignored, so it does
not exist in any corpus checkout — the same corpus-preparation gap #4101 records,
one config file over. So `lsp-known-failures.json` should not move in either
direction, and the evidence for this change is the probes and the unit tests
rather than the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSuCFoDV9gDHEVPQjPFDmH
