### PR TITLE
fix(release): a changeset tick that another PR earned says so (#4486)

### DIFF
--- a/scripts/release/check-core-consumer-changesets.mjs
+++ b/scripts/release/check-core-consumer-changesets.mjs
@@ -170,20 +170,58 @@ function changedFiles(base) {
   return out ? out.split('\n').filter(Boolean) : [];
 }
 
-// Names in the frontmatter of every pending changeset (working-tree state — the
-// set the Release workflow will consume), not just ones added in this PR.
+// Package names in one changeset's frontmatter. Both quote styles occur in this
+// repository, and a double-quoted-only reader returns a plausible empty set
+// rather than an error (#4486).
+export function packagesIn(text) {
+  const named = new Set();
+  const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return named;
+  for (const line of m[1].split('\n')) {
+    const pkg = line.match(/^\s*["']?(@[^"':]+)["']?\s*:/);
+    if (pkg) named.add(pkg[1]);
+  }
+  return named;
+}
+
+// Every pending changeset (working-tree state — the set the Release workflow
+// will consume), mapped to the files naming it. This is the set the verdict is
+// computed from, and it deliberately includes changesets already on main:
+// the question it answers is "will the changed code ship in some bump", not
+// "does this PR carry a changeset".
 function namedPackages() {
   const dir = path.join(repoRoot, '.changeset');
-  const named = new Set();
+  const named = new Map();
   for (const file of readdirSync(dir)) {
     if (!file.endsWith('.md') || file === 'README.md') continue;
-    const text = readFileSync(path.join(dir, file), 'utf8');
-    const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-    if (!m) continue;
-    for (const line of m[1].split('\n')) {
-      const pkg = line.match(/^\s*["']?(@[^"':]+)["']?\s*:/);
-      if (pkg) named.add(pkg[1]);
+    for (const pkg of packagesIn(readFileSync(path.join(dir, file), 'utf8'))) {
+      if (!named.has(pkg)) named.set(pkg, []);
+      named.get(pkg).push(file);
     }
+  }
+  return named;
+}
+
+// The changesets this PR itself adds or edits. Separate from the set above
+// because the two answer different questions and only this one is a statement
+// about the pull request.
+function changesetsTouchedHere(base) {
+  let out = '';
+  try {
+    out = sh(`git diff --name-only --diff-filter=AM ${base}...HEAD -- .changeset`);
+  } catch {
+    return new Set();
+  }
+  const named = new Set();
+  for (const rel of out ? out.split('\n').filter(Boolean) : []) {
+    if (!rel.endsWith('.md') || rel.endsWith('README.md')) continue;
+    let text;
+    try {
+      text = readFileSync(path.join(repoRoot, rel), 'utf8');
+    } catch {
+      continue; // added then removed again within the range
+    }
+    for (const pkg of packagesIn(text)) named.add(pkg);
   }
   return named;
 }
@@ -245,11 +283,37 @@ function main() {
   }
 
   const named = namedPackages();
+  const here = changesetsTouchedHere(base);
   const missing = [...required].filter(([pkg]) => !named.has(pkg));
 
   console.log('Shared-core changes require these packages to be named in a changeset:');
+  let borrowed = 0;
   for (const [pkg, prefix] of required) {
-    console.log(`  ${named.has(pkg) ? '✓' : '✗'} ${pkg}  (touched: ${prefix})`);
+    // A tick means "some pending changeset names this", which another PR's
+    // changeset can satisfy. Say so, rather than printing a line that reads as
+    // a claim about this PR (#4486).
+    let note = '';
+    if (named.has(pkg)) {
+      if (here.has(pkg)) {
+        note = '  — named by this PR';
+      } else {
+        borrowed++;
+        const by = named.get(pkg);
+        note =
+          `  — NOT named by this PR; satisfied by ${by.length} pending ` +
+          `changeset${by.length === 1 ? '' : 's'} already in the tree (${by.join(', ')})`;
+      }
+    }
+    console.log(`  ${named.has(pkg) ? '✓' : '✗'} ${pkg}  (touched: ${prefix})${note}`);
+  }
+  if (borrowed > 0) {
+    console.log(
+      `\nNote: ${borrowed} requirement${borrowed === 1 ? ' is' : 's are'} met only by ` +
+        `changeset(s) this PR did not add. The release is still correct while those ` +
+        `stay pending, but withdrawing one before the release would leave this change ` +
+        `with no version bump and no CHANGELOG entry — and this check would not have ` +
+        `said so.`,
+    );
   }
 
   if (missing.length > 0) {

--- a/scripts/release/test-core-consumer-changesets.mjs
+++ b/scripts/release/test-core-consumer-changesets.mjs
@@ -18,7 +18,7 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { RULES, uncoveredFixedGroups } from './check-core-consumer-changesets.mjs';
+import { RULES, packagesIn, uncoveredFixedGroups } from './check-core-consumer-changesets.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -137,9 +137,45 @@ check('changeset.yml still runs the guard', () => {
 	);
 });
 
