### PR TITLE
ci(lsp): the vendored html/css data's recorded SHA-256 becomes load-bearing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -729,6 +729,9 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
         with:
+          # rustfmt: the vendored-LSP-data gate below formats the generators'
+          # output before diffing it, because they emit unformatted Rust.
+          components: rustfmt
           targets: wasm32-unknown-unknown,wasm32-wasip2
           mold: 'true'
           wasm-pack: 'true'
@@ -753,6 +756,20 @@ jobs:
           pnpm --filter svelte-language-server... build
           cd "$GITHUB_WORKSPACE"
           node scripts/compat-lsp/pin-official-svelte.mjs
+
+      # `html_data/web.rs` and `css_data/web.rs` are vendored from
+      # `vscode-{html,css}-languageservice` and record a SHA-256 per input file
+      # — a RECORD nothing re-read. Their two tests compare the port against a
+      # JSON oracle the SAME generator run writes, so a language-tools bump
+      # nobody regenerated leaves port and oracle equally stale and both green
+      # forever (#4258). Re-running the generators is what makes the recorded
+      # hash load-bearing. It lives here because this is the only job that
+      # builds language-tools' `dist/`, which both generators require.
+      - name: Check vendored LSP data is regenerated
+        run: node scripts/ci/check-vendored-lsp-data.mjs
+
+      - name: Run vendored LSP data guard tests
+        run: node scripts/ci/test-check-vendored-lsp-data.mjs
 
       - name: Build lint wasm (nodejs target)
         run: pnpm run build:wasm:lint-node

--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
 		"build:vps-native": "node scripts/dev/build-vps-native-local.mjs",
 		"check:vps-version": "node scripts/dev/check-vps-version.mjs",
 		"test:bot-branch-guard": "node scripts/ci/test-bot-branch-guard.mjs",
+		"check:vendored-lsp-data": "node scripts/ci/check-vendored-lsp-data.mjs",
+		"fix:vendored-lsp-data": "node scripts/ci/check-vendored-lsp-data.mjs --fix",
 		"check:workflow-triggers": "node scripts/ci/workflow-trigger-guard.mjs",
 		"test:workflow-trigger-guard": "node scripts/ci/test-workflow-trigger-guard.mjs",
 		"test:capi-release-decision": "node scripts/release/test-capi-release-decision.mjs",

--- a/scripts/ci/check-vendored-lsp-data.mjs
+++ b/scripts/ci/check-vendored-lsp-data.mjs
@@ -1,0 +1,108 @@
+// Re-runs the two vendored-data generators and fails when the tree is not
+// byte-identical afterwards.
+//
+//   node scripts/ci/check-vendored-lsp-data.mjs [--fix]
+//
+// `html_data/web.rs` and `css_data/web.rs` are vendored from
+// `vscode-{html,css}-languageservice`, and each records the resolved version
+// plus a SHA-256 per input file in its header. That header is a RECORD and
+// nothing re-read it: the two vendored-data tests compare the Rust port against
+// a JSON oracle THE SAME GENERATOR RUN writes, so a version bump in
+// `submodules/language-tools` that nobody regenerates leaves the port and its
+// oracle equally stale and both tests green forever (#4258).
+//
+// Running the generators is what makes the recorded SHA-256 load-bearing: the
+// generator resolves the package from the language-tools lockfile and refuses
+// to write if the resolved version disagrees, so a bump fails here on the PR
+// that bumps it.
+//
+// The generators emit unformatted Rust, so `rustfmt` runs before the diff —
+// exactly the two steps a human regeneration takes.
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(fileURLToPath(import.meta.url), "../../..");
+const FIX = process.argv.includes("--fix");
+
+const GENERATORS = [
+  "scripts/dev/generate-html-data.mjs",
+  "scripts/dev/generate-css-data.mjs",
+];
+
+// Everything the two generators write. A path missing from this list is a path
+// the gate does not watch, so it is derived from the generators' own output
+// assignments rather than remembered — see the self-test.
+const GENERATED = [
+  "crates/rsvelte_language_server/src/html_data/web.rs",
+  "crates/rsvelte_language_server/src/html_data/svelte_html.rs",
+  "crates/rsvelte_language_server/src/css_data/web.rs",
+  "crates/rsvelte_language_server/src/css_data/svelte_css.rs",
+  "crates/rsvelte_language_server/tests/data/html-documentation.json",
+  "crates/rsvelte_language_server/tests/data/svelte-html-attributes.json",
+  "crates/rsvelte_language_server/tests/data/css-documentation.json",
+];
+
+const run = (cmd, args) =>
+  execFileSync(cmd, args, { cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] })
+    .toString()
+    .trim();
+
+function assertClean() {
+  const dirty = run("git", ["status", "--porcelain", "--", ...GENERATED]);
+  if (dirty) {
+    console.error(
+      "The generated files are already modified in the working tree, so this\n" +
+        "gate cannot tell its own output from yours. Commit or stash first:\n" +
+        dirty,
+    );
+    process.exit(2);
+  }
+}
+
+function main() {
+  for (const rel of GENERATED) {
+    if (!fs.existsSync(path.join(ROOT, rel))) {
+      console.error(`missing generated file: ${rel}`);
+      process.exit(2);
+    }
+  }
+  if (!FIX) assertClean();
+
+  for (const generator of GENERATORS) {
+    process.stderr.write(`[vendored-lsp-data] node ${generator}\n`);
+    execFileSync("node", [generator], { cwd: ROOT, stdio: "inherit" });
+  }
+
+  const rust = GENERATED.filter((f) => f.endsWith(".rs"));
+  process.stderr.write(`[vendored-lsp-data] rustfmt ${rust.length} files\n`);
+  execFileSync("rustfmt", ["--edition", "2024", ...rust], {
+    cwd: ROOT,
+    stdio: "inherit",
+  });
+
+  const drifted = run("git", ["status", "--porcelain", "--", ...GENERATED]);
+  if (!drifted) {
+    console.log(
+      `[vendored-lsp-data] OK — ${GENERATED.length} generated files reproduce byte-identically`,
+    );
+    return;
+  }
+  if (FIX) {
+    console.log(`[vendored-lsp-data] regenerated:\n${drifted}`);
+    return;
+  }
+  console.error(
+    "\nThe vendored LSP data is stale. These files are not what the generators\n" +
+      "produce from the currently pinned `submodules/language-tools`:\n\n" +
+      drifted +
+      "\n\nRegenerate with `pnpm run fix:vendored-lsp-data` and commit the result.\n" +
+      "If the version moved, the header's `sha256` lines move with it — that is\n" +
+      "the point: the record only means something because this gate re-reads it.\n",
+  );
+  console.error(run("git", ["diff", "--stat", "--", ...GENERATED]));
+  process.exit(1);
+}
+
+main();

--- a/scripts/ci/test-check-vendored-lsp-data.mjs
+++ b/scripts/ci/test-check-vendored-lsp-data.mjs
@@ -1,0 +1,114 @@
+// The gate watches a hand-written list of paths, which is the enumeration
+// hazard: a generator that grows an eighth output would be unwatched and the
+// gate would stay green. So the list is checked against the generators' own
+// source, in both directions.
+//
+//   node scripts/ci/test-check-vendored-lsp-data.mjs
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(fileURLToPath(import.meta.url), "../../..");
+const GATE = path.join(ROOT, "scripts/ci/check-vendored-lsp-data.mjs");
+const GENERATORS = [
+  "scripts/dev/generate-html-data.mjs",
+  "scripts/dev/generate-css-data.mjs",
+];
+// The generators write only under this subtree, which is what makes a literal
+// scan a partition rather than a work log.
+const WATCHED_PREFIX = "crates/rsvelte_language_server/";
+
+const gateSource = fs.readFileSync(GATE, "utf8");
+
+/** The `GENERATED` array the gate declares, read out of its source. */
+function declaredPaths() {
+  const body = gateSource.slice(
+    gateSource.indexOf("const GENERATED = ["),
+    gateSource.indexOf("];", gateSource.indexOf("const GENERATED = [")),
+  );
+  return new Set([...body.matchAll(/"([^"]+)"/g)].map((m) => m[1]));
+}
+
+/**
+ * Every repo-relative path under the watched subtree that the generators can
+ * write. An output is spelled either as one literal joined onto `ROOT`, or as a
+ * directory constant joined with a bare filename, so the scan resolves that one
+ * level of `path.join` from the constant's own binding rather than pairing every
+ * literal with every basename.
+ */
+function producedPaths() {
+  const found = new Set();
+  for (const rel of GENERATORS) {
+    const src = fs.readFileSync(path.join(ROOT, rel), "utf8");
+    for (const m of src.matchAll(/"([^"]*)"/g)) {
+      if (m[1].startsWith(WATCHED_PREFIX) && /\.(rs|json)$/.test(m[1])) {
+        found.add(m[1]);
+      }
+    }
+    // `const DIR = path.join(ROOT, "crates/.../css_data");`
+    const dirs = new Map();
+    for (const m of src.matchAll(
+      /const\s+(\w+)\s*=\s*path\.join\(\s*ROOT\s*,\s*"([^"]+)"\s*\)/g,
+    )) {
+      if (m[2].startsWith(WATCHED_PREFIX)) dirs.set(m[1], m[2]);
+    }
+    // `const OUTPUT = path.join(DIR, "web.rs");`
+    for (const m of src.matchAll(
+      /path\.join\(\s*(\w+)\s*,\s*"([^"]+)"\s*\)/g,
+    )) {
+      if (dirs.has(m[1])) found.add(`${dirs.get(m[1])}/${m[2]}`);
+    }
+  }
+  return found;
+}
+
+const declared = declaredPaths();
+const produced = producedPaths();
+
+// Positive control: the scan must find something, or every assertion below is
+// vacuous.
+// A count would be a second claim to keep in step with the generators; the set
+// comparison below is the assertion, and these two only rule out a scan or a
+// declaration that came back empty.
+assert.ok(produced.size > 0, "the generator scan found no output paths");
+assert.ok(declared.size > 0, "the gate declares no watched paths");
+
+const missing = [...produced].filter((p) => !declared.has(p)).sort();
+assert.deepEqual(
+  missing,
+  [],
+  `the generators write these and the gate does not watch them:\n  ${missing.join("\n  ")}`,
+);
+// The other direction is checked against the filesystem rather than against the
+// scan, because the join resolution above can over-generate a candidate no
+// assignment actually uses; a declared path that does not exist is a dead row.
+for (const rel of declared) {
+  assert.ok(
+    fs.existsSync(path.join(ROOT, rel)),
+    `the gate watches ${rel}, which does not exist`,
+  );
+}
+
+// Negative control on the derivation itself: a path outside the subtree must
+// not be picked up, or `produced` is just "every string in the file".
+assert.ok(
+  !produced.has("submodules/language-tools/pnpm-lock.yaml"),
+  "the scan is not filtering by the watched subtree",
+);
+
+// The gate has to run the generators; a gate that only diffs would be green on
+// a stale tree forever, which is exactly the defect it exists to close.
+for (const rel of GENERATORS) {
+  assert.ok(
+    gateSource.includes(rel),
+    `the gate does not run ${rel}, so it cannot see a bump nobody regenerated`,
+  );
+}
+// And it has to format, because the generators emit unformatted Rust: without
+// this the gate is red on a tree that is in fact current.
+assert.ok(gateSource.includes("rustfmt"), "the gate does not run rustfmt");
+
+console.log(
+  `check-vendored-lsp-data self-test OK — ${declared.size} generated paths, watched set == produced set`,
+);


### PR DESCRIPTION
Closes #4258.

`crates/rsvelte_language_server/src/html_data/web.rs` and `.../css_data/web.rs`
are vendored from `vscode-html-languageservice` and `vscode-css-languageservice`,
and each records the resolved version plus a SHA-256 per input file in its
header. **That header was a record, and nothing re-read it.**

The two vendored-data tests cannot close this: `tests/data/html-documentation.json`
is written by the *same script, in the same run*, as `web.rs`
(`generate-html-data.mjs:180` and `:403`; the css generator likewise at `:162`
and `:424`). Subject and oracle share a source, so a `submodules/language-tools`
bump that nobody regenerates leaves both equally stale and both tests green
forever.

## The gate

`scripts/ci/check-vendored-lsp-data.mjs` re-runs both generators, runs `rustfmt`
on their output — they emit unformatted Rust, so the diff is meaningless without
it — and fails unless the seven generated files are byte-identical. Running the
generators is what makes the recorded SHA-256 load-bearing: each resolves its
package out of language-tools' `pnpm-lock.yaml` and refuses to write when the
installed version disagrees, so a bump fails here on the PR that bumps it.

It is wired into `ci.yml`'s **Language server** job, which is the only job that
runs `pnpm --filter svelte-language-server... build` — both generators require
`packages/language-server/dist/` (`writeSvelteProvider`, `built()`), so no other
job can host it. That job's `setup-rust` gains `components: rustfmt`.

`pnpm run check:vendored-lsp-data` / `pnpm run fix:vendored-lsp-data`.

Both generators are gated together, as the issue asks: css-data was written to
the html-data precedent deliberately, and gating one leaves the same hole under a
different package name.

## Controls

**The gate, live, on the real tree** (the primary checkout, which has
language-tools installed and built):

| arm | result |
|---|---|
| unmodified tree | `OK — 7 generated files reproduce byte-identically`, exit 0 |
| one comment line appended to `html_data/svelte_html.rs` | exit **1**, naming that file |
| tree restored | byte-identical (`git status` clean) |

So the gate can produce both answers, and the green one is not a green over an
empty set.

**The watched path list is derived, not trusted.** It is hand-written in the
gate, which is the enumeration hazard — a generator that grew an eighth output
would be unwatched with the gate still green. `test-check-vendored-lsp-data.mjs`
reads the generators' own output assignments (a literal joined onto `ROOT`, or a
directory constant joined with a bare filename, resolved from the constant's own
binding) and asserts produced ⊆ declared, plus that every declared path exists.
Ablated one path at a time:

```
drop css_data/svelte_css.rs        -> exit 1, "the generators write these and the gate does not watch them"
drop html_data/web.rs              -> exit 1, same assertion
drop tests/data/css-documentation.json -> exit 1, same assertion
restored                           -> exit 0, byte-identical
```

The first version of that self-test **passed its own ablation**, because an
earlier edit had deleted the `assert.deepEqual(missing, [], …)` line and left
`missing` computed and unread — the ablation is what found it. It also had
`produced.size >= 7` / `declared.size >= 7` guards; those were the reason the
*second* ablation attempt went red, which is a control firing for the wrong
reason, so they are now liveness-only (`> 0`) and the set comparison carries the
assertion.

The self-test also pins the two things that make the gate's green mean anything:
that it *runs* both generators (a gate that only diffs is green on a stale tree
forever — the defect itself), and that it runs `rustfmt` (without it the gate is
red on a tree that is in fact current).

## Measured today

The tree is currently **up to date**: both generators plus `rustfmt` reproduce
all seven files byte-for-byte at `vscode-html-languageservice@5.4.0` and
`vscode-css-languageservice@6.3.5`. So this lands green and starts watching,
rather than landing with a backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
