### PR TITLE
chore(deps): update layercake submodule to da4d5b69955b

### DIFF
--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -903,7 +903,7 @@ Svelte structure, oxc for embedded JS, and PostCSS for embedded CSS) and require
 embedded CSS by default, so the ratchet intentionally includes CSS-engine parity
 as well as Svelte-structure parity. The ratchet may only shrink.
 
-**Current baseline: `fmt-known-failures.json`, 517 entries.** The 789-entry
+**Current baseline: `fmt-known-failures.json`, 519 entries.** The 789-entry
 split this paragraph used to give (22 pre-enrolment + 766 expanded population + 1
 pattern-corpus repro) no longer holds: 239 entries left the ratchet in the
 2026-09-01 re-baseline, and the CI report the baseline is derived from carries a
@@ -928,9 +928,9 @@ An id that carries two clusters' divergences at once is filed under its dominant
 one (see *Multiple clusters per id*), so the per-cluster counts below remain a
 partition of the ratchet rather than an over-count:
 
-Partition of `fmt-known-failures.json` by cluster: `240 + 212 + 15 + 36 + 12 + 1 + 1`
+Partition of `fmt-known-failures.json` by cluster: `240 + 214 + 15 + 36 + 12 + 1 + 1`
 
-**The partition is now the mechanical rule applied to all 517 entries**, where it
+**The partition is now the mechanical rule applied to all 519 entries**, where it
 used to be the hand-diagnosed Clusters 1-12 (23 entries) plus the mechanical
 Clusters 20-27 over the rest. The hand-diagnosed sections below are kept — their
 diagnoses did not stop being true — but their ids are now counted inside the
@@ -1436,9 +1436,9 @@ buckets per entry from the doc would be transcription, not measurement.
 | 2 | the two engines disagree about whitespace around a selector token neither models — the column combinator and a `nth-child(… of <selector>)` clause: rsvelte's `oxc_formatter_css` prints the space, the oracle's PostCSS path closes it up; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace | `crates/rsvelte_formatter/tests/css_native.rs` — `a_column_combinator_keeps_its_spaces`, `an_nth_child_of_clause_keeps_the_space_after_of` |
 | 1 | a hex escape ending a selector: rsvelte emits the escape's terminating space and the separator before `{` as two spaces where the oracle emits one — the same file's 18 other selectors, including every hex escape followed by more text, agree; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace | `crates/rsvelte_formatter/tests/css_native.rs` — `a_hex_escape_ending_a_selector_keeps_its_own_separator` |
 | 1 | continuation indent of a comma-separated multi-value declaration: rsvelte's engine prints every continuation at one depth where the oracle's PostCSS path indents the ones following an interleaved comment one level deeper than the first; measured through the official compiler, `js.code` is byte-identical for the two spellings and `css.code` differs only in that whitespace | `crates/rsvelte_formatter/tests/css_native.rs` — `every_continuation_of_a_multi_value_declaration_sits_at_one_depth` |
-| 512 | no upstream report and no pinned deliberate divergence; elimination is the only end state open to these entries | none |
+| 514 | no upstream report and no pinned deliberate divergence; elimination is the only end state open to these entries | none |
 
-Partition of `fmt-known-failures.json` by mechanism: `1 + 2 + 1 + 1 + 512`
+Partition of `fmt-known-failures.json` by mechanism: `1 + 2 + 1 + 1 + 514`
 
 Attribution of `fmt-known-failures.json`:
 
@@ -1604,7 +1604,7 @@ this cell is not a hug disagreement: it is a layout pass 1.6 does not have, name
 after the open tag and borrowing the closing tag's `>` onto its own line. How many corpus
 entries carry that shape is **unmeasured**.
 
-**What this population is not.** `fmt-known-failures.json` holds 517 entries; the 72 carriers
+**What this population is not.** `fmt-known-failures.json` holds 519 entries; the 72 carriers
 here are the ones whose *first differing line* is a `>` boundary, so this is a sub-population
 chosen by a signature, not a cluster of the partition above. An entry is retired only when
 every one of its differing regions is repaired.
@@ -1631,7 +1631,7 @@ every whitespace byte subsumes both of the tests below it, so evaluating that on
 | n | class | test |
 |---|---|---|
 | 27 | horizontal whitespace only | equal once spaces/tabs collapse and trailing ones are dropped |
-| 123 | line breaks only, whitespace-preserving | equal once whitespace runs collapse to one space |
+| 125 | line breaks only, whitespace-preserving | equal once whitespace runs collapse to one space |
 | 244 | whitespace **placement** only | equal once every whitespace byte is deleted from both |
 | 123 | a real token difference | none of the above |
 
