### PR TITLE
fix(compiler): repeat a speculated comment run whole, and once for both targets

### DIFF
--- a/.changeset/repeated-comment-runs.md
+++ b/.changeset/repeated-comment-runs.md
@@ -1,0 +1,12 @@
+---
+'@rsvelte/compiler': patch
+---
+
+repeat a speculated comment run whole, on the server as well as the client
+
+acorn-typescript's `tsLookAhead` leaves `isLookahead` unset, so a comment inside
+a `TSTypeLiteral`'s head fires `onComment` during the speculative parse and again
+after the rewind. The rewind replays the whole run, so two comments print
+`c d c d`; rsvelte repeated each comment in place (`c c d d`) and the server did
+not repeat at all. The repeat now happens once, in the stripped script both
+targets read, instead of in a client-only text pass.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -54,14 +54,6 @@ pub(crate) struct ScriptProjection {
     /// module Program drops them. Keeping the ranges separate lets Phase 3 make
     /// that distinction without trying to infer their origin from stripped JS.
     pub(crate) reemitted_comment_outputs: Vec<Range<u32>>,
-    /// The subset of `reemitted_comment_outputs` upstream prints TWICE.
-    ///
-    /// acorn-typescript's `tsLookAhead` does not set `isLookahead`, so a comment
-    /// consumed while speculatively parsing an object type fires `onComment`
-    /// once during the lookahead and again after the rewind. The region that
-    /// speculation covers is a `TSTypeLiteral`'s braces up to the end of its
-    /// first member, which is why an `interface` body never doubles.
-    pub(crate) repeated_comment_outputs: Vec<Range<u32>>,
     /// `(binding end, annotation end)` for every binding whose own type
     /// annotation was erased. Upstream's parser puts the annotation inside the
     /// binding's range, so a node ending at the first is located at the second.
@@ -672,11 +664,10 @@ fn strip_typescript_from_program_impl(
 
     let mut removals: Vec<(u32, u32)> = Vec::new();
     collect_ts_removals_from_program(program, source, &mut removals);
-    let repeat_regions = if include_projection {
-        collect_speculative_type_head_regions(program)
-    } else {
-        Vec::new()
-    };
+    // Not gated on `include_projection`: the repeat is in the emitted text now,
+    // so gating it would make the two strips disagree — and the server reads the
+    // projection-less one while the client reads the other.
+    let repeat_regions = collect_speculative_type_head_regions(program);
     let declarator_annotations = collect_declarator_annotations(program);
 
     // Text-based fallback: strip `declare global { ... }`, `declare module ... { ... }`,
@@ -761,7 +752,6 @@ fn strip_typescript_from_program_impl(
     let mut copied_chunks =
         include_projection.then(|| Vec::with_capacity(merged.len().saturating_add(1)));
     let mut reemitted_comment_outputs = include_projection.then(Vec::new);
-    let mut repeated_comment_outputs = include_projection.then(Vec::new);
     let mut pos = 0u32;
 
     // Comments an erased annotation left behind, waiting for the offset upstream
@@ -777,8 +767,6 @@ fn strip_typescript_from_program_impl(
                 &mut output,
                 copied_chunks.as_mut(),
                 reemitted_comment_outputs.as_mut(),
-                repeated_comment_outputs.as_mut(),
-                &repeat_regions,
             );
         }
         // The official compiler PARSES TypeScript and only removes the
@@ -811,49 +799,21 @@ fn strip_typescript_from_program_impl(
             if (removed.contains("/*") || removed.contains("//"))
                 && let Some(flush_at) = flush_at
             {
+                let plan = plan_reemitted_comments(*remove_start, removed, &repeat_regions);
                 if let Some(init_start) = flush_at {
-                    for (comment_offset, comment) in
-                        crate::compiler::phases::phase3_transform::server::transform_script::extract_comments_from_snippet_with_pos(removed)
-                    {
-                        let comment_start = *remove_start + comment_offset as u32;
-                        pending.push((
-                            init_start,
-                            comment_start,
-                            comment_start + comment.len() as u32,
-                        ));
-                    }
-                } else if let Some(copied_chunks) = copied_chunks.as_mut() {
-                    for (comment_offset, comment) in
-                        crate::compiler::phases::phase3_transform::server::transform_script::extract_comments_from_snippet_with_pos(removed)
-                    {
-                        let comment_start = *remove_start + comment_offset as u32;
-                        let comment_end = comment_start + comment.len() as u32;
-                        let output_start = output.len() as u32;
-                        push_source_range(
-                            source,
-                            comment_start..comment_end,
-                            &mut output,
-                            Some(copied_chunks),
-                        );
-                        let out_range = output_start..output.len() as u32;
-                        reemitted_comment_outputs
-                            .as_mut()
-                            .unwrap()
-                            .push(out_range.clone());
-                        if repeat_regions
-                            .iter()
-                            .any(|(from, to)| comment_start >= *from && comment_end <= *to)
-                        {
-                            repeated_comment_outputs.as_mut().unwrap().push(out_range);
-                        }
-                        output.push('\n');
+                    for (comment_start, comment_end) in plan {
+                        pending.push((init_start, comment_start, comment_end));
                     }
                 } else {
-                    for comment in
-                        crate::compiler::phases::phase3_transform::server::transform_script::extract_comments_from_snippet(removed)
-                    {
-                        output.push_str(&comment);
-                        output.push('\n');
+                    for (comment_start, comment_end) in plan {
+                        emit_pending_comment(
+                            source,
+                            comment_start,
+                            comment_end,
+                            &mut output,
+                            copied_chunks.as_mut(),
+                            reemitted_comment_outputs.as_mut(),
+                        );
                     }
                 }
             }
@@ -870,8 +830,6 @@ fn strip_typescript_from_program_impl(
             &mut output,
             copied_chunks.as_mut(),
             reemitted_comment_outputs.as_mut(),
-            repeated_comment_outputs.as_mut(),
-            &repeat_regions,
         );
     }
     // A flush point the copy never reached (an initializer inside a later removed
@@ -886,8 +844,6 @@ fn strip_typescript_from_program_impl(
                 &mut output,
                 copied_chunks.as_mut(),
                 reemitted_comment_outputs.as_mut(),
-                repeated_comment_outputs.as_mut(),
-                &repeat_regions,
             );
         }
     }
@@ -895,13 +851,64 @@ fn strip_typescript_from_program_impl(
     let projection = copied_chunks.map(|copied_chunks| ScriptProjection {
         copied_chunks,
         reemitted_comment_outputs: reemitted_comment_outputs.unwrap_or_default(),
-        repeated_comment_outputs: repeated_comment_outputs.unwrap_or_default(),
         binding_annotation_ends: collect_binding_annotation_ends(program),
         source_len: source.len() as u32,
         output_len: output.len() as u32,
     });
 
     (output, projection)
+}
+
+/// The comments a removed region re-emits, in order, with the RUNS upstream
+/// prints twice already doubled.
+///
+/// acorn-typescript's `tsLookAhead` does not set `isLookahead`, so a comment
+/// consumed while speculatively parsing an object type fires `onComment` once
+/// during the lookahead and again after the rewind. The rewind replays the whole
+/// speculated run, so two comments in a `TSTypeLiteral` head come out `c d c d`
+/// and not `c c d d` — a per-comment model agrees with a per-run one only for a
+/// single comment, which is why nothing had seen the difference. The region a
+/// speculation covers is the braces up to the end of the first member, which is
+/// why an `interface` body never doubles and a comment after the first member is
+/// left alone.
+///
+/// Doubling here rather than in a phase-3 consumer is what keeps this ONE port:
+/// the stripped text is what both the client's text pipeline and the server's
+/// parse read, so neither has to carry the rule.
+fn plan_reemitted_comments(
+    base: u32,
+    removed: &str,
+    repeat_regions: &[(u32, u32)],
+) -> Vec<(u32, u32)> {
+    let items: Vec<(u32, u32, Option<usize>)> =
+        crate::compiler::phases::phase3_transform::server::transform_script::extract_comments_from_snippet_with_pos(removed)
+            .into_iter()
+            .map(|(comment_offset, comment)| {
+                let start = base + comment_offset as u32;
+                let end = start + comment.len() as u32;
+                let region = repeat_regions
+                    .iter()
+                    .position(|(from, to)| start >= *from && end <= *to);
+                (start, end, region)
+            })
+            .collect();
+
+    let mut plan: Vec<(u32, u32)> = Vec::new();
+    let mut run_start = 0usize;
+    while run_start < items.len() {
+        let region = items[run_start].2;
+        let mut run_end = run_start;
+        while run_end < items.len() && items[run_end].2 == region {
+            run_end += 1;
+        }
+        let run = &items[run_start..run_end];
+        plan.extend(run.iter().map(|&(start, end, _)| (start, end)));
+        if region.is_some() {
+            plan.extend(run.iter().map(|&(start, end, _)| (start, end)));
+        }
+        run_start = run_end;
+    }
+    plan
 }
 
 /// Copy `source_range`, splitting it at every pending flush point it spans so an
@@ -918,8 +925,6 @@ fn push_range_flushing_pending(
     output: &mut String,
     mut copied_chunks: Option<&mut Vec<CopiedSourceChunk>>,
     mut reemitted: Option<&mut Vec<Range<u32>>>,
-    mut repeated: Option<&mut Vec<Range<u32>>>,
-    repeat_regions: &[(u32, u32)],
 ) {
     let mut cursor = source_range.start;
     while let Some(index) = pending
@@ -940,8 +945,6 @@ fn push_range_flushing_pending(
             output,
             copied_chunks.as_deref_mut(),
             reemitted.as_deref_mut(),
-            repeated.as_deref_mut(),
-            repeat_regions,
         );
         cursor = flush_at;
     }
@@ -961,21 +964,11 @@ fn emit_pending_comment(
     output: &mut String,
     copied_chunks: Option<&mut Vec<CopiedSourceChunk>>,
     reemitted: Option<&mut Vec<Range<u32>>>,
-    repeated: Option<&mut Vec<Range<u32>>>,
-    repeat_regions: &[(u32, u32)],
 ) {
     let output_start = output.len() as u32;
     push_source_range(source, comment_start..comment_end, output, copied_chunks);
-    let out_range = output_start..output.len() as u32;
     if let Some(reemitted) = reemitted {
-        reemitted.push(out_range.clone());
-    }
-    if let Some(repeated) = repeated
-        && repeat_regions
-            .iter()
-            .any(|(from, to)| comment_start >= *from && comment_end <= *to)
-    {
-        repeated.push(out_range);
+        reemitted.push(output_start..output.len() as u32);
     }
     output.push('\n');
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -735,28 +735,6 @@ pub(crate) fn transform_client(
         let needs_projection = analysis.runes
             && retained_instance.is_some()
             && instance_script.source_projection.is_some();
-        // A comment inside a `TSTypeLiteral`'s braces, before its first member,
-        // is printed TWICE by upstream: acorn-typescript's `tsLookAhead` leaves
-        // `isLookahead` unset, so the comment fires `onComment` during the
-        // speculative parse and again after the rewind. Phase 2 marks exactly
-        // those, so the text fallback reproduces the count without guessing
-        // from comment contents or script mode.
-        let repeated_projection_comments: Vec<String> = instance_script
-            .source_projection
-            .as_ref()
-            .map(|projection| {
-                projection
-                    .repeated_comment_outputs
-                    .iter()
-                    .filter_map(|range| {
-                        instance_script
-                            .raw
-                            .get(range.start as usize..range.end as usize)
-                    })
-                    .map(str::to_owned)
-                    .collect()
-            })
-            .unwrap_or_default();
         let can_borrow_projection = needs_projection
             && memmem::find(instance_raw.as_bytes(), b"import").is_none()
             && !instance_raw.as_bytes().contains(&b'\r');
@@ -812,18 +790,6 @@ pub(crate) fn transform_client(
             body_projection,
             &mut saw_prop_member_mutation,
         );
-        // Search forward from the previous insertion so two identical comment
-        // texts are matched to two different occurrences rather than both to
-        // the first one.
-        let mut from = 0usize;
-        for comment in &repeated_projection_comments {
-            let Some(rel) = transformed[from..].find(comment.as_str()) else {
-                continue;
-            };
-            let at = from + rel + comment.len();
-            transformed.insert_str(at, &format!("\n{comment}"));
-            from = at + comment.len() + 1;
-        }
         rest_excludes_hoists = extract_rest_excludes_hoists(&mut transformed);
         super::profile::record_script_text(super::profile::timer_elapsed(_script_start));
         super::profile::record_parent_site(false);
@@ -4576,7 +4542,6 @@ fn compose_script_projection(
         // projection. Erased-comment attachment remains source-relative and is
         // still needed when the retained body contains the following prop.
         reemitted_comment_outputs: Vec::new(),
-        repeated_comment_outputs: Vec::new(),
         binding_annotation_ends: source_projection.binding_annotation_ends.clone(),
         source_len: source_projection.source_len,
         output_len: body_len as u32,

--- a/crates/rsvelte_core/tests/repeated_type_head_comment_runs_4373.rs
+++ b/crates/rsvelte_core/tests/repeated_type_head_comment_runs_4373.rs
@@ -86,9 +86,62 @@ fn type_literal(head: &[&str], after_first_member: &str) -> String {
 const INTERFACE: &str = "<script lang=\"ts\">
 interface P {
   // c
+  // d
   a: number;
 }
 let { a }: P = $props();
+</script>
+<i>{a}</i>
+";
+
+/// The same head, written inline on the declarator instead of behind an alias.
+/// This is the host that reaches the held-back (`pending`) re-emission path,
+/// where the comments are flushed at the initializer rather than in place.
+const INLINE_TWO: &str = "<script lang=\"ts\">
+let { a }: {
+  // c
+  // d
+  a: number;
+} = $props();
+</script>
+<i>{a}</i>
+";
+
+const INLINE_ONE: &str = "<script lang=\"ts\">
+let { a }: {
+  // c
+  a: number;
+} = $props();
+</script>
+<i>{a}</i>
+";
+
+/// A declarator with NO initializer: upstream floats the comment to the next
+/// located node and rsvelte drops it (#4396), so nothing here reaches the
+/// repeat at all.
+const UNINITIALIZED: &str = "<script lang=\"ts\">
+let v: {
+  // c
+  // d
+  a: number;
+} | null;
+let { a } = $props();
+</script>
+<i>{a}{v}</i>
+";
+
+/// A `<script module>`'s Program is builder-made, so upstream's comment cursor
+/// starts dead and the comment is printed by neither compiler.
+const MODULE_ALIAS: &str = "<script module lang=\"ts\">
+type Q = {
+  // c
+  // d
+  b: number;
+};
+export const q: Q = { b: 1 };
+</script>
+<script lang=\"ts\">
+let { a } = $props();
 </script>
 <i>{a}</i>
 ";
@@ -127,10 +180,22 @@ fn cells() -> Vec<(&'static str, String, &'static str, &'static str)> {
             "c c d",
         ),
         (
+            "a nested literal in the first member",
+            type_literal(&["  // c", "  // d"], "").replace("a: number;", "a: { e: number };"),
+            "c d c d",
+            "c d c d",
+        ),
+        (
             "an interface body does not speculate",
             INTERFACE.to_string(),
-            "c",
-            "c",
+            "c d",
+            "c d",
+        ),
+        (
+            "a module script's Program is builder-made",
+            MODULE_ALIAS.to_string(),
+            "",
+            "",
         ),
     ]
 }
@@ -177,4 +242,28 @@ fn the_extractor_and_the_compile_are_live() {
         client.contains("export default function C("),
         "not a compiled component: {client}"
     );
+}
+
+/// The hosts where the repeat is right and something upstream of it is not.
+///
+/// These pin what rsvelte answers TODAY, which is not what the oracle answers,
+/// so that the residue is written down rather than merely unexamined. Each cell
+/// names the issue that owns it; when one is fixed this test fails and the row
+/// moves into the table above.
+#[test]
+fn the_blocked_hosts_are_pinned_rather_than_matched() {
+    // An inline annotation on a destructured `$props()` loses its comment on the
+    // CLIENT before the repeat can apply (#4398) — the declaration is rebuilt
+    // from the pattern. The server keeps it and repeats the run correctly.
+    assert_eq!(sequence(INLINE_TWO, GenerateMode::Client), "");
+    assert_eq!(sequence(INLINE_TWO, GenerateMode::Server), "c d c d");
+    assert_eq!(sequence(INLINE_ONE, GenerateMode::Client), "");
+    assert_eq!(sequence(INLINE_ONE, GenerateMode::Server), "c c");
+
+    // An annotation on an UNINITIALIZED declarator is dropped on both targets
+    // (#4396): upstream ends the declaration at the identifier and floats the
+    // comment to the next located node, which rsvelte has no channel for. The
+    // oracle prints `c d c d` on both.
+    assert_eq!(sequence(UNINITIALIZED, GenerateMode::Client), "");
+    assert_eq!(sequence(UNINITIALIZED, GenerateMode::Server), "");
 }

--- a/crates/rsvelte_core/tests/repeated_type_head_comment_runs_4373.rs
+++ b/crates/rsvelte_core/tests/repeated_type_head_comment_runs_4373.rs
@@ -1,0 +1,180 @@
+//! acorn-typescript's `tsLookAhead` does not set `isLookahead`, so a comment
+//! consumed while speculatively parsing an object type fires `onComment` once
+//! during the lookahead and again after the rewind. Upstream therefore prints
+//! that comment twice, and byte equality is the goal, so rsvelte reproduces it.
+//!
+//! The rewind replays everything the speculation consumed, so the unit repeated
+//! is the RUN, not the comment: two comments in a `TSTypeLiteral` head print
+//! `c d c d` and not `c c d d`. A per-comment model agrees with a per-run one
+//! for exactly one comment, which is the whole reason a grid built on a single
+//! comment could not see the difference.
+//!
+//! Every expected sequence below was read out of the oracle
+//! (`submodules/svelte/.../src/compiler/index.js`, `dev: false`) rather than
+//! reasoned about. The `interface` row is the negative control: upstream does
+//! not speculate over an interface body, so nothing repeats there and the cell
+//! must stay single on BOTH targets — an assertion set that only ever expects a
+//! doubling is satisfied by a compiler that doubles everything.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// The single-letter comments of `code`, in the order they are printed.
+///
+/// The letters are what the grid varies; every other comment the compiler emits
+/// (`/* @__PURE__ */`, a `svelte-ignore`) is longer than one character, so this
+/// reads the axis and not the noise.
+fn letters(code: &str) -> String {
+    let bytes = code.as_bytes();
+    let mut out: Vec<&str> = Vec::new();
+    let mut i = 0usize;
+    while i + 1 < bytes.len() {
+        let (from, to, next) = if &bytes[i..i + 2] == b"//" {
+            let end = code[i + 2..]
+                .find(NEWLINE)
+                .map_or(code.len(), |n| i + 2 + n);
+            (i + 2, end, end)
+        } else if &bytes[i..i + 2] == b"/*" {
+            let Some(n) = code[i + 2..].find("*/") else {
+                break;
+            };
+            (i + 2, i + 2 + n, i + 4 + n)
+        } else {
+            i += 1;
+            continue;
+        };
+        let text = code[from..to].trim();
+        if text.len() == 1 && text.chars().all(|c| c.is_ascii_lowercase()) {
+            out.push(text);
+        }
+        i = next;
+    }
+    out.join(" ")
+}
+
+const NEWLINE: char = '\n';
+
+fn sequence(source: &str, generate: GenerateMode) -> String {
+    let js = compile(
+        source,
+        CompileOptions {
+            filename: Some("C.svelte".to_string()),
+            generate,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    letters(&js)
+}
+
+/// `head` are the lines inside the `type P = {` braces before the first member.
+fn type_literal(head: &[&str], after_first_member: &str) -> String {
+    let mut lines = vec!["<script lang=\"ts\">".to_string(), "type P = {".to_string()];
+    for line in head {
+        lines.push((*line).to_string());
+    }
+    lines.push(format!("  a: number;{after_first_member}"));
+    lines.push("};".to_string());
+    lines.push("let { a }: P = $props();".to_string());
+    lines.push("</script>".to_string());
+    lines.push("<i>{a}</i>".to_string());
+    lines.push(String::new());
+    lines.join("\n")
+}
+
+const INTERFACE: &str = "<script lang=\"ts\">
+interface P {
+  // c
+  a: number;
+}
+let { a }: P = $props();
+</script>
+<i>{a}</i>
+";
+
+/// `(name, source, client, server)` — the last two are the oracle's answers.
+fn cells() -> Vec<(&'static str, String, &'static str, &'static str)> {
+    vec![
+        (
+            "one line comment in the head",
+            type_literal(&["  // c"], ""),
+            "c c",
+            "c c",
+        ),
+        (
+            "one block comment in the head",
+            type_literal(&["  /*c*/"], ""),
+            "c c",
+            "c c",
+        ),
+        (
+            "two line comments in the head",
+            type_literal(&["  // c", "  // d"], ""),
+            "c d c d",
+            "c d c d",
+        ),
+        (
+            "three line comments in the head",
+            type_literal(&["  // c", "  // d", "  // e"], ""),
+            "c d e c d e",
+            "c d e c d e",
+        ),
+        (
+            "one in the head, one after the first member",
+            type_literal(&["  // c"], " // d"),
+            "c c d",
+            "c c d",
+        ),
+        (
+            "an interface body does not speculate",
+            INTERFACE.to_string(),
+            "c",
+            "c",
+        ),
+    ]
+}
+
+#[test]
+fn a_speculated_comment_run_is_repeated_whole_on_both_targets() {
+    let mut wrong: Vec<String> = Vec::new();
+    for (name, source, client, server) in cells() {
+        for (generate, expected, target) in [
+            (GenerateMode::Client, client, "client"),
+            (GenerateMode::Server, server, "server"),
+        ] {
+            let actual = sequence(&source, generate);
+            if actual != expected {
+                wrong.push(format!("{name} / {target}: {actual:?} != {expected:?}"));
+            }
+        }
+    }
+    assert!(wrong.is_empty(), "{}", wrong.join("\n"));
+}
+
+/// The letter extractor reads a real axis rather than always answering the
+/// same thing: a source with no comment at all must come back empty, and the
+/// generated code must be the component it claims to be.
+#[test]
+fn the_extractor_and_the_compile_are_live() {
+    let plain = "<script lang=\"ts\">\ntype P = { a: number };\nlet { a }: P = $props();\n</script>\n<i>{a}</i>\n";
+    assert_eq!(sequence(plain, GenerateMode::Client), "");
+    assert_eq!(sequence(plain, GenerateMode::Server), "");
+
+    let source = type_literal(&["  // c"], "");
+    let client = compile(
+        &source,
+        CompileOptions {
+            filename: Some("C.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    assert!(
+        client.contains("export default function C("),
+        "not a compiled component: {client}"
+    );
+}


### PR DESCRIPTION
Closes #4373.

## What

`@sveltejs/acorn-typescript`'s `tsLookAhead` does not set `isLookahead`, so a comment consumed while speculatively parsing an object type fires `onComment` during the lookahead and again after the rewind. Upstream prints it twice; byte equality is the goal, so rsvelte reproduces it. Two things were wrong with how:

1. **The unit is the run, not the comment.** The rewind replays everything the speculation consumed, so two comments in a `TSTypeLiteral` head print `c d c d`; rsvelte repeated each comment in place and printed `c c d d`. One comment is where the two rules agree, which is the whole reason a grid built on a single comment could not see it.
2. **The server did not repeat at all.** `repeated_comment_outputs` had exactly one consumer — a client-side text pass — so the rule lived on one of the two ports.

## How

Both halves close together because the repeat moves into the stripped script text, which is what phase 3 reads on *both* targets. Emitting the run twice there is what makes it one port rather than two: the client's text pipeline and the server's parse each see the comment list upstream's `analysis.comments` holds, and neither carries the rule. The client's text-insertion pass is deleted rather than mirrored.

**Doubling it in the server's own comment list cannot work, and that was measured rather than reasoned.** The obvious server fix is to put a duplicate into the parsed comment list carrying the same range the original does — which is exactly what upstream's list holds, since `onComment` fires twice for one range. It moved 3 of the 5 server rows and then printed `c c d d`: `print_with_comments` builds a buffer, shifts every comment onto it and lets the printer flush in **span order**, so two copies at one range cannot be separated by list position. The run has to exist twice in the text.

`collect_speculative_type_head_regions` is no longer gated on `include_projection`. That gate was sound while the marker set was projection-only and is wrong once the repeat is in the emitted text: the server reads the projection-less strip and the client reads the other, so gating it makes the two strips disagree about their own output. With the repeat in place and the gate left alone, all six client rows went green and all five server rows stayed **byte-identical to `main`** — a fix that looks complete on one target and inert on the other, with no error anywhere.

## Grid

Oracle `submodules/svelte/…/src/compiler/index.js`, the pinned `7bc0a70fe` / `VERSION 5.57.0`, `dev: false`. Every expected sequence is read out of the oracle rather than reasoned about.

| cell | client | server | before |
|---|---|---|---|
| 1 line comment in the head | `c c` | `c c` | client EQ, server `c` |
| 1 block comment in the head | `c c` | `c c` | client EQ, server `/*c*/` |
| 2 line comments in the head | `c d c d` | `c d c d` | client `c c d d`, server `c d` |
| 3 line comments in the head | `c d e c d e` | `c d e c d e` | client `c c d d e e`, server `c d e` |
| 1 in the head + 1 after member 1 | `c c d` | `c c d` | client EQ, server `c d` |
| nested literal in the first member | `c d c d` | `c d c d` | client `c c d d`, server `c d` |
| `interface` body (negative control) | `c d` | `c d` | EQ — no speculation, nothing doubles |
| `<script module>` alias (negative control) | *(none)* | *(none)* | EQ — a builder-made Program, upstream prints nothing either |

The two negative controls are there because an assertion set that only ever expects a doubling is satisfied by a compiler that doubles everything.

## The host axis, and the two rows it pins

The first grid held the annotation's **host** fixed at a `type X = {}` alias. Crossed against the other hosts, the answers split three ways, not two — so a second test pins what rsvelte answers today and names the issue that owns each row:

| host | client | server |
|---|---|---|
| inline annotation on the declarator | *(nothing)* — **#4398**, the client rebuilds a destructured `$props()` declaration and loses the comment before the repeat can apply | `c d c d` ✔ matches |
| uninitialized declarator | *(nothing)* — **#4396** | *(nothing)* — **#4396** |

The oracle prints `c d c d` for both. Fixing either issue turns that test red, which is where those rows move.

## Reach

Two-arm sweep over the collected corpus, `client` + `server`, `dev: false`. Arms: `main + #4472` (`sha256 df8c2bed…`) and this branch (`c9f34430…`); identified by a two-sided probe on their own output — a two-comment head reads `c c d d` / `c d` on the base and `c d c d` / `c d c d` on the head, and a comment-free source reads the same on both. #4472 is in the base and not the head, and it can only fire when a **comment contains `$props`**: of the 159 screened carriers, **0** do, against a live positive control of **9** in the whole 33,890-file corpus — so the confound is measured to zero rather than argued away.

```
base rows 67780  distinct keys 67780  dead 2487
head rows 67780  distinct keys 67780  dead 2487
MOVED 146  {client: 1, server: 145}   over 145 files, 0 units where either side threw
```

Scored against the oracle on the moved set only, with raw bytes — **stricter** than the gate, which normalizes with oxfmt and rescues under `ast_equiv_batch`'s `CommentPolicy::Ignore`:

| | whole `js.code` | comment sequence |
|---|---:|---:|
| `MISMATCH -> match` | 5 | 11 |
| **`match -> MISMATCH`** | **0** | **0** |
| `MISMATCH -> MISMATCH` | 141 | 135 |

A zero under a stricter comparator is a zero under the gate, so that direction needs no fidelity argument. None of the 146 moved ids is listed in any of the four output ratchets (`0 / 2 / 0 / 2` entries), so there is nothing to re-baseline.

On a source-shape screen (159 carriers with a comment in a `type X = {` head), the issue's own key — how many comments each side prints — moves on the server from **79 short / 0 extra** to **2 short / 0 extra**.

**Two numbers here correct the issue's framing.** Only **one** client unit moves in 33,890 files, because per-comment and per-run repetition give the same output for a single-comment run and a multi-comment type head is that rare; the client half is an *ordering* fix that a count key cannot see at all. And the issue read "89 of 89 unanimous short" as this mechanism's reach — the direction was right and the attribution too wide: 141 of the 146 moved units still diverge, for comment-text reasons (#4244 / #4279) and for #4396 / #4398. A direction is not an attribution.

## Gates

`cargo test -p rsvelte_core --lib` (1,971 passed) plus `ssr`, `compiler_fixtures`, `compiler_errors`, `print`, `sourcemaps`, `parser_fixtures`, `validator`, `css`, `erased_annotation_comment`, `erased_annotation_comment_initializer`, `type_literal_head_comment_repeat`, `client_script_comments_pin`, `module_comment_ownership`, `module_server_comment_ownership_2307`, `server_removed_statement_comments_2567`, `ssr_typescript_erasure` — all green. `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
