### PR TITLE
test(lsp): a second case list for axes upstream has no `it()` to hang them on

### DIFF
--- a/crates/rsvelte_language_server/tests/support/upstream_fixtures.rs
+++ b/crates/rsvelte_language_server/tests/support/upstream_fixtures.rs
@@ -15,6 +15,12 @@ pub struct Manifest {
     pub unit_coverage: UnitCoverage,
     pub unit_suites: Vec<UnitSuite>,
     pub behavior_cases: Vec<BehaviorCase>,
+    /// Cases with no upstream `it()` to hang them on. Deliberately a second
+    /// list: `behavior_cases` is asserted to be an exact multiset transcription
+    /// of upstream's unit tests, which is what lets it detect an unported one,
+    /// and mixing rsvelte-authored cases in would end both properties.
+    #[serde(default)]
+    pub rsvelte_cases: Vec<RsvelteCase>,
     pub exclusions: Vec<Exclusion>,
 }
 
@@ -72,6 +78,42 @@ pub struct BehaviorCase {
     pub native_expected: Option<Value>,
     #[serde(default)]
     pub difference_reason: Option<String>,
+}
+
+/// A behavior case rsvelte authored. It carries `rsvelte_reason` where a
+/// `BehaviorCase` carries `upstream_suite` / `upstream_test`, so provenance is
+/// visible in the shape rather than inferred, and it is dispatched through the
+/// same `run_behavior_case` by `id`.
+#[derive(Debug, Deserialize)]
+pub struct RsvelteCase {
+    pub id: String,
+    /// Why no upstream `it()` covers this axis. Asserted non-empty.
+    pub rsvelte_reason: String,
+    pub method: String,
+    pub source: String,
+    #[serde(default)]
+    pub params: Value,
+    pub expected: Value,
+}
+
+impl RsvelteCase {
+    /// The same shape `run_behavior_case` dispatches on. The upstream fields
+    /// are empty because there is no upstream test; nothing in the runner
+    /// reads them.
+    pub fn as_behavior_case(&self) -> BehaviorCase {
+        BehaviorCase {
+            id: self.id.clone(),
+            upstream_suite: PathBuf::new(),
+            upstream_test: String::new(),
+            method: self.method.clone(),
+            fixture: None,
+            source: self.source.clone(),
+            params: self.params.clone(),
+            expected: self.expected.clone(),
+            native_expected: None,
+            difference_reason: None,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/rsvelte_language_server/tests/upstream_fixture_manifest.rs
+++ b/crates/rsvelte_language_server/tests/upstream_fixture_manifest.rs
@@ -247,6 +247,42 @@ fn ported_unit_cases_assert_native_provider_responses() -> Result<()> {
     Ok(())
 }
 
+/// `rsvelte_cases` runs through the same dispatch as an upstream case, and is
+/// the only list that may hold an axis upstream does not test. It is excluded
+/// from every coverage assertion above by living in its own field, and this is
+/// what stops that exclusion from also making it unread.
+#[test]
+fn rsvelte_authored_cases_assert_native_provider_responses() -> Result<()> {
+    let manifest = Manifest::load()?;
+    let upstream: BTreeSet<&str> = manifest
+        .behavior_cases
+        .iter()
+        .map(|case| case.id.as_str())
+        .collect();
+    let mut seen = BTreeSet::new();
+    for case in &manifest.rsvelte_cases {
+        assert!(
+            !case.rsvelte_reason.trim().is_empty(),
+            "{}: an rsvelte case has to say why no upstream `it()` covers it",
+            case.id
+        );
+        assert!(
+            !upstream.contains(case.id.as_str()),
+            "{}: an id in both lists makes its provenance unreadable",
+            case.id
+        );
+        assert!(seen.insert(case.id.as_str()), "duplicate id {}", case.id);
+        run_behavior_case(&case.as_behavior_case()).with_context(|| case.id.clone())?;
+    }
+    // The list exists so an axis has somewhere to live; an empty one is a
+    // declared-and-unread field, which is the shape this replaced.
+    assert!(
+        !manifest.rsvelte_cases.is_empty(),
+        "rsvelte_cases is empty, so nothing exercises the second list"
+    );
+    Ok(())
+}
+
 fn run_behavior_case(case: &BehaviorCase) -> Result<()> {
     match case.id.as_str() {
         "svelte-document-text" => {

--- a/scripts/compat-lsp/suites.mjs
+++ b/scripts/compat-lsp/suites.mjs
@@ -145,7 +145,11 @@ function positionAt(text, offset) {
 export function fixtureCases(root) {
   const manifest = fixtureManifest(root);
   const directory = path.join(root, "compatibility/lsp-fixtures");
-  return manifest.behavior_cases
+  // `behavior_cases` is asserted to be an exact multiset transcription of
+  // upstream's `it()` call sites, so an axis upstream does not test cannot live
+  // there. `rsvelte_cases` is the second list that assert does not cover; both
+  // are compared identically here, and only their provenance differs.
+  return [...manifest.behavior_cases, ...(manifest.rsvelte_cases ?? [])]
     .filter((entry) => entry.method.startsWith("textDocument/"))
     .map((entry) => {
       const marker = entry.source.indexOf("¦");

--- a/scripts/compat-lsp/suites.test.mjs
+++ b/scripts/compat-lsp/suites.test.mjs
@@ -102,3 +102,42 @@ test("every fixture request carries the members its method's params declare", ()
   assert.ok(seen.has("textDocument/colorPresentation"));
   assert.ok(!("textDocument/colorPresentation" in REQUIRED_PARAMS));
 });
+
+test("the fixtures suite reads both case lists, not only the upstream one", () => {
+  const root = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../..",
+  );
+  const manifest = JSON.parse(
+    fs.readFileSync(
+      path.join(root, "scripts/compat-lsp/upstream-fixture-manifest.json"),
+      "utf8",
+    ),
+  );
+  const ids = new Set(fixtureCases(root).map((entry) => entry.id));
+
+  // Positive control on each list separately: a `fixtureCases` that dropped
+  // either one would still satisfy an assertion written over the union.
+  const upstream = manifest.behavior_cases.filter((entry) =>
+    entry.method.startsWith("textDocument/"),
+  );
+  const authored = (manifest.rsvelte_cases ?? []).filter((entry) =>
+    entry.method.startsWith("textDocument/"),
+  );
+  assert.ok(upstream.length > 0, "no upstream textDocument case to check");
+  assert.ok(
+    authored.length > 0,
+    "rsvelte_cases holds no textDocument case, so this assertion is vacuous",
+  );
+  for (const entry of [...upstream, ...authored])
+    assert.ok(ids.has(`fixtures/${entry.id}`), `fixtures/${entry.id} is not run`);
+
+  // The two lists exist to keep provenance readable, so an id in both would
+  // make a divergence attributable to neither.
+  const upstreamIds = new Set(manifest.behavior_cases.map((e) => e.id));
+  for (const entry of manifest.rsvelte_cases ?? [])
+    assert.ok(
+      !upstreamIds.has(entry.id),
+      `${entry.id} is in both lists`,
+    );
+});

--- a/scripts/compat-lsp/upstream-fixture-manifest.json
+++ b/scripts/compat-lsp/upstream-fixture-manifest.json
@@ -2251,6 +2251,24 @@
       "difference_reason": "rsvelte does not yet complete id attributes from style selectors."
     }
   ],
+  "rsvelte_cases": [
+    {
+      "id": "code-action-error-with-code",
+      "rsvelte_reason": "Upstream's only test for the severity condition (`getCodeAction.test.ts`, `it('if diagnostic is error')`, ported as `code-action-error`) sends no `code`, and `isIgnorableSvelteDiagnostic` opens with `code &&`, so it returns before severity is read. This is that case with a `code` added and nothing else changed, which makes the severity arm the only thing either implementation can be answering here.",
+      "method": "textDocument/codeAction",
+      "source": "",
+      "params": {
+        "diagnostic_source": "svelte",
+        "diagnostic_code": "a11y_missing_attribute",
+        "severity": "error",
+        "range": {
+          "start": { "line": 0, "character": 0 },
+          "end": { "line": 0, "character": 1 }
+        }
+      },
+      "expected": { "titles": [] }
+    }
+  ],
   "exclusions": [
     {
       "suite": "typescript-diagnostics",


### PR DESCRIPTION
Closes #4217.

The fixtures suite built every case from `manifest.behavior_cases`, which
`upstream_fixture_manifest.rs` asserts is an exact **multiset** transcription of
upstream's `it()` call sites. That assert is what lets the suite detect an
unported upstream test, and it is the same assert that closes the population to
an rsvelte-authored case. Loosening it would end both properties — once the
population is "upstream's plus ours", a divergence has two possible causes — so
this adds a second list rather than widening the first.

## Shape

`rsvelte_cases` sits beside `behavior_cases` in the manifest. It carries
`rsvelte_reason` where a `BehaviorCase` carries `upstream_suite` /
`upstream_test`, so provenance is readable from the file structure rather than
inferred. `fixtureCases` compares both lists identically; every coverage
assertion (`ported_behavior_cases`, `upstream_it_call_sites`, the per-suite
multiset) still reads `behavior_cases` alone.

## The seeded case is the guard the issue names first

`code_actions.rs:284` gates the ignore action on `severity != Some(ERROR)`.
Upstream's `isIgnorableSvelteDiagnostic` (`getQuickfixes.ts:189-197`) is

```ts
code && !nonIgnorableWarnings.includes(code) && source === 'svelte' && severity !== Error
```

and its only test for the severity condition — `getCodeAction.test.ts`,
`it('if diagnostic is error')`, ported as `code-action-error` — sends
`severity: Error` and **no `code`**, so the leading `code &&` short-circuits and
severity is never reached. The transcription is faithful and the hole is
upstream's; being faithful is exactly what reproduces it.

`code-action-error-with-code` is `code-action-error` **with one field added**
(`diagnostic_code: "a11y_missing_attribute"`) and nothing else changed — same
empty source, same range, same `diagnostic_source`, same severity. That one-
variable construction is what makes the severity arm the only thing either
implementation can be answering.

Both answer `[]`: upstream because `severity !== Error` is the last conjunct and
false; rsvelte because its guard is the same test. Verified for rsvelte by
`rsvelte_authored_cases_assert_native_provider_responses`; the differential half
is confirmed by this PR's own `Language server` job, which runs the fixtures
suite against the pinned official server on every PR.

## Controls

**The two-sided ablation the issue asks for.** Adding an entry to
`rsvelte_cases` must leave the assert green; adding the *same* entry to
`behavior_cases` must make it fail. Run as a **move**, not a copy, so the
duplicate-id assertion cannot be what fires:

| manifest | result |
|---|---|
| case in `rsvelte_cases` | `7 passed; 0 failed` |
| same case moved into `behavior_cases` | `ts_independent_unit_sources_have_native_behavior_cases` FAILED — `svelte/features/getCodeAction.test.ts, left: 20, right: 19` |
| restored | `7 passed; 0 failed`, diff back to +18 lines |

So the exemption is shown rather than asserted, and the closed population is
still closed for `behavior_cases`.

**The second list is read, not merely declared.** `suites.test.mjs` gains a test
that every `textDocument/*` entry of **each** list appears in `fixtureCases` —
checked per list, because an assertion written over the union is satisfied by a
`fixtureCases` that drops either one — plus a liveness guard that
`rsvelte_cases` holds at least one such entry, or the assertion is vacuous.
Ablated by reverting `fixtureCases` to `[...manifest.behavior_cases]`: the test
fails (`✖ the fixtures suite reads both case lists`), and restores
byte-identically.

`rsvelte_authored_cases_assert_native_provider_responses` additionally requires a
non-empty `rsvelte_reason`, ids disjoint from `behavior_cases`, no duplicates,
and refuses an **empty** `rsvelte_cases` — an empty list is the declared-and-
unread field this replaced.

## Not seeded here, and why

The issue names two further axes. Neither is added:

* **an ignore action on an empty document** (what the two
  `differential:fixtures/code-action-foreign|…` entries were really observing) —
  needs the harness fix that retires them to land first, or the axis is
  double-counted.
* **a diagnostic `code` containing `/`** — rsvelte's `is_compiler_code` rejects
  it and upstream's predicate does not, so the two demonstrably diverge. That
  case would enrol a **new** ratchet key, which the two-sided ratchet fails and
  which cannot be baselined without a complete 17-artifact `lsp-corpus` run. It
  also depends on #4216's decision about whether `is_compiler_code` should exist
  at all. Recorded rather than added.

There is now a place to put both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
