### PR TITLE
docs(agents): the debug-disk figure is a rate, and rounding its count laundered the product

### DIFF
--- a/.claude/skills/perf-loop/SKILL.md
+++ b/.claude/skills/perf-loop/SKILL.md
@@ -72,7 +72,7 @@ PGO: `scripts/perf/pgo.sh` が `pgo/rsvelte.profdata` を再生成、`scripts/pe
 - **壁時計でなく CPU 時間**: `perf_bench` の CPU median を読む。壁時計は負荷で 2 倍動く。
 - **アームの同一性**: ファイル名・パス・ブランチは信用しない。`Compiling <crate> (<path>)` 行、2 成果物の `sha256`、出力での判別プローブ（含むべきもの／欠くべきもの両方）を読む。
 - **worktree**: 毎回 `cd <worktree> && CARGO_TARGET_DIR=<worktree>/target cargo …`。cwd は黙ってリセットされる。
-- **ディスク**: `df -g /System/Volumes/Data` が 20 GiB 未満なら cargo を起動しない。debug の `target/debug/deps` は 83 GB。
+- **ディスク**: `df -g /System/Volumes/Data` が 20 GiB 未満なら cargo を起動しない。debug の `target/debug/deps` は 1 バイナリ ~140 MB × `ls crates/rsvelte_core/tests/*.rs | wc -l` 本（積を持ち歩かない — AGENTS.md 参照）。
 - **分母**: 共有型（`JsNode` 等）を触ったら `--workspace`。`| tail`/`2>/dev/null` 越しに verdict を読まない。
 - **call count を先に読む**: 決定的。時間は 1 回ではノイズ。
 - **同居エージェント**: 計測窓の開始／終了は宣言で伝える。他人の窓の中で cargo を叩かない。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,8 +162,13 @@ pnpm run test-and-update                             # Refresh report + docs
 node scripts/diff/compare-parsers.mjs                # Diff a parse against official
 ```
 
-- **Disk runs out before time does.** A debug build of `rsvelte_core`'s ~590 test targets is
-  ~83 GB of `target/debug/deps`; the whole release profile is ~0.5 GB. Read
+- **Disk runs out before time does.** A debug test binary is ~140 MB and `rsvelte_core`
+  builds one per `crates/rsvelte_core/tests/*.rs`, so a full debug build costs that rate
+  times `ls crates/rsvelte_core/tests/*.rs | wc -l` — 716 on `main` at `a760be550`, i.e. ~98 GB
+  of `target/debug/deps` against ~0.5 GB for the whole release profile. Carry the rate, not
+  the product: this bullet read "~590 targets, ~83 GB" until 2026-09-09, and 83 GB **was**
+  589 x 140 MB, so rounding the count made it look like a soft approximation while it
+  silently carried the total 22% low. Read
   `df -g /System/Volumes/Data` before invoking cargo and do not start a build under ~20 GiB
   free (ENOSPC leaves partial artifacts and the *next* run fails for an unrelated-looking
   reason). Scope debug runs with `--test <name>` / `-p <crate> --lib`; reclaim with
@@ -174,7 +179,11 @@ node scripts/diff/compare-parsers.mjs                # Diff a parse against offi
   runs no hooks: after resolving a conflict by hand, run fmt + clippy yourself.
 - **The denominator of a test run is what you passed cargo.** `--test a --test b` does not run
   the lib; `-p rsvelte_core` does not build `rsvelte_bindings_support`, which matches `JsNode`
-  exhaustively. When a change touches a type another crate names, run `--workspace`.
+  exhaustively. When a change touches a type another crate names, run `--workspace`. And a
+  misspelled target aborts the **whole** invocation — `error: no test target named X` runs
+  none of the others, so a nine-suite run and a zero-suite run print the same nothing.
+  Read the `Running tests/` lines as the denominator, not the exit code; the needle is
+  `Running tests/`, because cargo indents that line and `^Running` matches nothing.
 - `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings` before every commit.
 
 ### Worktrees and the shared machine


### PR DESCRIPTION
`AGENTS.md` read **"~590 test targets, ~83 GB of `target/debug/deps`"**. The count is
not decoration beside the total — it is the total's *multiplicand*: 83 GB **is**
589 × ~140 MB, which the archived version states in the same sentence
(`docs/archive/agents-md-2026-09-06.md:1211`).

On `main` at `a760be550` the count is **716**, so the same rule gives **~98 GB**. The
guidance that has emptied this disk twice was carrying a figure **22% low**.

## The rounding is what hid it

A bare stale number invites a re-derivation. A number spelled as an approximation —
`~590` — reads as one whose drift is immaterial, so nobody recomputes the total sitting
next to it. Here the "soft" figure and the load-bearing one were one measurement, and the
rounding laundered the second.

Concretely, both of us working this repo today searched for `589` in `AGENTS.md`, got
**0 hits**, and read that as "the claim is gone". It had merely been rounded.

## The repair

Carry the **rate** and the way to **count**, not the product:

- `~140 MB` per debug test binary — the durable quantity;
- `ls crates/rsvelte_core/tests/*.rs | wc -l` — the multiplier, one command;
- today's reading written *beside its revision* (`716 on main at a760be550`), so a reader
  can check it rather than trust it.

The values in the diff were **derived by the patch script from the branch's own tree**, not
typed. That is not ceremony: the draft written before #4482 merged had `16e21f3a5` in it,
and would have shipped a stale revision beside a fresh count.

## A second copy of the same number

`git grep '83 GB'` outside `docs/archive` returns **two** hits, not one:

```
AGENTS.md:165
.claude/skills/perf-loop/SKILL.md:75    debug の target/debug/deps は 83 GB
```

No gate reads either. Two spellings of one number in two files rot separately, so both are
fixed here — a change titled "the figure is a rate" that left the other copy asserting the
product would be self-defeating. The only surviving `~590`/`83 GB` in the tracked tree
outside `docs/archive` is inside this bullet's own quoted history.

## Also: the failure that surfaced it

The denominator bullet gains the shape that started this. A misspelled `--test` target
aborts the **whole** invocation — `error: no test target named X` runs none of the other
nine — so a nine-suite run and a zero-suite run print the same nothing, with a non-zero
exit for a reason unrelated to any test.

And the needle for the denominator is `Running tests/`, **not** `^Running`: cargo indents
that line, so the anchored form matches nothing and returns the same `0` as a run where no
suite started. Measured — a Monitor of mine reported `0 running-lines` for a run in which
all ten suites had in fact started.

Docs and one skill file only; no changeset (no publishable package changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
