### PR TITLE
fix(client): a `$effect` chunk claims its source-map region (#4455)

### DIFF
--- a/.changeset/effect-chunk-claims-its-map-region.md
+++ b/.changeset/effect-chunk-claims-its-map-region.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Give a `$effect` chunk's source-map positions their source offsets back. `to_oxc.rs` claimed a chunk's comment-buffer region — the only thing that resolves a comment-space offset into the source — everywhere except the effect path, so any statement whose text contains `$effect` had its positions written into the map untranslated and landing past the end of the line they name. The guard is a substring scan, so those seven bytes inside a comment or a string literal did it to a component that uses no rune at all. Generated code is unchanged.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -2172,11 +2172,11 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 copied_spans,
             } => {
                 let mut stmts = self.parse_raw_statements(code, false, &[])?;
-                if effect_spans.is_empty()
-                    && self
-                        .take_chunk_region(Some(*source_offset), copied_spans)
-                        .is_some()
-                {
+                // The region has to be claimed even when the effect path is taken:
+                // it is the only thing that resolves this chunk's comment-space
+                // offsets back into the source.
+                let region = self.take_chunk_region(Some(*source_offset), copied_spans);
+                if effect_spans.is_empty() && region.is_some() {
                     return Some(stmts);
                 }
                 restore_raw_mapped_spans(&mut stmts, copied_spans, code);

--- a/crates/rsvelte_core/tests/effect_chunk_map_region_4455.rs
+++ b/crates/rsvelte_core/tests/effect_chunk_map_region_4455.rs
@@ -1,0 +1,188 @@
+//! A chunk whose text contains `$effect` must still claim its `loc_map` region,
+//! or its comment-space offsets reach the source map untranslated.
+//!
+//! `to_oxc.rs`'s `RawMappedEffect` arm called `take_chunk_region` only when
+//! `effect_spans` was empty, and `take_chunk_region` is the only thing that
+//! populates `loc_map` -- the table that resolves a comment-buffer offset back
+//! into the source. With no entry, `Printer::map_position` passes the
+//! comment-space offset through and the map names a position that is usually
+//! past the end of the line it claims.
+//!
+//! `effect_spans` is `original.match_indices("$effect")`, a SUBSTRING scan, so
+//! the guard fires on those seven bytes wherever they appear -- including inside
+//! a comment or a string literal, in a component that uses no rune at all. Two
+//! of the cells below are exactly that, and `$effecty` is there to pin that it
+//! is a substring rather than a token.
+//!
+//! `sourcemaps_gate.rs` owns this predicate and cannot see any of it: measured
+//! on this tree it reads `808/808 official segments reproduced, 0/1622
+//! out-of-range` both with and without the fix, because its 29 fixtures do not
+//! carry the shape. No corpus gate can see it either -- `verify.mjs` hashes
+//! `js.code` and `css.code` and no map at all.
+//!
+//! Expected positions come from the official compiler's own map, not from this
+//! port: for the `$effect` cell official maps generated `console.log(1);` to
+//! source line 3 column 2 (0-based), the line the call is written on.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client_map(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("X.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .map
+    .expect("client source map")
+}
+
+/// `[generated_line, generated_column, source_line, source_column]`, all 0-based.
+fn decode(map_json: &str) -> (Vec<[i64; 4]>, Vec<String>) {
+    let value: serde_json::Value = serde_json::from_str(map_json).expect("map json");
+    let obj = value.as_object().expect("map object");
+    let content = obj
+        .get("sourcesContent")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .map(|s| s.as_str().unwrap_or_default().to_string())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let mappings = obj
+        .get("mappings")
+        .and_then(|v| v.as_str())
+        .expect("mappings");
+
+    let mut out = Vec::new();
+    let mut state = [0i64; 4];
+    for (generated_line, line) in mappings.split(';').enumerate() {
+        state[0] = 0;
+        for field in line.split(',') {
+            if field.is_empty() {
+                continue;
+            }
+            let mut values = Vec::new();
+            let mut value = 0i64;
+            let mut shift = 0u32;
+            for c in field.bytes() {
+                let digit = match c {
+                    b'A'..=b'Z' => (c - b'A') as i64,
+                    b'a'..=b'z' => (c - b'a') as i64 + 26,
+                    b'0'..=b'9' => (c - b'0') as i64 + 52,
+                    b'+' => 62,
+                    b'/' => 63,
+                    _ => break,
+                };
+                value += (digit & 31) << shift;
+                if digit & 32 == 0 {
+                    let negative = value & 1 == 1;
+                    value >>= 1;
+                    values.push(if negative { -value } else { value });
+                    value = 0;
+                    shift = 0;
+                } else {
+                    shift += 5;
+                }
+            }
+            for (i, v) in values.iter().take(4).enumerate() {
+                state[i] += v;
+            }
+            if values.len() >= 4 {
+                out.push([generated_line as i64, state[0], state[2], state[3]]);
+            }
+        }
+    }
+    (out, content)
+}
+
+/// The predicate `sourcemaps_gate.rs` owns: a segment is out of range when its
+/// line is past the last line of the source, or its column is past the end of
+/// that line. `column == length` is legal -- it addresses the line terminator.
+/// Columns are UTF-16 code units.
+fn out_of_range(map_json: &str) -> (usize, usize) {
+    let (segments, content) = decode(map_json);
+    let source = content.first().cloned().unwrap_or_default();
+    let widths: Vec<i64> = source
+        .split('\n')
+        .map(|l| l.chars().map(|c| c.len_utf16() as i64).sum())
+        .collect();
+    let bad = segments
+        .iter()
+        .filter(|s| {
+            let line = s[2];
+            line < 0 || line as usize >= widths.len() || s[3] > widths[line as usize]
+        })
+        .count();
+    (bad, segments.len())
+}
+
+const EFFECT: &str =
+    "<script>\n\t// probe\n\t$effect(() => {\n\t\tconsole.log(1);\n\t});\n</script>\n";
+
+/// Same program in every cell; only the word inside the comment and the string
+/// changes, so nothing but the seven bytes can account for a difference.
+fn opaque(word: &str) -> String {
+    format!(
+        "<script>\n\t// {word}\n\tconst s = \"{word}\";\n\tqueueMicrotask(() => {{\n\t\tconsole.log(s);\n\t}});\n</script>\n"
+    )
+}
+
+#[test]
+fn an_effect_chunk_maps_inside_its_source() {
+    let (bad, total) = out_of_range(&client_map(EFFECT));
+    // Liveness: a map with no segments satisfies "nothing is out of range".
+    assert!(total > 10, "expected a populated map, got {total} segments");
+    assert_eq!(bad, 0, "{bad} of {total} segments point outside the source");
+}
+
+#[test]
+fn the_effect_body_maps_to_the_line_it_is_written_on() {
+    let map = client_map(EFFECT);
+    let (segments, content) = decode(&map);
+    let source = content.first().expect("sourcesContent").clone();
+    let lines: Vec<&str> = source.split('\n').collect();
+    // Official maps generated `console.log(1);` to source 3:2 -- the line the
+    // call is written on. Assert the line rather than the generated column, so
+    // an unrelated codegen change does not rewrite this test.
+    let named: Vec<i64> = segments
+        .iter()
+        .filter(|s| {
+            let line = s[2] as usize;
+            lines
+                .get(line)
+                .is_some_and(|l| l.contains("console.log(1);"))
+        })
+        .map(|s| s[2])
+        .collect();
+    assert!(
+        named.contains(&3),
+        "no segment names the source line holding `console.log(1);`; named lines were {named:?}"
+    );
+}
+
+#[test]
+fn seven_bytes_in_a_comment_or_a_string_do_not_move_the_map() {
+    // `aaaaaaa`, `$inspect` and `effect` are the cells that must NOT move: the
+    // first is a plain control, the second selects the same statement kind while
+    // leaving `effect_spans` empty, and the third is the rune name without its
+    // sigil. Without them a grid of only-`$effect` cells cannot tell "the
+    // statement kind" from "the substring".
+    let baseline = out_of_range(&client_map(&opaque("aaaaaaa")));
+    assert!(baseline.1 > 10, "expected a populated map");
+    for word in ["$effect", "$effecty", "$inspect", "effect"] {
+        let (bad, total) = out_of_range(&client_map(&opaque(word)));
+        assert_eq!(
+            (bad, total),
+            baseline,
+            "`{word}` inside a comment and a string changed the map: {bad}/{total} out of range against the control's {}/{}",
+            baseline.0,
+            baseline.1
+        );
+    }
+}


### PR DESCRIPTION
Closes #4455.

## What

`to_oxc.rs::take_chunk_region` is the only thing that populates `loc_map` — the table
that resolves a comment-buffer offset back into the source — and the `RawMappedEffect`
arm called it only `if effect_spans.is_empty()`. So any chunk whose text contains
`$effect` never claimed its region, `loc_map` stayed empty for it, and
`Printer::map_position` wrote the chunk's comment-space offsets into the source map
unchanged. The positions land past the end of the line they name.

`effect_spans` is `original.match_indices("$effect")` — a **substring** scan — so those
seven bytes inside a comment or a string literal do this to a component that uses no
rune at all.

The sibling `parse_raw_statement` at `to_oxc.rs:1063` already calls `take_chunk_region`
unconditionally while handling `effect_spans`, so the two sites disagreed about exactly
this. The fix claims the region on both paths and keeps the early return gated as before,
so a chunk with no effect spans behaves identically.

## Evidence

Five cells, predicted from the code before measuring, with `ranges` read out of the
printer's own probe:

| cell | `ranges` before | correct → | wrong → |
|---|---:|---|---|
| real `$effect` | 0 | 7 → **16** | 11 → **0** |
| `$effect` in a comment only | 0 | 4 → 16 | 14 → 2 |
| `$effect` in a string only | 0 | 4 → 22 | 20 → 2 |
| `$inspect`, no `$effect` | 8 | 8 → 8 | 4 → 4 |
| no rune at all | 1 | 16 → 16 | 2 → 2 |

The last two are the cells that must **not** move, and they do not. The `$inspect` cell
is the discriminating one: it is a `RawMappedEffect` with an *empty* `effect_spans`, so
it separates "the statement kind" from "the substring".

Confound-free — same program in every cell, only the word inside an existing comment and
an existing string literal changing (`out-of-range / total`, before → after):

```
aaaaaaa   (control)   0/26 -> 0/26        $inspect   0/26 -> 0/26
$effect              18/26 -> 0/26        effect     0/26 -> 0/26
$effecty             18/26 -> 0/26
```

`$effecty` is there because the guard matches a substring, not a token.

## Blast radius

**Generated code does not move.** Two arms over `compatibility/pattern-corpus` +
`submodules/svelte/packages/svelte/tests`, four targets, hashing `js.code` + `css.code`:

```
arm A a98d3c23b3ad4aaf  rows=23680 live=20670 dead=3010
arm B 6d589f7f2bf4fc78  rows=23680 live=20670 dead=3010
rows written 23680, keys surviving 23680 (both arms)
MOVED = 0 of 23680 pairs
```

Distinct artifacts, no key collapse, non-zero live units — and the arms are separately
shown to differ by the five-cell table above, so the zero is not two copies of one
binary.

Both source-map budgets move the right way on `pattern-corpus` (1,239 files where the
generated code is byte-identical to official's):

```
out-of-range        6016/110448  ->  5975/110448     (-41)
official positions
reproduced          69679/88368  ->  69714/88368     (+35)
official            0/91674      ->  0/91674         (negative control)
```

The **−41 was pre-registered**: the `$effect` + script-comment bucket was measured at 41
of 6,016 out-of-range segments *before* the fix was written (#4466), and the fix removes
exactly that many.

## What no gate sees

`sourcemaps_gate.rs` owns this exact predicate and cannot observe the change — measured
on this tree, with and without the fix:

```
out-of-range segments: 0/1622 (0.0%)
byte-identical generated outputs: 58/58
official segments reproduced: 808/808 (100.0%) - 0 missing, 0 wrong
```

Identical both ways: its population is 29 hand-written fixtures and none carries the
shape. The corpus output gate cannot see it either — `verify.mjs` hashes `js.code` and
`css.code` and no map at all. So the regression test is the only thing holding this.

`crates/rsvelte_core/tests/effect_chunk_map_region_4455.rs` has three tests, each
carrying its own liveness assertion (a map with no segments trivially satisfies "nothing
is out of range"). Ablated — the one-line guard restored — all three fail with distinct
messages (`12 of 22 segments point outside the source`; `no segment names the source
line holding console.log(1);`; `` `$effect` … 18/26 against the control's 0/26 ``), and
the tree restores byte-identically afterwards (`sha256` verified).

## Residue, so it is not read as this fix underperforming

−41 is 0.7% of `pattern-corpus`'s out-of-range segments. The other 94% sit in files that
never enter split coordinates at all and are a **second mechanism**, filed separately as
**#4466** before this fix was written.

## Scope

`generate: client`. The sweep covers all four targets for generated code; the map
measurements are `client, dev: false` only, and `server` / `client-dev` / `server-dev`
map behaviour is UNMEASURED. `compatibility/sources/` is not materialised on this
machine, so the map figures are over `pattern-corpus`, a constructed population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
