### PR TITLE
fix(client): a comment inside a `$props()` declaration no longer deletes the next statement (#4503)

### DIFF
--- a/.changeset/props-comment-keeps-same-line-statement.md
+++ b/.changeset/props-comment-keeps-same-line-statement.md
@@ -1,0 +1,16 @@
+---
+'@rsvelte/compiler': patch
+---
+
+client: a comment inside a `$props()` declaration no longer deletes the next statement
+
+The `$props()` destructuring rewrite is routed per source *line*, and the line
+that carries a block comment between `=` and `$props()` can hold a second
+statement after the declaration's `;`. The whole-line rewrite replaced it, so
+`let { a } = /* c */ $props(); console.log(a)` emitted no `console.log` — and
+the same for an `onMount` registration or a `$state` declaration. The output
+parses and runs, so only output equality could see it.
+
+The routing guard now requires the declaration's `;` to be the line's last code
+byte, which sends a line carrying a trailing statement to the statement-based
+path instead.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -10,7 +10,7 @@ use super::{
 };
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase3_transform::shared::js_scan::{
-    code_bytes, find_rune_code, find_rune_code_from, skip_opaque,
+    code_bytes, code_bytes_from, find_rune_code, find_rune_code_from, skip_opaque,
 };
 use crate::compiler::phases::phase3_transform::shared::rune_shadow::RuneShadows;
 use crate::compiler::phases::phase3_transform::shared::template::escape_js_string;
@@ -107,6 +107,16 @@ pub(super) fn transform_client_runes_with_skip_and_state<'a>(
             &result[assignment + 1..props_at],
         )
         .is_empty()
+        // The caller's unit is a line, not a statement, so it can hold a second
+        // statement after this declaration's `;` — which the whole-unit rewrite
+        // below would delete.
+        && {
+            let bytes = result.as_bytes();
+            match code_bytes_from(bytes, props_at).find(|&(_, byte)| byte == b';') {
+                Some((semi, _)) => code_bytes_from(bytes, semi + 1).next().is_none(),
+                None => true,
+            }
+        }
         && let Some(transformed) = super::props_transforms::transform_props_destructuring(
             &result,
             prop_source_vars,

--- a/crates/rsvelte_core/tests/props_comment_deletes_same_line_statement_4503.rs
+++ b/crates/rsvelte_core/tests/props_comment_deletes_same_line_statement_4503.rs
@@ -1,0 +1,122 @@
+//! A block comment between `=` and `$props()` deleted the statement after it on
+//! the same line (#4503). Silent code loss: the output parses, runs, and the
+//! deleted statement's effect simply never happens.
+//!
+//! The chain is four sites. `3_transform/client/mod.rs:8803` splits the script
+//! with `.lines()`, and the accumulator above it joins lines into "statements"
+//! but can never split one line into two — so two statements sharing a line are
+//! one indivisible unit. `client/rune_transforms.rs` routes to a text path when
+//! a comment sits between the last `=` and `$props(`, and its own comment says
+//! it handles that shape "while it is still one complete source statement" —
+//! an assumption the line split does not provide. `transform_props_destructuring`
+//! then replaces the whole unit, discarding everything else on the line.
+//!
+//! **One test per carrier, each failing on its own.** A single "no statement is
+//! lost" assertion over all three is satisfied by the other two when one
+//! regresses, and the three reach the deletion through different declarators.
+//!
+//! **What these tests cannot distinguish, stated because it bounds them.** The
+//! narrow guard under test and *deleting the routing branch outright* produce
+//! identical output on every cell here and on all 67,156 corpus cells
+//! (33,578 files x client/client-dev, three arms with distinct `sha256`). That
+//! is consistent rather than suspicious: the branch's own entry condition is a
+//! block comment between `=` and `$props(`, which occurs in **0** of 35,723
+//! real `.svelte` files (control: 8,711 files bearing `$props(`), so it never
+//! fires there. These tests therefore pin the *behaviour* and say nothing about
+//! whether the branch earns its place.
+//!
+//! Expected values were read out of `submodules/svelte`'s compiler at the pin
+//! `7bc0a70fe` (`VERSION 5.57.0`), not inferred from rsvelte's output.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compiles")
+    .js
+    .code
+}
+
+#[test]
+fn a_side_effect_after_a_commented_props_declaration_survives() {
+    let out = client(
+        "<script>let { a } = /* c */ $props(); console.log(\"SIDE_EFFECT\");</script><i>{a}</i>",
+    );
+    assert!(
+        out.contains("SIDE_EFFECT"),
+        "the console.log sharing the declaration's line was deleted:\n{out}"
+    );
+}
+
+#[test]
+fn a_state_declaration_after_a_commented_props_declaration_survives() {
+    let out =
+        client("<script>let { a } = /* c */ $props(); let s = $state(0);</script><i>{a}{s}</i>");
+    assert!(
+        out.contains("let s"),
+        "the `$state` declaration sharing the line was deleted:\n{out}"
+    );
+}
+
+#[test]
+fn a_side_effect_after_a_commented_non_destructured_props_declaration_survives() {
+    let out = client(
+        "<script>let p = /* c */ $props(); console.log(\"SIDE_EFFECT\");</script><i>{p.a}</i>",
+    );
+    assert!(
+        out.contains("SIDE_EFFECT"),
+        "the console.log after a non-destructured declaration was deleted:\n{out}"
+    );
+}
+
+/// The comment position is the carrier, so the neighbouring positions are what
+/// say the guard is not simply "never route to the text path". Each cell's name
+/// is a claim about its source text: the comment really is outside the `=` /
+/// `$props(` span in every one.
+#[test]
+fn a_comment_outside_the_value_position_never_deleted_the_statement() {
+    for (name, body) in [
+        (
+            "leading the declaration",
+            "/* c */ let { a } = $props(); console.log(\"KEEP\");",
+        ),
+        (
+            "inside the pattern",
+            "let { a /* c */ } = $props(); console.log(\"KEEP\");",
+        ),
+        (
+            "trailing the declaration",
+            "let { a } = $props(); /* c */ console.log(\"KEEP\");",
+        ),
+        (
+            "no comment at all",
+            "let { a } = $props(); console.log(\"KEEP\");",
+        ),
+    ] {
+        let out = client(&format!("<script>{body}</script><i>{{a}}</i>"));
+        assert!(out.contains("KEEP"), "{name}: statement deleted:\n{out}");
+    }
+}
+
+/// The same comment with the statement on its own line: the unit is then a
+/// single statement, the guard's new conjunct holds, and the text path still
+/// runs. This is the cell that would move if the guard were widened into
+/// "never route", so it is the one that bounds the fix from the other side.
+#[test]
+fn a_statement_on_its_own_line_still_survives() {
+    let out =
+        client("<script>let { a } = /* c */ $props();\nconsole.log(\"KEEP\");</script><i>{a}</i>");
+    assert!(
+        out.contains("KEEP"),
+        "statement on its own line deleted:\n{out}"
+    );
+}


