### PR TITLE
fix(lsp): find a document opened under a symlinked path by its resolved URI

### DIFF
--- a/.changeset/document-store-symlink-key.md
+++ b/.changeset/document-store-symlink-key.md
@@ -1,0 +1,19 @@
+---
+'@rsvelte/language-server': patch
+---
+
+fix(language-server): find a document opened through a symlink
+
+`DocumentStore` is keyed on the URI string the client sent, and several
+responses are post-processed by looking the document up with a URI the server
+derived from the overlay's *resolved* path. When the two differ — a workspace
+under macOS's `/var`, which is a symlink to `/private/var`, is enough — every
+one of those lookups misses and the post-processing is silently skipped.
+
+The store now also indexes each open document by its resolved path and consults
+that only after a direct hit fails, so the common request costs no extra
+syscall and a response still names the URI the client itself opened.
+
+Measured on the hover quote-widening, the loss this was found through: with a
+symlinked workspace the probe scored 2/11 EQ against 6/11 on the realpathed one;
+with the fix the two workspaces are identical cell for cell.

--- a/crates/rsvelte_language_server/src/document.rs
+++ b/crates/rsvelte_language_server/src/document.rs
@@ -3,11 +3,13 @@
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use lsp_types::{Position, Range, TextDocumentContentChangeEvent, Uri};
 
 use crate::text::LineIndex;
