### PR TITLE
fix(client): end a `$props()` declaration at its code `;` and count comments instead of testing substrings (#4510)

### DIFF
--- a/.changeset/props-comment-scan-pair.md
+++ b/.changeset/props-comment-scan-pair.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Keep a `$props()` declaration's comment whose text also occurs in a string, a template literal or another comment, and stop truncating the declaration at a `;` written inside its own comment — which emitted an unterminated `/*` fragment

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -99,8 +99,8 @@ use std::sync::LazyLock;
 
 use crate::compiler::phases::phase1_parse::parser::is_js_whitespace;
 use crate::compiler::phases::phase3_transform::shared::js_scan::{
-    after_keyword, after_keywords, code_bytes, contains_identifier, find_code, find_rune_code,
-    is_ident_byte, skip_opaque,
+    after_keyword, after_keywords, code_bytes, code_bytes_from, contains_identifier, find_code,
+    find_rune_code, is_ident_byte, skip_opaque,
 };
 use crate::compiler::phases::phase3_transform::shared::rune_shadow;
 use crate::compiler::phases::phase3_transform::shared::substring::Substring;
@@ -1455,8 +1455,20 @@ pub(crate) fn transform_client(
                 content.start + (text.len() - text.trim_start().len()) as u32
             });
         if !trimmed.is_empty() {
+            // A comment's text also occurs in a string, inside a longer comment,
+            // and sometimes a second time as its own comment, so presence is a
+            // count of comment tokens rather than a substring test: re-emit
+            // exactly the occurrences the transform dropped.
+            let mut live = script_comment_texts(&transformed_script);
+            let source_comments = script_comment_texts(&content.raw);
             for (offset, comment) in &props_comments {
-                if !transformed_script.contains(comment.as_str()) {
+                let kept = live.iter().filter(|text| *text == comment.as_str()).count();
+                let had = source_comments
+                    .iter()
+                    .filter(|text| *text == comment.as_str())
+                    .count();
+                if kept < had {
+                    live.push(comment.to_string());
                     component_body.push(JsStatement::RawMapped {
                         code: comment.clone(),
                         source_offset: content.start + *offset,
@@ -3259,6 +3271,14 @@ fn script_raw_statement(
     }
 }
 
+/// The text of every comment token in a script, in source order.
+fn script_comment_texts(script: &str) -> Vec<String> {
+    crate::compiler::phases::phase3_transform::server::transform_script::extract_comments_from_snippet_with_pos(script)
+        .into_iter()
+        .map(|(_, comment)| comment)
+        .collect()
+}
+
 /// Comments inside the `$props()` declaration survive upstream's lowering even
 /// though the declaration itself is removed from the component body.
 fn props_declaration_comments(raw: &str) -> Vec<(u32, CompactString)> {
@@ -3268,14 +3288,17 @@ fn props_declaration_comments(raw: &str) -> Vec<(u32, CompactString)> {
     let Some(props) = find_rune_code(bytes, b"$props(") else {
         return Vec::new();
     };
-    // The `;` scan stays raw: a code-aware one finds none in a semicolon-free
-    // source and the region then runs to the end of the script.
     let Some(start) = raw[..props].rfind_sub("let") else {
         return Vec::new();
     };
-    let end = raw[props..]
-        .find(';')
-        .map_or(raw.len(), |end| props + end + 1);
+    // Whichever bound comes first: a raw `;` scan stops inside a comment that
+    // contains one, and a code-aware scan finds none in a semicolon-free source
+    // and then runs to the end of the script.
+    let semi = code_bytes_from(bytes, props)
+        .find(|&(_, byte)| byte == b';')
+        .map_or(raw.len(), |(at, _)| at + 1);
+    let line_end = raw[props..].find('\n').map_or(raw.len(), |at| props + at);
+    let end = semi.min(line_end);
     crate::compiler::phases::phase3_transform::server::transform_script::extract_comments_from_snippet_with_pos(&raw[start..end])
         .into_iter()
         .map(|(offset, comment)| ((start + offset) as u32, comment.into()))

--- a/crates/rsvelte_core/tests/props_comment_scan_pair_4510.rs
+++ b/crates/rsvelte_core/tests/props_comment_scan_pair_4510.rs
@@ -1,0 +1,158 @@
+//! Two raw scans in the `$props()` comment path were wrong in opposite
+//! directions, and the error of one hid the error of the other.
+//!
+//! `props_declaration_comments` ended the declaration's region at the first raw
+//! `;`, so a `;` written inside a comment truncated it and the extracted
+//! "comment" was a fragment; `client/mod.rs`'s re-emission gate then asked
+//! `transformed_script.contains(comment)`, and a fragment is a substring of the
+//! comment it came from, so the fragment was suppressed. Repairing either alone
+//! measured worse than repairing neither — the substring gate was the stage
+//! cancelling the truncation.
+//!
+//! The region now ends at whichever comes first of the declaration's own code
+//! `;` and the end of the line carrying `$props(`, which bounds it in both
+//! semicolon styles, and presence is counted over comment *tokens* rather than
+//! tested as a substring.
+//!
+//! Ablating each half reddens a disjoint set: the raw `;` scan fails the two
+//! truncation cells, the substring gate the four decoy cells. Three cells fail
+//! under neither — the two negative controls and the semicolon-free one, whose
+//! later comment the counting gate keeps whatever the region does, so it
+//! records the shape rather than defending the bound.
+//!
+//! Every expected value below is the official compiler's, taken by compiling
+//! these exact cells rather than inferred from neighbouring ones. The cells
+//! assert counts and not placement: the comment's position still diverges
+//! (#4448) whichever way these scans answer.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compiles")
+    .js
+    .code
+}
+
+/// The template has to read the prop: with the prop unused the declaration is
+/// elided and every arm agrees on an output that never reached these scans.
+fn component(body: &str) -> String {
+    format!("<script>\n\t{body}\n</script>\n<i>{{p.a}}</i>")
+}
+
+fn count(haystack: &str, needle: &str) -> usize {
+    haystack.matches(needle).count()
+}
+
+#[test]
+fn a_comment_text_repeated_inside_a_string_is_not_read_as_the_comment() {
+    let out = client(&component(
+        "let p = /* c */ $props();\n\tconst s = \"/* c */\";\n\tconsole.log(s);",
+    ));
+    assert_eq!(count(&out, "/* c */"), 2, "output:\n{out}");
+}
+
+#[test]
+fn a_comment_text_repeated_inside_a_template_literal_is_not_read_as_the_comment() {
+    let out = client(&component(
+        "let p = /* c */ $props();\n\tconst s = `x/* c */y`;\n\tconsole.log(s);",
+    ));
+    assert_eq!(count(&out, "/* c */"), 2, "output:\n{out}");
+}
+
+#[test]
+fn a_comment_text_repeated_inside_a_longer_comment_is_not_read_as_the_comment() {
+    let out = client(&component(
+        "let p = /* c */ $props();\n\tlet b = 1; // see /* c */ below\n\tconsole.log(b);",
+    ));
+    assert_eq!(count(&out, "/* c */"), 2, "output:\n{out}");
+}
+
+/// The gate's premise fails on ordinary code too: the second occurrence here is
+/// a real comment with the same text, so a presence test has to count rather
+/// than answer yes.
+#[test]
+fn a_second_real_comment_of_the_same_text_does_not_suppress_the_declarations() {
+    let out = client(&component(
+        "let p = /* c */ $props();\n\tlet b = 1; /* c */\n\tconsole.log(b);",
+    ));
+    assert_eq!(count(&out, "/* c */"), 2, "output:\n{out}");
+}
+
+/// A `;` written inside a comment between `$props(` and the statement's own `;`
+/// truncated the region, so the extracted "comment" was an unterminated prefix
+/// of it — and `main` emits that prefix, producing output no JS parser accepts.
+/// Ending the region at the first *code* `;` is what the counting gate alone
+/// does not fix: with a raw `;` scan the comment is lost instead.
+#[test]
+fn a_semicolon_inside_the_declarations_comment_does_not_truncate_the_region() {
+    let out = client(&component(
+        "let p = /* c */ $props(/* ; */);\n\tlet q = 1;\n\tconsole.log(q);",
+    ));
+    assert_eq!(count(&out, "/* c */"), 1, "output:\n{out}");
+    assert_eq!(count(&out, "/* ; */"), 1, "output:\n{out}");
+    assert_eq!(
+        count(&out, "/*"),
+        count(&out, "*/"),
+        "an unterminated block comment was emitted:\n{out}"
+    );
+}
+
+/// The same truncation with the decoy after the call rather than inside it.
+#[test]
+fn a_semicolon_inside_a_trailing_comment_does_not_truncate_the_region() {
+    let out = client(&component(
+        "let p = /* c */ $props() /* ; */;\n\tlet q = 1;\n\tconsole.log(q);",
+    ));
+    assert_eq!(count(&out, "/* ; */"), 1, "output:\n{out}");
+    assert_eq!(
+        count(&out, "/*"),
+        count(&out, "*/"),
+        "an unterminated block comment was emitted:\n{out}"
+    );
+}
+
+/// A semicolon-free source has no code `;` to end the region, so it is bounded
+/// by the end of the line carrying `$props(` — without which the region runs to
+/// the end of the script. threlte's `Svg` and `ContactShadows` are that shape:
+/// their only `;` is inside a template literal.
+#[test]
+fn a_semicolon_free_declaration_does_not_sweep_in_later_comments() {
+    let out = client(&component(
+        "let p = /* c */ $props()\n\tlet b = 1\n\t// svelte-ignore x\n\tconsole.log(b)",
+    ));
+    assert_eq!(count(&out, "/* c */"), 1, "output:\n{out}");
+    assert_eq!(count(&out, "// svelte-ignore x"), 1, "output:\n{out}");
+}
+
+/// Negative control: a sibling comment of different text is emitted once and
+/// the declaration's once, which is what a rule that merely emitted more would
+/// break.
+#[test]
+fn a_sibling_comment_of_different_text_is_unaffected() {
+    let out = client(&component(
+        "let p = /* c */ $props();\n\tlet b = 1; /* d */\n\tconsole.log(b);",
+    ));
+    assert_eq!(count(&out, "/* c */"), 1, "output:\n{out}");
+    assert_eq!(count(&out, "/* d */"), 1, "output:\n{out}");
+}
+
+/// Negative control: with no comment in the declaration neither scan may
+/// conjure one out of the script's other comments.
+#[test]
+fn a_declaration_with_no_comment_emits_nothing_extra() {
+    let out = client(&component(
+        "let p = $props(); // a; b\n\tlet b = 1; /* d */\n\tconsole.log(b);",
+    ));
+    assert_eq!(count(&out, "// a; b"), 1, "output:\n{out}");
+    assert_eq!(count(&out, "/* d */"), 1, "output:\n{out}");
+}


### PR DESCRIPTION
Closes #4510.

## The two scans

`props_declaration_comments` ended the `$props()` declaration's region at the
first **raw** `;`. A `;` written inside the declaration's own comment therefore
truncated it, and the extracted "comment" was an unterminated prefix — which
`main` emits:

```svelte
<script>
	let p = /* c */ $props(/* ; */);
	let q = 1;
	console.log(q);
</script>
<i>{p.a}</i>
```

```js
	$.push($$props, true);
	/* c */
	/* ;
	let p = $.rest_props($$props, rest_excludes);
```

acorn: `Unterminated comment (10:1)`. official emits `/* ; */` intact. Two
characters, and **zero carriers in the collected corpus** — the corpus never
holding it is the argument for the cell, not a caveat about it.

The re-emission gate asked `transformed_script.contains(comment)`, so a comment
whose text also occurs in a string, a template literal, a longer comment, or a
second time as its own comment read as "already emitted". A truncated fragment
is also a substring of the comment it came from, which is why the two scans had
to be repaired together: **fixing either alone measures worse than fixing
neither** (#4510's table records 19 and 4 regressing units for the two partial
arms).

## The fix

- the region ends at whichever comes first of the first **code** `;` and the end
  of the line carrying `$props(`. A code-aware scan alone finds none in a
  semicolon-free source and then runs to the end of the script — threlte's `Svg`
  and `ContactShadows` are that shape, their only `;` being inside a template
  literal;
- presence is a **count over comment tokens** rather than a substring test:
  re-emit exactly the occurrences the transform dropped.

## Measured

Corpus, 33,578 files × {client, client-dev} = 67,156 cells, 63,324 live, key
sets identical, base `b8084573760a5c89` (= `main`) against `7338cafd252c5efa`:

```
MOVED = 214 over 107 files

MISMATCH -> match     169
match -> MISMATCH       0
MISMATCH -> MISMATCH   45     (other mechanisms, unrelated to this change)
```

Oracle is `submodules/svelte` at this branch's own pin, `7bc0a70fe` /
`VERSION 5.57.0`. The first run of this comparison used a checkout parked
thirteen commits back, whose pin is `56a036f4c` / `5.56.10`; the two oracles
disagree on **48 of the 214** moved units, which moved the improvement count
(136 → 169) and left the regression count at 0 either way. Corrected below in a
comment rather than silently.

Raw bytes, which is **stricter** than the gate (`ast_equiv_batch` runs with
`CommentPolicy::Ignore`), so the zero on the regressing side is free: a zero
under a stricter comparison is a zero under the gate. Both output ratchets
(`known-failures.client.json`, `known-failures.client-dev.json`) are empty, so
there is nothing to re-baseline.

Generated shape matrix run locally on the same arm: 7,714 cases, 30,424
comparisons, `match 26096 / error-parity 4328`, every other verdict **0**.

## Controls

Nine cells, every expected value taken by compiling that exact cell through
`submodules/svelte`'s source compiler rather than inferred from a neighbour.
Ablating each half reddens a **disjoint** set — the raw `;` scan fails the two
truncation cells, the substring gate the four decoy cells — and restoring is
byte-identical.

Three arms with distinct hashes: `b8084573760a5c89` base, `d6054abf11068502`
gate-only, `7338cafd252c5efa` gate+region. The first four cells written could not
separate the last two; the `$props(/* ; */)` cell is what does, and it reports
`/* ; */` × 0 on the gate-only arm against × 1 on the shipping one.

The doc comment records which cells fail under neither ablation and why, so the
two negative controls and the semicolon-free cell are not read as coverage they
do not have.

## Not in scope

The `$props(); // a b` shape — a comment after the declaration on its own line
being deleted on the client when the declaration also carries one — is a
different stage and is filed as #4512, measured unchanged on this branch's arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