### PR DESCRIPTION
Closes #4503.

## What was wrong

The `$props()` destructuring rewrite is routed per source **line**, not per
statement. `client/mod.rs:8803` splits the instance script with `.lines()`, and
`props_transforms::transform_props_destructuring` takes a `&str` line and
replaces that unit whole. A line carrying a block comment between `=` and
`$props()` can also hold a second statement after the declaration's `;`, and the
whole-unit rewrite deleted it:

```svelte
<script>
  let { a } = /* c */ $props(); console.log(a);
</script>
```

emits no `console.log`. The same is true for an `onMount` registration and for
`let s = $state(0)`. `function f() {}` survives, because it is hoisted by a
separate pass — which is what made the loss look shape-dependent rather than
positional.

The output **parses and runs**, so the parse gate cannot see it; only output
equality can.

The carrier is the `init` comment position specifically. `lead`, `patt`, `tail`,
a `//` line comment, and no comment at all are all unaffected, and a
non-destructured `let a = /* c */ $props()` is affected too.

## The fix

The routing guard in `rune_transforms.rs` now requires the declaration's `;` to
be the **last code byte on the line** (`js_scan::code_bytes_from`, so a trailing
comment does not count). A line carrying a statement after the `;` is sent down
the statement-based path instead of being replaced whole.

The guard sits next to that branch's own comment, which already stated the
precondition it did not check — *"Handle only that comment-straddled shape while
it is still one complete source statement"*.

## Evidence

Corpus sweep, 33,578 files x 2 targets = **67,156 cells** (63,324 live, 3,832
rejected by both arms), `keys == files` printed beside the result:

```
base arm    f47de20348511bc1
fix arm     00b3aa50314872cb      base vs FIX      MOVED = 0
ablated arm 25fc2f12c8c9e81c      base vs ABLATED  MOVED = 0
```

Distinct arm hashes, with a discriminating probe run through each binary.

The third arm ablates the **whole** routing branch, and it moves nothing either.
The tests record that as the bound it is: **the narrow guard and full ablation
are indistinguishable on every cell measured and on all 67,156 corpus cells.**
That is consistent rather than suspicious — the branch's entry condition has
**0 carriers in 35,723 real files** (live control: 8,711 files reach the
enclosing scan), so no corpus input can separate them. It is stated in the test
file's doc comment so the next reader does not take `MOVED = 0` for reach.

Ablation control: the three carrier tests fail without the guard, the two
control tests still pass, and reverting restores the tree byte-identically.

Arm provenance: both arms were built at `5ad043008`, and `origin/main` has since
moved to `62410db75` — the three intervening commits touch
`crates/rsvelte_language_server/` only, which is not in the compile path either
arm links, so the measurement is of this change against a compiler-identical
base.

## Tests

`crates/rsvelte_core/tests/props_comment_deletes_same_line_statement_4503.rs` —
five tests, one per carrier, each failing on its own:

- a side effect after a commented destructured declaration
- a `$state` declaration after one
- a side effect after a commented **non**-destructured declaration
- a comment outside the value position (negative control: never affected)
- the same declaration with the statement on its own line (negative control)

## What this does not close

#4501, #4398's client half and #4396 all live in the same pipeline and are
untouched here. #4503 is the root of two of #4501's nine cells — the rows whose
`trimmed.is_empty()` reads `true` only because this defect had already deleted
the statement — so #4501 will need re-measuring on top of this, not before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