+// A reader that accepts only one quote style returns a plausible EMPTY set
+// rather than an error, so it reads as "this changeset names nothing" (#4486).
+// Both spellings occur in this repository, so both are pinned here.
+check('packagesIn reads every quote style the repository uses', () => {
+	const one = packagesIn("---\n'@rsvelte/language-server': patch\n---\nbody\n");
+	assert.deepEqual([...one], ['@rsvelte/language-server'], 'single-quoted');
+	const two = packagesIn('---\n"@rsvelte/compiler": patch\n---\nbody\n');
+	assert.deepEqual([...two], ['@rsvelte/compiler'], 'double-quoted');
+	const bare = packagesIn('---\n@rsvelte/fmt: patch\n---\nbody\n');
+	assert.deepEqual([...bare], ['@rsvelte/fmt'], 'unquoted');
+});
+
+// The negative half. Without it the test above is satisfied by a reader that
+// returns every @-looking token it can find anywhere in the file.
+check('packagesIn reads the frontmatter only', () => {
+	assert.deepEqual([...packagesIn('no frontmatter here\n@rsvelte/compiler: patch\n')], []);
+	assert.deepEqual(
+		// The body line must itself look like a frontmatter entry. With prose there,
+		// a reader that scans the whole file passes anyway, because the regex anchors at ^.
+		[...packagesIn("---\n'@rsvelte/compiler': patch\n---\n@rsvelte/fmt: patch\n")],
+		['@rsvelte/compiler'],
+	);
+});
+
+// A live control on the tree: the guard's verdict is computed from these files,
+// so a reader that silently matches none of them would make every requirement
+// look unmet -- or, with the tick logic, every one look borrowed.
+check('every pending changeset names at least one @rsvelte package', () => {
+	const dir = join(ROOT, '.changeset');
+	const files = readdirSync(dir).filter((f) => f.endsWith('.md') && f !== 'README.md');
+	assert.ok(files.length > 0, 'no pending changesets -- this control cannot fire');
+	const silent = files.filter((f) => packagesIn(readFileSync(join(dir, f), 'utf8')).size === 0);
+	assert.deepEqual(silent, [], 'these changesets parse to no package');
+});
+
 console.log(
 	failures === 0
 		? '\ncore-consumer-changesets self-test: all checks passed'
 		: `\ncore-consumer-changesets self-test: ${failures} failure(s)`,
 );
+
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #4486.

`check-core-consumer-changesets` computes its verdict from **every pending changeset in the tree**, and that is deliberate — its own comment says so, and the question it answers ("will the changed code ship in some bump") is the right one for a release gate. What was wrong is the line it printed, which reads as the *other* question:

```
✓ @rsvelte/compiler  (touched: crates/rsvelte_core/src/)
```

That tick can be earned by a changeset somebody else added. **The verdict is unchanged by this PR** — no new failures, no policy change — only the report now says which question each tick answered.

## What it prints now

Forced end-to-end with a temporary commit touching `crates/rsvelte_core/src/`, then reverted:

```
Shared-core changes require these packages to be named in a changeset:
  ✓ @rsvelte/compiler  (touched: crates/rsvelte_core/src/)  — NOT named by this PR;
    satisfied by 12 pending changesets already in the tree (attribute-key-quote-anchor.md, …)

Note: 1 requirement is met only by changeset(s) this PR did not add. The release is
still correct while those stay pending, but withdrawing one before the release would
leave this change with no version bump and no CHANGELOG entry — and this check would
not have said so.
```

## Re-measured, because the issue's numbers were taken against an older tree

At `5ad043008`, 16 pending changesets (the issue measured 13 at `16e21f3a5`), for the 7 packages any rule can require:

| | packages |
|---|---|
| satisfiable by someone else's changeset | `@rsvelte/compiler` (**12**), `@rsvelte/language-server` (5), `@rsvelte/svelte-check` (4), `@rsvelte/svelte2tsx` (4) |
| discriminating | `@rsvelte/capi`, `@rsvelte/fmt`, `@rsvelte/vite-plugin-svelte-native` |

Still **3 of 7**, and the mechanism has got worse rather than better — the discriminating power is a function of the release backlog, so it is weakest exactly when the most PRs are landing. Positive control on the re-measurement: 16 of 16 changesets parse to at least one `@rsvelte` package.

## `packagesIn` is extracted so it can be pinned

The issue records that a first count of this read **7 of 7 discriminating**, because the extractor matched only double-quoted names while changesets on `main` use single quotes. That failure mode returns a plausible **empty set** rather than an error, so it reads as "this changeset names nothing". Both spellings occur here, so both are now pinned, along with an unquoted one.

## Controls, and one of them was dead when written

Three new checks, each ablated and required to go red:

- **double-quotes-only** (the actual #4486 bug) → 3 checks fail. ✅
- **scan the whole file instead of the frontmatter** → **green on the first attempt.** The `frontmatter only` cell used `mentions @rsvelte/fmt: in prose` as its body line, and the regex anchors at `^`, so scanning the whole file changed nothing. The cell was named for a property it did not test. Re-written with a body line that itself looks like a frontmatter entry, the ablation goes red. ✅
- **every pending changeset names a package** — a live control on the tree, so a reader matching none of them cannot pass quietly.

After each ablation the file was restored and `cmp` confirmed byte-identical, with a clean re-run at exit 0.

The end-to-end check was worth its cost for the same reason: on this branch the script exits 0 saying *"No shared-code source touched"*, so the new code never runs. A green here proves nothing about it without forcing a rule to fire.

## Scope

`scripts/release/` only; no package source, so no changeset (and no rule prefix matches, so the guard does not ask for one). Node-only — no cargo, no ratchet, and it does not trigger the LSP corpus job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSuCFoDV9gDHEVPQjPFDmH
