### PR TITLE
fix(client): a comment is a separator wherever whitespace is one in a $props() call

### DIFF
--- a/.changeset/props-call-comment-gap.md
+++ b/.changeset/props-call-comment-gap.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Lower `$props()` when a comment sits between the callee and its parentheses. The client canonicalises the call before its byte matchers run, and that regex admitted a comment only in the gap after `=` — so `$props/* c */()` and `$props(/* c */)` matched nothing, the text helper returned `None`, and its caller read that `None` as *not a props declaration*. The rune was then emitted verbatim: output that parses and throws `ReferenceError: $props is not defined` at first render, with no `rest_excludes` and no import. A comment is a separator wherever whitespace is one, so one gap now spells all three positions. The comment's own slot is unchanged and still differs from upstream, which is a separate defect; this restores the lowering, not the byte.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
@@ -1280,10 +1280,11 @@ pub(crate) fn canonicalize_props_call(s: &str) -> Cow<'_, str> {
     static REGEX_PROPS_ASSIGN: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
         // `[\s\u{feff}]` rather than `\s`: JS counts U+FEFF as whitespace and
         // Unicode's `White_Space` property, which Rust's `\s` follows, does not.
-        regex::Regex::new(
-            r"=[\s\u{feff}]*(?:(?://[^\n]*\n|/\*(?s:.*?)\*/[\s\u{feff}]*))*\$props[\s\u{feff}]*\([\s\u{feff}]*\)",
-        )
-        .unwrap()
+        // A comment is a separator wherever whitespace is one, so the same gap
+        // spells every position; admitting it only after `=` left the rune
+        // un-lowered for `$props/* c */()` and `$props(/* c */)`.
+        const GAP: &str = r"(?:[\s\u{feff}]|//[^\n]*\n|/\*(?s:.*?)\*/)*";
+        regex::Regex::new(&format!(r"={GAP}\$props{GAP}\({GAP}\)")).unwrap()
     });
     // `$$` is the regex-crate escape for a literal `$` in the replacement
     // string (a bare `$props` would be read as a capture-group reference).
@@ -1368,6 +1369,34 @@ mod tests {
         assert_eq!(
             canonicalize_props_call("let { x } =\u{feff}$props()"),
             "let { x } = $props()"
+        );
+    }
+
+    #[test]
+    fn canonicalize_props_call_admits_a_comment_wherever_whitespace_is_admitted() {
+        // A comment is a separator in all three gaps, not only after `=`.
+        for input in [
+            "let p = $props/* c */()",
+            "let p = $props(/* c */)",
+            "let p = /* c */ $props/* c */(/* c */)",
+            "let p = $props //x\n()",
+            "let p = $props(//x\n)",
+        ] {
+            assert_eq!(
+                canonicalize_props_call(input),
+                "let p = $props()",
+                "{input}"
+            );
+        }
+        // A comment does not make a non-call into one, and the callee still has
+        // to be `$props`.
+        assert_eq!(
+            canonicalize_props_call("let p = other/* c */()"),
+            "let p = other/* c */()"
+        );
+        assert_eq!(
+            canonicalize_props_call("let p = $props/* c */(1)"),
+            "let p = $props/* c */(1)"
         );
     }
 

--- a/crates/rsvelte_core/tests/props_call_comment_is_lowered.rs
+++ b/crates/rsvelte_core/tests/props_call_comment_is_lowered.rs
@@ -1,0 +1,111 @@
+//! Pins that a comment adjacent to a `$props()` call does not stop the rune from
+//! being lowered (#4471).
+//!
+//! The client canonicalises the call before its byte matchers run, and that regex
+//! admitted a comment only in the gap after `=`. `$props/* c */()` and
+//! `$props(/* c */)` matched nothing, so `transform_props_destructuring` returned
+//! `None` and its caller read that `None` as *not a props declaration*: the rune
+//! reached the output verbatim, giving text that parses and throws
+//! `ReferenceError: $props is not defined` at first render.
+//!
+//! The assertion is a **property**, not byte-equality with the oracle. A comment
+//! left in the canonicalised span is still dropped from the client output where
+//! official trails it after the declaration's `;` — that is #4448's class, so no
+//! comment-bearing input reaches byte-equality yet and a `pattern-corpus` entry
+//! would have to be listed in a shrink-only ratchet. This gate holds the half the
+//! fix restores; #4448 owns the other half.
+//!
+//! The whitespace rows are the controls that matter. They were lowered before the
+//! fix and after it, and it is the whitespace/comment asymmetry — not the presence
+//! of a separator — that named the mechanism.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            dev: false,
+            filename: Some("T.svelte".into()),
+            ..Default::default()
+        },
+    )
+    .expect("compiles")
+    .js
+    .code
+}
+
+/// A bare `$props` in the output is the defect: it is not imported, not `$$props`,
+/// and not a member of anything.
+fn rune_survives(code: &str) -> bool {
+    code.replace("$$props", "").contains("$props")
+}
+
+const COMMENT_GAPS: &[(&str, &str)] = &[
+    (
+        "between callee and paren",
+        "let { a, ...r } = $props/* c */();",
+    ),
+    ("inside the parens", "let { a, ...r } = $props(/* c */);"),
+    (
+        "both gaps at once",
+        "let { a, ...r } = $props/* c */(/* d */);",
+    ),
+    (
+        "after `=`, already worked",
+        "let { a, ...r } = /* c */ $props();",
+    ),
+];
+
+const WHITESPACE_GAPS: &[(&str, &str)] = &[
+    ("space before paren", "let { a, ...r } = $props ();"),
+    ("space inside parens", "let { a, ...r } = $props( );"),
+    ("newline before paren", "let { a, ...r } = $props\n\t\t();"),
+];
+
+fn wrap(decl: &str) -> String {
+    format!("<script>\n\t{decl}\n</script>\n\n<p>{{a}}{{r.b}}</p>\n")
+}
+
+#[test]
+fn a_comment_next_to_the_props_call_still_lowers_the_rune() {
+    for (name, decl) in COMMENT_GAPS {
+        let code = client(&wrap(decl));
+        assert!(
+            !rune_survives(&code),
+            "{name}: `$props` reached the output\n{code}"
+        );
+        assert!(
+            code.contains("$.rest_props("),
+            "{name}: the rest prop was not lowered\n{code}"
+        );
+    }
+}
+
+#[test]
+fn whitespace_next_to_the_props_call_was_never_the_axis() {
+    for (name, decl) in WHITESPACE_GAPS {
+        let code = client(&wrap(decl));
+        assert!(
+            !rune_survives(&code),
+            "{name}: `$props` reached the output\n{code}"
+        );
+    }
+}
+
+/// Without this the two tests above are satisfied by a compiler that lowers any
+/// call whose callee is followed by a comment.
+///
+/// A locally declared `$props` is **not** available as the control: both compilers
+/// reject a `$`-prefixed declaration outright (`The $ prefix is reserved`), so an
+/// input written that way fails at `expect("compiles")` — which reads as the
+/// control firing when it means the control never ran.
+#[test]
+fn the_widened_gap_does_not_lower_a_different_callee() {
+    let code = client(&wrap("let { a, ...r } = other/* c */();"));
+    assert!(
+        !code.contains("$.rest_props("),
+        "a call to `other` was lowered as the props rune\n{code}"
+    );
+}


