### PR TITLE
fix(svelte2tsx): a generic arrow's type-parameter list is copied verbatim

### DIFF
--- a/.changeset/svelte2tsx-generic-arrow-verbatim.md
+++ b/.changeset/svelte2tsx-generic-arrow-verbatim.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+svelte2tsx: a script's angle-bracket type-parameter list is copied into the TSX shadow verbatim. rsvelte inserted a disambiguating comma (`<T>` → `<T,>`) that upstream never inserts, which changed the program the type checker sees — `<string>() => a` is a type assertion, `<string,>() => a` is a generic arrow whose type parameter is named `string`.

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -61,7 +61,7 @@ use script_facts::ScriptFacts;
 use stores::{
     inject_store_subscriptions_vars_only_with_program, inject_store_subscriptions_with_program,
 };
-use type_assertion::{disambiguate_arrow_type_params, rewrite_type_assertions};
+use type_assertion::rewrite_type_assertions;
 
 /// Classify a Svelte component basename for `SvelteKit` autotype injection.
 ///
@@ -661,10 +661,6 @@ pub fn process_instance_script(
         // so we don't re-parse the instance script content with OXC.
         inject_store_subscriptions_with_program(program, module_program, offset, store_scan, str);
 
-        // Pass 6: disambiguate generic arrow type-parameter lists for the
-        // `.tsx` overlay (`<T>` → `<T,>`) so they aren't misparsed as JSX.
-        disambiguate_arrow_type_params(&script_facts.arrow_generic_commas, str);
-
         // Pass 7: rewrite TS angle-bracket type assertions (`<X>e` → `e as X`).
         // `processInstanceScriptContent` gates this on `mode !== 'ts'` because
         // `<X>e` is still a valid assertion in `ts` mode; the module script
@@ -729,11 +725,6 @@ pub fn process_module_script(
         // required because the generated `.tsx` parses the module-script
         // body at top level, where `<X>e` would be lexed as JSX.
         rewrite_type_assertions(&script_facts.type_assertions, str);
-
-        // Disambiguate generic arrow type-parameter lists (`<T>` → `<T,>`) so
-        // the module-script body, parsed at the top level of the `.tsx`
-        // overlay, doesn't lex a single-parameter arrow generic as JSX.
-        disambiguate_arrow_type_params(&script_facts.arrow_generic_commas, str);
 
         collect_module_names(program, exported_names)?;
         Ok(())

--- a/crates/rsvelte_projection/src/svelte2tsx/script/script_facts.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/script_facts.rs
@@ -9,7 +9,6 @@ use super::stores::{
 
 pub(super) struct ScriptFacts {
     pub(super) type_assertions: Vec<TypeAssertionFacts>,
-    pub(super) arrow_generic_commas: Vec<u32>,
     #[cfg(test)]
     pub(super) visitor_dispatches: VisitorDispatches,
 }
@@ -38,7 +37,6 @@ impl ScriptFacts {
             has_props_rune_declaration: false,
             facts: Self {
                 type_assertions: Vec::new(),
-                arrow_generic_commas: Vec::new(),
                 #[cfg(test)]
                 visitor_dispatches: VisitorDispatches::default(),
             },
@@ -139,29 +137,6 @@ impl ScriptFactsCollector<'_, '_, '_> {
             self.store_scan.add_self_named_rune_call(pos);
         }
     }
-
-    fn add_arrow_generic_comma(&mut self, arrow: &oxc::ArrowFunctionExpression<'_>) {
-        let Some(type_parameters) = arrow.type_parameters.as_deref() else {
-            return;
-        };
-        if type_parameters.params.len() != 1 {
-            return;
-        }
-        let param = &type_parameters.params[0];
-        if param.constraint.is_some() || param.default.is_some() {
-            return;
-        }
-        let bytes = self.raw_content.as_bytes();
-        let mut index = param.span.end as usize;
-        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
-            index += 1;
-        }
-        if index >= bytes.len() || bytes[index] != b',' {
-            self.facts
-                .arrow_generic_commas
-                .push(param.span.end + self.offset);
-        }
-    }
 }
 
 impl<'a> Visit<'a> for ScriptFactsCollector<'_, '_, '_> {
@@ -180,7 +155,6 @@ impl<'a> Visit<'a> for ScriptFactsCollector<'_, '_, '_> {
             self.facts.visitor_dispatches.arrows += 1;
         }
         self.add_params(&it.params, it.span);
-        self.add_arrow_generic_comma(it);
         oxc_ast_visit::walk::walk_arrow_function_expression(self, it);
     }
 
@@ -351,10 +325,6 @@ function outer($outer) {
                 arrows: 2,
                 type_assertions: 3,
             }
-        );
-        assert_eq!(
-            facts.arrow_generic_commas,
-            vec![source.find("<T>").unwrap() as u32 + 2 + offset]
         );
 
         let outer_start = source.find("function outer").unwrap() as u32 + offset;