+use crate::uri::uri_to_path;
 
 pub struct Document {
     pub uri: Uri,
@@ -87,21 +89,46 @@ impl Document {
 #[derive(Default)]
 pub struct DocumentStore {
     docs: HashMap<String, Document>,
+    /// Resolved path -> the key the client opened it under. A client may open a
+    /// file through a symlink (macOS `/var` is one), and a URI the server
+    /// derives from a resolved path is then not this store's key.
+    by_resolved_path: HashMap<PathBuf, String>,
+}
+
+/// The document's path with every symlink resolved, when it is a file that
+/// exists. `canonicalize` needs the file, so an unsaved buffer has none.
+fn resolved_path(uri: &Uri) -> Option<PathBuf> {
+    std::fs::canonicalize(uri_to_path(uri.as_str())).ok()
 }
 
 impl DocumentStore {
     pub fn open(&mut self, uri: Uri, language_id: String, version: i32, text: String) {
         let key = uri.as_str().to_string();
+        if let Some(path) = resolved_path(&uri) {
+            self.by_resolved_path.insert(path, key.clone());
+        }
         self.docs
             .insert(key, Document::new(uri, language_id, version, text));
     }
 
     pub fn close(&mut self, uri: &Uri) -> Option<Document> {
-        self.docs.remove(uri.as_str())
+        let key = uri.as_str();
+        self.by_resolved_path.retain(|_, opened| opened != key);
+        self.docs.remove(key)
     }
 
     pub fn get(&self, uri: &Uri) -> Option<&Document> {
-        self.get_by_key(uri.as_str())
+        if let Some(document) = self.docs.get(uri.as_str()) {
+            return Some(document);
+        }
+        self.docs.get(self.resolved_key(uri)?)
+    }
+
+    /// The store key for a URI that names the same file through a different
+    /// path. Only consulted after a direct hit fails, so the common request
+    /// costs no syscall.
+    fn resolved_key(&self, uri: &Uri) -> Option<&String> {
+        self.by_resolved_path.get(&resolved_path(uri)?)
     }
 
     /// Look a document up by the raw URI string used as the store's key.
@@ -111,7 +138,11 @@ impl DocumentStore {
     }
 
     pub fn get_mut(&mut self, uri: &Uri) -> Option<&mut Document> {
-        self.docs.get_mut(uri.as_str())
+        if self.docs.contains_key(uri.as_str()) {
+            return self.docs.get_mut(uri.as_str());
+        }
+        let key = self.resolved_key(uri)?.clone();
+        self.docs.get_mut(&key)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Document> {
@@ -145,6 +176,70 @@ mod tests {
             range_length: None,
             text: text.to_string(),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_document_opened_through_a_symlink_is_found_by_its_resolved_uri() {
+        use crate::uri::path_to_uri;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "rsvelte-doc-symlink-{}-{nonce}",
+            std::process::id()
+        ));
+        let real = root.join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        let file = real.join("App.svelte");
+        std::fs::write(&file, "<p>hi</p>\n").unwrap();
+        let link = root.join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        // The client opens through the symlink; the server derives the resolved
+        // path from the overlay and asks for that.
+        let opened = path_to_uri(&link.join("App.svelte")).unwrap();
+        let resolved = path_to_uri(&std::fs::canonicalize(&file).unwrap()).unwrap();
+        assert_ne!(
+            opened.as_str(),
+            resolved.as_str(),
+            "the two paths must differ"
+        );
+
+        let mut store = DocumentStore::default();
+        store.open(
+            opened.clone(),
+            "svelte".to_string(),
+            1,
+            "<p>hi</p>\n".to_string(),
+        );
+
+        assert!(store.get(&opened).is_some(), "the opened URI is the key");
+        assert!(
+            store.get(&resolved).is_some(),
+            "the resolved URI must find it too"
+        );
+        assert!(store.get_mut(&resolved).is_some());
+        // The stored document keeps the client's own URI, because that is what a
+        // response has to name.
+        assert_eq!(store.get(&resolved).unwrap().uri.as_str(), opened.as_str());
+
+        // A file that exists and was never opened must still miss.
+        let other = real.join("Other.svelte");
+        std::fs::write(&other, "x").unwrap();
+        assert!(store.get(&path_to_uri(&other).unwrap()).is_none());
+
+        assert!(store.close(&opened).is_some());
+        assert!(store.get(&opened).is_none());
+        assert!(
+            store.get(&resolved).is_none(),
+            "close must drop the resolved index too"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]


### PR DESCRIPTION
Fixes #4458.

`DocumentStore` keys on the URI string the client sent
(`document.rs`, `docs: HashMap<String, Document>`). Several response rewrites
then look the document up with a URI the server derived from the **overlay's
resolved path** — `source_uri` comes from `ShadowDocument::source_uri`, which is
`path_to_uri` of a canonicalized path. When a workspace sits under a symlink the
two spell the same file differently, every one of those lookups misses, and the
rewrite is skipped with no error anywhere.

macOS's `/var` is a symlink to `/private/var`, so anything under `os.tmpdir()`
is enough to trigger it. That is how it was found: it produced a plausible,
reproducible, **wrong** reading of an unrelated hover range while chasing #4097 —
rsvelte appeared to answer a narrower range than official, when in fact
`widen_hover_range_over_string_quotes` was simply never reached.

## The fix

The store additionally indexes each open document by its resolved path, and
consults that index **only after a direct hit fails**. So the common request
costs no extra syscall, `canonicalize` runs once per open, and the stored
`Document` keeps the client's own URI — which is what a response has to name.
`close` drops the index entry.

## Measured

`zz-hover-4097.mjs` against the pinned official language server, one binary at a
time, varying only whether the workspace path is realpathed:

| binary | composition | symlinked workspace | realpathed workspace |
|---|---|---|---|
| `b8eab7c48b666303` | main + #4097, **without** this fix | 2/11 EQ | 6/11 EQ |
| `376ed9d15699f0bd` | main + this fix, **without** #4097 | **4/11 EQ** | **4/11 EQ** |

Read the rows **across**, not down. The two arms differ by two things, not one —
each carries a different PR — so the down-column `4` against `6` is not a
regression and is not evidence about anything. The claim is entirely
within-arm: before the fix a symlinked workspace and its realpathed twin
disagree (2 against 6); after it they are identical **cell for cell**. Neither
of those comparisons crosses the arm boundary, so #4097's presence or absence
cannot reach them.

The cells that additionally isolate *this* change are the `.ts` specifiers
`'./other'` and `"./two"`, which #4097 does not touch — both go `DIFF -> EQ` on
the symlinked arm, `'./other'` from rsvelte `1:25-1:32` to official's
`1:24-1:33`.

The two binaries no longer exist to re-hash; the prefixes above are the
identifiers recorded when the runs were taken, and they are consistent across
the four notes that mention them.

Note the scale the earlier issue understated: **four** cells move, not two. The
two `.svelte` specifier cells lose their widening under a symlink as well.

## Controls

The unit test is two-sided and is not satisfied by an accident: the resolved URI
must find the document, the opened URI must still find it, the stored
`Document.uri` must remain the client's, a **different file that exists** and was
never opened must still miss, and `close` must drop the resolved index too. It
was ablated by deleting the index write, which reddens it at the resolved-lookup
assertion and nowhere else; restoring leaves the tree byte-identical.

409 language-server tests over 8 targets, 0 failed — that is main's 409 declared minus its one `#[ignore]`d, plus this branch's new test, and the new test's name is in the run. Workspace clippy with
`-D warnings` clean.

## What is not claimed

`self.documents` is read in ~30 places and this measures what the hover guard
loses. Whether other features degrade under a symlinked workspace is
**UNMEASURED** — which is why the fix is at the key rather than at that one call
site. And no gate can see this class: `scripts/compat-lsp/` drives both servers
against paths under the repository checkout, which is not symlinked, so every
unit of the LSP differential gate is on the insensitive side of the axis.

## What this PR's green does not cover

Two different questions, and the checks here answer one of them.

**Ratchet conflict — answered, no.** This branch touches zero files under
`compatibility/lsp-*` or `scripts/compat-lsp/`, so it cannot collide with
another PR moving the same ratchet, and it does not re-admit the ~950
job-minute `lsp-corpus` job. A path test is the right instrument there because
the hazard is a file.

**Whether it moves what the LSP corpus gate measures — UNMEASURED.** That is a
different question and a path test cannot answer it: the gate drives
`rsvelte-language-server`, and this PR changes that binary's document store. A
change with no `scripts/compat-lsp/` path in its diff can still move the gate's
output. `LSP fixture parity current` runs here and is green; the real-world
corpus population is on a schedule, by a deliberate cost decision recorded in
AGENTS.md, so the nightly `lsp-corpus` run is the detector for that axis and
this PR does not pre-empt it.

I am stating this rather than letting the green imply it, and I have narrowed
it one step instead of leaving it as an intuition. The keying change is a no-op
for any document whose path holds no symlink component, so the question is
whether the gate's paths hold one. `scripts/compat-lsp/` calls `realpathSync`
in exactly two places — the pinned-Svelte link and the tsgo binary — and
**never on a workspace root or a document path**, so nothing in the harness
normalises them away; it reduces to the checkout path itself. On a Linux runner
that path has no symlink component. On macOS `/tmp` is a symlink to
`private/tmp`, which is how this defect was found at all.

That makes the residual risk platform-shaped rather than unknown, and it is
still not a measurement of the corpus population — I do not have those
submodules checked out here to count. Read it as: no mechanism identified,
one named place where a mechanism would live, and the nightly as the detector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSuCFoDV9gDHEVPQjPFDmH
