### PR TITLE
fix(svelte2tsx): reproduce upstream's case-sensitive script and style scan (#4456)

### DIFF
--- a/.changeset/script-like-component-names.md
+++ b/.changeset/script-like-component-names.md
@@ -1,0 +1,25 @@
+---
+'@rsvelte/compiler': patch
+'@rsvelte/svelte2tsx': patch
+'@rsvelte/svelte-check': patch
+---
+
+fix(svelte2tsx): reproduce upstream's case-sensitive script and style scan
+
+`find_ci` folded ASCII case, so every scan that locates a verbatim `<script>` or
+`<style>` block — the style blanker, the orphan-script scan and its fast path —
+also matched a component named `<Script>`, `<SCRIPT>` or `<Style>`. Upstream's
+`scriptRegex` and `styleRegex` (`htmlxparser.ts:33-36`) carry `g` and no `i`, so
+those are component names there.
+
+Both scans feed a rewrite, so the consequence was not only a wrong range.
+`remove_orphan_scripts` blanks the matched source and, when the file has no
+top-level `<script>`, injects the blanked body into `$$render()` as a statement:
+`<Script><p>hello</p></Script>` alone in a file produced TSX no parser accepts.
+`blank_style_tags` replaces its match with spaces, so a `<Style>` component's
+children vanished from the projection while the output still compiled.
+
+Measured against official svelte2tsx over five cells, three move to byte-equal
+and two could not move (`<Style />` is self-closing, so the style blanker's
+fallback never finds a `</style>`; the lowercase spelling is a script on both
+sides).

--- a/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
@@ -14,11 +14,11 @@ fn source_offset(value: usize) -> u32 {
     u32::try_from(value).expect("HTML source offsets are represented as u32")
 }
 
-/// Case-insensitive byte search: position of the first occurrence of
-/// `needle` in `haystack[from..]` (absolute index). ASCII-only folding —
-/// exactly what `to_ascii_lowercase` matching gave, without allocating a
-/// lowercased copy of the whole source.
-fn find_ci(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
+/// Position of the first occurrence of `needle` in `haystack[from..]`
+/// (absolute index). Case-sensitive, because upstream's `scriptRegex` and
+/// `styleRegex` (`htmlxparser.ts:33-36`) carry `g` and no `i` — so `<Script>`
+/// is a component, not a verbatim script tag.
+fn find_bytes(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
     if from > haystack.len() {
         return None;
     }
@@ -28,18 +28,11 @@ fn find_ci(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
         return None;
     }
 
-    let first_lower = needle[0].to_ascii_lowercase();
-    let first_upper = needle[0].to_ascii_uppercase();
     let mut search = from;
     while search <= last_start {
-        let candidates = &haystack[search..=last_start];
-        let offset = if first_lower == first_upper {
-            memchr::memchr(first_lower, candidates)
-        } else {
-            memchr::memchr2(first_lower, first_upper, candidates)
-        }?;
+        let offset = memchr::memchr(needle[0], &haystack[search..=last_start])?;
         let candidate = search + offset;
-        if haystack[candidate..candidate + needle.len()].eq_ignore_ascii_case(needle) {
+        if &haystack[candidate..candidate + needle.len()] == needle {
             return Some(candidate);
         }
         search = candidate + 1;
@@ -56,7 +49,7 @@ fn is_tag_boundary(byte: Option<u8>) -> bool {
 
 fn find_tag(haystack: &[u8], from: usize, name: &[u8]) -> Option<usize> {
     let mut search = from;
-    while let Some(start) = find_ci(haystack, search, name) {
+    while let Some(start) = find_bytes(haystack, search, name) {
         if is_tag_boundary(haystack.get(start + name.len()).copied()) {
             return Some(start);
         }
@@ -67,7 +60,7 @@ fn find_tag(haystack: &[u8], from: usize, name: &[u8]) -> Option<usize> {
 
 fn close_tag_end(haystack: &[u8], from: usize, name: &[u8]) -> Option<(usize, usize)> {
     let start = find_tag(haystack, from, name)?;
-    let gt = find_ci(haystack, start + name.len(), b">")?;
+    let gt = find_bytes(haystack, start + name.len(), b">")?;
     Some((start, gt + 1))
 }
 
@@ -80,7 +73,7 @@ pub fn blank_style_content(source: &str) -> Cow<'_, str> {
     let sb = source.as_bytes();
     let mut search = 0usize;
     loop {
-        let comment = find_ci(sb, search, b"<!--");
+        let comment = find_bytes(sb, search, b"<!--");
         let script = find_tag(sb, search, b"<script");
         let style = find_tag(sb, search, b"<style");
         let Some((tag_start, kind)) = [
@@ -95,11 +88,11 @@ pub fn blank_style_content(source: &str) -> Cow<'_, str> {
         };
 
         if kind == 0 {
-            search = find_ci(sb, tag_start + 4, b"-->").map_or(sb.len(), |end| end + 3);
+            search = find_bytes(sb, tag_start + 4, b"-->").map_or(sb.len(), |end| end + 3);
             continue;
         }
 
-        let Some(gt) = find_ci(sb, tag_start, b">") else {
+        let Some(gt) = find_bytes(sb, tag_start, b">") else {
             break;
         };
         let content_start = gt + 1;
@@ -153,7 +146,7 @@ pub(crate) fn verbatim_regions(source: &str) -> Vec<VerbatimRegion> {
     let mut regions = Vec::new();
     let mut search = 0usize;
     loop {
-        let comment = find_ci(sb, search, b"<!--");
+        let comment = find_bytes(sb, search, b"<!--");
         let script = find_tag(sb, search, b"<script");
         let style = find_tag(sb, search, b"<style");
         let Some((tag_start, kind)) = [
@@ -168,7 +161,7 @@ pub(crate) fn verbatim_regions(source: &str) -> Vec<VerbatimRegion> {
         };
 
         if kind == 0 {
-            let Some(end) = find_ci(sb, tag_start + 4, b"-->") else {
+            let Some(end) = find_bytes(sb, tag_start + 4, b"-->") else {
                 break;
             };
             regions.push(VerbatimRegion {
@@ -180,7 +173,7 @@ pub(crate) fn verbatim_regions(source: &str) -> Vec<VerbatimRegion> {
             search = end + 3;
             continue;
         }
-        let Some(gt) = find_ci(sb, tag_start, b">") else {
+        let Some(gt) = find_bytes(sb, tag_start, b">") else {
             break;
         };
         let content_start = gt + 1;
@@ -258,10 +251,7 @@ pub fn blank_style_tags(ast: &Root, source: &str, str: &mut MagicString<'_>) {
         // appears verbatim in the async template body.
         let has_proper_style_close = {
             let slice = slice_src(source, css.start as usize, css.end as usize);
-            slice
-                .as_bytes()
-                .windows(8)
-                .any(|w| w.eq_ignore_ascii_case(b"</style>"))
+            slice.as_bytes().windows(8).any(|w| w == b"</style>")
         };
         if has_proper_style_close {
             // `handleStyleTag` removes exactly the node range — whitespace
@@ -502,7 +492,7 @@ fn only_has_script_candidates_in_ranges(
         let Some(tag) = bytes.get(tag_start..tag_start + 7) else {
             continue;
         };
-        if !tag.eq_ignore_ascii_case(b"<script") {
+        if tag != b"<script" {
             continue;
         }
 
@@ -558,14 +548,13 @@ fn find_orphan_scripts(ast: &Root, source: &str) -> Vec<(u32, u32, String)> {
     let mut html_tag_ranges: Vec<(u32, u32)> = Vec::new();
     collect_html_tag_ranges(&ast.fragment, &mut html_tag_ranges);
 
-    // 3. Scan the source for `<script` occurrences (case-insensitive, without
-    // allocating a lowercased copy of the whole source).
+    // 3. Scan the source for `<script` occurrences.
     let bytes = source.as_bytes();
     let mut result: Vec<(u32, u32, String)> = Vec::new();
     let mut search: usize = 0;
 
     while search < source.len() {
-        let Some(abs) = find_ci(bytes, search, b"<script") else {
+        let Some(abs) = find_bytes(bytes, search, b"<script") else {
             break;
         };
         let tag_start = source_offset(abs);
@@ -606,8 +595,8 @@ fn find_orphan_scripts(ast: &Root, source: &str) -> Vec<(u32, u32, String)> {
             continue;
         }
 
-        // Find the matching `</script>` (case-insensitive).
-        let Some(close_abs) = find_ci(bytes, tag_start as usize, b"</script>") else {
+        // Find the matching `</script>`.
+        let Some(close_abs) = find_bytes(bytes, tag_start as usize, b"</script>") else {
             break; // unterminated — skip
         };
         let close_rel = close_abs - tag_start as usize;
@@ -652,17 +641,23 @@ mod tests {
     }
 
     #[test]
-    fn case_insensitive_search_preserves_utf8_byte_offsets() {
-        let source = "前😀<STYLE>色</StYlE>後";
-        let open = source.find("<STYLE>").unwrap();
-        let close = source.find("</StYlE>").unwrap();
+    fn search_is_case_sensitive_and_preserves_utf8_byte_offsets() {
+        let source = "前😀<style>色</style>後";
+        let open = source.find("<style>").unwrap();
+        let close = source.find("</style>").unwrap();
 
-        assert_eq!(find_ci(source.as_bytes(), 0, b"<style"), Some(open));
+        assert_eq!(find_bytes(source.as_bytes(), 0, b"<style"), Some(open));
         assert_eq!(
-            find_ci(source.as_bytes(), open + 1, b"</style>"),
+            find_bytes(source.as_bytes(), open + 1, b"</style>"),
             Some(close)
         );
-        assert_eq!(find_ci(source.as_bytes(), close + 1, b"<style"), None);
+        assert_eq!(find_bytes(source.as_bytes(), close + 1, b"<style"), None);
+
+        // `styleRegex` has no `i` flag, so an uppercase spelling is a
+        // component name and never a verbatim style tag.
+        let upper = "前😀<STYLE>色</StYlE>後";
+        assert_eq!(find_bytes(upper.as_bytes(), 0, b"<style"), None);
+        assert_eq!(find_bytes(upper.as_bytes(), 0, b"</style>"), None);
     }
 
     #[test]
@@ -670,23 +665,23 @@ mod tests {
         let source = "<stale><StYlInG><style lang=\"scss\">";
         let expected = source.find("<style lang").unwrap();
 
-        assert_eq!(find_ci(source.as_bytes(), 0, b"<style"), Some(expected));
-        assert_eq!(find_ci(source.as_bytes(), expected + 1, b"<style"), None);
-        assert_eq!(find_ci(source.as_bytes(), 0, b">"), source.find('>'));
+        assert_eq!(find_bytes(source.as_bytes(), 0, b"<style"), Some(expected));
+        assert_eq!(find_bytes(source.as_bytes(), expected + 1, b"<style"), None);
+        assert_eq!(find_bytes(source.as_bytes(), 0, b">"), source.find('>'));
         assert_eq!(
-            find_ci(source.as_bytes(), source.len() + 1, b"<style"),
+            find_bytes(source.as_bytes(), source.len() + 1, b"<style"),
             None
         );
     }
 
     #[test]
     fn style_blanking_keeps_unicode_offsets_and_line_endings() {
-        let source = "前<STYLE lang=\"x\">色 {\r\n color: red;\n}</StYlE>後";
+        let source = "前<style lang=\"x\">色 {\r\n color: red;\n}</style>後";
         let blanked = blank_style_content(source);
 
         assert_eq!(blanked.len(), source.len());
-        assert!(blanked.starts_with("前<STYLE lang=\"x\">"));
-        assert!(blanked.ends_with("</StYlE>後"));
+        assert!(blanked.starts_with("前<style lang=\"x\">"));
+        assert!(blanked.ends_with("</style>後"));
         assert_eq!(
             blanked
                 .bytes()
@@ -760,12 +755,15 @@ const instance_marker = `<script data-marker>`;
     }
 
     #[test]
-    fn orphan_script_fast_path_defers_uppercase_and_nested_scripts() {
+    fn an_uppercase_tag_is_a_component_and_never_an_orphan_script() {
+        // `<SCRIPT>` matches neither `scriptRegex` nor the `isScriptTag`
+        // check upstream, so it stays a component. Blanking it here would
+        // delete a component's body from the projection.
         let uppercase = "<SCRIPT>console.log('upper')</SCRIPT>";
         let nested = "<main><script>console.log('nested')</script></main>";
-        assert!(!can_skip(uppercase));
+        assert!(can_skip(uppercase));
         assert!(!can_skip(nested));
-        assert_eq!(orphans(uppercase)[0].2, "console.log('upper')");
+        assert!(orphans(uppercase).is_empty());
         assert!(orphans(nested).is_empty());
     }
 

--- a/crates/rsvelte_projection/tests/svelte2tsx_script_like_component_names.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_script_like_component_names.rs
@@ -1,0 +1,61 @@
+//! Upstream's `scriptRegex` / `styleRegex` (`htmlxparser.ts:33-36`) carry `g`
+//! and no `i`, so `<Script>` and `<Style />` are components. rsvelte scanned
+//! for them case-insensitively, blanked their source range as if they were
+//! verbatim tags, and — with no top-level `<script>` to hold it — injected the
+//! blanked body into `$$render()` as a bare statement, emitting TSX no parser
+//! accepts. The expected strings below are official svelte2tsx's byte-exact
+//! output for the same source, called with the options
+//! `Svelte2TsxOptions::default()` carries (`filename: "Test.svelte"`,
+//! `mode: 'ts'`, `namespace: 'html'`, `version: '5'`).
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(source: &str) -> String {
+    let options = Svelte2TsxOptions {
+        filename: "Test.svelte".to_string(),
+        ..Svelte2TsxOptions::default()
+    };
+    svelte2tsx(source, options)
+        .expect("a component named like a script tag is not an error")
+        .code
+}
+
+#[test]
+fn script_like_component_is_not_blanked() {
+    assert_eq!(
+        convert("<Script>\n\t<p>hello</p>\n</Script>\n"),
+        "///<reference types=\"svelte\" />\n;function $$render() {\nasync () => { { const $$_tpircS0C = __sveltets_2_ensureComponent(Script); new $$_tpircS0C({ target: __sveltets_2_any(), props: {children:() => { return __sveltets_2_any(0); },}});\n\t { svelteHTML.createElement(\"p\", {});  }\n Script}\n};\nreturn { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: \"\", slots: {}, events: {} }}\nconst Test__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event($$render())));\n/*Ωignore_startΩ*/type Test__SvelteComponent_ = InstanceType<typeof Test__SvelteComponent_>;\n/*Ωignore_endΩ*/export default Test__SvelteComponent_;"
+    );
+}
+
+#[test]
+fn uppercase_script_like_component_is_not_blanked() {
+    assert_eq!(
+        convert("<SCRIPT>\n\t<p>hello</p>\n</SCRIPT>\n"),
+        "///<reference types=\"svelte\" />\n;function $$render() {\nasync () => { { const $$_TPIRCS0C = __sveltets_2_ensureComponent(SCRIPT); new $$_TPIRCS0C({ target: __sveltets_2_any(), props: {children:() => { return __sveltets_2_any(0); },}});\n\t { svelteHTML.createElement(\"p\", {});  }\n SCRIPT}\n};\nreturn { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: \"\", slots: {}, events: {} }}\nconst Test__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event($$render())));\n/*Ωignore_startΩ*/type Test__SvelteComponent_ = InstanceType<typeof Test__SvelteComponent_>;\n/*Ωignore_endΩ*/export default Test__SvelteComponent_;"
+    );
+}
+
+#[test]
+fn style_like_component_is_not_blanked() {
+    assert_eq!(
+        convert("<Style />\n"),
+        "///<reference types=\"svelte\" />\n;function $$render() {\nasync () => { { const $$_elytS0C = __sveltets_2_ensureComponent(Style); new $$_elytS0C({ target: __sveltets_2_any(), props: {}});}\n};\nreturn { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: \"\", slots: {}, events: {} }}\nconst Test__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event($$render())));\n/*Ωignore_startΩ*/type Test__SvelteComponent_ = InstanceType<typeof Test__SvelteComponent_>;\n/*Ωignore_endΩ*/export default Test__SvelteComponent_;"
+    );
+}
+
+#[test]
+fn a_real_lowercase_script_is_still_hoisted() {
+    assert_eq!(
+        convert("<script>\n\tlet a = 1;\n</script>\n<p>{a}</p>\n"),
+        "///<reference types=\"svelte\" />\n;function $$render() {\n\n\tlet a = 1;\n;\nasync () => {\n { svelteHTML.createElement(\"p\", {});a; }\n};\nreturn { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: \"\", slots: {}, events: {} }}\nconst Test__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event($$render())));\n/*Ωignore_startΩ*/type Test__SvelteComponent_ = InstanceType<typeof Test__SvelteComponent_>;\n/*Ωignore_endΩ*/export default Test__SvelteComponent_;"
+    );
+}
+
+#[test]
+fn style_like_component_with_a_close_tag_is_not_blanked() {
+    assert_eq!(
+        convert("<Style>\n\t<p>hello</p>\n</Style>\n"),
+        "///<reference types=\"svelte\" />\n;function $$render() {\nasync () => { { const $$_elytS0C = __sveltets_2_ensureComponent(Style); new $$_elytS0C({ target: __sveltets_2_any(), props: {children:() => { return __sveltets_2_any(0); },}});\n\t { svelteHTML.createElement(\"p\", {});  }\n Style}\n};\nreturn { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: \"\", slots: {}, events: {} }}\nconst Test__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event($$render())));\n/*Ωignore_startΩ*/type Test__SvelteComponent_ = InstanceType<typeof Test__SvelteComponent_>;\n/*Ωignore_endΩ*/export default Test__SvelteComponent_;"
+    );
+}


### PR DESCRIPTION
Fixes #4456.

`find_ci` folded ASCII case, and every scan that locates a verbatim `<script>`
or `<style>` block went through it — the style blanker, the orphan-script scan
and its fast path. Upstream locates the same blocks with `scriptRegex` /
`styleRegex` (`htmlxparser.ts:33-36`), and both carry `g` and **no `i`**, so a
component named `<Script>`, `<SCRIPT>` or `<Style>` is a component there and was
a verbatim tag here.

Both scans feed a rewrite, so this was not only a wrong range:
`remove_orphan_scripts` overwrites the match with `""` and returns the blanked
body for injection into `$$render()` when the file has no top-level `<script>`,
and `blank_style_tags` replaces its match with spaces.

## Measured

Five cells, one `.svelte` source each, `filename: "Test.svelte"`, `mode: 'ts'`,
`namespace: 'html'`, `version: '5'` on both sides. The expected strings are
**generated** from `submodules/language-tools/packages/svelte2tsx/index.js`
rather than transcribed. The arms differ by the `find_ci` predicate alone — the
fixed source was copied aside, `git checkout --` restored `main`'s, and the test
file was held fixed.

| # | source | ablated (`main`) | fixed |
|---|---|---|---|
| 1 | `<Script>\n\t<p>hello</p>\n</Script>\n` | DIFF | **EQ** |
| 2 | `<SCRIPT>…</SCRIPT>` | DIFF | **EQ** |
| 3 | `<Style>\n\t<p>hello</p>\n</Style>\n` | DIFF | **EQ** |
| 4 | `<Style />` | EQ | EQ |
| 5 | `<script>\n\tlet a = 1;\n</script>\n<p>{a}</p>\n` | EQ | EQ |

Cells 4 and 5 are the two that **cannot** move, and both are named as such
rather than counted as passes: `<Style />` is self-closing, so the style
blanker's fallback never finds a `</style>`, and 5 is the positive control that
the lowercase spelling is still a script on both sides — which is what says the
divergence is the fold and not the scan.

Cell 1 on `main` is TSX no JS parser accepts — the component's body arrives as a
statement in TS position:

```
;function $$render() {

	<p>hello</p>

async () => { { const $$_tpircS0C = __sveltets_2_ensureComponent(Script); …
```

Cell 3 is the quiet half: the child is replaced by thirteen spaces and the
`children` prop official emits is absent, so every diagnostic and every hover
inside a `<Style>` component was lost while the output still compiled.

## Reach

The scan is what varies, so the measurement is **paired** — every `.svelte` file
in the two populations on this box, run through both scans with the file held
fixed.

| population | `.svelte` files | denominator (≥ 1 case-insensitive hit) | scans differ |
|---|---|---|---|
| `submodules/svelte/packages/svelte/tests` | 4,488 | 3,753 | **0** |
| `compatibility/pattern-corpus` | 1,366 | 1,298 | **0** |

Only the letter-bearing needles can differ — `>`, `<!--` and `-->` fold to
themselves — so token equality implies range equality here. The denominator is
files that *could* have differed, not the file count.

## Blast radius

The whole `-p rsvelte_projection` suite under both arms of an env-gated
`find_ci`, so the arms differed by exactly that predicate: 96 integration
binaries (= `ls crates/rsvelte_projection/tests/*.rs`) plus the lib unittests.
**Three** failures, all unit tests inside `htmlxparser.rs` itself, and every one
of them asserted the folding rather than the convention — they are rewritten
here with the upstream citation.

`svelte2tsx_fixtures` passed under both arms, which matters because upstream's
own `script-style-like-component` sample is in it and its expected output
requires `Script` to survive. It does not reach the injection arm because it
carries a top-level `<script>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSuCFoDV9gDHEVPQjPFDmH
