### PR TITLE
fix(lsp): append the Svelte guidance upstream adds to two TypeScript diagnostics (#4498)

### DIFF
--- a/.changeset/diagnostic-message-adjustments.md
+++ b/.changeset/diagnostic-message-adjustments.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/language-server": patch
+---
+
+Append the Svelte-specific guidance upstream adds to two TypeScript diagnostics: a component
+constructor-type error (TS2345 mentioning `ConstructorOfATypedSvelteComponent`) and
+`Modifiers cannot appear here.` (TS1184).

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -3400,6 +3400,7 @@ impl Server {
                     }
                     if method == "textDocument/diagnostic" {
                         fill_diagnostic_tags(result);
+                        adjust_diagnostic_messages(result);
                     }
                     if let Some(fallback) = fallback_result {
                         merge_tsgo_result(&method, result, fallback);
@@ -4305,6 +4306,59 @@ const DEPRECATED_CODES: [i64; 2] = [6385, 6387];
 /// `reportsDeprecated` off the TypeScript API instead, and its `getDiagnosticTag`
 /// returns `[]` rather than `undefined`, so every diagnostic it emits carries the
 /// key. The code decides both flags, so the LSP surface can reproduce them.
+/// Upstream rewrites two diagnostics' message text before returning them
+/// (`typescript-go/features/DiagnosticsProvider.ts:946-981`). Svelte 5 is the
+/// only target here, so the `isSvelte5Plus` arm's `SvelteComponentTyped`
+/// paragraph is never appended -- which is why the first suffix ends in a space.
+const COMPONENT_CONSTRUCTOR_HINT: &str = "\n\nPossible causes:\n\
+    - You use the instance type of a component where you should use the constructor type\n\
+    - Type definitions are missing for this Svelte Component. ";
+
+const DECLARE_STATEMENT_HINT: &str =
+    "\nIf this is a declare statement, move it into <script context=\"module\">..</script>";
+
+fn adjust_diagnostic_messages(result: &mut serde_json::Value) {
+    fn adjust_items(value: &mut serde_json::Value) {
+        let Some(items) = value
+            .get_mut("items")
+            .and_then(serde_json::Value::as_array_mut)
+        else {
+            return;
+        };
+        for item in items {
+            let Some(object) = item.as_object_mut() else {
+                continue;
+            };
+            let code = object.get("code").and_then(serde_json::Value::as_i64);
+            let Some(message) = object.get("message").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            let suffix = match code {
+                Some(2345) if message.contains("ConstructorOfATypedSvelteComponent") => {
+                    COMPONENT_CONSTRUCTOR_HINT
+                }
+                Some(1184) => DECLARE_STATEMENT_HINT,
+                _ => continue,
+            };
+            if message.ends_with(suffix) {
+                continue;
+            }
+            let adjusted = format!("{message}{suffix}");
+            object.insert("message".to_string(), serde_json::Value::String(adjusted));
+        }
+    }
+
+    adjust_items(result);
+    if let Some(related) = result
+        .get_mut("relatedDocuments")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        for report in related.values_mut() {
+            adjust_items(report);
+        }
+    }
+}
+
 fn fill_diagnostic_tags(result: &mut serde_json::Value) {
     fn tag_items(value: &mut serde_json::Value) {
         let Some(items) = value
@@ -4621,6 +4675,95 @@ fn might_be_at_start_tag_whitespace(text: &str, offset: usize) -> bool {
     let at = text.get(offset..).and_then(|text| text.chars().next());
     before.is_some_and(char::is_whitespace)
         && at.is_some_and(|character| character.is_whitespace() || matches!(character, '>' | '/'))
+}
+
+#[cfg(test)]
+mod diagnostic_message_tests {
+    use super::{COMPONENT_CONSTRUCTOR_HINT, DECLARE_STATEMENT_HINT, adjust_diagnostic_messages};
+
+    fn messages(items: serde_json::Value) -> Vec<String> {
+        let mut result = serde_json::json!({ "kind": "full", "items": items });
+        adjust_diagnostic_messages(&mut result);
+        result["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|item| item["message"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    /// The expected bytes are official's own, read out of the LSP gate artifact
+    /// rather than retyped: the line-continuations above must rebuild exactly
+    /// this, trailing space included -- it is the `isSvelte5Plus` ternary's empty
+    /// arm, and a version that drops it still looks right.
+    #[test]
+    fn the_constructor_hint_is_byte_identical_to_the_official_server() {
+        assert_eq!(
+            COMPONENT_CONSTRUCTOR_HINT,
+            "\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. "
+        );
+        assert!(COMPONENT_CONSTRUCTOR_HINT.ends_with(' '));
+        assert!(!COMPONENT_CONSTRUCTOR_HINT.contains("SvelteComponentTyped"));
+    }
+
+    #[test]
+    fn only_a_component_constructor_2345_is_adjusted() {
+        let out = messages(serde_json::json!([
+            { "code": 2345, "message": "x ConstructorOfATypedSvelteComponent y" },
+            { "code": 2345, "message": "an ordinary argument-type error" },
+            { "code": 1184, "message": "Modifiers cannot appear here." },
+            { "code": 2322, "message": "untouched" },
+            { "message": "no code at all" }
+        ]));
+        assert_eq!(
+            out[0],
+            format!("x ConstructorOfATypedSvelteComponent y{COMPONENT_CONSTRUCTOR_HINT}")
+        );
+        assert_eq!(out[1], "an ordinary argument-type error");
+        assert_eq!(
+            out[2],
+            format!("Modifiers cannot appear here.{DECLARE_STATEMENT_HINT}")
+        );
+        assert_eq!(out[3], "untouched");
+        assert_eq!(out[4], "no code at all");
+    }
+
+    /// The response passes this once, but a merged fallback or a re-entered
+    /// pipeline must not append a second copy.
+    #[test]
+    fn adjusting_twice_appends_once() {
+        let mut result = serde_json::json!({
+            "kind": "full",
+            "items": [{ "code": 1184, "message": "Modifiers cannot appear here." }]
+        });
+        adjust_diagnostic_messages(&mut result);
+        adjust_diagnostic_messages(&mut result);
+        assert_eq!(
+            result["items"][0]["message"].as_str().unwrap(),
+            format!("Modifiers cannot appear here.{DECLARE_STATEMENT_HINT}")
+        );
+    }
+
+    #[test]
+    fn related_documents_are_adjusted_too() {
+        let mut result = serde_json::json!({
+            "kind": "full",
+            "items": [],
+            "relatedDocuments": {
+                "file:///a.ts": {
+                    "kind": "full",
+                    "items": [{ "code": 1184, "message": "Modifiers cannot appear here." }]
+                }
+            }
+        });
+        adjust_diagnostic_messages(&mut result);
+        assert_eq!(
+            result["relatedDocuments"]["file:///a.ts"]["items"][0]["message"]
+                .as_str()
+                .unwrap(),
+            format!("Modifiers cannot appear here.{DECLARE_STATEMENT_HINT}")
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #4498.

Upstream rewrites a diagnostic's message before returning it — `adjustIfNecessary`,
`typescript-go/features/DiagnosticsProvider.ts:946` — and rsvelte forwarded tsgo's text
unchanged. Two arms: a TS2345 whose message mentions `ConstructorOfATypedSvelteComponent`
gains a "Possible causes:" paragraph naming the instance-vs-constructor mistake, and TS1184
(`Modifiers cannot appear here.`) gains a line pointing at `<script context="module">`.

## The carrier is measured, not asserted

Read out of **#4483's own CI log** rather than from a run of mine — the gate's own output is a
better oracle than a local arm, and it cost no build:

```
upstream-features/component-invalid/input.svelte, 4 diagnostics
  4 official WITH-suffix
  4 rsvelte  NO-suffix
```

Official's text ends with exactly `COMPONENT_CONSTRUCTOR_HINT`, trailing space included. The
trailing space is not a transcription slip: upstream concatenates a Svelte-3.31
`SvelteComponentTyped` paragraph after it and selects `''` when `isSvelte5Plus`, so on the only
target this port has, the message ends with the separator still attached.

The 1184 arm has **0** occurrences in that same log, against 48 of `Possible causes` as the live
control. So it is ported by inspection with a *measured* absence of carriers rather than an
assumed one.

## What this PR should move: 0 ratchet keys

Pre-registered before pushing, and this is a correction — my first prediction was 8 re-keys and
it was wrong. `diff.mjs:20-21` decides it by reading:

```js
if (method === "textDocument/diagnostic" && pointer.endsWith("/items")) {
  return `diagnostic-${digest([value.code, value.source, value.range?.start])}`;
}
```

Identity is `(code, source, range.start)` — message is not in it — and the `extra`/`missing` set
digest is over those identity keys, not over values. So a message change moves neither pairing
nor any set hash. Three legs:

1. Pairing and set hashes exclude `message`, per the code above.
2. The whole ratchet holds exactly **2** `message:value-mismatch` keys of any method, both on
   `upstream-testfiles/completions/string-completion.svelte`, whose source is `abc('@')` against
   `function abc(str: 'hi' | '@hi' | '~hi')` — a TS2345 with no
   `ConstructorOfATypedSvelteComponent`, which the guard declines. It is the live corpus case for
   `only_a_component_constructor_2345_is_adjusted`.
3. On `main`, `component-invalid`'s items do not pair (`extra 13 / missing 5`), so no message
   there is compared until #4483 lands.

Can it *break* a currently-matching diagnostic? Structurally no: official appends the suffix
unconditionally for that code-and-substring, so a paired carrier could only be matching today if
rsvelte already emitted the suffix, which it never has. Every such pair would already be listed,
and neither listed key is that shape.

If the LSP gate goes red here, the argument is wrong somewhere and I would rather learn it from
the gate.

## What a green gate here does NOT establish

Stated plainly because it is the thing most likely to be misread later. The prediction above is
0 keys **on `main`**, and the risk is not that it fails — it is that it succeeds and the success
is later cited as validation of the fix.

Nothing in the ratchet distinguishes *0 because the carrier is unobservable until #4483 makes
those four diagnostics pair* from *0 because the change does nothing at all*. Both produce an
identical green. So a green `Language server` here confirms that this PR is inert on the current
tree, which is what it was predicted to be, and it is not evidence that the transformation is
correct.

The evidence for correctness is the five-row table above — in particular the second row, which is
the gate's own digest over the whole diagnostic object rather than a restatement of the string
equality, and the negative control that dropping one trailing space from a 162-character constant
breaks the match. Those were measured against the oracle's real output. The green was not.

The check that *would* validate this against the gate arrives when #4483 lands, since that is
what makes the carrier observable at all.

## Merge order: this lands before #4483 re-baselines

#4483 narrows `component-invalid` to `extra 9 / missing 1`; four items pair for the first time;
their messages are compared for the first time; and 16 keys appear (4 items × opened/`phase=edit`
× `differential`/`expected`), all carrying the identical
`official=32c129f586d1, rsvelte=224effe9a18b`. That is GATES.md 39b's adding direction, not
something either PR breaks — but if #4483 re-baselines those 16 in and this PR merges after, the
16 go stale and the two-sided ratchet turns **`main`** red, visible on neither PR because each
merge ref holds only the other's absence.

## Tests, and what they do not cover

Four unit tests, all passing; `cargo test -p rsvelte_language_server --lib` reads
380 passed / 0 failed / 1 ignored.

Two ablations, because "4 tests pass" is not a coverage claim:

- **Drop the trailing space from the constant** → exactly one test fails, and it is
  `the_constructor_hint_is_byte_identical_to_the_official_server`. The other three are written in
  terms of the constant, so they are self-consistent and cannot catch a wrong one — the
  port-vs-port oracle problem inside a single test file. Only the independently-pinned test can.
- **Remove the call site, keep the function** → **381 passed, 0 failed**. The function can go
  dead with the suite green. `fill_diagnostic_tags` beside it has the identical gap. What covers
  the wiring is the LSP fixtures gate's `component-invalid` carrier, which is this change's
  falsifiable prediction rather than a claim of coverage.

## Not ported

Upstream calls `swapDiagRangeStartEndIfNecessary` on the following line. rsvelte has that swap in
`map_preprocessed_diagnostic` — the preprocessor source-map path — and the crate's only
`std::mem::swap` is that one, so the tsgo proxy path has none. Whether that path can produce an
inverted range is unmeasured. It is a range defect rather than a message one and is deliberately
left out.

One incidental worth recording: the oracle carries **two** copies of this function,
`typescript/features/` (706 lines, `adjustIfNecessary` at :423) and `typescript-go/features/`
(1281 lines, at :946). They are byte-identical over that function, so the strings do not depend
on which plugin a run selects — but the line number does, and rsvelte proxies tsgo. I nearly
"corrected" the right citation to the wrong port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSuCFoDV9gDHEVPQjPFDmH
