### PR TITLE
fix(client): a method's parameter list runs its comment window to the body (#4468)

### DIFF
--- a/.changeset/method-param-comment-window.md
+++ b/.changeset/method-param-comment-window.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Keep a comment written between a method's `)` and its body. esrap runs a parameter list's comment window until the body starts, and in the acorn AST a method is a `FunctionExpression`, so upstream reaches methods, getters, setters and object-literal methods through that same rule. rsvelte routed them through a helper that ended the window at the `)` instead, which put such a comment outside every window and dropped it from the output on all four targets. The three bodied sites now share one expression; the five bodyless TS signature callers keep the paren-ending default, which is the only place it is correct.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.39"
+version = "0.10.40"
 dependencies = [
  "compact_str",
  "memchr",

--- a/compatibility/GATES.md
+++ b/compatibility/GATES.md
@@ -8090,6 +8090,101 @@ same holds for `void 0`. Which inputs *do* reach it is **unmeasured**, so the ro
 port that disagrees with upstream and is currently unreachable is one refactor away from being
 reachable, and nothing here would notice.
 
+#### 34. Where does a parameter list's comment window end? — [D], one port pair closed, one left unreachable
+
+**Upstream** ends it with `sequence(context, node.params, <until>, false)` and spells `<until>`
+**twice**, split by whether the node has a body
+(`esrap/src/languages/ts/index.js`, pinned at `esrap@2.2.12`):
+
+| upstream | expression | reaches |
+|---|---|---|
+| `:744` | `(node.returnType ?? node.body).loc?.start ?? null` | `FunctionDeclaration` / `FunctionExpression` — which in the acorn model is *also* every method, getter, setter and object-literal method |
+| `:988` | the same expression, character for character | `ArrowFunctionExpression` |
+| `:1771` | `node.returnType?.loc?.start ?? node.loc?.end ?? null` | bodyless TS signatures, which have no `node.body` to ask |
+
+**Ports, before #4468.** rsvelte spelled it three times and the split did not line up with
+upstream's: `printer.rs:2493-2501` (function declarations), `formal_parameters` (**`params.span().end`**,
+the `)`, at eight callers), and the arrow's four-arm `match`. Ports 1 and 3 answered upstream's
+`:744`/`:988`. Port 2 served callers upstream splits across `:744` — methods, which *are*
+`FunctionExpression`s — **and** `:1771`, so it was one answer where upstream has two, and for the
+`:744` half it was the wrong one.
+
+**Named input, and it separated two rsvelte ports rather than only rsvelte from upstream.** A
+comment between `)` and the body is inside port 1's window and outside port 2's:
+
+```
+function f() /*W*/ { return 1; }          port 1 -> kept
+class C { m() /*W*/ { return 1; } }       port 2 -> dropped from the output entirely
+```
+
+Measured host × comment slot, with `before )` as the negative control every port must keep:
+4 DIFF of 12 cells, the control firing on all six hosts, and 16 DIFF of 24 across the four
+targets — the predicate being whole-output containment, so the comment was dropped rather than
+relocated.
+
+**Closed at degree 1 for the bodied half.** `function_params_until` is now the single expression
+for every bodied function, called from the function, method and object-method sites, so the
+question has one answer wherever upstream's `:744` answers it. What remains is a genuine second
+port: `formal_parameters` keeps `params.span().end` and is now called from exactly the five
+bodyless TS signature sites — which a `grep` confirms, and which is what its doc comment claims,
+so the claim is checkable rather than asserted.
+
+**The remaining pair is [S], and its divergence is unreachable rather than absent.** Upstream's
+`:1771` is `returnType?.loc?.start ?? node.loc?.end`, and a `TSFunctionType` always has a return
+type, so upstream stops at the return type where rsvelte stops at the `)`. Nothing reaches it: a
+named type threaded through `TSFunctionType`, `TSConstructorType`, `TSMethodSignature` and
+`TSDeclareFunction` is absent from `js.code` on `client` and `server` **on both compilers**, while
+the same marker written as a value survives on both — so the probe is live rather than blind.
+`rsvelte_esrap`'s only consumers besides `rsvelte_core` are `rsvelte_devtools` and `rsvelte_bench`,
+neither of which is shipped output. What that does *not* establish is that the five sites are never
+called; a `#[track_caller]` counter would, and was not built.
+
+**Port 3's `Some(_) => None` arm is a deliberate divergence, recorded rather than dropped.**
+`arrow_function` passes `owned_comment_until = None` and takes the `None => Some(body_start)` arm,
+which is upstream's expression; over 8 arrow body shapes × 4 targets that is 32 cells, 0 DIFF, with
+the method grid as the control that the same instrument does report DIFF. None of the 32 reaches
+the other arm: it needs `owned_comment_until` to be `Some`, supplied only by `printer.rs:4495` and
+`:4678`, both synthesized arrows owning a *call argument's* comments. The comment above it gives
+the reason — a generated arrow's empty parameter list would otherwise consume a located body's
+leading comments before the `=>`. Unmeasured against upstream, and kept here because a comment
+asserting a considered difference is exactly where this class hides.
+
+**Reach was 0 before the fix, against the caller population.** Every `.svelte` file under
+`submodules/svelte/packages/svelte/tests` and `compatibility/pattern-corpus` was parsed with the
+official compiler and walked for the two node shapes that route to port 2, and for each one found
+the source between the parameter list's own `)` and the body's `start` was read for a comment
+marker:
+
+```
+.svelte files              5,920
+parsed by official         5,737   (183 rejected — the deliberately-invalid fixtures)
+reach port 2                 214   <- the live control: the port is exercised here
+carry the disputed slot        0
+```
+
+The 214 is what makes the 0 readable — without it, a population holding no methods at all produces
+the identical zero and nothing in the output says so.
+
+**Two instrument corrections, neither of which moved the number.** The first version counted
+*source shapes* with a loose `\)\s*comment\s*\{` regex, which is a scan of sources where the
+population that decides port 2 is *callers*; it returned one file and printing it disqualified it
+(an object literal's `)`), so "0 carriers" and "0 carriers among the files that reach this port"
+are different claims and only the second survives being quoted. The second is sharper: the AST
+version was first written with the gap running from the **last parameter's end**, which for a
+zero-parameter method is the whole parameter list — so `m(/*W*/) {}`, the negative-control slot
+both compilers keep, counted as a carrier. It was found by injecting a manufactured carrier *and*
+a manufactured non-carrier and requiring the count to move by exactly one; it moved by two.
+**Printing the hits could not have found it**, because there were no hits — an over-counting
+instrument that returns zero is validated by neither cheap check, only by an injected pin, and the
+published 0 survives on the sign alone (an over-counting instrument reporting zero has a true zero
+underneath).
+
+One qualification stands: the collected corpus (~33.9k components) is not materialised on this
+machine, so 5,737 is not the denominator this project normally quotes.
+
+Tracked as #4468. Not a duplicate of #4452, which reports eleven checked-in repro files diverging
+with the gate passing them; this shape had no repro file and no carrier.
+
 ### Formatting — collapses
 
 Whitespace, line breaks and indentation. Quote style. Optional semicolons.

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.146", features = ["serialize"] }
 oxc_span = "0.146"
 oxc_diagnostics = "0.146"
 oxc_codegen = "0.146"
-rsvelte_esrap = { version = "=0.10.39", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.40", path = "../rsvelte_esrap" }
 oxc_syntax = "0.146"
 oxc_semantic = "0.146"
 

--- a/crates/rsvelte_core/tests/method_param_comment_window_4468.rs
+++ b/crates/rsvelte_core/tests/method_param_comment_window_4468.rs
@@ -1,0 +1,100 @@
+//! A comment between a parameter list's `)` and the body belongs inside the
+//! window esrap runs the parameter sequence over, so it is flushed between the
+//! parens. Upstream reaches every bodied function through one expression;
+//! rsvelte routed methods through the paren-ending default and dropped the
+//! comment. Expected strings are the official compiler's own output.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn emit(script: &str, generate: GenerateMode) -> String {
+    let source = format!(
+        "<script>\n\t{}\n</script>\n\n<p>x</p>\n",
+        script.replace('\n', "\n\t")
+    );
+    compile(
+        &source,
+        CompileOptions {
+            generate,
+            ..Default::default()
+        },
+    )
+    .expect("compile failed")
+    .js
+    .code
+}
+
+#[track_caller]
+fn both_targets(script: &str, client: &str, server: &str) {
+    for (generate, needle) in [
+        (GenerateMode::Client, client),
+        (GenerateMode::Server, server),
+    ] {
+        let code = emit(script, generate);
+        assert!(
+            code.contains(needle),
+            "expected\n  {needle:?}\nin {generate:?} output:\n{code}"
+        );
+    }
+}
+
+#[test]
+fn a_class_method_keeps_a_comment_before_its_body() {
+    both_targets(
+        "class C { m() /*W*/ { return 1; } }\nexport const a = new C();",
+        "\t\tm(/*W*/) {",
+        "\t\t\tm(/*W*/) {",
+    );
+}
+
+#[test]
+fn a_class_getter_keeps_a_comment_before_its_body() {
+    both_targets(
+        "class C { get p() /*W*/ { return 1; } }\nexport const a = new C();",
+        "\t\tget p(/*W*/) {",
+        "\t\t\tget p(/*W*/) {",
+    );
+}
+
+#[test]
+fn a_class_setter_keeps_a_comment_before_its_body() {
+    both_targets(
+        "class C { set p(v) /*W*/ { globalThis.x = v; } }\nexport const a = new C();",
+        "\t\tset p(v /*W*/) {",
+        "\t\t\tset p(v /*W*/) {",
+    );
+}
+
+#[test]
+fn an_object_literal_method_keeps_a_comment_before_its_body() {
+    both_targets(
+        "const o = { m() /*W*/ { return 1; } };\nexport const a = o;",
+        "\t\tm(/*W*/) {",
+        "\t\tm(/*W*/) {",
+    );
+}
+
+/// The host that already agreed with upstream. It shares the window expression
+/// with the three above after this fix, so it would go red on a regression that
+/// changed the expression rather than the routing.
+#[test]
+fn a_function_declaration_still_keeps_it() {
+    both_targets(
+        "function f() /*W*/ { return 1; }\nexport const a = f;",
+        "\tfunction f(/*W*/) {",
+        "\tfunction f(/*W*/) {",
+    );
+}
+
+/// The near-miss slot, one position to the left. It is what separates "the
+/// window starts at the `)`" from "the window starts after the last parameter";
+/// a fix that widened the window by starting it earlier passes every test above
+/// and changes this one, because a parameter would then be separated from its
+/// own trailing comment.
+#[test]
+fn a_comment_inside_the_parens_is_unmoved() {
+    both_targets(
+        "class C { m(v /*W*/) { globalThis.x = v; } }\nexport const a = new C();",
+        "\t\tm(v /*W*/) {",
+        "\t\t\tm(v /*W*/) {",
+    );
+}

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.39"
+version = "0.10.40"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -2486,14 +2486,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             self.type_parameter_declaration(tp, ctx);
         }
         ctx.write_ascii(b'(');
-        // esrap: until `(returnType ?? body).loc.start`; a bodyless declare /
-        // overload falls back to the node's own end.
-        let until = node
-            .return_type
-            .as_ref()
-            .map(|rt| rt.span().start)
-            .or_else(|| node.body.as_ref().map(|b| b.span().start))
-            .unwrap_or(node.span.end);
+        let until = Self::function_params_until(node);
         self.formal_parameters_with_this(
             &node.params,
             node.this_param.as_deref(),
@@ -2802,7 +2795,12 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             self.type_parameter_declaration(tp, ctx);
         }
         ctx.write_ascii(b'(');
-        self.formal_parameters(&node.value.params, ctx);
+        self.formal_parameters_with_this(
+            &node.value.params,
+            None,
+            Some(Self::function_params_until(&node.value)),
+            ctx,
+        );
         ctx.write_ascii(b')');
         if let Some(rt) = &node.value.return_type {
             self.type_annotation(rt, ctx);
@@ -3169,7 +3167,23 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         ctx.write_ascii(b']');
     }
 
+    /// esrap runs a bodied function's parameter sequence until
+    /// `(returnType ?? body).loc.start`, so a comment between `)` and the body
+    /// is inside the window. A bodyless declare / overload falls back to the
+    /// node's own end.
+    fn function_params_until(f: &Function) -> u32 {
+        f.return_type
+            .as_ref()
+            .map(|rt| rt.span().start)
+            .or_else(|| f.body.as_ref().map(|b| b.span().start))
+            .unwrap_or(f.span.end)
+    }
+
     /// Parameter list via esrap's `sequence` (no padding): `a, b, ...rest`.
