### PR TITLE
fix(client): anchor $.head's callee on the tag name, as upstream does (#4480)

### DIFF
--- a/.changeset/head-call-carries-its-tag-name-loc.md
+++ b/.changeset/head-call-carries-its-tag-name-loc.md
@@ -1,0 +1,12 @@
+---
+'@rsvelte/compiler': patch
+---
+
+anchor `$.head`'s callee on the tag name, as upstream does
+
+Upstream stamps the call's callee with the tag name's own source position
+(`b.id('$.head', node.name_loc)`), which is where esrap flushes a comment left
+pending at the end of the instance script. rsvelte built the call unanchored, so
+the comment was dropped where official keeps it. `<svelte:head>` now passes
+`node.name_loc` through a `b::stmt_anchored`. The `{#snippet}` half of the same
+symptom is a different mechanism and is tracked separately (#4489).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/svelte_head.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/svelte_head.rs
@@ -45,13 +45,17 @@ pub fn svelte_head(node: &SvelteElement, context: &mut ComponentContext) {
     // Build the head call: $.head('hash', ($$anchor) => { ... })
     let content_fn = b::arrow_block(vec![b::id_pattern("$$anchor")], content_block.body);
 
-    let head_call = b::stmt(
+    // Upstream stamps the callee with the tag name's own source position
+    // (`b.id('$.head', node.name_loc)`), which is where esrap flushes a comment
+    // left pending by an earlier chunk.
+    let head_call = b::stmt_anchored(
         &context.arena,
         b::call(
             &context.arena,
             b::member_path(&context.arena, "$.head"),
             vec![b::string(&hash), content_fn],
         ),
+        node.name_loc.as_ref().map(|loc| loc.start.character),
     );
 
     context.state.init.push(head_call);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
@@ -1511,6 +1511,16 @@ pub fn stmt(arena: &JsArena, expression: JsExpr) -> JsStatement {
     })
 }
 
+/// `expr;` whose callee carries the original-source offset upstream stamps on it
+/// (`b.id('$.head', node.name_loc)`), which is where esrap flushes comments left
+/// over from an earlier chunk.
+pub fn stmt_anchored(arena: &JsArena, expression: JsExpr, anchor: Option<u32>) -> JsStatement {
+    JsStatement::Expression(JsExpressionStatement {
+        expression: arena.alloc_expr(expression),
+        comment_anchor: anchor,
+    })
+}
+
 /// Create a return statement.
 pub fn return_stmt(arena: &JsArena, argument: Option<JsExpr>) -> JsStatement {
     JsStatement::Return(JsReturnStatement {

--- a/crates/rsvelte_core/tests/svelte_head_comment_anchor.rs
+++ b/crates/rsvelte_core/tests/svelte_head_comment_anchor.rs
@@ -1,0 +1,89 @@
+//! Upstream stamps `$.head`'s callee with the tag name's own source position
+//! (`b.id('$.head', node.name_loc)`), so esrap flushes a comment left pending at
+//! the end of the instance script there. rsvelte built the call unanchored, and
+//! the comment was dropped.
+//!
+//! Expectations are read off the pinned official compiler
+//! (`submodules/svelte/.../src/compiler/index.js`) rather than typed, and pin
+//! *whether the comment survives* per target so unrelated codegen movement does
+//! not re-pin this class silently. The corpus output gates cannot hold it:
+//! `ast_equiv_batch` compares with `CommentPolicy::Ignore` and `verify.mjs`
+//! normalizes with oxfmt, so both arms score equivalent.
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// `(name, template, comments kept with dev off, comments kept with dev on)`.
+const CELLS: &[(&str, &str, usize, usize)] = &[
+    (
+        "head",
+        "<svelte:head><title>{c}</title></svelte:head>",
+        1,
+        1,
+    ),
+    ("plain", "<b>{c}</b>", 1, 1),
+    ("if_", "{#if c}<b>{c}</b>{/if}", 0, 0),
+    ("each", "{#each [1] as n}<b>{c}{n}</b>{/each}", 1, 1),
+    ("key", "{#key c}<b>{c}</b>{/key}", 1, 1),
+    ("await_", "{#await p}<b>{c}</b>{/await}", 1, 1),
+    ("html", "{@html c}", 1, 1),
+    ("const_", "{#if c}{@const d = c}<b>{d}</b>{/if}", 0, 0),
+    ("window", "<svelte:window on:resize={() => c} />", 1, 0),
+    ("bind", "<input bind:value={c} />", 1, 1),
+    ("empty", "", 1, 1),
+];
+
+const HEAD: &str = "<script>\n\tlet c = 1;\n\tlet p = Promise.resolve(1);\n\t// x\n</script>\n";
+
+fn compile_cell(template: &str, dev: bool) -> String {
+    let source = format!("{HEAD}{template}\n");
+    let output = compile(
+        &source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            filename: Some("C.svelte".into()),
+            dev,
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|error| panic!("compile failed: {error:?}"))
+    .js
+    .code;
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &output, SourceType::mjs()).parse();
+    assert!(
+        !parsed.panicked && parsed.diagnostics.is_empty(),
+        "output must parse:\n{output}"
+    );
+    output
+}
+
+fn kept(output: &str) -> usize {
+    output.matches("// x").count()
+}
+
+#[test]
+fn svelte_head_keeps_the_trailing_script_comment_exactly_where_official_does() {
+    // A grid whose cells all expect the same answer measures nothing: an
+    // implementation that never emits a comment and one that always does would
+    // each pass half of it. The dev axis needs its own two-sidedness, because a
+    // cell that answers alike on both targets cannot see a dev-only rule.
+    assert!(CELLS.iter().any(|cell| cell.2 == 0));
+    assert!(CELLS.iter().any(|cell| cell.2 > 0));
+    assert!(CELLS.iter().any(|cell| cell.2 != cell.3));
+    // Removing the anchor must redden this suite, so the cell the fix moves has
+    // to be one the grid actually asserts on.
+    assert!(CELLS.iter().any(|cell| cell.0 == "head" && cell.2 > 0));
+
+    for &(name, template, prod, dev_kept) in CELLS {
+        assert_eq!(kept(&compile_cell(template, false)), prod, "cell={name}");
+        assert_eq!(
+            kept(&compile_cell(template, true)),
+            dev_kept,
+            "dev cell={name}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #4480 (the `<svelte:head>` half; the `{#snippet}` half is a different producer and is
tracked in #4489 — see below).

## The defect

A comment at the end of the instance script is dropped when the template holds a `<svelte:head>`.

```svelte
<script>
	let c = 1;
	// x
</script>
<svelte:head><title>{c}</title></svelte:head>
```

Official keeps `// x` and rsvelte drops it, on `client` and `client-dev`.

## Cause

esrap's `_` visitor flushes every pending comment at the first printed node that carries a source
`loc` (`languages/ts/index.js:961`, `if (node.loc) flush_comments_until(context, null,
node.loc.start, true)`). Upstream stamps `$.head`'s callee with the tag name's own source position
so that node is the flush point:

```js
// packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteHead.js:17
b.stmt(b.call(b.id('$.head', node.name_loc), …))
```

rsvelte built the same call unanchored, so nothing after the script chunk carried a comment-space
position and the comment was never flushed. The fix passes `node.name_loc` through a new
`b::stmt_anchored`.

**Upstream's loc-carrying builder sites are a closed set, not a work log.** Every `_loc` use under
`phases/3-transform` is `SvelteSelf.js:11`, `BindDirective.js:56,58`, `SvelteHead.js:17`,
`TitleElement.js:23`, `shared/component.js:277,278`, `shared/fragment.js:116`, `Component.js:10`,
`Fragment.js:89`, and all of them take `name_loc` from the parser
(`1-parse/state/element.js:186/203/660/691`). The enumeration here is the grammar.

## Why the `{#snippet}` half is not in this PR

`SnippetBlock.js:82` reuses the **source AST** identifier verbatim (`b.const(node.expression,
snippet)`), so acorn's own `loc` rides along — which makes "rsvelte does not stamp it" the obvious
hypothesis. I implemented it (a `const_decl_anchored` taking `node.expression.start()`) and it
moved **0 of 32** grid cells. A counter at the port said the anchor was produced and *rejected*,
and a counter at the chunk appender named why:

```
plain:   [chunk] region=(78,123) src=Some(10)   THEN  [ca] anchor=67 last_region_source=Some(10) -> CLAIMED
head:    [chunk] region=(47,92)  src=Some(10)   THEN  [ca] anchor=67 last_region_source=Some(10) -> CLAIMED
snippet: [ca] anchor=76 last_region_source=None -> rejected  THEN  [chunk] region=(92,137)
```

A top-level `{#snippet}` declaration is hoisted above the instance script's statements; esrap
flushes by *source offset* while rsvelte's comment buffer is built lazily in *walk order*, so at
the snippet's claim the script chunk is not in the buffer yet. That is a model change, not a
builder edit. Full write-up, with 13 candidate carriers of which 3 confirmed divergent, in #4489.

## Measurement

**Grid** — 16 templates × 2 dev modes, expectations generated from the pinned official compiler
per run, each cell also compiled with the comment removed so a divergence counts only when the
comment-free pair is byte-equal:

| arm | EQ | DIFF |
|---|---:|---:|
| base | 24 | 8 |
| this PR | **26** | 6 |

No cell moved the wrong way. The 6 remaining are `snippet`/`snippet_rnd` (#4489) and `boundary`
(a separate residue, 0 real-world carriers). Oracle liveness: 13 keeps / 3 drops, so the grid is
two-sided rather than measuring one answer.

**Arm identity** — `base 9b50b1c4c07eff34`, `head 72082a9b1eb1e009`, distinct; two-sided probe
run before the result was read: `head 0 → 1` (contains the fix) and `if_ 0 → 0`, `plain 1 → 1`
(lacks what it should lack).

**Corpus sweep** — two arms, one process per arm, over the 104 declared corpus sources read from
the primary checkout (this worktree has 117 of 119 submodules empty; `submodules/vize` is the one
empty directory there and is not a corpus source).

```
files=37397  live=141662  dead=7926   (identical on both arms)
rows=149588  distinctKeys=149588      (no key collapse)
MOVED = 6
stage 2, raw bytes against the oracle:
  base   {"MISMATCH": 6}
  this   {"match": 6}
  match -> MISMATCH : 0
```

The 6 are three real-world files × `client` and `client-dev`:
`skeleton/.../themes/create/+page.svelte`, `svelte-bits/.../PixelBlastDemo.svelte`,
`svelte-commerce/.../my/addresses/[id]/+page.svelte`. `known-failures.client.json` and
`known-failures.client-dev.json` are both empty and no server unit moved, so there is no
re-baseline. Only 6 rows changed bytes at all, so no other entry's verdict can have moved either.

The sweep was measured at `a605c9d55`; the branch now sits on `68d3b8e5b`, whose single
intervening commit touches `AGENTS.md` and `.claude/skills/perf-loop/SKILL.md` and no compiler
code — a complement, so the sweep holds for the tree CI scores.

## Test

`crates/rsvelte_core/tests/svelte_head_comment_anchor.rs`. The corpus output gates cannot hold
this class — `ast_equiv_batch` runs with `CommentPolicy::Ignore` and `verify.mjs` normalizes with
oxfmt plus blank-line stripping, so a comment-placement divergence is erased twice and a
`pattern-corpus` repro would be green on both arms.

Expectations are read off the pinned official compiler rather than typed, and the grid asserts its
own two-sidedness on both axes (a cell expecting 0, a cell expecting > 0, and a cell whose dev and
prod answers differ). Ablation control: replacing `b::stmt_anchored` with `b::stmt` reddens the
suite naming `cell=head`; restoring leaves the tree byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
