### PR TITLE
fix(client): locate the `$props()` declaration among code bytes, not by substring (#4493)

### DIFF
--- a/.changeset/props-comment-decoy-scans.md
+++ b/.changeset/props-comment-decoy-scans.md
@@ -1,0 +1,15 @@
+---
+'@rsvelte/compiler': patch
+---
+
+client: a `$props()` decoy in a string or comment no longer drops the declaration's comment
+
+`props_declaration_comments` located the declaration with
+`find_sub("$props()")`, so a `$props()` written inside a string or a comment
+earlier in the script took the anchor. The backward `let` search before that
+offset then found nothing, the function returned no comments, and the real
+declaration's comment was dropped rather than misplaced. It now walks
+`js_scan::find_rune_code`, which skips strings, comments, templates and regex
+literals.
+
+Both outputs parse and run identically, so only comment text differs.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -3262,9 +3262,14 @@ fn script_raw_statement(
 /// Comments inside the `$props()` declaration survive upstream's lowering even
 /// though the declaration itself is removed from the component body.
 fn props_declaration_comments(raw: &str) -> Vec<(u32, CompactString)> {
-    let Some(props) = raw.find_sub("$props()") else {
+    let bytes = raw.as_bytes();
+    // A `$props(` in a string, comment or template is not the declaration, and a
+    // raw scan that takes the decoy loses the real declaration's comments.
+    let Some(props) = find_rune_code(bytes, b"$props(") else {
         return Vec::new();
     };
+    // The `;` scan stays raw: a code-aware one finds none in a semicolon-free
+    // source and the region then runs to the end of the script.
     let Some(start) = raw[..props].rfind_sub("let") else {
         return Vec::new();
     };

--- a/crates/rsvelte_core/tests/props_declaration_comment_raw_scans_4493.rs
+++ b/crates/rsvelte_core/tests/props_declaration_comment_raw_scans_4493.rs
@@ -1,0 +1,88 @@
+//! A `$props()` decoy in a string or a comment no longer loses the real
+//! declaration's comment.
+//!
+//! Four raw text scans decide where that declaration is and whether its comment
+//! still needs emitting: `find_sub("$props()")` and `rfind_sub("let")` locate it
+//! (`client/mod.rs:3264`), `find(';')` ends it, and
+//! `transformed_script.contains(comment)` at `client/mod.rs:1459` decides
+//! whether to re-emit. Only the first is fixed here.
+//!
+//! The other three are entangled, which is a measurement rather than a scope
+//! choice. Hardening the `contains` gate to compare against the script's real
+//! comments fixes three constructed cells and regresses **19 corpus units**,
+//! because the `;` scan truncates the region at a `;` written inside a comment
+//! — so the extracted "props comment" is a partial line comment, and the
+//! substring test was the only thing hiding it. Hardening the `;` scan instead
+//! regresses **4 other units**: threlte's `Svg` and `ContactShadows` have every
+//! `;` inside a string or a template literal, so a code-aware scan finds none,
+//! the region runs to the end of the script, and unrelated comments are swept
+//! into the declaration. Two wrong scans whose errors cancel, with the
+//! substring test as the cancelling stage; fixing either alone measures worse
+//! than fixing neither, so they go together in a separate change.
+//!
+//! Every cell diverges from official on comment *placement* (#4448) whichever
+//! way these scans answer, so the assertions are about the comment being
+//! present, which is what this defect decides.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compiles")
+    .js
+    .code
+}
+
+/// The template has to read the prop: with the prop unused the declaration is
+/// elided and every arm agrees on an output that never reached these scans.
+fn component(body: &str) -> String {
+    format!("<script>\n\t{body}\n</script>\n<i>{{p.a}}</i>")
+}
+
+fn count(haystack: &str, needle: &str) -> usize {
+    haystack.matches(needle).count()
+}
+
+#[test]
+fn a_props_decoy_in_a_string_does_not_lose_the_declarations_comment() {
+    let out = client(&component(
+        "const s = \"$props()\";\n\tconsole.log(s);\n\tlet p = /* c */ $props();",
+    ));
+    assert_eq!(count(&out, "/* c */"), 1, "output:\n{out}");
+}
+
+#[test]
+fn a_props_decoy_in_a_comment_does_not_lose_the_declarations_comment() {
+    let out = client(&component("// $props() here\n\tlet p = /* c */ $props();"));
+    assert_eq!(count(&out, "/* c */"), 1, "output:\n{out}");
+}
+
+/// Negative control: without a decoy the declaration's comment was never lost,
+/// and a sibling comment of different text must still be emitted exactly once.
+#[test]
+fn a_declaration_with_no_decoy_is_unaffected() {
+    let out = client(&component(
+        "let p = /* c */ $props();\n\tlet b = 1; /* d */\n\tconsole.log(b);",
+    ));
+    assert_eq!(count(&out, "/* c */"), 1, "output:\n{out}");
+    assert_eq!(count(&out, "/* d */"), 1, "output:\n{out}");
+}
+
+/// Negative control: with no comment in the declaration the decoy must not
+/// conjure one, which is what a scan that merely moved its anchor would do.
+#[test]
+fn a_decoy_with_no_declaration_comment_emits_nothing() {
+    let out = client(&component(
+        "let p = $props();\n\tconst s = \"$props()\";\n\tconsole.log(s);",
+    ));
+    assert_eq!(count(&out, "/*"), 0, "output:\n{out}");
+}


### PR DESCRIPTION
Closes #4493.

## What was wrong

`props_declaration_comments` (`client/mod.rs:3264`) found the declaration with
`raw.find_sub("$props()")` — a plain substring search — so a `$props()` written
inside a string or a comment earlier in the instance script took the anchor:

```svelte
<script>
	const s = "$props()";
	console.log(s);
	let p = /* c */ $props();
</script>
<i>{p.a}</i>
```

The backward `let` search before that offset then found nothing, the function
returned an empty vec, no `props_comment_anchor` was computed (`mod.rs:1394`),
and the declaration's comment had no anchored node to be flushed at — so it was
**dropped**, not merely misplaced. `find_rune_code` now skips strings, comments,
templates and regex literals.

This is the `opaque-keyword` class recorded for #2986 / #2987 / #2988, at a site
the earlier sweep did not reach.

## Scope — three sibling scans left alone, and why that is a measurement

The same feature has three more raw scans: `rfind_sub("let")`, `find(';')`, and
the re-emission gate `transformed_script.contains(comment)` at `mod.rs:1459`.
The last of these is a real defect and was in my first version of this PR. Two
of the three turn out to be **entangled**, each hiding the other:

| arm | change | MOVED | match → MISMATCH |
|---|---|---:|---:|
| `040e1a34b91ccb62` | anchor + `let` + `;` + gate | 4 | **4** |
| `a33a5cdf078732de` | anchor + gate | 32 | **19** |
| `b8084573760a5c89` | anchor only *(this PR)* | **0** | **0** |

The raw `;` scan truncates the declaration's region at a `;` written inside a
comment, so the extracted "props comment" is a fragment
(`// Header chrome is store-editable theme content;` cut out of a longer line) —
and the substring gate is the only thing suppressing it, because a fragment is a
substring of the comment it came from. Repair the gate and 19 units start
emitting fragments. Repair the `;` scan instead and threlte's `Svg` and
`ContactShadows` regress the other way: every `;` in those two instance scripts
sits inside a string or a template literal, so a code-aware scan finds none, the
region runs to the end of the script, and each file gains a stray
`// svelte-ignore non_reactive_update`.

Each partial repair is measurably worse than neither, so they go together in a
separate change. #4510 carries all three arms' numbers and the constructed cells; nothing here
depends on it landing.

## Evidence

Corpus sweep, 33,578 files × {client, client-dev} = **67,156 cells** (63,324
live, 3,832 rejected by both arms), `keys == files` printed beside the result:

```
base f47de20348511bc1   fix b8084573760a5c89   MOVED = 0
```

Distinct arm hashes, and a 13-cell grid run through each binary separates them —
2 cells `RESTORED`, 0 regressed — so the zero is a statement about the corpus and
not about the arms.

Ablation control: the two carrier tests fail without the fix, the two controls
still pass, and the tree restores byte-identically.

Arm provenance: base was built at `5ad043008`; `origin/main` has since moved to
`62410db75` and the three intervening commits touch
`crates/rsvelte_language_server/` only, which neither arm links.

Stage-2 counts above are **raw bytes**, which is stricter than the gate
(`ast_equiv_batch` runs with `CommentPolicy::Ignore`, so it erases comment-only
divergences on both sides). For this PR that costs nothing — a zero under a
stricter comparison is a zero under the gate. For the two rejected arms the 19
and 4 are regression *candidates*, and the part that is not a candidate is the
direction: 0 units improve under either partial repair.

## Tests

`crates/rsvelte_core/tests/props_declaration_comment_raw_scans_4493.rs` — two
carriers (a decoy in a string, a decoy in a comment) and two negative controls
(no decoy; a decoy with no declaration comment, which must not conjure one). The
assertions count the comment rather than comparing bytes, because every cell
diverges from official on comment *placement* (#4448) whichever way these scans
answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA

