### PR TITLE
fix(client): locate the `$props()` call among code bytes, not by substring

### DIFF
--- a/.changeset/props-scan-code-only.md
+++ b/.changeset/props-scan-code-only.md
@@ -1,0 +1,15 @@
+---
+'@rsvelte/compiler': patch
+---
+
+client: locate the `$props()` call among code bytes, not by substring
+
+`transform_props_destructuring` found the call with a last-occurrence,
+boundary-free substring search, so a trailing comment mentioning `$props` moved
+the anchor into the comment and the declaration was spliced around it — the
+client emitted the comment's own words in code position, which no JS parser
+accepts. It now walks `js_scan::find_code_from`, which skips comments, strings,
+templates and regex literals.
+
+The comment's output slot is unchanged and still differs from upstream; that is
+a separate defect. This restores the code, not the byte.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -7,8 +7,8 @@ use std::fmt::Write as _;
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase2_analyze::scope::BindingKind;
 use crate::compiler::phases::phase3_transform::shared::js_scan::{
-    after_keywords, code_bytes, comment_ranges, ends_inside_line_comment, find_code, skip_opaque,
-    skip_ws_and_comments_back,
+    after_keywords, code_bytes, comment_ranges, ends_inside_line_comment, find_code,
+    find_code_from, skip_opaque, skip_ws_and_comments_back,
 };
 use crate::compiler::phases::phase3_transform::shared::offsets::{
     ByteOffset, CharOffset, CharToByte,
@@ -3132,7 +3132,18 @@ pub(super) fn transform_props_destructuring(
     // distinguish a same-line comment (which may trail a default value inside
     // `$.prop(...)`) from one that has already crossed a line boundary.
     let original_trimmed = line.trim();
-    let props_call = original_trimmed.rfind_sub("$props")?;
+    // The last `$props` **in code**: a plain substring search takes one written in
+    // a trailing comment, and the declaration is then spliced around that.
+    let props_call = {
+        let bytes = original_trimmed.as_bytes();
+        let mut last = None;
+        let mut from = 0;
+        while let Some(at) = find_code_from(bytes, b"$props", from) {
+            last = Some(at);
+            from = at + 1;
+        }
+        last?
+    };
     let assignment = code_bytes(&original_trimmed.as_bytes()[..props_call])
         .filter_map(|(offset, byte)| (byte == b'=').then_some(offset))
         .last()?;

--- a/crates/rsvelte_core/tests/props_comment_text_does_not_steer_the_transform.rs
+++ b/crates/rsvelte_core/tests/props_comment_text_does_not_steer_the_transform.rs
@@ -1,0 +1,133 @@
+//! Pins that a **comment's text** cannot steer the `$props()` declaration
+//! transform (#4472).
+//!
+//! `transform_props_destructuring` located the call with a last-occurrence,
+//! boundary-free substring search, so a trailing comment mentioning `$props`
+//! moved the anchor into the comment and the declaration was spliced around it.
+//! The client emitted `let a } = $.prop($$props, 'a }', 3, $props(): { a: b;);`
+//! — the comment's own words in code position, and text no JS parser accepts.
+//!
+//! The assertion is that every one of these sources generates the **same code**,
+//! because they differ only in the words of a trailing comment. That is the
+//! property the defect violates, and it needs no JS parser to state.
+//!
+//! Byte-equality with the oracle is deliberately not asserted: the comment's
+//! own slot still diverges here (#4448's class, and #4475's), so no
+//! comment-bearing input of this shape reaches EQ and a `pattern-corpus` entry
+//! would have to be listed in a shrink-only ratchet.
+//!
+//! The rows are chosen so the ones that were *already* correct stay in: a scan
+//! keyed on the whole `$props(): { … }` spelling is what the reported cases
+//! share, and `foo(): { … }` / `a plain word` are the neighbours that were fine
+//! before the fix and must stay fine after it.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            dev: false,
+            filename: Some("T.svelte".into()),
+            ..Default::default()
+        },
+    )
+    .expect("compiles")
+    .js
+    .code
+}
+
+/// The generated code with every comment removed. Two sources differing only in
+/// a comment's words must agree here; what the comment itself looks like in the
+/// output is a different question, and one this gate does not answer.
+fn code_without_comments(source: &str) -> String {
+    let code = client(source);
+    let mut out = String::with_capacity(code.len());
+    let bytes = code.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+        } else if bytes[i] == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i = (i + 2).min(bytes.len());
+        } else {
+            out.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// The reported shape: a multi-line type annotation carrying a comment, which is
+/// what sends the declaration down the text path in the first place.
+fn source(trailing_comment: &str) -> String {
+    format!(
+        "<script lang=\"ts\">\n\tlet {{ a }}: {{ // x\n\t\ta: string;\n\t}} = $props(); // {trailing_comment}\n</script>\n<p>x</p>\n"
+    )
+}
+
+/// Each was `UNPARSEABLE` before the fix except the last three, which were
+/// already correct and are here as the neighbours a wider fix would break.
+const TRAILING_COMMENTS: &[&str] = &[
+    "$props(): { a: b; }",
+    "$props(): { a: b }",
+    "$props():{a:b;}",
+    "$props() : { a: b; }",
+    "$props(): { }",
+    "my$props(): { a: b; }",
+    "foo(): { a: b; }",
+    "$props()",
+    "a plain word",
+];
+
+#[test]
+fn a_trailing_comments_words_do_not_change_the_generated_code() {
+    let baseline = code_without_comments(&source("a plain word"));
+
+    // Liveness: without this the test passes for a compiler that emits nothing.
+    assert!(
+        baseline.contains("export default function T($$anchor, $$props)"),
+        "the baseline cell generated no component function, so the comparison below is vacuous:\n{baseline}"
+    );
+
+    for text in TRAILING_COMMENTS {
+        let got = code_without_comments(&source(text));
+        assert_eq!(
+            got, baseline,
+            "the trailing comment `// {text}` changed the generated code; a comment's words must not reach the transform"
+        );
+    }
+}
+
+#[test]
+fn b_the_comments_words_never_reach_code_position() {
+    // The defect's own signature: the comment's braces and semicolon spliced into
+    // the declaration. `a: b` appears in no correct output for this source.
+    for text in TRAILING_COMMENTS {
+        let code = code_without_comments(&source(text));
+        assert!(
+            !code.contains("a: b"),
+            "the trailing comment `// {text}` left its text in code position:\n{code}"
+        );
+    }
+}
+
+#[test]
+fn c_the_annotations_own_comment_is_still_what_selects_this_path() {
+    // Control: drop the comment inside the type annotation and the declaration
+    // never reaches the text path at all. It was correct before the fix and must
+    // stay correct, which is what says the fix did not simply disable the path.
+    let single_line = "<script lang=\"ts\">\n\tlet { a }: { a: string } = $props(); // $props(): { a: b; }\n</script>\n<p>x</p>\n";
+    let code = code_without_comments(single_line);
+    assert!(
+        code.contains("export default function T($$anchor, $$props)") && !code.contains("a: b"),
+        "the single-line-annotation control changed shape:\n{code}"
+    );
+}


### PR DESCRIPTION
Closes #4472.

`transform_props_destructuring` located the `$props()` call with
`original_trimmed.rfind_sub("$props")` — a **last-occurrence, boundary-free
substring** search. A trailing comment mentioning `$props` therefore moved the
anchor into the comment, and the declaration was spliced around it. Measured
output, not inferred:

```js
// rsvelte, before
let a } = $.prop($$props, 'a }', 3, $props(): { a: b;);
```

The comment's own words in code position, and a binder of `a }`. `acorn` rejects
it; the compile call returns successfully. The fix walks
`js_scan::find_code_from`, which skips comments, strings, templates and regex
literals — the same helper the module rune loops already use, and the file
already imports four of its siblings.

## Both arms, pinned oracle

Arms are `sha256 21ff8d48…` (base) and `df8c2bed…` (fix); the oracle is the
recorded submodule pin `7bc0a70fe` (`VERSION 5.57.0`) via
`submodules/svelte/packages/svelte/src/compiler/index.js`. Client, `dev: false`.
Every row's parse verdict is `acorn@8.18.0` on the emitted text.

| trailing comment | base | fix | official |
|---|---|---|---|
| `// $props(): { a: b; }` | **UNPARSEABLE** | PARSES | PARSES |
| `// $props(): { a: b }` | **UNPARSEABLE** | PARSES | PARSES |
| `// $props():{a:b;}` | **UNPARSEABLE** | PARSES | PARSES |
| `// $props() : { a: b; }` | **UNPARSEABLE** | PARSES | PARSES |
| `// $props(): { }` | **UNPARSEABLE** | PARSES | PARSES |
| `// my$props(): { a: b; }` | **UNPARSEABLE** | PARSES | PARSES |
| `// foo(): { a: b; }` | PARSES | PARSES | PARSES |
| `// $props()` | PARSES | PARSES | PARSES |
| `// a plain word` | PARSES | PARSES | PARSES |

The last three are the neighbours that were already correct: they are here so a
wider fix that simply stopped scanning would be visible.

The five single-term rows of the issue's conjunction (no comment in the
annotation / single-line annotation / no annotation / identifier binding / plain
`<script>`) are `EQ` against the oracle on **both** arms, on client and server —
the fix does not move them in either direction.

