### PR TITLE
docs: a probe separates your arm from the alternative you handed it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,7 +291,9 @@ are in the archived file.
 - **Never read a verdict through a truncating or discarding stage.** `| tail`, `| head`,
   `2>/dev/null`, `|| echo 0`, `; echo EXIT=$?` and `head` closing a pipe before a buffered
   process flushes all turn a failure into a green. Write to a file, then read the file; a
-  pipeline's status is its last stage's.
+  pipeline's status is its last stage's. In code the same shape is a conservative
+  `unwrap_or`/`unwrap_or_default` on a computed boundary: a wrong argument then reads as
+  "the change is inert" rather than as a broken instrument.
 - **A negative result needs a positive control, and a control must bypass a stage the
   measurement passed through.** `grep` here is a `ugrep --ignore-files` wrapper (`command
   grep`); quote every glob-shaped argument (`--include='*.svelte'`); a NUL byte makes
@@ -305,6 +307,11 @@ are in the archived file.
   change's own diff, probe for what it should contain **and** lack, `sha256` both artifacts
   (equal hashes mean one arm measured twice), and settle provenance with
   `git merge-base --is-ancestor`. A staged input can be corrupt: `diff -q` it against the source.
+  A probe separates your arm from the alternative you handed it and from no other: when the
+  question is "did commit X make my change dead", a cell **X and your change both satisfy**
+  answers yes either way, and an arm built from a worktree whose working copy still held the
+  change then reads as the base. Prefer building the base from a pristine checkout of the
+  merge base, or believe CI over a local arm — CI's tree is one nobody in this session made.
 - **Ratios pair arms in time** (official and rsvelte back to back inside each round, ABBA), one
   statistic on both sides; read a profile's call counts before its timings; a shortfall smaller
   than the deciding arm's within-run drift is not a shortfall. Nothing commits on an unmeasured


### PR DESCRIPTION
Two rules, added to the bullets that already own them rather than as new sections — `## Maintaining This File` asks for short and general, and #4367 slimmed this file on purpose.

Both cost a near-miss on #4398 today.

## An ablation is a measurement of a tree

I ran the prescribed control the prescribed way: revert the fix, require red, restore, confirm `git diff` is empty. It passed — at `bf815241a`, the tree the fix was written against.

The branch was then rebased onto `b003aae56` and I re-ran the unit test: **4/4 pass**. That is true, and it is also exactly what a fix that does nothing produces. The run I did not repeat is the ablation.

Three commits sat in the range — #4444, **#4425** and #4443 — and #4425 is the erased-annotation comment machinery the fix was adjacent to. Re-measuring the same 16-cell product across the two bases:

```
                    bf815241a   b003aae56
inside/alone          DIFF        EQ      <== #4425
inside/precedes       DIFF        EQ      <== #4425
inside/both           DIFF        EQ      <== #4425
outside/*             DIFF        DIFF    (unchanged)
none/*                EQ          EQ      (controls)
```

With #4425 in, the change moved **0 of 337** real-world carriers and **0 of 3,000** non-carriers, on two binaries whose `sha256` differ and which *do* answer differently on the older base — so those zeros are inertness, not one arm measured twice. It was dead code that had passed its own ablation.

What found it was not discipline. A peer pushed back that the narrowing had been derived from the single cell it was written for, so I built a 4×4 product to check the other orders; running that product on **both** bases is what showed the moving cells were already green on the merge base. The enumeration was requested to find cells the fix missed and instead found the fix unnecessary.

## `unwrap_or` on a computed boundary is `|| echo 0` in Rust

The same PR narrowed a carry using `find_matching_bracket(...).unwrap_or(0)`. That helper's doc says its index argument is **the position after the opening bracket**, and it opens with `brackets = 1`; passing the bracket's own index leaves the count permanently above zero, so it returned `None` on every input. The fallback then emptied the set it guarded and **all 22 cells reverted to base**.

The natural reading of that output is "this narrowing removed the fix" — a claim about the change, when the truth was a broken instrument. No control fires on it: the measurement is self-consistent, the fallback is the *safe* direction, and every cell that must not move did not move. What separated it was a shape that cannot occur — a narrowing whose purpose is to keep one class of cell and drop another cannot produce "nothing moved at all".

## Scope

Two bullet extensions, six lines added. No new section, no numbers in the file (both bullets are rules, and the case histories live here and in #4447's description). I checked first that no open PR touches `AGENTS.md` — 18 open, none, with a positive control confirming the scan reads file lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