--- a/crates/rsvelte_projection/src/svelte2tsx/script/type_assertion.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/type_assertion.rs
@@ -28,45 +28,28 @@ pub(super) fn rewrite_type_assertions(
     }
 }
 
-/// Add a trailing comma to every collected generic arrow type-parameter list
-/// that would otherwise be misparsed as JSX in the generated `.tsx` overlay.
-///
-/// In a `.tsx` file `const f = <T>(x: T) => x` is lexed as a JSX element
-/// (`<T>…`), producing a cascade of bogus "JSX element 'T' has no corresponding
-/// closing tag" errors. TypeScript itself disambiguates by requiring either a
-/// trailing comma (`<T,>`), a constraint (`<T extends X>`), a default
-/// (`<T = Y>`), or more than one parameter (`<T, U>`). Only the bare
-/// single-parameter form `<T>` is ambiguous, so that is the only shape we
-/// rewrite — to `<T,>`.
-///
-/// Note: this targets arrow functions only. `function foo<T>()`, call type
-/// arguments `f<T>()`, and class / interface generics are all unambiguous in
-/// TSX and are left untouched.
-pub(super) fn disambiguate_arrow_type_params(insert_at: &[u32], str: &mut MagicString<'_>) {
-    for &pos in insert_at {
-        str.append_left(pos, ",");
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::test_support::run_svelte2tsx;
 
     #[test]
-    fn test_generic_arrow_gets_trailing_comma() {
-        // A bare single-parameter generic arrow `<T>` would be lexed as a JSX
-        // element in the `.tsx` overlay; svelte2tsx must rewrite it to `<T,>`.
+    fn test_generic_arrow_is_copied_verbatim() {
+        // Upstream copies a `<T>` arrow into the overlay unchanged. It really is
+        // lexed as JSX there — but reproducing that is what byte parity means,
+        // and inserting a disambiguating comma changes the program the checker
+        // sees: `<string>() => a` becomes a generic arrow whose type parameter
+        // is named `string`.
         let source =
             "<script lang=\"ts\">\nconst id = <T>(x: T): T => x;\n</script>\n<p>{id(1)}</p>";
         let result = run_svelte2tsx(source);
         assert!(
-            result.code.contains("<T,>(x: T)"),
-            "Generic arrow should be disambiguated to `<T,>`.\nGot: {}",
+            result.code.contains("<T>(x: T)"),
+            "Generic arrow must be copied verbatim.\nGot: {}",
             result.code
         );
         assert!(
-            !result.code.contains("<T>(x: T)"),
-            "The ambiguous `<T>` form must not survive into the overlay.\nGot: {}",
+            !result.code.contains("<T,>(x: T)"),
+            "No disambiguating comma is inserted.\nGot: {}",
             result.code
         );
     }
@@ -82,8 +65,8 @@ mod tests {
             const call = fn<number>(1);\n\
             </script>";
         let result = run_svelte2tsx(source);
-        // None of these forms are ambiguous in TSX, so they must be emitted
-        // verbatim — in particular no double comma on the already-safe arrow.
+        // Every type-parameter list is copied verbatim — in particular the
+        // already-comma'd arrow does not gain a second one.
         assert!(
             result.code.contains("<T, U>(x: T, y: U)"),
             "got: {}",
@@ -132,7 +115,7 @@ mod tests {
         let result = run_svelte2tsx(source);
 
         assert!(
-            result.code.contains("<T,>($inner: T)"),
+            result.code.contains("<T>($inner: T)"),
             "got: {}",
             result.code
         );
@@ -164,7 +147,7 @@ mod tests {
         let result = run_svelte2tsx(source);
 
         assert!(
-            result.code.contains("<T,>(value: T)"),
+            result.code.contains("<T>(value: T)"),
             "got: {}",
             result.code
         );

--- a/crates/rsvelte_projection/tests/svelte2tsx_generic_arrow_verbatim_4399.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_generic_arrow_verbatim_4399.rs
@@ -1,0 +1,90 @@
+//! svelte2tsx copies a script's angle-bracket type-parameter list into the TSX
+//! shadow verbatim. rsvelte used to insert a disambiguating comma (`<T>` →
+//! `<T,>`) so the shadow would not lex the arrow as JSX; upstream inserts none,
+//! in either `isTsFile` mode, and the rewrite changed the program the type
+//! checker sees — `<string>() => a` is a type assertion, `<string,>() => a` is a
+//! generic arrow whose type parameter is named `string` (TS2368).
+//!
+//! Every expected line below is the official `svelte2tsx`'s own output
+//! (`submodules/language-tools/packages/svelte2tsx`), not a prediction.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+/// `(name, script body, the expected shadow line)`.
+const CELLS: &[(&str, &str, &str)] = &[
+    (
+        "assertion_arrow",
+        "let a: any;\nconst x = <string>() => a;",
+        "const x = <string>() => a;",
+    ),
+    (
+        "assertion_arrow_named",
+        "let a: any;\nconst z = <Foo>() => a;",
+        "const z = <Foo>() => a;",
+    ),
+    (
+        "generic_arrow",
+        "const id = <T>(x: T): T => x;",
+        "const id = <T>(x: T): T => x;",
+    ),
+    (
+        "generic_multi",
+        "const m = <T, U>(x: T, y: U): T => x;",
+        "const m = <T, U>(x: T, y: U): T => x;",
+    ),
+    (
+        "generic_already_comma",
+        "const c = <T,>(x: T): T => x;",
+        "const c = <T,>(x: T): T => x;",
+    ),
+    (
+        "assertion_plain",
+        "let a: any;\nconst y = <string>a;",
+        "const y = <string>a;",
+    ),
+];
+
+fn shadow(body: &str, is_ts_file: bool) -> String {
+    let src = format!("<script lang=\"ts\">\n{body}\n</script>\n<p>{{1}}</p>");
+    svelte2tsx(
+        &src,
+        Svelte2TsxOptions {
+            filename: "x.svelte".to_string(),
+            is_ts_file,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code
+}
+
+#[test]
+fn every_cell_is_copied_verbatim_in_both_modes() {
+    for is_ts_file in [true, false] {
+        for (name, body, expected) in CELLS {
+            let code = shadow(body, is_ts_file);
+            assert!(
+                code.lines().any(|l| l.trim() == *expected),
+                "{name} (is_ts_file={is_ts_file}): expected a line `{expected}`\n{code}"
+            );
+        }
+    }
+}
+
+/// A shadow that dropped the declaration entirely would satisfy an
+/// "inserts no comma" assertion, so pin the count instead of the absence: the
+/// shadow must carry exactly as many `,>` sequences as the source body did.
+#[test]
+fn no_cell_gains_a_disambiguating_comma() {
+    for is_ts_file in [true, false] {
+        for (name, body, _) in CELLS {
+            let code = shadow(body, is_ts_file);
+            let in_source = body.matches(",>").count();
+            let in_shadow = code.matches(",>").count();
+            assert_eq!(
+                in_shadow, in_source,
+                "{name} (is_ts_file={is_ts_file}): `,>` count moved\n{code}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #4399.

## What was wrong

`svelte2tsx` copies a `<script lang="ts">` into the TSX shadow. rsvelte inserted a disambiguating comma into every bare single-parameter angle-bracket type-parameter list (`<T>` → `<T,>`) so the shadow would not lex the arrow as JSX. **Upstream inserts none**, in either `isTsFile` mode:

```
                          official                          rsvelte (before)
generic_arrow             const id = <T>(x: T): T => x;     const id = <T,>(x: T): T => x;
assertion_arrow           const x = <string>() => a;        const x = <string,>() => a;
assertion_arrow_named     const z = <Foo>() => a;           const z = <Foo,>() => a;
```

The issue reports the middle row, where the rewrite is not merely a byte difference: `<string>() => a` is a **type assertion**, and `<string,>() => a` is a **generic arrow whose type parameter is named `string`** — `TS(2368) Type parameter name cannot be 'string'`. Any diagnostic the LSP or `svelte-check` derives from that line is derived from a different statement.

The issue's own "Not located" note says `,>` appears nowhere as a literal and guesses a re-print. It is neither: `script/type_assertion.rs`'s `disambiguate_arrow_type_params` inserts it, from positions `script_facts.rs`'s `add_arrow_generic_comma` collects. It is an rsvelte-only pass with no upstream counterpart — `grep`ping the oracle for a trailing-comma rewrite returns nothing, and running it confirms it.

## The fix

Delete the collector, the field and both passes. A type-parameter list is now copied verbatim, as upstream does.

## Measured

Oracle: `submodules/language-tools/packages/svelte2tsx`.

- Six cells × two `isTsFile` modes, expected lines taken from the oracle's own output — `crates/rsvelte_projection/tests/svelte2tsx_generic_arrow_verbatim_4399.rs`. `generic_multi` (`<T, U>`) and `generic_already_comma` (`<T,>`) are the controls that were already right, and `assertion_plain` (`<string>a`, no arrow) is the control the pass never touched.
- The second test pins the **count** of `,>` rather than its absence, so a shadow that dropped the declaration entirely cannot pass it.
- The two collected-corpus components that carry a bare single-parameter generic arrow — `svelteui/packages/svelteui-dates/src/components/Month/Month.svelte:48` and `threlte/packages/studio/src/lib/extensions/inspector/bindings/Light.svelte:28` — produce a shadow **byte-identical** to the oracle's after this change (whole-file diff, not a line grep).
- `cargo test -p rsvelte_projection --lib` 285 passed, including the three `type_assertion` unit tests whose expectations this moves.

## Note on the gate

Both corpus carriers are in `compatibility/manifest.json` as `kind: component` and neither is in `compatibility/svelte2tsx-known-failures.json` (2 entries, both `cnblocks`). Applying the collector's predicate by hand to `const castType = <T>(value: unknown) => value as T;` says it fired, so those two units should have been diverging before this change. Whatever the reason they were not listed, the direction here is one-way: the post-fix output is byte-identical to the oracle on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj