### PR TITLE
test(client): the each-host fallback pin is the oracle's answer, not the defect it watched

### DIFF
--- a/crates/rsvelte_core/tests/unary_fallback_arm_4386.rs
+++ b/crates/rsvelte_core/tests/unary_fallback_arm_4386.rs
@@ -179,14 +179,36 @@ fn the_table_exercises_both_arms_and_puts_the_unary_rows_on_the_lazy_one() {
     }
 }
 
-/// A concise-body arrow in an `{#each}` destructure comes back with a BLOCK body, so the
-/// default function returns `undefined`. That is #4417 and a different mechanism; it is pinned
-/// here so fixing it turns this row red rather than passing unnoticed.
+/// The `{#each}` destructuring host takes the same lazy/eager split as the snippet host, on
+/// both arms. #4417 was the concise-body arrow coming back with a BLOCK body here — this row
+/// was pinned to that wrong shape so fixing it would go red rather than pass unnoticed, and
+/// #4428 fixed it. The pin is now the oracle's own answer, and it carries the eager and lazy
+/// arms beside the arrow so a port that re-broke either one is caught by the same test.
+///
+/// Three of these rows also appear in `each_destructure_concise_arrow_default_4417.rs`. That is
+/// deliberate and not a duplicate: that table asks whether the concise body is PRESERVED, this
+/// one asks which `$.fallback` arm is TAKEN, and deleting either leaves its own question with
+/// no witness.
 #[test]
-fn the_each_host_concise_arrow_default_is_still_wrong() {
-    let line = fallback_line(&client(&each_host("() => 1")));
-    assert_eq!(
-        line, "let a = $.derived_safe_equal(() => $.fallback($.get($$item).a, () => {",
-        "#4417 changed: official emits `, () => 1));` on one line"
-    );
+fn the_each_host_matches_the_official_compiler() {
+    /// `(default, the line the official compiler emits)`.
+    #[rustfmt::skip]
+    const EACH: &[(&str, &str)] = &[
+        ("() => 1",        "let a = $.derived_safe_equal(() => $.fallback($.get($$item).a, () => 1));"),
+        ("function () {}", "let a = $.derived_safe_equal(() => $.fallback($.get($$item).a, function () {}));"),
+        ("1",              "let a = $.derived_safe_equal(() => $.fallback($.get($$item).a, 1));"),
+        ("-1",             "let a = $.derived_safe_equal(() => $.fallback($.get($$item).a, () => -1, true));"),
+    ];
+
+    for (default, expected) in EACH {
+        assert_eq!(
+            fallback_line(&client(&each_host(default))).as_str(),
+            *expected,
+            "each host, default `{default}`"
+        );
+    }
+
+    // Both arms have to be present or the grid is satisfied by a port that only ever takes one.
+    assert!(EACH.iter().any(|c| is_lazy(c.1)), "no lazy row");
+    assert!(EACH.iter().any(|c| !is_lazy(c.1)), "no eager row");
 }


### PR DESCRIPTION
`main` is red, and it is not a flake or anyone's regression — it is a deliberate tripwire firing as designed.

```
crates/rsvelte_core/tests/unary_fallback_arm_4386.rs:188
test  the_each_host_concise_arrow_default_is_still_wrong
assertion `left == right` failed: #4417 changed: official emits `, () => 1));` on one line
```

`625f97208` (#4386 / #4421) added that pin, asserting **rsvelte's own wrong output** so that fixing #4417 would go red rather than pass unnoticed. `903827b01` (#4428) then fixed #4417 and did not update the pin. Both are mine, both were green in their own merge ref, and only the combination is red — the ordering hazard `AGENTS.md` records, met from the side where nothing on either PR could have caught it.

## The replacement is not a one-row re-point

A single row cannot tell *"the each host takes the right arm"* from *"the each host always takes the eager arm"*, and neither can a table that is all one arm. So the row becomes four, spanning both arms of the `is_simple_expression` split that #4386 is about:

| default | official emits | arm |
|---|---|---|
| `() => 1` | `$.fallback($.get($$item).a, () => 1)` | eager |
| `function () {}` | `$.fallback($.get($$item).a, function () {})` | eager |
| `1` | `$.fallback($.get($$item).a, 1)` | eager |
| `-1` | `$.fallback($.get($$item).a, () => -1, true)` | **lazy** |

with `any(is_lazy)` and `any(!is_lazy)` asserted under the loop, so a later edit that collapses the table to one arm fails rather than passing quietly.

Every value is the official compiler's own output — `scratchpad/svelte-pin/packages/svelte/src/compiler/index.js`, `VERSION === '5.57.0'`, `generate: 'client'`, `dev: false` — generated, not written by hand.

## Independently corroborated

The concise-arrow row rests on two derivations with no shared stage: the oracle above, and the CI panic itself, which prints both sides. Its `left` (rsvelte's current output) is byte-identical to the oracle row. @rsvelte-21 read that off the failing job while I read it off the oracle. The other three rows rest on the oracle alone.

## Why the row is not simply deleted

`each_destructure_concise_arrow_default_4417.rs:35` already asserts the same string for `() => 1`, so deleting this one looks like removing a duplicate. It is not: that table asks whether the concise body is **preserved**, this one asks which `$.fallback` arm is **taken**. Deleting either leaves its own question with no witness, and the `-1` row here has no counterpart there at all. A comment now says so at the test.

## Verification

- `cargo test --release -p rsvelte_core --test unary_fallback_arm_4386` — 4 passed, 0 failed.
- The failing state is not hypothetical: measured red on `main` at `2c7d0f345` (`Test (ubuntu-latest, 3)`, `Test (macos-latest, 3)`) and `192592b8a`, same file, same line, same assertion text.
- Live control that the shard itself is healthy: `Test (ubuntu-latest, 1)` is SUCCESS on #4413, #4419, #4422 and #4423 — all cut before both commits — so only trees containing **both** fail.

Test-only; no changeset (the gate requires one for `fix`/`feat` titles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj