### PR TITLE
fix(client): a lowering's block has no loc, so the brace discards pending comments

### DIFF
--- a/.changeset/lowered-block-has-no-loc.md
+++ b/.changeset/lowered-block-has-no-loc.md
@@ -1,0 +1,14 @@
+---
+'@rsvelte/compiler': patch
+---
+
+discard pending comments at a lowering's block brace, as upstream does
+
+Upstream builds a template lowering's statement-position block with
+`b.block([…])`, which carries no `loc`, so esrap's `body` discards every pending
+comment there; a block the instance script wrote is acorn-parsed and keeps its
+own position. rsvelte derived a comment-buffer span for both from the region the
+block's children consumed, so a comment at the end of the instance script was
+flushed at the brace of an `{#if}` wrapper and kept where official drops it.
+`JsStatement::Block` now carries a `BlockOrigin`, set to `Lowered` only where
+upstream would call `b.block`.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -767,9 +767,10 @@ impl<'a> ComponentContext<'a> {
         } else {
             // Wrap multiple statements in a block, matching the official compiler:
             // context.state.init.push(statements.length === 1 ? statements[0] : b.block(statements))
-            self.state
-                .init
-                .push(JsStatement::Block(JsBlockStatement::with_body(statements)));
+            self.state.init.push(JsStatement::Block(
+                JsBlockStatement::with_body(statements),
+                BlockOrigin::Lowered,
+            ));
         }
 
         TransformResult::None
@@ -1241,7 +1242,8 @@ impl<'a> ComponentContext<'a> {
             statements.push(b::stmt(&self.arena, slot_call));
             // Wrap in block scope so $0, $1, etc. don't leak
             self.state.init.push(JsStatement::Block(
-                crate::compiler::phases::phase3_transform::js_ast::nodes::JsBlockStatement::with_body(statements)
+                crate::compiler::phases::phase3_transform::js_ast::nodes::JsBlockStatement::with_body(statements),
+                BlockOrigin::Lowered,
             ));
         } else {
             self.state.init.push(b::stmt(&self.arena, slot_call));

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -4313,7 +4313,7 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
         }
         "BlockStatement" => {
             let block = convert_block_statement(obj, context);
-            Some(JsStatement::Block(block))
+            Some(JsStatement::Block(block, BlockOrigin::Source))
         }
         "IfStatement" => {
             let test = obj
@@ -7066,7 +7066,7 @@ fn convert_statement_from_jsnode(
         }
         JsNode::BlockStatement { body, .. } => {
             let block = convert_block_statement_from_jsnode(body, context);
-            Some(JsStatement::Block(block))
+            Some(JsStatement::Block(block, BlockOrigin::Source))
         }
         JsNode::VariableDeclaration {
             declarations, kind, ..

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -802,7 +802,7 @@ pub fn collect_identifiers_from_statement(
         JsStatement::Expression(expr_stmt) => {
             collect_ids_from_expr(arena.get_expr(expr_stmt.expression), arena, names);
         }
-        JsStatement::Block(block_stmt) => {
+        JsStatement::Block(block_stmt, _) => {
             for s in &block_stmt.body {
                 collect_identifiers_from_statement(s, arena, names);
             }
@@ -974,7 +974,7 @@ pub fn collect_identifiers_from_statement_props(
         JsStatement::Expression(expr_stmt) => {
             collect_ids_from_expr_props(arena.get_expr(expr_stmt.expression), arena, names);
         }
-        JsStatement::Block(block_stmt) => {
+        JsStatement::Block(block_stmt, _) => {
             for s in &block_stmt.body {
                 collect_identifiers_from_statement_props(s, arena, names);
             }
@@ -1181,7 +1181,7 @@ pub fn collect_identifiers_from_statement_deep(
         JsStatement::Expression(expr_stmt) => {
             collect_ids_from_expr_deep(arena.get_expr(expr_stmt.expression), arena, names);
         }
-        JsStatement::Block(block_stmt) => {
+        JsStatement::Block(block_stmt, _) => {
             for s in &block_stmt.body {
                 collect_identifiers_from_statement_deep(s, arena, names);
             }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -2962,6 +2962,7 @@ fn visit_slot_children(
                             .init
                             .push(crate::compiler::phases::phase3_transform::js_ast::JsStatement::Block(
                                 block,
+                                BlockOrigin::Lowered,
                             ));
                     }
                     _ => {}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
@@ -494,7 +494,7 @@ pub fn process_children<F>(
                                 context.state.init.push(stmt);
                             }
                             crate::compiler::phases::phase3_transform::client::types::TransformResult::Block(block) => {
-                                context.state.init.push(JsStatement::Block(block));
+                                context.state.init.push(JsStatement::Block(block, BlockOrigin::Lowered));
                             }
                             _ => {}
                         }
@@ -510,7 +510,7 @@ pub fn process_children<F>(
                                 context.state.init.push(stmt);
                             }
                             crate::compiler::phases::phase3_transform::client::types::TransformResult::Block(block) => {
-                                context.state.init.push(JsStatement::Block(block));
+                                context.state.init.push(JsStatement::Block(block, BlockOrigin::Lowered));
                             }
                             _ => {}
                         }
@@ -538,7 +538,7 @@ pub fn process_children<F>(
                             context.state.init.push(stmt);
                         }
                         crate::compiler::phases::phase3_transform::client::types::TransformResult::Block(block) => {
-                            context.state.init.push(JsStatement::Block(block));
+                            context.state.init.push(JsStatement::Block(block, BlockOrigin::Lowered));
                         }
                         _ => {}
                     }
@@ -564,7 +564,7 @@ pub fn process_children<F>(
                             context.state.init.push(stmt);
                         }
                         crate::compiler::phases::phase3_transform::client::types::TransformResult::Block(block) => {
-                            context.state.init.push(JsStatement::Block(block));
+                            context.state.init.push(JsStatement::Block(block, BlockOrigin::Lowered));
                         }
                         _ => {}
                     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -328,7 +328,7 @@ fn collect_hoisted_var_declarations<'x>(
         JsStatement::VariableDeclaration(decl) if matches!(decl.kind, JsVariableKind::Var) => {
             out.push(decl)
         }
-        JsStatement::Block(block) => {
+        JsStatement::Block(block, _) => {
             for stmt in &block.body {
                 collect_hoisted_var_declarations(stmt, arena, out);
             }
@@ -2257,7 +2257,7 @@ fn apply_transforms_to_statement_with_shadowed(
             }),
         }),
 
-        JsStatement::Block(block) => {
+        JsStatement::Block(block, origin) => {
             // Create a new scope with block-local variable declarations so that
             // locally-declared names (e.g. `const children = ...`) shadow outer
             // transforms and are not rewritten to `$$props.children`.
@@ -2268,7 +2268,7 @@ fn apply_transforms_to_statement_with_shadowed(
                 .iter()
                 .map(|s| apply_transforms_to_statement_with_shadowed(s, context, &block_scope))
                 .collect();
-            JsStatement::Block(JsBlockStatement::with_body(transformed_body))
+            JsStatement::Block(JsBlockStatement::with_body(transformed_body), *origin)
         }
 
         JsStatement::For(for_stmt) => {
@@ -3369,7 +3369,7 @@ fn collect_reactive_references_from_statement(
                 );
             }
         }
-        JsStatement::Block(block) => {
+        JsStatement::Block(block, _) => {
             for s in &block.body {
                 collect_reactive_references_from_statement(s, context, getters, seen);
             }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/svelte_boundary.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/svelte_boundary.rs
@@ -264,10 +264,10 @@ pub fn svelte_boundary(node: &SvelteElement, context: &mut ComponentContext) {
         // Wrap in block with hoisted snippets first
         let mut block_body = hoisted_snippets;
         block_body.push(boundary_call);
-        context
-            .state
-            .init
-            .push(JsStatement::Block(JsBlockStatement::with_body(block_body)));
+        context.state.init.push(JsStatement::Block(
+            JsBlockStatement::with_body(block_body),
+            BlockOrigin::Lowered,
+        ));
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
@@ -1539,7 +1539,7 @@ pub fn if_stmt(
 
 /// Create a block statement.
 pub fn block(body: Vec<JsStatement>) -> JsStatement {
-    JsStatement::Block(JsBlockStatement::with_body(body))
+    JsStatement::Block(JsBlockStatement::with_body(body), BlockOrigin::Lowered)
 }
 
 /// Create a debugger statement.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -391,7 +391,7 @@ impl<'a> JsCodegen<'a> {
             JsStatement::While(while_stmt) => self.emit_while_statement(while_stmt),
             JsStatement::DoWhile(do_while) => self.emit_do_while_statement(do_while),
             JsStatement::Switch(sw) => self.emit_switch_statement(sw),
-            JsStatement::Block(block) => self.emit_block_statement(block),
+            JsStatement::Block(block, _) => self.emit_block_statement(block),
             JsStatement::Empty => self.needs_semicolon = true,
             JsStatement::Debugger => {
                 self.output.push_str("debugger");
@@ -692,7 +692,7 @@ impl<'a> JsCodegen<'a> {
     /// - Other -> inline statement (e.g. `expr;`)
     fn emit_if_branch(&mut self, stmt: &JsStatement) {
         match stmt {
-            JsStatement::Block(block) => self.emit_block_inline(block),
+            JsStatement::Block(block, _) => self.emit_block_inline(block),
             JsStatement::If(nested_if) => self.emit_if_statement(nested_if),
             _ => {
                 // Single statement without braces (like esrap)
@@ -779,7 +779,7 @@ impl<'a> JsCodegen<'a> {
     /// block bodies are emitted inline, non-block bodies are emitted bare.
     fn emit_loop_body(&mut self, stmt: &JsStatement) {
         match stmt {
-            JsStatement::Block(block) => self.emit_block_inline(block),
+            JsStatement::Block(block, _) => self.emit_block_inline(block),
             _ => {
                 self.emit_statement_inner(stmt);
                 if self.needs_semicolon {
@@ -866,7 +866,7 @@ impl<'a> JsCodegen<'a> {
 
     fn emit_statement_as_block(&mut self, stmt: &JsStatement) {
         match stmt {
-            JsStatement::Block(block) => self.emit_block_inline(block),
+            JsStatement::Block(block, _) => self.emit_block_inline(block),
             _ => {
                 self.output.push('{');
                 self.newline();
@@ -2044,7 +2044,7 @@ impl<'a> JsCodegen<'a> {
             | JsStatement::Switch(_)
             | JsStatement::ExportDefault(_) => true,
             // Block is multiline if it has any statements
-            JsStatement::Block(block) => !block.body.is_empty(),
+            JsStatement::Block(block, _) => !block.body.is_empty(),
             // If statement is always multiline
             JsStatement::If(_) => true,
             // Labeled inherits from body
@@ -2428,7 +2428,7 @@ fn stmt_type_name(stmt: &JsStatement) -> &'static str {
         JsStatement::While(_) => "WhileStatement",
         JsStatement::DoWhile(_) => "DoWhileStatement",
         JsStatement::Switch(_) => "SwitchStatement",
-        JsStatement::Block(_) => "BlockStatement",
+        JsStatement::Block(_, _) => "BlockStatement",
         JsStatement::Empty => "EmptyStatement",
         JsStatement::Debugger => "DebuggerStatement",
         JsStatement::Labeled(_) => "LabeledStatement",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
@@ -80,7 +80,7 @@ pub enum JsStatement {
     /// Switch statement
     Switch(JsSwitchStatement),
     /// Block statement
-    Block(JsBlockStatement),
+    Block(JsBlockStatement, BlockOrigin),
     /// Empty statement
     Empty,
     /// Debugger statement
@@ -322,6 +322,16 @@ pub struct JsDoWhileStatement {
 #[derive(Debug, Clone)]
 pub struct JsBlockStatement {
     pub body: Vec<JsStatement>,
+}
+
+/// Where a statement-position block came from. Upstream builds a template
+/// lowering's block with `b.block([…])`, which carries no `loc`, so esrap
+/// discards the pending comments at the brace instead of flushing them there;
+/// a block the instance script wrote keeps its own position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockOrigin {
+    Source,
+    Lowered,
 }
 
 impl JsBlockStatement {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -939,8 +939,15 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 )))
             }
             JsStatement::VariableDeclaration(decl) => self.variable_declaration(decl),
-            JsStatement::Block(b) => {
+            JsStatement::Block(b, origin) => {
                 let (stmts, span) = self.statements(&b.body)?;
+                // Upstream builds a lowering's block with `b.block([…])`, which
+                // carries no `loc`, so esrap's `body` discards the pending
+                // comments instead of flushing them at the brace.
+                let span = match origin {
+                    BlockOrigin::Source => span,
+                    BlockOrigin::Lowered => rsvelte_esrap::UNLOCATED_SPAN,
+                };
                 Some(Statement::BlockStatement(BlockStatement::boxed(
                     span, stmts, &self.ab,
                 )))

--- a/crates/rsvelte_core/tests/trailing_script_comment_block.rs
+++ b/crates/rsvelte_core/tests/trailing_script_comment_block.rs
@@ -1,0 +1,88 @@
+//! A statement-position block is `b.block([…])` upstream and so carries no
+//! `loc`, which makes esrap's `body` discard every pending comment at the brace.
+//! rsvelte derived a comment-buffer span for it instead, so a comment at the end
+//! of the instance script was flushed there and kept where official drops it.
+//!
+//! Expectations are read off the pinned official compiler
+//! (`submodules/svelte/.../src/compiler/index.js`), which is the entry point the
+//! corpus gates use. They pin *whether the comment survives* per target rather
+//! than the whole program, so unrelated codegen movement does not re-pin this
+//! class silently. The corpus output gates cannot hold this: `ast_equiv_batch`
+//! compares with `CommentPolicy::Ignore`, so both arms score equivalent.
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// `(name, template, comments kept on client, comments kept on server)`.
+/// A bare block only exists in the client lowering, so every server cell is 1 —
+/// a fix that reaches the server would take those to 0.
+const CELLS: &[(&str, &str, usize, usize)] = &[
+    ("if", "{#if c}\n\t<b>y</b>\n{/if}\n", 0, 1),
+    ("if_const", "{#if c}{@const d = c}<b>{d}</b>{/if}\n", 0, 1),
+    ("element", "<b>{c}</b>\n", 1, 1),
+    ("await", "{#await p}\n\t<b>y</b>\n{/await}\n", 1, 1),
+    ("no_template", "", 1, 1),
+    ("bind", "<input bind:value={c} />\n", 1, 1),
+    (
+        "options",
+        "<svelte:options runes={false} />\n<b>{c}</b>\n",
+        1,
+        1,
+    ),
+];
+
+const HEAD: &str = "<script>\n\tlet c = 1;\n\tlet p = Promise.resolve(1);\n\t// x\n</script>\n\n";
+
+fn compile_cell(template: &str, generate: GenerateMode, dev: bool) -> String {
+    let source = format!("{HEAD}{template}");
+    let output = compile(
+        &source,
+        CompileOptions {
+            generate,
+            filename: Some("C.svelte".into()),
+            dev,
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|error| panic!("compile failed: {error:?}"))
+    .js
+    .code;
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &output, SourceType::mjs()).parse();
+    assert!(
+        !parsed.panicked && parsed.diagnostics.is_empty(),
+        "output must parse:\n{output}"
+    );
+    output
+}
+
+fn kept(output: &str) -> usize {
+    output.matches("// x").count()
+}
+
+#[test]
+fn trailing_script_comment_survives_exactly_where_official_keeps_it() {
+    // A grid every cell of which expects the same answer measures nothing: an
+    // implementation that never emits a comment, and one that always does,
+    // would each pass half of it.
+    assert!(CELLS.iter().any(|cell| cell.2 == 0));
+    assert!(CELLS.iter().any(|cell| cell.2 > 0));
+
+    for &(name, template, client, server) in CELLS {
+        for dev in [false, true] {
+            assert_eq!(
+                kept(&compile_cell(template, GenerateMode::Client, dev)),
+                client,
+                "client dev={dev} cell={name}"
+            );
+            assert_eq!(
+                kept(&compile_cell(template, GenerateMode::Server, dev)),
+                server,
+                "server dev={dev} cell={name}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #4475.

## The rule, read out of the pinned oracle

esrap 2.2.12's `body(context, node)` opens with `reset_comment_index(node)`, and
when `!node.loc` that sets `comment_index = comments.length` — **every pending
comment is discarded**, not flushed at the brace. Its tail flush is gated on
`node.loc` too, and the only other flush site is the `_` wildcard visitor
(`languages/ts/index.js:957-966`), which flushes before a node **iff** that node
has a `loc`. So the whole rule is one sentence:

> the pending comment is written at the first printed node that has a source
> `loc` after it — unless a `body()` on a node with **no** `loc` is reached
> first, which discards every pending comment.

Upstream builds a template lowering's block with `b.block([...])` — no `loc` —
so a trailing `// x` in the instance script dies at that brace.

rsvelte's `JsBlockStatement` carries no span field, so `to_oxc` derived one from
the comment-buffer region the subtree consumed. That made every lowered block a
flush point upstream does not have, and the comment was re-emitted inside it.

## The fix

`BlockOrigin` on `JsStatement::Block`, and the split is a complement rather than
a list: every constructor in the tree is either a converted source
`BlockStatement` (`Source`, keeps its own position) or a site mirroring
upstream's `b.block` (`Lowered`, prints `UNLOCATED_SPAN`), with
`transform_statement` propagating whichever it was handed. Every other
`JsStatement::Block(` site is a read-only pattern match.

A blanket `UNLOCATED_SPAN` was measured first and **regressed 10 real files** —
e.g. `appwrite-console/src/lib/layout/wizard.svelte` lost `// clear exit` from a
source-written `if (onExit) { … }`. That is why the origin is threaded rather
than assumed.

## Measurement

Two arms, distinct `sha256`, two-sided discriminating probe run before the
result. Stage 1 hashes every corpus unit under both arms; stage 2 compares only
the moved set to the pinned oracle (`submodules/svelte` at its declared gitlink,
VERSION 5.57.0).

| target | moved | fixed | regressed | CLOSER | FURTHER | SAME |
|---|---|---|---|---|---|---|
| client | 16 | 5 | **0** | 16/16 | 0 | 0 |
| client-dev | 15 | — | **0** | 15/15 | 0 | 0 |
| server | 0 | — | 0 | — | — | — |
| server-dev | 0 | — | 0 | — | — | — |

Denominator: 33,890 components (`find -name '*.svelte'` reports 33,893; the 3
extras are *directories* with that suffix). Live units 32,646 / 32,647 — 1,244 /
1,243 error in **both** arms and cannot move.

0 of the 16 moved ids appear in any of `known-failures.{client,client-dev,server,server-dev}.json`,
so no ratchet moves and none needs re-baselining.

## Why the repro is a unit test

`ast_equiv_batch` is invoked with empty argv, which is `CommentPolicy::Ignore`,
and `verify.mjs` normalizes with oxfmt + blank-line stripping. A comment-only
divergence is erased twice, so a `pattern-corpus` entry would be green on a
broken tree. `crates/rsvelte_core/tests/trailing_script_comment_block.rs` holds
it instead, with expectations generated from the oracle on the test's **own**
sources, and it is two-sided by construction — the cell list is asserted to
contain both a cell where official keeps the comment and one where it drops it,
so a compiler that always keeps (or always drops) fails.

Ablated: `client dev=false cell=if left: 1 right: 0`. Restored: `git diff` empty.

## Scope

#4480 and #4481 share this **root** — which comment-space position a node
carries — but are the other half of it (a template node that has *no* position in
rsvelte's comment buffer at all, because `source_anchor.rs` only reserves a
region when that region itself contains a comment). This PR claims #4475 only;
the mechanism write-up goes on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
