### PR TITLE
fix(parse): a destructured parameter's default keeps the span the source wrote

### DIFF
--- a/.changeset/param-pattern-span-conventions.md
+++ b/.changeset/param-pattern-span-conventions.md
@@ -1,0 +1,11 @@
+---
+'@rsvelte/compiler': patch
+---
+
+`parse()` reports a destructured parameter's default value and a `function`
+expression's parameters at the spans the source wrote. A template expression is
+parsed inside a `(`-wrapper, and the two ways this file carries that one-byte
+shift — pre-subtracted into the converter's base, or subtracted from the span
+by `convert_expression` — meet at four places, of which one converted between
+them. Every destructured default (`{(({ a = 1 }) => a)({})}`) was reported one
+byte early and every `function` expression parameter one byte late.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -2728,8 +2728,12 @@ pub fn parse_typescript_params<'a>(
             if let Some(rest) = &arrow.params.rest {
                 let rest_start = (offset - 1) + rest.span.start as usize;
                 let rest_end = (offset - 1) + rest.span.end as usize;
-                let argument =
-                    convert_binding_pattern(arena, &rest.rest.argument, offset - 1, line_offsets);
+                let argument = convert_binding_pattern(
+                    arena,
+                    &rest.rest.argument,
+                    AdjustedOffset::wrapped(offset, 1),
+                    line_offsets,
+                );
                 p.push(Expression::from_node(JsNode::RestElement {
                     start: rest_start as u32,
                     end: rest_end as u32,
@@ -5853,7 +5857,12 @@ fn create_function_expression<'a>(
         // The whole conversion is in the paren-wrapper's coordinates, as the
         // `id` and rest spans above and below already are.
         .map(|param| {
-            convert_binding_pattern(arena, &param.pattern, offset.wrapping_sub(1), line_offsets)
+            convert_binding_pattern(
+                arena,
+                &param.pattern,
+                AdjustedOffset::wrapped(offset, 1),
+                line_offsets,
+            )
         })
         .collect();
     // Handle rest parameter (`...args`).
@@ -5863,7 +5872,7 @@ fn create_function_expression<'a>(
         let argument = convert_binding_pattern(
             arena,
             &rest.rest.argument,
-            offset.wrapping_sub(1),
+            AdjustedOffset::wrapped(offset, 1),
             line_offsets,
         );
         params.push(JsNode::RestElement {
@@ -7563,15 +7572,24 @@ fn convert_binding_pattern_for_decl_as_node(
                 expr_to_node(create_identifier(&id.name, start, end, line_offsets))
             }
         }
-        oxc_ast::ast::BindingPattern::ObjectPattern(obj_pat) => {
-            convert_object_pattern(arena, obj_pat, offset - 1, line_offsets)
-        }
-        oxc_ast::ast::BindingPattern::ArrayPattern(arr_pat) => {
-            convert_array_pattern(arena, arr_pat, offset - 1, line_offsets)
-        }
-        oxc_ast::ast::BindingPattern::AssignmentPattern(assign_pat) => {
-            convert_assignment_pattern(arena, assign_pat, offset - 1, line_offsets)
-        }
+        oxc_ast::ast::BindingPattern::ObjectPattern(obj_pat) => convert_object_pattern(
+            arena,
+            obj_pat,
+            AdjustedOffset::wrapped(offset, 1),
+            line_offsets,
+        ),
+        oxc_ast::ast::BindingPattern::ArrayPattern(arr_pat) => convert_array_pattern(
+            arena,
+            arr_pat,
+            AdjustedOffset::wrapped(offset, 1),
+            line_offsets,
+        ),
+        oxc_ast::ast::BindingPattern::AssignmentPattern(assign_pat) => convert_assignment_pattern(
+            arena,
+            assign_pat,
+            AdjustedOffset::wrapped(offset, 1),
+            line_offsets,
+        ),
     }
 }
 
@@ -9982,7 +10000,7 @@ fn convert_statement_for_program(
                     arena.alloc_js_node(convert_binding_pattern(
                         arena,
                         &param.pattern,
-                        offset,
+                        AdjustedOffset::plain(offset),
                         line_offsets,
                     ))
                 });
@@ -11450,7 +11468,8 @@ fn convert_variable_declarator_for_program(
     // carrying the annotation as an opaque boundary blob; an annotated
     // destructuring pattern (`let { a }: T = …`) keeps the Value (Raw) form
     // since the annotation hangs off a pattern node.
-    let id_pattern = convert_binding_pattern(arena, &decl.id, offset, line_offsets);
+    let id_pattern =
+        convert_binding_pattern(arena, &decl.id, AdjustedOffset::plain(offset), line_offsets);
     let id_node = if let Some(type_annotation) = &decl.type_annotation {
         let ts_start = type_annotation.span.start as usize + offset;
         let ts_end = type_annotation.span.end as usize + offset;
@@ -11708,7 +11727,12 @@ fn convert_expression_for_program<'a>(
                     oxc_ast::ast::ObjectPropertyKind::ObjectProperty(p) => {
                         let prop_start = offset + p.span.start as usize;
                         let prop_end = offset + p.span.end as usize;
-                        let key = convert_property_key(arena, &p.key, offset, line_offsets);
+                        let key = convert_property_key(
+                            arena,
+                            &p.key,
+                            AdjustedOffset::plain(offset),
+                            line_offsets,
+                        );
                         let value =
                             convert_expression_for_program(arena, &p.value, offset, line_offsets);
                         let mut value_node = expr_to_node(value);
@@ -11777,8 +11801,12 @@ fn convert_expression_for_program<'a>(
             if let Some(rest) = &arrow.params.rest {
                 let rest_start = offset + rest.span.start as usize;
                 let rest_end = offset + rest.span.end as usize;
-                let argument =
-                    convert_binding_pattern(arena, &rest.rest.argument, offset, line_offsets);
+                let argument = convert_binding_pattern(
+                    arena,
+                    &rest.rest.argument,
+                    AdjustedOffset::plain(offset),
+                    line_offsets,
+                );
                 params.push(JsNode::RestElement {
                     start: rest_start as u32,
                     end: rest_end as u32,
@@ -12723,7 +12751,12 @@ fn convert_class_element_for_program_as_node(
                 oxc_ast::ast::MethodDefinitionKind::Get => "get",
                 oxc_ast::ast::MethodDefinitionKind::Set => "set",
             };
-            let key = convert_property_key(arena, &method.key, offset, line_offsets);
+            let key = convert_property_key(
+                arena,
+                &method.key,
+                AdjustedOffset::plain(offset),
+                line_offsets,
+            );
             // A method's generics live on the MethodDefinition, not the inner
             // function (acorn-typescript), so the inner function gets `None`.
             let value = convert_function_expression_for_program_as_node(
@@ -12774,7 +12807,12 @@ fn convert_class_element_for_program_as_node(
             }
             let start = offset + prop.span.start as usize;
             let end = offset + prop.span.end as usize;
-            let key = convert_property_key(arena, &prop.key, offset, line_offsets);
+            let key = convert_property_key(
+                arena,
+                &prop.key,
+                AdjustedOffset::plain(offset),
+                line_offsets,
+            );
             let value = prop.value.as_ref().map(|value| {
                 arena.alloc_js_node(expr_to_node(convert_expression_for_program(
                     arena,
@@ -12873,7 +12911,12 @@ fn convert_class_element_for_program(
             obj.set_field("kind", Value::String(kind.to_string()));
 
             // key
-            let key = convert_property_key(arena, &method.key, offset, line_offsets);
+            let key = convert_property_key(
+                arena,
+                &method.key,
+                AdjustedOffset::plain(offset),
+                line_offsets,
+            );
             obj.set_field("key", key.to_value());
 
             // value (function expression). acorn-typescript gives a bodyless
@@ -12925,7 +12968,12 @@ fn convert_class_element_for_program(
             obj.set_field("computed", Value::Bool(prop.computed));
 
             // key
-            let key = convert_property_key(arena, &prop.key, offset, line_offsets);
+            let key = convert_property_key(
+                arena,
+                &prop.key,
+                AdjustedOffset::plain(offset),
+                line_offsets,
+            );
             obj.set_field("key", key.to_value());
 
             if let Some(ta) = opt_type_annotation(
@@ -12971,7 +13019,12 @@ fn convert_class_element_for_program(
             obj.set_field("static", Value::Bool(prop.r#static));
             obj.set_field("computed", Value::Bool(prop.computed));
 
-            let key = convert_property_key(arena, &prop.key, offset, line_offsets);
+            let key = convert_property_key(
+                arena,
+                &prop.key,
+                AdjustedOffset::plain(offset),
+                line_offsets,
+            );
             obj.set_field("key", key.to_value());
 
             if let Some(ta) = opt_type_annotation(
@@ -13361,7 +13414,7 @@ fn convert_function_body_for_program_as_node(
 fn convert_binding_pattern(
     arena: &ParseArena,
     pattern: &oxc_ast::ast::BindingPattern,
-    offset: usize,
+    offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> JsNode {
     match pattern {
@@ -13386,7 +13439,7 @@ fn convert_binding_pattern(
 fn convert_object_pattern(
     arena: &ParseArena,
     obj_pat: &oxc_ast::ast::ObjectPattern,
-    offset: usize,
+    offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> JsNode {
     let start = offset + obj_pat.span.start as usize;
@@ -13429,7 +13482,7 @@ fn convert_object_pattern(
 fn convert_array_pattern(
     arena: &ParseArena,
     arr_pat: &oxc_ast::ast::ArrayPattern,
-    offset: usize,
+    offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> JsNode {
     let start = offset + arr_pat.span.start as usize;
@@ -13475,7 +13528,7 @@ fn convert_array_pattern(
 fn convert_assignment_pattern(
     arena: &ParseArena,
     assign_pat: &oxc_ast::ast::AssignmentPattern,
-    offset: usize,
+    offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> JsNode {
     let start = offset + assign_pat.span.start as usize;
@@ -13500,7 +13553,7 @@ fn convert_assignment_pattern(
         right: arena.alloc_js_node(expr_to_node(convert_expression_for_program(
             arena,
             &assign_pat.right,
-            offset,
+            offset.for_plain_converter(),
             line_offsets,
         ))),
     }
@@ -13849,7 +13902,12 @@ fn convert_assignment_target_property_for_program(
             let start = offset + prop_prop.span.start as usize;
             let end = offset + prop_prop.span.end as usize;
 
-            let key = convert_property_key(arena, &prop_prop.name, offset, line_offsets);
+            let key = convert_property_key(
+                arena,
+                &prop_prop.name,
+                AdjustedOffset::plain(offset),
+                line_offsets,
+            );
             let value = convert_assignment_target_maybe_default_for_program(
                 arena,
                 &prop_prop.binding,
@@ -14005,7 +14063,7 @@ fn convert_assignment_target_maybe_default_for_program(
 fn convert_binding_property(
     arena: &ParseArena,
     prop: &oxc_ast::ast::BindingProperty,
-    offset: usize,
+    offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> JsNode {
     let start = offset + prop.span.start as usize;
@@ -14031,7 +14089,7 @@ fn convert_binding_property(
 fn convert_property_key(
     arena: &ParseArena,
     key: &oxc_ast::ast::PropertyKey,
-    offset: usize,
+    offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> JsNode {
     match key {
@@ -14059,7 +14117,7 @@ fn convert_property_key(
                 expr_to_node(convert_expression_for_program(
                     arena,
                     expr,
-                    offset,
+                    offset.for_plain_converter(),
                     line_offsets,
                 ))
             } else {
@@ -15627,6 +15685,13 @@ mod tests {
         // and the base genuinely is -1, which no `usize` spells. Making it
         // signed is a change to the whole TS conversion subtree, not to these
         // three helpers, so it is tracked separately rather than half-done here.
+        //
+        // A parameter DEFAULT is the same wider class and is deliberately absent
+        // below: its value goes to `convert_expression_for_program`, whose base
+        // in a paren-wrapped host genuinely is -1. Measured, giving that one
+        // function the type produces 59 further type errors, so it is the same
+        // out-of-scope subtree as the TS conversion above and not a cell this
+        // change can turn green.
         for source in [
             "work()",
             "new C(1)",
@@ -15637,6 +15702,17 @@ mod tests {
             "o.m(1)",
             "function q(a) { return a; }",
             "({ x: 1 })",
+            // The binding-pattern family: every one of these reaches it with a
+            // base the paren wrapper has shifted, so a pre-subtracted `usize`
+            // is `usize::MAX` here and only a debug build says so.
+            "function q({ a }) { return a; }",
+            "function q([a]) { return a; }",
+            "function q(...r) { return r; }",
+            "function q({ a, ...r }) { return r; }",
+            "function q([a, ...r]) { return r; }",
+            "({ a }) => a",
+            "([a]) => a",
+            "(...r) => r",
         ] {
             let arena = ParseArena::new();
             let line_offsets = super::super::super::compute_line_offsets(source, false);

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -1677,7 +1677,7 @@ pub fn parse_destructuring_pattern<'a>(
             result.program.body.first()
             && let Some(declarator) = var_decl.declarations.first()
         {
-            let adjusted_offset = offset.wrapping_sub(4);
+            let adjusted_offset = AdjustedOffset::wrapped(offset, 4);
             let pattern_node = convert_binding_pattern_for_param_as_node(
                 arena,
                 &declarator.id,
@@ -2714,7 +2714,12 @@ pub fn parse_typescript_params<'a>(
         {
             let mut p = Vec::new();
             for param in &arrow.params.items {
-                let param_expr = convert_formal_parameter(arena, param, offset - 1, line_offsets);
+                let param_expr = convert_formal_parameter(
+                    arena,
+                    param,
+                    AdjustedOffset::wrapped(offset, 1),
+                    line_offsets,
+                );
                 p.push(param_expr);
             }
             // A rest parameter (`...args`) lives in `params.rest`, not `items`.
@@ -2734,7 +2739,7 @@ pub fn parse_typescript_params<'a>(
                         Box::new(convert_type_annotation_adjusted(
                             arena,
                             ta,
-                            offset - 1,
+                            AdjustedOffset::wrapped(offset, 1),
                             line_offsets,
                         ))
                     }),
@@ -2767,7 +2772,12 @@ pub fn parse_typescript_params<'a>(
             let mut p = Vec::new();
             for param in &arrow.params.items {
                 let param_expr = if stripped.removed_positions.is_empty() {
-                    convert_formal_parameter(arena, param, offset - 1, line_offsets)
+                    convert_formal_parameter(
+                        arena,
+                        param,
+                        AdjustedOffset::wrapped(offset, 1),
+                        line_offsets,
+                    )
                 } else {
                     convert_formal_parameter_with_remap(
                         arena,
@@ -2815,7 +2825,12 @@ pub fn parse_typescript_params<'a>(
                     && let Some(param) = arrow.params.items.first()
                 {
                     let param_expr = if stripped_part.removed_positions.is_empty() {
-                        convert_formal_parameter(arena, param, offset - 1, line_offsets)
+                        convert_formal_parameter(
+                            arena,
+                            param,
+                            AdjustedOffset::wrapped(offset, 1),
+                            line_offsets,
+                        )
                     } else {
                         convert_formal_parameter_with_remap(
                             arena,
@@ -2894,7 +2909,12 @@ fn convert_formal_parameter_with_remap<'a>(
     // This is a pragmatic fix: the inner spans (like type annotations) may still be slightly off,
     // but for snippet parameters, only the top-level span is used to extract source text.
 
-    let expr = convert_formal_parameter(arena, param, base_offset - 1, line_offsets);
+    let expr = convert_formal_parameter(
+        arena,
+        param,
+        AdjustedOffset::wrapped(base_offset, 1),
+        line_offsets,
+    );
 
     // Fix up the top-level span: remap start and end from cleaned positions to original
     let mut val = expr.as_json().clone();
@@ -2950,12 +2970,56 @@ fn convert_formal_parameter_with_remap<'a>(
     Expression::from_json(val)
 }
 
+/// The base a `wrap_for_parse` parse resolves its spans against.
+///
+/// The wrapper shifts every node right by `prefix`, so a node at relative `p`
+/// sits at `base + p - prefix`. Spelling that as a pre-subtracted `usize` makes
+/// the base itself negative whenever `base < prefix` — which is every position
+/// when a caller starts at 0 — so the type keeps the two halves apart and only
+/// ever hands out a sum. Every sum is non-negative, because `p` is at least
+/// `prefix` for any node inside the wrapped content.
+#[derive(Clone, Copy, Debug)]
+struct AdjustedOffset {
+    base: usize,
+    prefix: usize,
+}
+
+impl AdjustedOffset {
+    /// Spans measured inside `wrap_for_parse(prefix, content, ..)`.
+    fn wrapped(base: usize, prefix: usize) -> Self {
+        Self { base, prefix }
+    }
+
+    /// Spans already measured against `base` itself.
+    fn plain(base: usize) -> Self {
+        Self { base, prefix: 0 }
+    }
+
+    /// The base `convert_expression` wants: it removes a one-character wrapper
+    /// from the span itself, so it needs a base that has not had one removed.
+    fn for_paren_converter(self) -> usize {
+        self.base.wrapping_add(1).wrapping_sub(self.prefix)
+    }
+
+    /// The base `convert_ts_type` wants: it removes no wrapper of its own.
+    fn for_plain_converter(self) -> usize {
+        self.base.wrapping_sub(self.prefix)
+    }
+}
+
+impl std::ops::Add<usize> for AdjustedOffset {
+    type Output = usize;
+
+    fn add(self, rhs: usize) -> usize {
+        self.base.wrapping_add(rhs).wrapping_sub(self.prefix)
+    }
+}
+
 /// Convert oxc FormalParameter to our Expression format with type annotations.
-/// Caller should pass pre-adjusted offset if needed (e.g., offset - 1 for paren-wrapped content).
 fn convert_formal_parameter<'a>(
     arena: &ParseArena,
     param: &oxc_ast::ast::FormalParameter,
-    adjusted_offset: usize,
+    adjusted_offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> Expression<'a> {
     // Check for TypeScript parameter properties (e.g., `constructor(private x: number)`)
@@ -2991,7 +3055,7 @@ fn convert_formal_parameter<'a>(
 fn convert_formal_parameter_inner<'a>(
     arena: &ParseArena,
     param: &oxc_ast::ast::FormalParameter,
-    adjusted_offset: usize,
+    adjusted_offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> Expression<'a> {
     use oxc_ast::ast::BindingPattern;
@@ -3070,7 +3134,12 @@ fn convert_formal_parameter_inner<'a>(
         let pattern_start = adjusted_offset + param.span.start as usize;
         let pattern_end = adjusted_offset + param.span.end as usize;
 
-        let right = convert_expression(arena, initializer, adjusted_offset + 1, line_offsets);
+        let right = convert_expression(
+            arena,
+            initializer,
+            adjusted_offset.for_paren_converter(),
+            line_offsets,
+        );
 
         return Expression::from_node(JsNode::AssignmentPattern {
             start: pattern_start as u32,
@@ -3097,7 +3166,7 @@ fn attach_param_type_annotation<'a>(
     arena: &ParseArena,
     expr: Expression<'a>,
     param: &oxc_ast::ast::FormalParameter,
-    adjusted_offset: usize,
+    adjusted_offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> Expression<'a> {
     let Some(type_ann) = &param.type_annotation else {
@@ -3138,7 +3207,7 @@ fn attach_param_type_annotation<'a>(
 fn convert_object_pattern_to_expr<'a>(
     arena: &ParseArena,
     obj_pat: &oxc_ast::ast::ObjectPattern,
-    adjusted_offset: usize,
+    adjusted_offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> Expression<'a> {
     let start = adjusted_offset + obj_pat.span.start as usize;
@@ -3207,7 +3276,7 @@ fn convert_object_pattern_to_expr<'a>(
 fn convert_array_pattern_to_expr<'a>(
     arena: &ParseArena,
     arr_pat: &oxc_ast::ast::ArrayPattern,
-    adjusted_offset: usize,
+    adjusted_offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> Expression<'a> {
     let start = adjusted_offset + arr_pat.span.start as usize;
@@ -3259,7 +3328,7 @@ fn convert_array_pattern_to_expr<'a>(
 fn convert_assignment_pattern_to_expr<'a>(
     arena: &ParseArena,
     assign_pat: &oxc_ast::ast::AssignmentPattern,
-    adjusted_offset: usize,
+    adjusted_offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> Expression<'a> {
     let start = adjusted_offset + assign_pat.span.start as usize;
@@ -3298,7 +3367,7 @@ fn convert_assignment_pattern_to_expr<'a>(
 fn convert_binding_pattern_for_param(
     arena: &ParseArena,
     pattern: &oxc_ast::ast::BindingPattern,
-    adjusted_offset: usize,
+    adjusted_offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> Value {
     use oxc_ast::ast::BindingPattern;
@@ -3390,8 +3459,12 @@ fn convert_binding_pattern_for_param(
             // Convert right (the default value) using the full expression converter.
             // Must use with_serialize_arena to resolve IdRange children
             // allocated in the parse arena during serialization.
-            let right_expr =
-                convert_expression(arena, &assign_pat.right, adjusted_offset, line_offsets);
+            let right_expr = convert_expression(
+                arena,
+                &assign_pat.right,
+                adjusted_offset.for_paren_converter(),
+                line_offsets,
+            );
             let right_val =
                 crate::ast::arena::with_serialize_arena(arena, || right_expr.as_json().clone());
             obj.set_field("right", right_val);
@@ -3412,7 +3485,7 @@ fn convert_binding_pattern_for_param(
 fn convert_property_key_for_param_as_node(
     arena: &ParseArena,
     key: &oxc_ast::ast::PropertyKey,
-    adjusted_offset: usize,
+    adjusted_offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> JsNode {
     use oxc_ast::ast::PropertyKey;
@@ -3438,7 +3511,7 @@ fn convert_property_key_for_param_as_node(
                 expr_to_node(convert_expression(
                     arena,
                     expr,
-                    adjusted_offset,
+                    adjusted_offset.for_paren_converter(),
                     line_offsets,
                 ))
             } else {
@@ -3466,7 +3539,7 @@ fn convert_property_key_for_param_as_node(
 fn convert_binding_pattern_for_param_as_node(
     arena: &ParseArena,
     pattern: &oxc_ast::ast::BindingPattern,
-    adjusted_offset: usize,
+    adjusted_offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> JsNode {
     use oxc_ast::ast::BindingPattern;
@@ -3498,7 +3571,12 @@ fn convert_binding_pattern_for_param_as_node(
                 adjusted_offset,
                 line_offsets,
             );
-            let right = convert_expression(arena, &assign_pat.right, adjusted_offset, line_offsets);
+            let right = convert_expression(
+                arena,
+                &assign_pat.right,
+                adjusted_offset.for_paren_converter(),
+                line_offsets,
+            );
             JsNode::AssignmentPattern {
                 start: start as u32,
                 end: end as u32,
@@ -3514,7 +3592,7 @@ fn convert_binding_pattern_for_param_as_node(
 fn convert_type_annotation_adjusted(
     arena: &ParseArena,
     type_ann: &oxc_ast::ast::TSTypeAnnotation,
-    adjusted_offset: usize,
+    adjusted_offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> Value {
     let start = adjusted_offset + type_ann.span.start as usize;
@@ -3566,16 +3644,21 @@ fn ts_assertion_value(
 fn convert_ts_type_adjusted(
     arena: &ParseArena,
     ts_type: &oxc_ast::ast::TSType,
-    adjusted_offset: usize,
+    adjusted_offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> Value {
-    convert_ts_type(arena, ts_type, adjusted_offset, line_offsets)
+    convert_ts_type(
+        arena,
+        ts_type,
+        adjusted_offset.for_plain_converter(),
+        line_offsets,
+    )
 }
 
 /// Convert TSTypeName with pre-adjusted offset.
 fn convert_ts_type_name_adjusted(
     type_name: &oxc_ast::ast::TSTypeName,
-    adjusted_offset: usize,
+    adjusted_offset: AdjustedOffset,
     line_offsets: &[usize],
 ) -> Value {
     match type_name {
@@ -3697,7 +3780,11 @@ fn convert_ts_type(
             let mut obj = base("TSTypeReference");
             obj.set_field(
                 "typeName",
-                convert_ts_type_name_adjusted(&type_ref.type_name, offset, line_offsets),
+                convert_ts_type_name_adjusted(
+                    &type_ref.type_name,
+                    AdjustedOffset::plain(offset),
+                    line_offsets,
+                ),
             );
             if let Some(args) = &type_ref.type_arguments {
                 obj.set_field(
@@ -3853,7 +3940,12 @@ fn convert_ts_type(
             );
             obj.set_field(
                 "typeAnnotation",
-                convert_type_annotation_adjusted(arena, &f.return_type, offset, line_offsets),
+                convert_type_annotation_adjusted(
+                    arena,
+                    &f.return_type,
+                    AdjustedOffset::plain(offset),
+                    line_offsets,
+                ),
             );
             Value::Object(obj)
         }
@@ -3885,7 +3977,12 @@ fn convert_ts_type(
             );
             obj.set_field(
                 "typeAnnotation",
-                convert_type_annotation_adjusted(arena, &c.return_type, offset, line_offsets),
+                convert_type_annotation_adjusted(
+                    arena,
+                    &c.return_type,
+                    AdjustedOffset::plain(offset),
+                    line_offsets,
+                ),
             );
             Value::Object(obj)
         }
@@ -3963,7 +4060,13 @@ fn convert_ts_type(
                 }
                 other => other
                     .as_ts_type_name()
-                    .map(|name| convert_ts_type_name_adjusted(name, offset, line_offsets))
+                    .map(|name| {
+                        convert_ts_type_name_adjusted(
+                            name,
+                            AdjustedOffset::plain(offset),
+                            line_offsets,
+                        )
+                    })
                     .unwrap_or(Value::Null),
             };
             obj.set_field("exprName", expr_name);
@@ -3998,7 +4101,14 @@ fn convert_ts_type(
                 predicate
                     .type_annotation
                     .as_ref()
-                    .map(|ta| convert_type_annotation_adjusted(arena, ta, offset, line_offsets))
+                    .map(|ta| {
+                        convert_type_annotation_adjusted(
+                            arena,
+                            ta,
+                            AdjustedOffset::plain(offset),
+                            line_offsets,
+                        )
+                    })
                     .unwrap_or(Value::Null),
             );
             Value::Object(obj)
@@ -4279,7 +4389,12 @@ fn convert_this_param(
     if let Some(type_ann) = &this_param.type_annotation {
         obj.set_field(
             "typeAnnotation",
-            convert_type_annotation_adjusted(arena, type_ann, offset, line_offsets),
+            convert_type_annotation_adjusted(
+                arena,
+                type_ann,
+                AdjustedOffset::plain(offset),
+                line_offsets,
+            ),
         );
     }
     Value::Object(obj)
@@ -4300,12 +4415,22 @@ fn convert_rest_parameter(
     push_span_fields(&mut obj, start, end, line_offsets);
     obj.set_field(
         "argument",
-        convert_binding_pattern_for_param(arena, &rest.rest.argument, offset, line_offsets),
+        convert_binding_pattern_for_param(
+            arena,
+            &rest.rest.argument,
+            AdjustedOffset::plain(offset),
+            line_offsets,
+        ),
     );
     if let Some(type_ann) = &rest.type_annotation {
         obj.set_field(
             "typeAnnotation",
-            convert_type_annotation_adjusted(arena, type_ann, offset, line_offsets),
+            convert_type_annotation_adjusted(
+                arena,
+                type_ann,
+                AdjustedOffset::plain(offset),
+                line_offsets,
+            ),
         );
     }
     Value::Object(obj)
@@ -4328,7 +4453,7 @@ fn convert_ts_function_like_params(
 
     for param in &params.items {
         out.push(
-            convert_formal_parameter(arena, param, offset, line_offsets)
+            convert_formal_parameter(arena, param, AdjustedOffset::plain(offset), line_offsets)
                 .as_json()
                 .clone(),
         );
@@ -4373,7 +4498,12 @@ fn convert_ts_signature(
             if let Some(type_ann) = &prop.type_annotation {
                 obj.set_field(
                     "typeAnnotation",
-                    convert_type_annotation_adjusted(arena, type_ann, offset, line_offsets),
+                    convert_type_annotation_adjusted(
+                        arena,
+                        type_ann,
+                        AdjustedOffset::plain(offset),
+                        line_offsets,
+                    ),
                 );
             }
             Value::Object(obj)
@@ -4424,7 +4554,12 @@ fn convert_ts_signature(
             if let Some(return_type) = &method.return_type {
                 obj.set_field(
                     "typeAnnotation",
-                    convert_type_annotation_adjusted(arena, return_type, offset, line_offsets),
+                    convert_type_annotation_adjusted(
+                        arena,
+                        return_type,
+                        AdjustedOffset::plain(offset),
+                        line_offsets,
+                    ),
                 );
             }
             Value::Object(obj)
@@ -4457,7 +4592,12 @@ fn convert_ts_signature(
             if let Some(return_type) = &call.return_type {
                 obj.set_field(
                     "typeAnnotation",
-                    convert_type_annotation_adjusted(arena, return_type, offset, line_offsets),
+                    convert_type_annotation_adjusted(
+                        arena,
+                        return_type,
+                        AdjustedOffset::plain(offset),
+                        line_offsets,
+                    ),
                 );
             }
             Value::Object(obj)
@@ -4490,7 +4630,12 @@ fn convert_ts_signature(
             if let Some(return_type) = &constructor.return_type {
                 obj.set_field(
                     "typeAnnotation",
-                    convert_type_annotation_adjusted(arena, return_type, offset, line_offsets),
+                    convert_type_annotation_adjusted(
+                        arena,
+                        return_type,
+                        AdjustedOffset::plain(offset),
+                        line_offsets,
+                    ),
                 );
             }
             Value::Object(obj)
@@ -4533,7 +4678,7 @@ fn convert_ts_index_signature(
                 convert_type_annotation_adjusted(
                     arena,
                     &param.type_annotation,
-                    offset,
+                    AdjustedOffset::plain(offset),
                     line_offsets,
                 ),
             );
@@ -4543,7 +4688,12 @@ fn convert_ts_index_signature(
     obj.set_field("parameters", Value::Array(parameters));
     obj.set_field(
         "typeAnnotation",
-        convert_type_annotation_adjusted(arena, &index.type_annotation, offset, line_offsets),
+        convert_type_annotation_adjusted(
+            arena,
+            &index.type_annotation,
+            AdjustedOffset::plain(offset),
+            line_offsets,
+        ),
     );
     Value::Object(obj)
 }
@@ -5700,13 +5850,22 @@ fn create_function_expression<'a>(
         .params
         .items
         .iter()
-        .map(|param| convert_binding_pattern(arena, &param.pattern, offset, line_offsets))
+        // The whole conversion is in the paren-wrapper's coordinates, as the
+        // `id` and rest spans above and below already are.
+        .map(|param| {
+            convert_binding_pattern(arena, &param.pattern, offset.wrapping_sub(1), line_offsets)
+        })
         .collect();
     // Handle rest parameter (`...args`).
     if let Some(rest) = &func.params.rest {
         let rest_start = offset + rest.span.start as usize - 1;
         let rest_end = offset + rest.span.end as usize - 1;
-        let argument = convert_binding_pattern(arena, &rest.rest.argument, offset, line_offsets);
+        let argument = convert_binding_pattern(
+            arena,
+            &rest.rest.argument,
+            offset.wrapping_sub(1),
+            line_offsets,
+        );
         params.push(JsNode::RestElement {
             start: rest_start as u32,
             end: rest_end as u32,
@@ -5716,7 +5875,7 @@ fn create_function_expression<'a>(
                 Box::new(convert_type_annotation_adjusted(
                     arena,
                     ta,
-                    offset - 1,
+                    AdjustedOffset::wrapped(offset, 1),
                     line_offsets,
                 ))
             }),
@@ -5762,7 +5921,7 @@ fn create_function_expression<'a>(
         return_type: opt_type_annotation(
             arena,
             func.return_type.as_deref(),
-            || offset - 1,
+            || AdjustedOffset::wrapped(offset, 1),
             line_offsets,
         ),
     })
@@ -5993,7 +6152,7 @@ fn convert_class_element_for_expr(
             if let Some(ta) = opt_type_annotation(
                 arena,
                 prop.type_annotation.as_deref(),
-                || offset - 1,
+                || AdjustedOffset::wrapped(offset, 1),
                 line_offsets,
             ) {
                 obj.set_field("typeAnnotation", *ta);
@@ -6798,7 +6957,7 @@ fn create_arrow_function<'a>(
             expr_to_node(convert_formal_parameter(
                 arena,
                 param,
-                offset - 1,
+                AdjustedOffset::wrapped(offset, 1),
                 line_offsets,
             ))
         })
@@ -6810,7 +6969,7 @@ fn create_arrow_function<'a>(
         let argument = convert_binding_pattern_for_param_as_node(
             arena,
             &rest.rest.argument,
-            offset - 1,
+            AdjustedOffset::wrapped(offset, 1),
             line_offsets,
         );
         params.push(JsNode::RestElement {
@@ -6822,7 +6981,7 @@ fn create_arrow_function<'a>(
                 Box::new(convert_type_annotation_adjusted(
                     arena,
                     ta,
-                    offset - 1,
+                    AdjustedOffset::wrapped(offset, 1),
                     line_offsets,
                 ))
             }),
@@ -6861,7 +7020,7 @@ fn create_arrow_function<'a>(
         return_type: opt_type_annotation(
             arena,
             arrow.return_type.as_deref(),
-            || offset - 1,
+            || AdjustedOffset::wrapped(offset, 1),
             line_offsets,
         ),
     })
@@ -7134,7 +7293,7 @@ fn convert_statement(
                     arena.alloc_js_node(convert_binding_pattern_for_param_as_node(
                         arena,
                         &param.pattern,
-                        offset - 1,
+                        AdjustedOffset::wrapped(offset, 1),
                         line_offsets,
                     ))
                 });
@@ -7215,7 +7374,7 @@ fn convert_statement(
                     expr_to_node(convert_formal_parameter(
                         arena,
                         param,
-                        offset - 1,
+                        AdjustedOffset::wrapped(offset, 1),
                         line_offsets,
                     ))
                 })
@@ -7226,7 +7385,7 @@ fn convert_statement(
                 let argument = convert_binding_pattern_for_param_as_node(
                     arena,
                     &rest.rest.argument,
-                    offset - 1,
+                    AdjustedOffset::wrapped(offset, 1),
                     line_offsets,
                 );
                 params.push(JsNode::RestElement {
@@ -7238,7 +7397,7 @@ fn convert_statement(
                         Box::new(convert_type_annotation_adjusted(
                             arena,
                             ta,
-                            offset - 1,
+                            AdjustedOffset::wrapped(offset, 1),
                             line_offsets,
                         ))
                     }),
@@ -7272,7 +7431,7 @@ fn convert_statement(
                     Box::new(convert_type_annotation_adjusted(
                         arena,
                         rt,
-                        offset - 1,
+                        AdjustedOffset::wrapped(offset, 1),
                         line_offsets,
                     ))
                 }),
@@ -7385,8 +7544,12 @@ fn convert_binding_pattern_for_decl_as_node(
                 // annotation blob verbatim (same as the Value form at
                 // `convert_binding_pattern_for_decl`).
                 let end = offset + type_ann.span.end as usize - 1;
-                let ta_value =
-                    convert_type_annotation_adjusted(arena, type_ann, offset - 1, line_offsets);
+                let ta_value = convert_type_annotation_adjusted(
+                    arena,
+                    type_ann,
+                    AdjustedOffset::wrapped(offset, 1),
+                    line_offsets,
+                );
                 JsNode::Identifier {
                     start: start as u32,
                     end: end as u32,
@@ -9396,7 +9559,7 @@ fn convert_statement_for_program(
                             expr_to_node(convert_formal_parameter(
                                 arena,
                                 param,
-                                offset,
+                                AdjustedOffset::plain(offset),
                                 line_offsets,
                             ))
                         })
@@ -9426,7 +9589,7 @@ fn convert_statement_for_program(
                             Box::new(convert_type_annotation_adjusted(
                                 arena,
                                 rt,
-                                offset,
+                                AdjustedOffset::plain(offset),
                                 line_offsets,
                             ))
                         }),
@@ -10267,7 +10430,11 @@ fn convert_ts_module_reference(
             push_span_fields(&mut obj, start, end, line_offsets);
             obj.set_field(
                 "left",
-                convert_ts_type_name_adjusted(&qualified.left, offset, line_offsets),
+                convert_ts_type_name_adjusted(
+                    &qualified.left,
+                    AdjustedOffset::plain(offset),
+                    line_offsets,
+                ),
             );
             obj.set_field(
                 "right",
@@ -10558,7 +10725,11 @@ fn convert_ts_interface_declaration_as_node(
             );
             heritage_obj.set_field(
                 "expression",
-                convert_ts_type_name_adjusted(&heritage.type_name, offset, line_offsets),
+                convert_ts_type_name_adjusted(
+                    &heritage.type_name,
+                    AdjustedOffset::plain(offset),
+                    line_offsets,
+                ),
             );
             if let Some(arguments) = &heritage.type_arguments {
                 heritage_obj.set_field(
@@ -10694,11 +10865,14 @@ fn convert_function_declaration_as_node(
         })
         .into_iter()
         .collect();
-    params.extend(
-        func_decl.params.items.iter().map(|param| {
-            expr_to_node(convert_formal_parameter(arena, param, offset, line_offsets))
-        }),
-    );
+    params.extend(func_decl.params.items.iter().map(|param| {
+        expr_to_node(convert_formal_parameter(
+            arena,
+            param,
+            AdjustedOffset::plain(offset),
+            line_offsets,
+        ))
+    }));
     if let Some(rest) = &func_decl.params.rest {
         params.push(expr_to_node(Expression::from_json(convert_rest_parameter(
             arena,
@@ -10741,7 +10915,7 @@ fn convert_function_declaration_as_node(
             Box::new(convert_type_annotation_adjusted(
                 arena,
                 rt,
-                offset,
+                AdjustedOffset::plain(offset),
                 line_offsets,
             ))
         }),
@@ -11020,7 +11194,7 @@ fn convert_declaration_for_program(
                 .into_iter()
                 .collect();
             params.extend(func_decl.params.items.iter().map(|param| {
-                convert_formal_parameter(arena, param, offset, line_offsets)
+                convert_formal_parameter(arena, param, AdjustedOffset::plain(offset), line_offsets)
                     .as_json()
                     .clone()
             }));
@@ -11592,7 +11766,12 @@ fn convert_expression_for_program<'a>(
                 .items
                 .iter()
                 .map(|param| {
-                    expr_to_node(convert_formal_parameter(arena, param, offset, line_offsets))
+                    expr_to_node(convert_formal_parameter(
+                        arena,
+                        param,
+                        AdjustedOffset::plain(offset),
+                        line_offsets,
+                    ))
                 })
                 .collect();
             if let Some(rest) = &arrow.params.rest {
@@ -11609,7 +11788,7 @@ fn convert_expression_for_program<'a>(
                         Box::new(convert_type_annotation_adjusted(
                             arena,
                             ta,
-                            offset,
+                            AdjustedOffset::plain(offset),
                             line_offsets,
                         ))
                     }),
@@ -11652,7 +11831,7 @@ fn convert_expression_for_program<'a>(
                 return_type: opt_type_annotation(
                     arena,
                     arrow.return_type.as_deref(),
-                    || offset,
+                    || AdjustedOffset::plain(offset),
                     line_offsets,
                 ),
             })
@@ -12752,7 +12931,7 @@ fn convert_class_element_for_program(
             if let Some(ta) = opt_type_annotation(
                 arena,
                 prop.type_annotation.as_deref(),
-                || offset,
+                || AdjustedOffset::plain(offset),
                 line_offsets,
             ) {
                 obj.set_field("typeAnnotation", *ta);
@@ -12798,7 +12977,7 @@ fn convert_class_element_for_program(
             if let Some(ta) = opt_type_annotation(
                 arena,
                 prop.type_annotation.as_deref(),
-                || offset,
+                || AdjustedOffset::plain(offset),
                 line_offsets,
             ) {
                 obj.set_field("typeAnnotation", *ta);
@@ -12875,15 +13054,19 @@ fn convert_function_expression_for_program(
         .into_iter()
         .collect();
     params.extend(func.params.items.iter().map(|param| {
-        convert_formal_parameter(arena, param, offset, line_offsets)
+        convert_formal_parameter(arena, param, AdjustedOffset::plain(offset), line_offsets)
             .as_json()
             .clone()
     }));
     if let Some(rest) = &func.params.rest {
         let rest_start = offset + rest.span.start as usize;
         let rest_end = offset + rest.span.end as usize;
-        let argument =
-            convert_binding_pattern_for_param(arena, &rest.rest.argument, offset, line_offsets);
+        let argument = convert_binding_pattern_for_param(
+            arena,
+            &rest.rest.argument,
+            AdjustedOffset::plain(offset),
+            line_offsets,
+        );
         let mut rest_obj = Map::new();
         rest_obj.set_field("type", Value::String("RestElement".to_string()));
         rest_obj.set_field("start", Value::Number((rest_start as i64).into()));
@@ -12895,7 +13078,12 @@ fn convert_function_expression_for_program(
         if let Some(type_ann) = &rest.type_annotation {
             rest_obj.set_field(
                 "typeAnnotation",
-                convert_type_annotation_adjusted(arena, type_ann, offset, line_offsets),
+                convert_type_annotation_adjusted(
+                    arena,
+                    type_ann,
+                    AdjustedOffset::plain(offset),
+                    line_offsets,
+                ),
             );
         }
         params.push(Value::Object(rest_obj));
@@ -12906,7 +13094,12 @@ fn convert_function_expression_for_program(
     if let Some(return_type) = &func.return_type {
         obj.set_field(
             "returnType",
-            convert_type_annotation_adjusted(arena, return_type, offset, line_offsets),
+            convert_type_annotation_adjusted(
+                arena,
+                return_type,
+                AdjustedOffset::plain(offset),
+                line_offsets,
+            ),
         );
     }
 
@@ -12957,18 +13150,21 @@ fn convert_function_expression_for_program_as_node(
         })
         .into_iter()
         .collect();
-    params.extend(
-        func.params.items.iter().map(|param| {
-            expr_to_node(convert_formal_parameter(arena, param, offset, line_offsets))
-        }),
-    );
+    params.extend(func.params.items.iter().map(|param| {
+        expr_to_node(convert_formal_parameter(
+            arena,
+            param,
+            AdjustedOffset::plain(offset),
+            line_offsets,
+        ))
+    }));
     if let Some(rest) = &func.params.rest {
         let rest_start = offset + rest.span.start as usize;
         let rest_end = offset + rest.span.end as usize;
         let argument = convert_binding_pattern_for_param_as_node(
             arena,
             &rest.rest.argument,
-            offset,
+            AdjustedOffset::plain(offset),
             line_offsets,
         );
         params.push(JsNode::RestElement {
@@ -12980,7 +13176,7 @@ fn convert_function_expression_for_program_as_node(
                 Box::new(convert_type_annotation_adjusted(
                     arena,
                     ta,
-                    offset,
+                    AdjustedOffset::plain(offset),
                     line_offsets,
                 ))
             }),
@@ -13023,7 +13219,7 @@ fn convert_function_expression_for_program_as_node(
         return_type: opt_type_annotation(
             arena,
             func.return_type.as_deref(),
-            || offset,
+            || AdjustedOffset::plain(offset),
             line_offsets,
         ),
     }
@@ -13048,13 +13244,12 @@ fn program_function_expression_type_parameters(
     })
 }
 
-/// The caller supplies the adjusted offset because the two parse contexts
-/// disagree: an expression is parsed from a slice wrapped in parens, so its
-/// spans need `offset - 1`, while a program's need `offset`.
+/// The caller supplies the base because the two parse contexts disagree: an
+/// expression is parsed from a slice wrapped in parens, a program's is not.
 fn opt_type_annotation(
     arena: &ParseArena,
     type_ann: Option<&oxc_ast::ast::TSTypeAnnotation<'_>>,
-    adjusted_offset: impl FnOnce() -> usize,
+    adjusted_offset: impl FnOnce() -> AdjustedOffset,
     line_offsets: &[usize],
 ) -> Option<Box<serde_json::Value>> {
     type_ann.map(|ta| {
@@ -14897,7 +15092,7 @@ fn create_arrow_function_with_adjustment(
     // system; use convert_binding_pattern_for_param with (doc_offset - prefix_len)
     // so that span positions map back to document coordinates.
     let mut params: Vec<Value> = Vec::with_capacity(arrow.params.items.len() + 1);
-    let adjusted_offset = doc_offset.saturating_sub(prefix_len);
+    let adjusted_offset = AdjustedOffset::wrapped(doc_offset, prefix_len);
     for param in &arrow.params.items {
         params.push(convert_binding_pattern_for_param(
             arena,

--- a/crates/rsvelte_core/tests/param_pattern_spans_4432.rs
+++ b/crates/rsvelte_core/tests/param_pattern_spans_4432.rs
@@ -1,0 +1,192 @@
+//! A template expression is parsed inside `wrap_for_parse("(", ..)`, so a node
+//! at relative `p` sits at `base + p - 1`. Two conventions for carrying that
+//! subtraction live in `read/expression.rs`: the pattern converters pre-subtract
+//! it into their base, and `convert_expression` subtracts it from the span
+//! itself. Every place the first hands a base to the second has to convert
+//! between them, and only one of the four did — so the default value of a
+//! destructured parameter reported a span one byte early, and a `function`
+//! expression's parameters one byte late.
+//!
+//! Expectations are the official compiler's own answers, taken by running the
+//! pinned `submodules/svelte` parser on these sources; a span is asserted as the
+//! source text it slices to, because a bare number cannot be read.
+
+use rsvelte_core::ast::arena::with_serialize_arena;
+use rsvelte_core::{ParseOptions, parse};
+use serde_json::Value;
+
+fn ast_of(source: &str) -> Value {
+    let ast = parse(
+        source,
+        &oxc_allocator::Allocator::default(),
+        ParseOptions::default(),
+    )
+    .expect("parse should succeed");
+    with_serialize_arena(&ast.arena, || serde_json::to_value(&ast).unwrap())
+}
+
+fn collect<'a>(value: &'a Value, want: &str, out: &mut Vec<&'a Value>) {
+    match value {
+        Value::Object(map) => {
+            if map.get("type").and_then(|t| t.as_str()) == Some(want) {
+                out.push(value);
+            }
+            for child in map.values() {
+                collect(child, want, out);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                collect(child, want, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn slice(source: &str, node: &Value) -> String {
+    let start = node.get("start").and_then(Value::as_u64).expect("start") as usize;
+    let end = node.get("end").and_then(Value::as_u64).expect("end") as usize;
+    assert!(start <= end && end <= source.len(), "span {start}..{end}");
+    source[start..end].to_string()
+}
+
+fn source(template: &str) -> String {
+    format!("<script>let z=1,k='a',o={{k:1}},f=x=>x,xs=[];</script>\n{template}\n")
+}
+
+/// `(cell, template, the text official's `AssignmentPattern.right` covers)`.
+const DEFAULTS: &[(&str, &str, &str)] = &[
+    ("obj", "{(({ a = 1 }) => a)({})}", "1"),
+    ("arr", "{(([a = 1]) => a)([])}", "1"),
+    ("plain", "{((a = 1) => a)()}", "1"),
+    ("nested-obj", "{(({ a: { b = 2 } }) => b)({ a: {} })}", "2"),
+    ("obj-rename", "{(({ a: q = 3 }) => q)({})}", "3"),
+    ("obj-computed-key", "{(({ [k]: v = 4 }) => v)({})}", "4"),
+    ("arr-hole", "{(([, a = 5]) => a)([])}", "5"),
+    ("arr-nested-obj", "{(([{ a = 6 }]) => a)([{}])}", "6"),
+    ("obj-in-arr", "{(({ a: [b = 7] }) => b)({ a: [] })}", "7"),
+    ("obj-rest-after", "{(({ a = 8, ...r }) => a)({})}", "8"),
+    ("second-param", "{((x, { a = 9 }) => a)(0, {})}", "9"),
+    (
+        "fn-expr",
+        "{(function ({ a = 10 }) { return a; })({})}",
+        "10",
+    ),
+    ("member", "{(({ a = o.k }) => a)({})}", "o.k"),
+    ("call", "{(({ a = f(1) }) => a)({})}", "f(1)"),
+    ("arrow", "{(({ a = () => 1 }) => a)({})}", "() => 1"),
+    ("each-pattern", "{#each xs as { a = 1 }}{a}{/each}", "1"),
+];
+
+/// `(cell, template, the text official's parameter spans cover)`.
+const PARAMS: &[(&str, &str, &[&str])] = &[
+    ("arrow-ident", "{((a) => a)(1)}", &["a"]),
+    ("fnexpr-ident", "{(function (a) { return a; })(1)}", &["a"]),
+    (
+        "fnexpr-two",
+        "{(function (a, b) { return a; })(1,2)}",
+        &["a", "b"],
+    ),
+    (
+        "fnexpr-object",
+        "{(function ({ a }) { return a; })({})}",
+        &["{ a }"],
+    ),
+    (
+        "fnexpr-rest",
+        "{(function (...r) { return r; })(1)}",
+        &["...r"],
+    ),
+    (
+        "fnexpr-named",
+        "{(function nm(a) { return a; })(1)}",
+        &["a"],
+    ),
+    ("arrow-object", "{(({ a }) => a)({})}", &["{ a }"]),
+];
+
+#[test]
+fn a_parameter_default_covers_the_value_the_source_wrote() {
+    let mut wrong = Vec::new();
+    for (cell, template, want) in DEFAULTS {
+        let src = source(template);
+        let value = ast_of(&src);
+        let mut found = Vec::new();
+        collect(&value, "AssignmentPattern", &mut found);
+        let Some(node) = found.first() else {
+            wrong.push(format!("{cell}: no AssignmentPattern"));
+            continue;
+        };
+        let right = node.get("right").expect("right");
+        let got = slice(&src, right);
+        if got != *want {
+            wrong.push(format!("{cell}: right is {got:?}, official says {want:?}"));
+        }
+    }
+    assert!(wrong.is_empty(), "{}", wrong.join("\n"));
+}
+
+#[test]
+fn a_function_parameter_covers_the_pattern_the_source_wrote() {
+    let mut wrong = Vec::new();
+    for (cell, template, want) in PARAMS {
+        let src = source(template);
+        let value = ast_of(&src);
+        let mut found = Vec::new();
+        collect(&value, "FunctionExpression", &mut found);
+        collect(&value, "ArrowFunctionExpression", &mut found);
+        let Some(node) = found.first() else {
+            wrong.push(format!("{cell}: no function node"));
+            continue;
+        };
+        let params: Vec<String> = node
+            .get("params")
+            .and_then(Value::as_array)
+            .expect("params")
+            .iter()
+            .map(|p| slice(&src, p))
+            .collect();
+        if params != *want {
+            wrong.push(format!(
+                "{cell}: params are {params:?}, official says {want:?}"
+            ));
+        }
+    }
+    assert!(wrong.is_empty(), "{}", wrong.join("\n"));
+}
+
+/// Both tables have to contain a cell that separates the two conventions from
+/// each other, or a fix that applies one of them everywhere passes.
+#[test]
+fn the_tables_carry_both_conventions() {
+    let arrow_defaults = DEFAULTS
+        .iter()
+        .filter(|(_, t, _)| !t.contains("function") && t.contains("=>"))
+        .count();
+    let fn_defaults = DEFAULTS
+        .iter()
+        .filter(|(_, t, _)| t.contains("function"))
+        .count();
+    let each_defaults = DEFAULTS
+        .iter()
+        .filter(|(_, t, _)| t.contains("#each"))
+        .count();
+    assert!(
+        arrow_defaults >= 10,
+        "arrow-hosted defaults: {arrow_defaults}"
+    );
+    assert!(fn_defaults >= 1, "function-hosted defaults: {fn_defaults}");
+    assert!(each_defaults >= 1, "each-hosted defaults: {each_defaults}");
+
+    let arrow_params = PARAMS
+        .iter()
+        .filter(|(_, t, _)| !t.contains("function"))
+        .count();
+    let fn_params = PARAMS
+        .iter()
+        .filter(|(_, t, _)| t.contains("function"))
+        .count();
+    assert!(arrow_params >= 2, "arrow parameter cells: {arrow_params}");
+    assert!(fn_params >= 4, "function parameter cells: {fn_params}");
+}


### PR DESCRIPTION
## What

A template expression is parsed inside `wrap_for_parse("(", content, ")")`, so a node at
relative `p` sits at `base + p - 1`. **Two conventions for carrying that one byte live in
`1_parse/read/expression.rs`**, and they are never named:

- the twelve pattern converters take a base with the wrapper **already subtracted**
  (`convert_formal_parameter(arena, param, offset - 1, …)`), then add spans to it;
- `convert_expression` takes the **unsubtracted** base and removes the wrapper from the span
  itself (`offset + id.span.start as usize - 1`).

They meet at four places. **One of the four converted between them** —
`convert_formal_parameter_inner` passes `adjusted_offset + 1`, with no comment saying why —
and the other three did not. So every destructured parameter default was reported one byte
early. A second instance of the same class sits in `create_function_expression`, which is
written entirely in the paren convention (`id` and the rest element both spell `- 1`) and
handed its parameters the raw `offset`, one byte late.

Neither is visible in generated code; both are in the public `parse()` AST, which
`svelte2tsx`, `rsvelte-lint` and the language server all read.

## Measured against the pinned oracle

`submodules/svelte`'s own `parse()`, 23 cells, spans asserted as the source text they slice:

| | before | after |
|---|---|---|
| destructured parameter defaults (16 cells) | **14 wrong** | 0 wrong |
| function/arrow parameters (7 cells) | **4 wrong** | 0 wrong |

Before, the defaults sliced to `" "` and the parameters to `")"` — one byte off in opposite
directions, which is what named the two conventions rather than one bug:

```
                    official                    rsvelte (before)
obj-default         62..63="1"                  61..62=" "
default-is-arrow    62..69="() => 1"            61..68=" () => "
fnexpr-param        38..39="a"                  39..40=")"
fnexpr-two          38..39="a",41..42="b"       39..40=",",42..43=")"
```

Two cells were already correct and are kept as controls, because a fix that applies one
convention everywhere passes a table that contains only the broken shapes: `plain-default`
(`(a = 1) => a`) is the site that already compensated, and `each-pattern` reaches a different
entry point entirely.

## What changed

`AdjustedOffset { base, prefix }` replaces the pre-subtracted `usize` on the twelve
converters. It hands out only sums, so the two conventions become two named accessors
(`for_paren_converter`, `for_plain_converter`) instead of a `+ 1` at one call site and nothing
at three. The three missing conversions are then a type error rather than an off-by-one, and
`create_function_expression` gets the `- 1` its neighbours already had.

## What this does NOT close

#4432 is the same file's other symptom — `offset - 1` underflows when the entry point is
called at offset 0 — and it is **narrowed, not closed**. The twelve converters no longer
evaluate a negative base, so `(v) => v` stops panicking; `(v: number) => v` and `o as string`
still reach `convert_ts_type`, which takes a `usize` base and adds to it in checked
arithmetic. Giving that converter the same type cascades: measured, its signature alone takes
the build from 4 errors to 44, and its callers are themselves `offset: usize` functions. That
is a separate change and #4432 stays open for it. No production caller passes 0 — both
`parse_expression` and `parse_expression_with_end` derive their offset from a position inside
a component, which always has a `{` or a `<script>` ahead of it.

## Verification

- 23 cells against the pinned oracle, above; expectations generated by running that oracle,
  not inferred from rsvelte's output.
- `crates/rsvelte_core/tests/param_pattern_spans_4432.rs`, with a liveness test asserting both
  tables carry both hosts — a table of only-arrow cells cannot separate the two conventions.
- 16 suites, 2041 tests, 0 failed — `--lib` (1969) plus every parser, span, snippet and
  `compiler_errors` target. `parser_fixtures` printed its own denominators (modern 28/28,
  legacy 83/84, the one incompatible sample being the pre-existing documented case).
- **Two-arm corpus sweep, `MOVED=0`.** 33,891 sources x 4 targets over
  `compatibility/sources`: `rows=135560 distinct=135560 unparsed=0 live=130585 dead=4975`,
  0 hashes differing. That is the wanted answer rather than a null result — these spans are
  read by `parse()` consumers (svelte2tsx, the linter, the language server) and not by
  codegen, so a compiled-output sweep is the control that says the change is confined.
  Arms identified by provenance rather than by label: the fix commit is an ancestor of the
  fix arm and **not** of the base arm, the two `corpus_hash` binaries hash differently, and
  `git diff` between the two trees is exactly the two files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