### PR DESCRIPTION
Closes #4471.

## The defect

```svelte
<script>
	let { a, ...r } = $props/* c */();
</script>
```

`canonicalize_props_call` normalises a `$props()` call before the text helper's byte matchers run, and its regex admitted a comment only in the gap after `=`:

```
=[\s\u{feff}]*(?:(?://[^\n]*\n|/\*(?s:.*?)\*/[\s\u{feff}]*))*\$props[\s\u{feff}]*\([\s\u{feff}]*\)
                                                                    ^ whitespace only   ^ whitespace only
```

So `$props/* c */()` and `$props(/* c */)` matched nothing, `transform_props_destructuring` returned `None`, and `try_rewrite_props_destructuring_declaration` returned that `None` as `false` — **a helper failure spelled as a classification negative**. The rune then reached the output verbatim:

```js
export default function T($$anchor, $$props) {
	let p = $props(); /* c */     // not imported, not $$props, not a member
```

Output that parses, and throws `ReferenceError: $props is not defined` at first render. No `rest_excludes`, no import. Client only; the server was already correct.

## The axis is the separator's KIND, not its presence

An 8-cell grid over the three gaps, measured against the pinned oracle:

| cell | rune |
|---|---|
| control, no comment | lowered |
| comment after `=` | lowered |
| **comment between `$props` and `(`** | **UNLOWERED** |
| **comment inside the parens** | **UNLOWERED** |
| whitespace between `$props` and `(` | lowered |
| whitespace inside the parens | lowered |
| newline between `$props` and `(` | lowered |

The whitespace rows were always lowered, and that asymmetry is what named the mechanism — the regex distinguished a separator's kind rather than its presence. One `GAP` now spells all three positions, so the omission is no longer expressible per-position.

## Measurement

**Reach.** Over the 9,475 corpus `.svelte` files that mention `$props`, this shape occurs **0** times (positive control: 8,704 contain the literal `$props()`; 284 carry a comment elsewhere in the same declaration). So no collected corpus can hold it at any size.

**Regression.** Two-arm hash sweep over the whole affected population — the one production call site is `props_transforms.rs:3165`, reached only from the client, so `$props`-mentioning files on `client` and `client-dev` is the closed population:

```
A rows 18950  distinct keys 18950     dead A 318
B rows 18950  distinct keys 18950     dead B 318     live 18632
MOVED = 0
```

Arms are hash-distinct (`21ff8d48…` / `79d8c266…`) and probe-distinct (the two cells flip `UNLOWERED -> lowered`), so the zero is a property of the population and not of the arms.

**Ablation.** Reverting the regex reddens `a_comment_next_to_the_props_call_still_lowers_the_rune` and leaves `whitespace_next_to_the_props_call_was_never_the_axis` and `the_widened_gap_does_not_lower_a_different_callee` green. Restored, `git diff` is empty.

## What this deliberately does not fix

A comment left in the canonicalised span is still **dropped** from the client output, where official trails it after the declaration's `;`. That is #4448's class, so no comment-bearing input reaches byte-equality and a `pattern-corpus` entry would have to be **added** to a shrink-only ratchet. The new test pins the property this restores — the rune is lowered — rather than byte-equality with the oracle, which #4448 owns.

One note on the negative control: a locally shadowed `$props` is not available as one, because both compilers reject a `$`-prefixed declaration outright (`The $ prefix is reserved`). An input written that way fails at `expect("compiles")`, which reads as the control firing when it means the control never ran. The control is a different callee instead.

## Verification

`cargo fmt` clean; `cargo clippy --workspace --all-targets --all-features -- -D warnings` exit 0; `props_call_comment_is_lowered` 3 passed; `canonicalize` unit tests 2 passed. Rebased onto `2d553a9c1`; the two intervening merges touch 3 files, none under `crates/rsvelte_core`, `crates/rsvelte_napi`, `compatibility` or `submodules`, so the measurements above still describe this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
