### PR TITLE
fix(svelte2tsx): give a component's tag name its own source range

### DIFF
--- a/.changeset/component-name-source-range.md
+++ b/.changeset/component-name-source-range.md
@@ -1,0 +1,19 @@
+---
+'@rsvelte/compiler': patch
+'@rsvelte/svelte2tsx': patch
+'@rsvelte/svelte-check': patch
+---
+
+fix(svelte2tsx): give a component's tag name its own source range
+
+`handle_component` interpolated the tag name into the
+`__sveltets_2_ensureComponent(<name>)` header with `format!`, so the name
+reached the shadow as generated text with no map segment and
+`textDocument/hover` on a `<Comp />` tag answered `null`. Upstream pushes
+`[nodeNameStart, nodeNameEnd]` — a source range — into that exact position
+(`InlineComponent.ts:101-110`), and `<svelte:component this={…}>` is the same
+shape with `[node.expression.start, node.expression.end]`.
+
+Both now go through `segs_push_src`, so the name and the `this` expression reach
+the shadow as unedited source chunks. The generated TSX is unchanged; only the
+map moves.

--- a/.changeset/svelte-specifier-hover.md
+++ b/.changeset/svelte-specifier-hover.md
@@ -1,0 +1,19 @@
+---
+'@rsvelte/language-server': patch
+---
+
+fix(language-server): hover a `.svelte` import specifier
+
+The overlay rewrites `'./Other.svelte'` to `'./Other.svelte.tsx'` so tsgo can
+resolve it, and registered those four inserted bytes in the same
+`generated_ranges` list as the `Ωignore` regions. `is_generated_range` is an
+intersection test and `map_generated_range` bails on it, so every tsgo response
+whose range covers the specifier — the hover, and any range-carrying feature
+anchored there — was discarded before it was mapped, and the client saw `null`.
+
+The two kinds are not the same thing: an `Ωignore` region is whole synthetic
+text with no source, while a `.tsx` insertion is four synthetic bytes inside a
+token the user wrote. The insertions move to their own list, consulted for a
+*position* as before and not for a *range*; a range lying wholly inside an
+insertion still returns `None`, because both its endpoints fail the position
+check.

--- a/crates/rsvelte_language_server/src/tsgo_overlay.rs
+++ b/crates/rsvelte_language_server/src/tsgo_overlay.rs
@@ -179,6 +179,10 @@ struct ShadowState {
     source_map: Option<String>,
     tokens: Vec<MappingToken>,
     generated_ranges: Vec<std::ops::Range<usize>>,
+    /// The `.tsx` bytes inserted into a `.svelte` module specifier. Unlike an
+    /// `Ωignore` region these sit *inside* a real token, so a range that spans
+    /// one is still the user's own text and must map.
+    specifier_insertions: Vec<std::ops::Range<usize>>,
     identity: bool,
     plain_insertions: Vec<(usize, std::ops::Range<usize>)>,
     /// Byte offset in `source_text` that generated offset 0 corresponds to,
@@ -190,6 +194,16 @@ struct ShadowState {
     /// `None` for an `identity` entry, whose text is the user's own: a
     /// `function $$render()` they wrote is a real declaration, not ours.
     render_return_type: Option<usize>,
+}
+
+impl ShadowState {
+    /// Whether a shadow byte offset carries no source text of its own.
+    fn is_generated_offset(&self, offset: usize) -> bool {
+        self.generated_ranges
+            .iter()
+            .chain(&self.specifier_insertions)
+            .any(|range| range.contains(&offset))
+    }
 }
 
 /// Workspace-scoped diskless overlay used by the tsgo LSP proxy.
@@ -390,12 +404,11 @@ impl TsgoOverlay {
             text: generated_text,
             version,
         };
-        let mut generated_ranges = ignored_ranges(&document.text);
-        generated_ranges.extend(
-            import_insertions
-                .iter()
-                .map(|(_, generated)| generated.clone()),
-        );
+        let generated_ranges = ignored_ranges(&document.text);
+        let specifier_insertions = import_insertions
+            .iter()
+            .map(|(_, generated)| generated.clone())
+            .collect();
         let state = ShadowState {
             source_path: source_path.clone(),
             shadow_path: shadow_path.clone(),
@@ -414,6 +427,7 @@ impl TsgoOverlay {
             tokens,
             generated_ranges,
             render_return_type: render_return_type_offset(&document.text),
+            specifier_insertions,
             identity: false,
             plain_insertions: Vec::new(),
             fragment_offset: 0,
@@ -468,6 +482,7 @@ impl TsgoOverlay {
             source_map: None,
             generated_ranges: Vec::new(),
             render_return_type: None,
+            specifier_insertions: Vec::new(),
             identity: true,
             plain_insertions: Vec::new(),
             fragment_offset,
@@ -531,6 +546,7 @@ impl TsgoOverlay {
             source_map: None,
             generated_ranges: Vec::new(),
             render_return_type: None,
+            specifier_insertions: Vec::new(),
             identity: true,
             plain_insertions,
             fragment_offset: 0,
@@ -812,11 +828,7 @@ impl TsgoOverlay {
                     .position(&entry.source_text, source_offset),
             );
         }
-        if entry
-            .generated_ranges
-            .iter()
-            .any(|range| range.contains(&generated_offset))
-        {
+        if entry.is_generated_offset(generated_offset) {
             return None;
         }
 
@@ -868,10 +880,7 @@ impl TsgoOverlay {
             return false;
         };
         let offset = utf8_offset(&entry.document.text, position);
-        entry
-            .generated_ranges
-            .iter()
-            .any(|range| range.contains(&offset))
+        entry.is_generated_offset(offset)
     }
 
     /// Whether a tsgo position is the return-type slot of the generated
@@ -891,7 +900,10 @@ impl TsgoOverlay {
         utf8_offset(&entry.document.text, position) == offset
     }
 
-    /// Whether any byte of a tsgo range intersects generated-code markers.
+    /// Whether any byte of a tsgo range intersects an `Ωignore` region.
+    ///
+    /// A `.tsx` specifier insertion is deliberately not counted: it sits inside
+    /// a token the user wrote, so the enclosing range is theirs and must map.
     #[must_use]
     pub fn is_generated_range(&self, shadow_path: &Path, range: Range) -> bool {
         let Some(source_path) = self.source_for_shadow(shadow_path) else {
@@ -3056,6 +3068,57 @@ mod tests {
         let position = utf8_position(&shadow.text, ignored);
         assert!(overlay.is_generated_position(&shadow_path, position));
         assert_eq!(overlay.map_generated_position(&shadow_path, position), None);
+    }
+
+    #[test]
+    fn a_svelte_specifier_range_maps_back_across_its_tsx_insertion() {
+        let workspace = TestWorkspace::new("specifier-range");
+        let other = workspace.0.join("Other.svelte");
+        write(&other, "<p>other</p>\n");
+        let app = workspace.0.join("App.svelte");
+        let source = "<script>import Other from './Other.svelte';</script>\n<Other />\n";
+        write(&app, source);
+        let overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let shadow_path = overlay.shadow_dir.join("App.svelte.tsx");
+        let shadow = overlay.shadow_for_source(&app).unwrap();
+
+        let rewritten = "'./Other.svelte.tsx'";
+        let start = shadow.text.find(rewritten).unwrap();
+        let insertion = shadow.text.find(".tsx'").unwrap();
+
+        // The whole specifier: the user's own token, four synthetic bytes long.
+        let quoted = Range::new(
+            utf8_position(&shadow.text, start),
+            utf8_position(&shadow.text, start + rewritten.len()),
+        );
+        assert!(!overlay.is_generated_range(&shadow_path, quoted));
+        let mapped = overlay.map_generated_range(&shadow_path, quoted).unwrap();
+        let mapped_text = {
+            let index = crate::text::LineIndex::new(source);
+            let from = index.offset(source, mapped.start);
+            let to = index.offset(source, mapped.end);
+            source[from..to].to_string()
+        };
+        assert_eq!(mapped_text, "'./Other.svelte'");
+
+        // A range lying wholly inside the insertion has no source text at all,
+        // so narrowing the range rule must not let it through.
+        let synthetic = Range::new(
+            utf8_position(&shadow.text, insertion),
+            utf8_position(&shadow.text, insertion + 4),
+        );
+        assert_eq!(overlay.map_generated_range(&shadow_path, synthetic), None);
+        assert!(overlay.is_generated_position(&shadow_path, synthetic.start));
+
+        // An `Ωignore` region is the other kind and still rejects a range that
+        // merely touches it.
+        let ignored = shadow.text.find(IGNORE_START).unwrap();
+        let touching = Range::new(
+            utf8_position(&shadow.text, ignored.saturating_sub(2)),
+            utf8_position(&shadow.text, ignored + IGNORE_START.len() + 1),
+        );
+        assert!(overlay.is_generated_range(&shadow_path, touching));
+        assert_eq!(overlay.map_generated_range(&shadow_path, touching), None);
     }
 
     #[cfg(unix)]

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -7,6 +7,18 @@ fn source_offset(value: usize) -> u32 {
     u32::try_from(value).expect("template source offsets are represented as u32")
 }
 
+/// The source range of a component's tag name, located the way upstream locates
+/// it (`InlineComponent.ts:103`, `str.original.indexOf(node.name, node.start)`).
+fn component_name_range(comp: &Component, source: &str) -> Option<(u32, u32)> {
+    let start = comp.start as usize;
+    let offset = source.get(start..)?.find(comp.name.as_str())?;
+    let name_start = start + offset;
+    Some((
+        source_offset(name_start),
+        source_offset(name_start + comp.name.len()),
+    ))
+}
+
 use crate::ast::template::{
     Attribute, Component, SvelteComponentElement, SvelteElement, TemplateNode,
 };
@@ -26,7 +38,9 @@ use crate::svelte2tsx::template::attributes::let_::{
 };
 use crate::svelte2tsx::template::attributes::spread::format_spread_attribute_segments;
 use crate::svelte2tsx::template::ctx::{Counter, ElementOpenerCommentIndex};
-use crate::svelte2tsx::template::segs::{Seg, bake_out_of_order_src, emit_segmented_overwrite};
+use crate::svelte2tsx::template::segs::{
+    Seg, bake_out_of_order_src, emit_segmented_overwrite, segs_push_lit, segs_push_src,
+};
 use crate::svelte2tsx::template::utils::expr::{
     extend_expr_end_with_ts_postfix, get_binding_lhs_text, get_expression_end_stripping_ts,
     get_expression_range, get_expression_text, get_set_binding_ranges,
@@ -315,30 +329,35 @@ pub fn handle_component(
     // is appended (as ignore-wrapped statements) for every non-`bind:this`
     // binding on a component.
     let component_bind_suffix = build_component_bind_suffix(&comp.attributes, source, &inst_var);
-    let (header_lit, trailer_lit) = if needs_instance {
+    let (header_pre, header_post, trailer_lit) = if needs_instance {
         let on_calls = if has_events {
             build_on_calls(&inst_var, &on_directives, source)
         } else {
             String::new()
         };
         (
+            format!("{block_indent}{{ const {inst_var}C = __sveltets_2_ensureComponent("),
             format!(
-                "{}{{ const {}C = __sveltets_2_ensureComponent({}); const {} = new {}C({{ target: __sveltets_2_any(), props: {{",
-                block_indent, inst_var, comp.name, inst_var, inst_var,
+                "); const {inst_var} = new {inst_var}C({{ target: __sveltets_2_any(), props: {{"
             ),
             format!("}}}});{component_bind_suffix}{on_calls}"),
         )
     } else {
         (
-            format!(
-                "{}{{ const {}C = __sveltets_2_ensureComponent({}); new {}C({{ target: __sveltets_2_any(), props: {{",
-                block_indent, inst_var, comp.name, inst_var,
-            ),
+            format!("{block_indent}{{ const {inst_var}C = __sveltets_2_ensureComponent("),
+            format!("); new {inst_var}C({{ target: __sveltets_2_any(), props: {{"),
             "}});".to_string(),
         )
     };
-    let mut opener_segs: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 2);
-    opener_segs.push(Seg::Lit(header_lit));
+    let mut opener_segs: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 4);
+    opener_segs.push(Seg::Lit(header_pre));
+    // The name is the `__sveltets_2_ensureComponent` argument and upstream gives
+    // it its own source range, so hover on the tag name resolves through it.
+    match component_name_range(comp, source) {
+        Some((start, end)) => segs_push_src(&mut opener_segs, start, end),
+        None => segs_push_lit(&mut opener_segs, comp.name.as_str()),
+    }
+    segs_push_lit(&mut opener_segs, &header_post);
     opener_segs.extend(attr_segs);
     if !use_snippet_props {
         // The snippet-prop path leaves the `props: { … ` object literal open so
@@ -703,30 +722,39 @@ pub fn handle_svelte_component(
     } else {
         " ".repeat(scomp_spacing.before_block)
     };
-    let (header_lit, trailer_lit) = if needs_inst {
+    let (header_pre, header_post, trailer_lit) = if needs_inst {
         let on_calls = if has_events {
             build_on_calls(&inst_var, &on_directives, source)
         } else {
             String::new()
         };
         (
+            format!("{block_indent}{{ const {inst_var}C = __sveltets_2_ensureComponent("),
             format!(
-                "{block_indent}{{ const {inst_var}C = __sveltets_2_ensureComponent({expr_text}); const {inst_var} = new {inst_var}C({{ target: __sveltets_2_any(), props: {{"
+                "); const {inst_var} = new {inst_var}C({{ target: __sveltets_2_any(), props: {{"
             ),
             format!("}}}});{component_bind_suffix}{on_calls}"),
         )
     } else {
         (
-            format!(
-                "{block_indent}{{ const {inst_var}C = __sveltets_2_ensureComponent({expr_text}); new {inst_var}C({{ target: __sveltets_2_any(), props: {{"
-            ),
+            format!("{block_indent}{{ const {inst_var}C = __sveltets_2_ensureComponent("),
+            format!("); new {inst_var}C({{ target: __sveltets_2_any(), props: {{"),
             "}});".to_string(),
         )
     };
     // The snippet-props path keeps the props object open so the demoted
     // `{#snippet}` children can be moved inside it.
-    let mut opener: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 3);
-    opener.push(Seg::Lit(header_lit));
+    let mut opener: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 4);
+    opener.push(Seg::Lit(header_pre));
+    // `this={expr}` is upstream's `[node.expression.start, node.expression.end]`
+    // entry, so the expression reaches the shadow as an unedited source chunk.
+    match get_expression_range(&comp.expression) {
+        Some((start, end)) if !expr_text.is_empty() => {
+            segs_push_src(&mut opener, start, end);
+        }
+        _ => segs_push_lit(&mut opener, expr_text),
+    }
+    segs_push_lit(&mut opener, &header_post);
     opener.extend(attr_segs);
     if !use_snippet_props {
         opener.push(Seg::Lit(trailer_lit.clone()));

--- a/crates/rsvelte_projection/tests/svelte2tsx_component_name_map_4097.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_component_name_map_4097.rs
@@ -1,0 +1,145 @@
+//! A component's tag name was interpolated into the
+//! `__sveltets_2_ensureComponent(<name>)` header as generated text, so the name
+//! reached the shadow with no map segment and `textDocument/hover` on a
+//! `<Comp />` tag answered `null` where official answers. Upstream pushes
+//! `[nodeNameStart, nodeNameEnd]` — a source RANGE — into the same position
+//! (`InlineComponent.ts:101-110`), and `this={…}` on `<svelte:component>` is
+//! `[node.expression.start, node.expression.end]` at `:102`.
+//!
+//! The generated TSX is unchanged, so neither the 253 svelte2tsx fixtures nor
+//! the map gate (which asserts well-formedness, not equality) can see this.
+//! The attribute-value cells already pass on `main` — they are regression
+//! guards, not discriminating cells.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+use std::collections::HashSet;
+
+struct Projected {
+    code: String,
+    map: sourcemap::SourceMap,
+}
+
+fn project(source: &str) -> Projected {
+    let result = svelte2tsx(
+        source,
+        Svelte2TsxOptions {
+            filename: "A.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx");
+    let map = sourcemap::SourceMap::from_slice(result.map.as_deref().expect("map").as_bytes())
+        .expect("valid source map");
+    Projected {
+        code: result.code,
+        map,
+    }
+}
+
+fn mapped_source_positions(projected: &Projected) -> HashSet<(u32, u32)> {
+    projected
+        .map
+        .tokens()
+        .map(|token| (token.get_src_line(), token.get_src_col()))
+        .collect()
+}
+
+/// `(line, first column)` of `needle` in `text`.
+fn locate(text: &str, needle: &str) -> (u32, u32) {
+    let line = text
+        .lines()
+        .position(|line| line.contains(needle))
+        .unwrap_or_else(|| panic!("needle {needle:?} not found in\n{text}"));
+    let column = text.lines().nth(line).unwrap().find(needle).unwrap();
+    (line as u32, column as u32)
+}
+
+fn span_of(source: &str, marker: &str, name: &str) -> (u32, u32, u32) {
+    // `marker.find(name)` takes the FIRST occurrence, so a name that also occurs
+    // inside the attribute/directive name silently points the assertion at text
+    // that is never mapped (`style:color={col}` finds the `col` of `color`).
+    assert_eq!(
+        marker.matches(name).count(),
+        1,
+        "{name:?} occurs {} times in {marker:?}; pick a name unique within the marker",
+        marker.matches(name).count(),
+    );
+    let (line, column) = locate(source, marker);
+    let start = column + (marker.find(name).expect("name inside marker") as u32);
+    (line, start, start + name.len() as u32)
+}
+
+/// Every character of `name` inside `marker` carries a map segment.
+fn assert_mapped(source: &str, marker: &str, name: &str) {
+    let projected = project(source);
+    let mapped = mapped_source_positions(&projected);
+    let (line, start, end) = span_of(source, marker, name);
+    for c in start..end {
+        assert!(
+            mapped.contains(&(line, c)),
+            "{marker}: source {line}:{c} carries no map segment\n--- generated ---\n{}",
+            projected.code,
+        );
+    }
+}
+
+/// No character of `name` inside `marker` carries a map segment.
+fn assert_unmapped(source: &str, marker: &str, name: &str) {
+    let projected = project(source);
+    let mapped = mapped_source_positions(&projected);
+    let (line, start, end) = span_of(source, marker, name);
+    for c in start..end {
+        assert!(
+            !mapped.contains(&(line, c)),
+            "{marker}: source {line}:{c} unexpectedly carries a map segment\n--- generated ---\n{}",
+            projected.code,
+        );
+    }
+}
+
+const HEAD: &str =
+    "<script lang=\"ts\">\n\timport Comp from './Comp.svelte';\n\tlet hue = 'red';\n</script>\n\n";
+
+fn with_head(body: &str) -> String {
+    format!("{HEAD}{body}\n")
+}
+
+#[test]
+fn a_component_tag_name_carries_its_own_map_segments() {
+    assert_mapped(&with_head("<Comp title={hue} />"), "<Comp title=", "Comp");
+}
+
+#[test]
+fn a_component_tag_name_is_mapped_when_the_tag_has_no_attributes() {
+    assert_mapped(&with_head("<Comp />"), "<Comp />", "Comp");
+}
+
+#[test]
+fn a_svelte_component_this_expression_carries_its_own_map_segments() {
+    assert_mapped(
+        &with_head("<svelte:component this={Comp} title={hue} />"),
+        "this={Comp}",
+        "Comp",
+    );
+}
+
+/// Pre-registered as already passing on `main`: the attribute value in the same
+/// start tag is segmented by the opener work this builds on, so a green here
+/// says the name change did not un-map its neighbours.
+#[test]
+fn an_attribute_value_beside_the_name_stays_mapped() {
+    assert_mapped(&with_head("<Comp title={hue} />"), "title={hue}", "hue");
+}
+
+/// `<svelte:self>` is lowered to `__sveltets_2_createComponentAny` and upstream
+/// pushes no name range for it, so the source text of the tag name must stay
+/// unmapped — the negative direction of the same check.
+#[test]
+fn a_svelte_self_tag_name_carries_no_map_segment() {
+    assert_unmapped(
+        &with_head("<svelte:self title={hue} />"),
+        "<svelte:self ",
+        "svelte:self",
+    );
+}


### PR DESCRIPTION
Fixes #4097.

Two positions whose subject is the component itself answered `null`, and they are
two different defects that happen to share a symptom.

## (a) A component's tag name had no source range

`handle_component` interpolated the tag name into the
`__sveltets_2_ensureComponent(<name>)` header with `format!`, so the name reached
the shadow as generated text with no map segment and a hover on a `<Comp />` tag
resolved through whatever mapping sat to its left. Upstream pushes
`[nodeNameStart, nodeNameEnd]` — a source **range** — into that exact argument
position (`InlineComponent.ts:101-110`), locating the name with
`str.original.indexOf(node.name, node.start)`, and `<svelte:component this={…}>`
is the same shape with `[node.expression.start, node.expression.end]`. Both now go
through `segs_push_src`, so the name and the `this` expression reach the shadow as
unedited source chunks. The generated TSX is unchanged; only the map moves.

## (b) A `.tsx` specifier insertion was classified as generated code

The overlay rewrites `'./Other.svelte'` to `'./Other.svelte.tsx'` so tsgo can
resolve it, and registered those four inserted bytes in the same
`generated_ranges` list as the `Ωignore` regions. `is_generated_range` is an
intersection test and `map_generated_range` bails on it before mapping anything,
so a tsgo response whose range covers the specifier was discarded and the client
saw `null`.

Instrumenting `map_range` is what named it, and it falsified the reading the code
suggested: **both endpoints map, and map correctly** — the shadow range is 18
columns and its image is 14, so the insertion was already accounted for.

    in=3:35-3:53  out=None  start=Some(2:36)  end=Some(2:50)  is_gen_range=true

The two kinds are not the same thing: an `Ωignore` region is whole synthetic text
with no source, while an insertion is four synthetic bytes inside a token the user
wrote — and `map_generated_position` never consulted the predicate at all, so a
bare position already passed through an insertion while a range spanning the same
one did not. The insertions move to `specifier_insertions`, consulted for a
position as before and not for a range. A range lying wholly inside an insertion
still returns `None`, because both its endpoints fail the position check. The
three tests that pin this predicate are every one of them about `Ωignore` regions;
`git log -S` on the `extend` reaches only a squashed history commit, so nothing
recorded a reason for the union.

## Measured against the official language server

`zz-hover-4097.mjs` drives the issue's own repro against the pinned official
server over stdio with `verify.mjs`'s `initializationOptions`. Positions are
derived from the source text and printed beside the issue's claimed coordinates,
so a stale coordinate shows as a mismatch rather than as a silently different
cell — three of the issue's are stale and are flagged. Four arms, each built and
hashed here, each adding one change to the previous:

    A  fc1a0b917b6f259b   main
    B  e6ac92eee4764865   A + #4385
    C  5b9753c86dde0368   B + (a)
    D  b8eab7c48b666303   C + (b)

| cell | A | B | C | D |
|---|---|---|---|---|
| `<Other />` tag name | null | null | official's range `10:1-10:6` | same |
| `<Deep />` tag name | null | null | official's range `11:1-11:5` | same |
| `'./Other.svelte'` specifier | null | null | null | **EQ**, `module "./Other.svelte"` `2:35-2:51` |
| `'./deep/Deep.svelte'` specifier | null | null | null | **EQ**, `4:18-4:38` |
| `'./other'`, `"./two"` (`.ts`) | EQ | EQ | EQ | EQ |
| `{h}`, `{v}` mustaches | EQ | EQ | EQ | EQ |

`#4385` does not reach either position, which is what makes B a control rather
than a step. The release binary was rebuilt from the committed tree after the
probe and hashes byte-identically to D.

## What is left, and why it is not this issue

Five cells still differ and both axes are ones the issue itself separates out.
The `fromSvelte` row it calls "a tsgo-vs-tsc difference". The tag-name cells now
carry official's exact range and differ in *contents* —
`(alias) const Other: __sveltets_2_IsomorphicComponent<…>` where official says
`import Other` — and that reproduces **at the import clause**, with identical
ranges on both sides, on a position no part of this PR touches. It is a
pre-existing alias-rendering divergence, not something the tag introduces.

## Two workspace properties are measurement inputs

Both produced a wrong finding before they were controlled. macOS `/var` is a
symlink to `/private/var`, so a workspace under `os.tmpdir()` makes the server's
document lookup miss on every request — filed as #4458, and it is what produced
an earlier, retracted claim that rsvelte answers a *narrower* range than
official. And a workspace outside the checkout has no `node_modules` on any
ancestor; that one was hypothesised to explain the tag-name contents gap and was
**falsified** — re-running with the workspace under the worktree gave
byte-identical results.

## Blast radius

`crates/rsvelte_language_server`: 409 tests over 8 targets, 0 failed — main's 409 declared minus its one `#[ignore]`d, plus this branch's new test, whose name is in the run. Workspace
clippy with `-D warnings` clean. The new overlay test is two-sided and was
ablated — restoring the union reddens it at the range assertion and nowhere else.

## The LSP fixture gate moves, and what moves is `textDocument/inlayHint`

Measured as two arms in this checkout — one holding #4385 only, one holding #4385 + both
halves of this PR — so the ~208-entry baseline churn this checkout produces against
`origin/main` (and CI does not) cancels between them. Ratchet total 2104 -> 2102; the
`textDocument/inlayHint` subset 314 -> 328 keys, 143 -> 151 diverging files, 8 newly
diverging and 0 newly clean.

| `inlayHint` class | before | after |
|---|---:|---:|
| `:extra-rsvelte` (both sides lists, rsvelte has surplus elements) | 130 | **152** |
| `:missing-rsvelte` | 28 | 26 |
| value mismatch, official `null`, rsvelte a list | 92 | **110** |
| value mismatch, both lists | 58 | **36** |
| value mismatch, official `null`, rsvelte `[]` | 6 | 4 |

The `+22` extra and `-22` both-lists pair up: a file that used to differ in hint *content*
now differs by carrying *more* hints. That is this PR's doing and it is expected —
`textDocument/inlayHint` is forwarded generically (`server.rs:711`), so the response mapper
drops any hint whose position does not map, and until (a) the `__sveltets_2_ensureComponent`
argument was unmapped generated text. Giving the tag name a source range removes an
accidental suppression.

The deliberate suppression was never ported, and that is not this PR: upstream's
`InlayHintProvider.ts:66-74` filters six classes of generated hint and rsvelte ports **none**
of them. Measured on `main` with no part of this PR in the tree, a ten-line component
produces seven hints official does not (`type:`, `options:` and
`: __sveltets_2_IsomorphicComponent<…>` on each `<Comp />`, plus the render function's return
type) — filed with the probe as #4464, which also records the opposite defect the same probe
found: a request whose range **starts at 0:0** answers `[]`, which is the range a real editor
sends. The standing backlog there is 314 keys over 143 files; this PR moves it by 14, i.e.
4.5%, and porting one of six filter rules inside a hover fix would be scope creep.

One reading caution for the re-baseline: `74234e98afe7` in a key is the digest of **`null`**,
not of `[]` (`[]` is `4f53cda18c2b`). I had read those keys the other way at first, and they
are the difference between "official found no hints" and "official's arm had hints disabled".

Read CI's own delta on this PR rather than any number measured here.

**The ratchet is NOT updated in this PR as pushed**, and that is deliberate rather than an
oversight. `verify.mjs:54-59` refuses a direct `--update-baseline`, so a correct re-baseline needs
the fixture artifact plus all 16 corpus artifacts from one `workflow_dispatch` Corpus Compat run at
one revision, through `merge-current.mjs --update-baseline`. Until that run exists on this branch,
`LSP fixture parity current` is expected to fail here, and the failing run's own artifact is what
the re-baseline must be taken from.

Do not take it from a local run in this checkout. This checkout produces ≈208 `textDocument/inlayHint`
keys that differ from `origin/main` and that CI does not reproduce — measured twice, once as the
two-arm cancellation described above and once directly, where CI's value equals `origin/main`'s for
all 208 while a local artifact's matched neither. The cause is not established; the best-supported
hypothesis is the tsgo **platform build**, since the pinned `~7.0.0-dev.20260703.1` resolves to seven
different binaries and this machine runs `darwin-arm64` against CI's `linux-x64`. That is consistent
with the churn being inlayHint-only (those payloads carry tsgo-rendered type text), with it being
independent of which rsvelte fix is in the arm, and with CI and `origin/main` agreeing exactly. It
is not measured. Tracked as #4479.

### The corpus half is not measured on this PR, so the dispatch run is required

Measured on this PR's own file list, with both halves read because they answer different questions:

```
$ node scripts/ci/corpus-compat-job-filter.mjs --changed-files <this PR's files>
lsp-fixtures-current=true
lsp-corpus=true
lsp-ratchet=false          <- no compatibility/ or scripts/compat-lsp/ path in the diff

corpus-compat.yml, lsp-corpus:
  if: (schedule || workflow_dispatch || lsp-ratchet == 'true') && lsp-corpus != 'false'
```

On a `pull_request` the event is neither `schedule` nor `workflow_dispatch` and `lsp-ratchet` is
false, so the first disjunct fails and **the 16 real-world shards do not run here** — even though
the filter's blast radius says `lsp-corpus=true`. The fixture gate does run, and will fail until
the re-baseline lands.

That asymmetry is the reason the `workflow_dispatch` run is not optional. This PR changes the
projection, so corpus-scope keys can move; nothing on the PR would measure that, and the first run
to see it would be the nightly — on `main`, after merge. That is the shape #4465 records for the
`#4407` submodule bump, where an unmeasured population entered the gate and every ratchet-touching
PR afterwards failed on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSuCFoDV9gDHEVPQjPFDmH