## Blast radius: `MOVED = 0` over 43,064 pairs

Two arms, one process each (loading two addons in one process segfaults), hashing
`js.code + css.code` per `(id, target)` over the four targets.

| | n |
|---|---|
| rows per arm | 43,064 |
| **distinct keys** per arm | **43,064** (no key collapse) |
| live units | 42,168 |
| rejected by the compiler in both arms | 896 |
| **MOVED** | **0** |
| …of which in the negative control | **0** |

Population is every manifest component whose source mentions `$props` (9,548) —
the changed line is inside `transform_props_destructuring`, which no other
declaration reaches — plus a deterministic 1-in-20 sample of components that
never mention `$props` (1,218) as the negative control.

A `MOVED 0` needs the two arms shown to be distinct, and it is shown two ways
rather than one: the artifacts' `sha256` differ, and a discriminating probe on
the output separates them (the repro is UNPARSEABLE on base and PARSES on fix).
Neither alone would do — equal hashes could still behave identically, and a
probe answers only the hypothesis it is handed.

## The gate is a property, and why it is not a corpus entry

`crates/rsvelte_core/tests/props_comment_text_does_not_steer_the_transform.rs`
asserts that nine sources differing **only** in a trailing comment's words
generate the same comment-stripped code, plus that the comment's text never
reaches code position. That states the defect class without needing a JS parser.

It is not a `compatibility/pattern-corpus` entry because no cell of this shape
reaches `EQ`: the comment's own output slot still diverges (#4448's class, and
#4475's), so an entry would have to be *added* to a shrink-only ratchet. This is
the same call #4473 made for #4471.

Three tests, ablated two-sided: with the fix reverted, `a_…` and `b_…` fail and
`c_…` — the control saying the fix did not simply disable the text path — still
passes. Restored, the tree is byte-identical and all three pass. The ablation was
verified to have *applied* (grep counts on both spellings) before the build was
spent, because a `cargo fmt` reflow silently missed an anchor earlier today and
the resulting green read as "the gate does not discriminate".

## Denominators

`--lib` plus 13 named props test targets: 14 `Running` lines, `running 1972
tests` on the lib, 0 failed anywhere. `cargo fmt` clean; `cargo clippy
--workspace --all-targets --all-features -- -D warnings` exit 0 — `--workspace`
rather than `-p` because `js_scan`'s exports are named across crates.

`scripts/ci/corpus-compat-job-filter.mjs --changed-files` on the real diff
returns `lsp-ratchet=false` (live positive control: the ratchet path returns
`true`), so this PR does not re-admit the 16-shard corpus LSP job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