@@ -1643,7 +1643,7 @@ the four classes come out `27 / 122 / 244 / 127` under the order now printed, an
 ungated half rot separately — `known-failures-md-check` reads the partition line and reads no
 prose, so the line stayed right while the table drifted.
 
-Partition of `fmt-known-failures.json` by diff shape: `244 + 123 + 123 + 27`
+Partition of `fmt-known-failures.json` by diff shape: `244 + 123 + 125 + 27`
 
 **Three of every four entries agree on every token and differ only in layout** — every row above
 except the token one. The placement and line-break rows are separated on purpose: collapsing runs

--- a/compatibility/fmt-known-failures.json
+++ b/compatibility/fmt-known-failures.json
@@ -179,6 +179,8 @@
 	"kite-public/src/lib/components/story/StoryQuote.svelte",
 	"layercake/src/_components/AxisY.percent-range.html.svelte",
 	"layercake/src/_components/AxisYRight.percent-range.html.svelte",
+	"layercake/src/_components/Scatter.percent-range.html.svelte",
+	"layercake/src/routes/_components/ArrowheadMarker.svelte",
 	"layerchart/docs/src/examples/components/Chart/facet-click.svelte",
 	"layerchart/docs/src/examples/components/Chart/facet-wrap.svelte",
 	"layerchart/docs/src/routes/+page.svelte",

--- a/compatibility/fmt-mechanisms.json
+++ b/compatibility/fmt-mechanisms.json
@@ -203,6 +203,8 @@
 		"kite-public/src/lib/components/story/StoryQuote.svelte": "unattributed",
 		"layercake/src/_components/AxisY.percent-range.html.svelte": "unattributed",
 		"layercake/src/_components/AxisYRight.percent-range.html.svelte": "unattributed",
+		"layercake/src/_components/Scatter.percent-range.html.svelte": "unattributed",
+		"layercake/src/routes/_components/ArrowheadMarker.svelte": "unattributed",
 		"layerchart/docs/src/examples/components/Chart/facet-click.svelte": "unattributed",
 		"layerchart/docs/src/examples/components/Chart/facet-wrap.svelte": "unattributed",
 		"layerchart/docs/src/routes/+page.svelte": "css-engine-multi-value-indent",


### PR DESCRIPTION
Supersedes #4410, #4459 and #4460, all of which sat on `chore/update-layercake` — a branch that stopped producing workflow runs entirely (a push, several reopen cycles, two fresh PRs and an empty commit created **zero** runs across three head SHAs, while other branches created runs normally in the same window). Redone as a fresh commit on current `main`, which also fixes a staleness those PRs carried: they edited a **521**-entry `fmt-known-failures.json`, while `main` has since shrunk to **517** (4 entries retired from cluster 20 / *a real token difference*).

`Formatter parity` on the stale base reported `included 33753 / matched 33205 / failed 523` with **2 NEW failures** — `layercake/src/_components/Scatter.percent-range.html.svelte` and `layercake/src/routes/_components/ArrowheadMarker.svelte`. Both carry the pre-existing *breaks-earlier* divergence (rsvelte-fmt wraps a markup expression before the oracle does); the bump introduces no defect, it adds two more inputs carrying one.

- Enrolled both in `fmt-known-failures.json` (517 -> 519) and in `fmt-mechanisms.json` as `unattributed`, beside their existing siblings `AxisY.percent-range.html.svelte` / `AxisYRight.percent-range.html.svelte`.
- Cluster and diff-shape placement were **measured, not inferred from a neighbouring cell**: the CI `corpus-fmt-report` artifact was downloaded, the local `rsvelte-fmt` was confirmed to reproduce CI's differing line byte-for-byte, the oracle side was regenerated with `node_modules/.bin/oxfmt` 0.64.0 under `fmt-corpus.oxfmtrc.json`, and the four diff-shape tests were applied to the whole files. Both land in *line breaks only, whitespace-preserving* (123 -> 125) and *Cluster 21 - breaks-earlier* (212 -> 214). The classifier was validated by reproducing the published `27` for *horizontal whitespace only* over the existing `compatibility/fmt/{oracle,actual}` trees.
- `known-failures-md-check.mjs` exits 0, as do the two gated attribution checks (`attribution-check --gate-known`, `attribution-progress-check`).

The failing set was measured on the stale base, so **this run's own `Formatter parity` is the gate**: if it reports a different new-failure set against the 517-entry baseline, the enrolment needs adjusting rather than accepting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyd6xc1EN5Jt4yNWeiWtuy