+    ///
+    /// Ends the window at `)`. Only the bodyless TS signatures use this — a
+    /// bodied function must go through [`Self::function_params_until`], or a
+    /// comment ahead of its body falls outside the window and is never flushed.
     fn formal_parameters(&mut self, params: &FormalParameters, ctx: &mut Context<DIRECT>) {
         self.formal_parameters_with_this(params, None, Some(params.span().end), ctx);
     }
@@ -4404,7 +4418,12 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 self.property_key(&prop.key, ctx);
             }
             ctx.write_ascii(b'(');
-            self.formal_parameters(&f.params, ctx);
+            self.formal_parameters_with_this(
+                &f.params,
+                None,
+                Some(Self::function_params_until(f)),
+                ctx,
+            );
             ctx.write_ascii(b')');
             ctx.write_ascii(b' ');
             match &f.body {

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.39"
+version = "0.10.40"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
Closes #4468.

A comment written between a method's `)` and its body was dropped from the output entirely, on all four targets. The same comment on a `function` declaration or an arrow is kept, by rsvelte and by official alike.

```
class C { m() /*W*/ { return 1; } }

official  m(/*W*/) {
rsvelte   (the comment appears nowhere in the output)
```

## The rule

esrap ends a parameter list's comment window with `sequence(context, node.params, <until>, false)`, and spells `<until>` twice — split by whether the node has a body:

| upstream | expression | reaches |
|---|---|---|
| `esrap/src/languages/ts/index.js:744` | `(node.returnType ?? node.body).loc?.start ?? null` | `FunctionDeclaration` / `FunctionExpression` — which in the acorn model is *also* every method, getter, setter and object-literal method |
| `:988` | the same expression, character for character | `ArrowFunctionExpression` |
| `:1771` | `node.returnType?.loc?.start ?? node.loc?.end ?? null` | bodyless TS signatures, which have no `node.body` to ask |

rsvelte spelled it three times, and the split did not line up: `formal_parameters` ended the window at `params.span().end` — the `)` — for eight callers, four of which upstream routes through `:744`. A comment after the `)` therefore sat outside every window and nothing downstream claimed it.

The three bodied sites now share `function_params_until`. `formal_parameters` keeps the paren-ending default and is, after this change, called from exactly the five bodyless TS signature sites — which is what its doc comment now claims, and `grep -n 'formal_parameters('` can check.

## Measurement

Two `--release` NAPI arms, both built from this tree at `2de8dfce1`: base `0b22513a83fc84ec`, head `65bfced0b78140d5`, **distinct** by `sha256`. The base arm is built at this branch's own merge base rather than reused from an older binary — reusing one would have differed by #4467 as well as by the change under test.

Arm probe, two-sided:

```
base   method (SUBJECT, must be false): false    function (CONTROL, both true): true
head   method (SUBJECT, must be false): true     function (CONTROL, both true): true
```

Host × comment slot against the oracle, before and after. `before )` is the negative control every port must keep:

```
host                   slot                  before fix   after fix
class method    :2805  before )  [neg ctl]   EQ           EQ
class method    :2805  after  )  [subject]   DIFF         EQ
object method   :4407  before )  [neg ctl]   EQ           EQ
object method   :4407  after  )  [subject]   DIFF         EQ
class getter    :2805  before )  [neg ctl]   EQ           EQ
class getter    :2805  after  )  [subject]   DIFF         EQ
class setter    :2805  before )  [neg ctl]   EQ           EQ
class setter    :2805  after  )  [subject]   DIFF         EQ
function decl   :2497  both slots [ctl]      EQ           EQ
arrow           :3308  both slots [ctl]      EQ           EQ
```

## Blast radius

```
arm A 0b22513a83fc84ec   arm B 65bfced0b78140d5   (distinct)
files 6,155   pairs compared 24,620   rows 24,620, distinct ids 6,155   (no key collapse)
live 21,174 / dead 3,446 on both arms

MOVED = 0 of 24,620
```

**That zero has a manufactured pin.** Re-running the same sweep with two injected files:

```
files 6,155 -> 6,157                            <- both entered the population
MOVED = 4
   manufactured-carrier.svelte -> client, client-dev, server, server-dev
   manufactured-noncarrier.svelte -> (0 targets)
   any real corpus file -> 0
```

The carrier is `m() /*W*/ {}` and the non-carrier is `m(/*W*/) {}`, one position to the left. So the sweep is demonstrably able to report movement from *this* change, and rejects the near-miss; the zero is a property of the population.

## Why a local sweep rather than the merge queue

The corpus output gate cannot see this class. `ast_equiv_batch` is invoked with empty argv, which is `CommentPolicy::Ignore`, so a comment-only divergence normalizes to `match` — that is #4452's whole subject. A comment-placement regression from this change would be invisible to CI, which is why the evidence is two local arms rather than a green corpus job.

For the same reason there is no `pattern-corpus` repro: the file would be checked in, the divergence live, and the gate would pass it. The regression suite is `crates/rsvelte_core/tests/method_param_comment_window_4468.rs` instead.

## Tests

Six, one per host so that a single "all four are kept" assertion cannot be satisfied by three. Expected strings are the official compiler's own output, generated rather than inferred. Ablated — the fix reverted, the suite re-run, the fix reapplied and the restore confirmed byte-identical by patch `sha256`:

```
with the fix       6 passed
fix reverted       4 failed, 2 passed
                   FAILED  a_class_method / a_class_getter / a_class_setter / an_object_literal_method
                   ok      a_function_declaration_still_keeps_it        <- already agreed
                   ok      a_comment_inside_the_parens_is_unmoved       <- the near-miss
```

## Reach

0 carriers, against the caller population rather than a source-text guess. Every `.svelte` under `submodules/svelte/packages/svelte/tests` and `compatibility/pattern-corpus` parsed with the official compiler and walked for the two node shapes that route through the changed site:

```
parsed by official   5,737   (183 rejected — the deliberately-invalid fixtures)
reach the site         214   <- the live control
carry the slot           0
```

The 214 is what makes the 0 readable; without it a population holding no methods produces the identical zero. The collected corpus (~33.9k components) is not materialised on this machine, so 5,737 is not the denominator this project normally quotes.

## The GATES row

`compatibility/GATES.md` row 34 of the two-ports inventory. It records the closed pair *and* the one that remains: `formal_parameters` still answers upstream's `:1771` with the `)`, and nothing reaches it — a TS signature's type is erased from generated output by both compilers, while the same marker written as a value survives on both, so the probe is live rather than blind. It also records both instrument corrections made while measuring the reach, neither of which moved the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
