### PR TITLE
fix(sourcemap): a comment-buffer region records its own `LocRange`

### DIFF
--- a/.changeset/source-region-locmap.md
+++ b/.changeset/source-region-locmap.md
@@ -1,0 +1,12 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(sourcemap): a comment-buffer region records its own `LocRange`
+
+`open_source_region_parts` and `open_island_region` append a verbatim slice of
+the source to the comment buffer and returned spans inside it without recording
+the region. `map_position`'s `loc_map` lookup then missed, fell through
+`None => offset`, and resolved a comment-space offset against the source line
+table — so segments landed past the end of the line they named. Both regions map
+back linearly, which is one `LocRange` each.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -849,6 +849,16 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
             let base = synth.cursor();
             synth.source.push_str(region);
             synth.source.push('\n');
+            // The region is a verbatim slice of the source, so comment-space
+            // offsets inside it resolve linearly; without this a map lookup
+            // falls through untranslated and reports a position past EOF.
+            synth.loc_map.push(LocRange {
+                start: base,
+                end: base + region.len() as u32,
+                source: Some(region_start),
+                linear: true,
+                source_end_override: None,
+            });
             for &(source_start, source_end, line) in comments {
                 if !synth.source_comments.insert((source_start, source_end)) || claim_only {
                     continue;
@@ -898,6 +908,15 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
         let base = synth.cursor();
         synth.source.push_str(text);
         synth.source.push('\n');
+        // Same as `open_source_region_parts`: the island's text is the source's
+        // own, so its buffer region maps back linearly.
+        synth.loc_map.push(LocRange {
+            start: base,
+            end: base + text.len() as u32,
+            source: Some(island.source_offset),
+            linear: true,
+            source_end_override: None,
+        });
         synth.open_source_region = None;
         base.checked_sub(island.source_offset)
     }

--- a/crates/rsvelte_core/tests/map_region_locmap_4466.rs
+++ b/crates/rsvelte_core/tests/map_region_locmap_4466.rs
@@ -1,0 +1,82 @@
+//! A region appended to the comment buffer must record its `LocRange`, or its
+//! offsets reach the source map untranslated and resolve against the source line
+//! table as if they were source offsets.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+use sourcemap::SourceMap;
+
+/// Every one of these puts a comment inside a template expression, which is what
+/// opens a source region; before the fix each reported segments past the end of
+/// the source line they name.
+const CASES: &[(&str, &str)] = &[
+    (
+        "handler-comment-only-body",
+        "<script>\n\tlet a = 1;\n</script>\n\n<button\n\tonclick={function (e) {\n\t\t// nothing to do yet\n\t}}>{a}</button\n>\n",
+    ),
+    (
+        "arrow-inline-block-comment",
+        "<script>\n\tlet v = $state(1);\n</script>\n\n<button onclick={() => /* c */ v++}>x</button>\n",
+    ),
+    (
+        "each-const-parameter-comment",
+        "<script>\n\tlet v = $state(1);\n</script>\n\n{#each [1] as i}{@const c = /* c */ v * i}<p>{c}</p>{/each}\n",
+    ),
+];
+
+fn out_of_range(source: &str, map_json: &str) -> Vec<String> {
+    let map = SourceMap::from_slice(map_json.as_bytes()).expect("map parses");
+    let lines: Vec<&str> = source.split('\n').collect();
+    let mut bad = Vec::new();
+    for token in map.tokens() {
+        let line = token.get_src_line() as usize;
+        let col = token.get_src_col() as usize;
+        match lines.get(line) {
+            None => bad.push(format!("line {line} past EOF")),
+            // A column equal to the line length is the exclusive end of the last
+            // token on that line, which upstream also emits.
+            Some(text) if col > text.chars().count() => bad.push(format!(
+                "{}:{} but line is {} wide",
+                line + 1,
+                col,
+                text.chars().count()
+            )),
+            Some(_) => {}
+        }
+    }
+    bad
+}
+
+#[test]
+fn a_source_region_maps_back_into_its_own_source() {
+    let mut failures = Vec::new();
+    for (name, source) in CASES {
+        for generate in [GenerateMode::Client, GenerateMode::Server] {
+            for dev in [false, true] {
+                let result = compile(
+                    source,
+                    CompileOptions {
+                        generate,
+                        dev,
+                        filename: Some(format!("{name}.svelte")),
+                        ..Default::default()
+                    },
+                )
+                .unwrap_or_else(|e| {
+                    panic!("{name} {generate:?} dev={dev} failed to compile: {e:?}")
+                });
+                let Some(map) = result.js.map.as_ref() else {
+                    continue;
+                };
+                let bad = out_of_range(source, map);
+                if !bad.is_empty() {
+                    failures.push(format!("{name} {generate:?} dev={dev}: {}", bad.join(", ")));
+                }
+            }
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "source-map segments point outside their source line:\n{}",
+        failures.join("\n")
+    );
+}


### PR DESCRIPTION
Closes nothing. Narrows #4466 and files its residue as #4521.

## What

`open_source_region_parts` and `open_island_region` append a verbatim slice of the source to the
comment buffer and hand out spans inside it, without recording the region. `map_position`'s
`loc_map` binary search then misses, falls through `None => offset`, and resolves a comment-space
offset against the **source** line table — so a segment points past the end of the line it names.

Both regions map back linearly (the region's bytes *are* the source's bytes, starting at
`region_start` / `island.source_offset`), so the missing entry is one `LocRange` each.

## Measured

Arms: `origin/main` `15ef4ec31` (`sha256 f788b5a09c2c5cd7`, built from a tree whose `crates/` is
byte-identical to it) against this branch (`d7b83710b0de76cb`). Oracle for the accuracy column is
the `origin/main` gitlink `7bc0a70fe`, `VERSION 5.57.0`.

Over **33,623** live real-world components (every `.svelte` under `submodules/`, `generate: client`,
`dev: false`):

```
js.code MOVED = 0        js.map MOVED = 73
```

On those 73, scoring every segment whose *generated* position starts an identifier by whether the
*source* position it claims starts the same identifier:

| arm | segments | judged | correct | out-of-range |
|---|---:|---:|---:|---:|
| `main` | 45,383 | 18,738 | 12,965 (69.2%) | 732 |
| this branch | 45,383 | 18,738 | **13,811 (73.7%)** | **12** |
| official | 59,634 | 25,475 | 23,179 (91.0%) | 0 |

Per file: **69 better, 1 worse, 3 unchanged**; segment total unchanged on all 73, and 0 files whose
out-of-range count rises. The segment-total column is there deliberately — "corrected" and "no
longer emitted" are the same `0` without it.

`sourcemaps_gate`: 0 out-of-range of 1,622, 58/58 byte-identical outputs, 808/808 official segments,
0 known failures. `cargo test --release -p rsvelte_core --lib --test sourcemaps --test sourcemaps_gate
--test map_region_locmap_4466` → 1,971 + 2 + 4 + 1 passed, 0 failed.

## The one file that gets worse, and why it is not fixed here

`svelte-eslint-parser/tests/fixtures/parser/ast/svelte5/ts-event03-type-output.svelte` nets −1 of 9
judged segments: two go to official's exact positions and three move away. It is a **pre-existing**
`loc_base` under-computation, filed as **#4521** — source offset 375 (`<button`) sits *above*
`loc_base`, so it is indistinguishable from a comment-space offset, and `main` is right there only
because the fall-through returns the identity.

The variant that also fixes the boundary (one `note_span` per region) measures **70 / 0** and is
deliberately not in this PR: raising `loc_base` moves `has_loc`, which drives comment flushing, and
it moves `js.code` on that same file in the wrong direction — official emits 2 comments there,
`main` 4, and the variant 0. That is a comment-cursor change and belongs behind #4489 / #4492 /
#4500 / #4516 / #4517. Both arms' numbers are in #4521.

## What this does not close

#4466's out-of-range class is a **filter artefact** — a segment counts as out of range only when a
line length happens to expose it. Paired over the same 1,215 `pattern-corpus` components, official
scores 84.8% and `main` 57.1%, and of 20,318 judged-and-wrong segments only 2,614 are out of range;
17,704 are wrong while staying inside a line. The mechanism behind that residue is `parse_chunk`'s
comment-free path returning chunk-local spans that reach the map with no split coordinates in play.
Detail and controls in [#4466](https://github.com/baseballyama/rsvelte/issues/4466#issuecomment-5603275788).

## Test

`map_region_locmap_4466.rs` asserts no segment lands past the end of the source line it names, for
three comment-in-template shapes × client/server × dev/prod. Ablated: reverting the patch reddens
all three cases independently, and restoring leaves the tree byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
