### PR TITLE
docs(agents): an experiment built from a remembered classification tests the memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -516,6 +516,23 @@ are in the archived file.
   when the observation is accurate. Related, and about the reader rather than the artifact: the
   same four-cell table was over-read twice in one session by one person, with a correction in
   between — being corrected on an artifact does not fix how you read it.
+- **An experiment designed against a remembered classification tests the memory, not the
+  mechanism.** A prototype's residue had been written up as *"5 of 7 regression files are
+  duplications (official 1 / off 1 / on 2), 2 are relocations"*, and the next arm — a high-water
+  clamp that stops a comment being written twice — was built and pre-registered against exactly
+  that split, with the artifact named on both halves of the falsification condition. It retired
+  **0 of 12** regressions and cost **6 of 40** fixes: same regression set, fix set a proper
+  subset, strictly worse than not having it. Counting comment tokens per arm says why in one
+  command and no build — official / off / on are equal on all seven files (26/26/26, 6/6/6,
+  8/8/8, …), so nothing was ever written twice and the clamp had nothing to clamp. The rule this
+  file already carries about a recalled number is weaker than this case needs: **a
+  classification is a word, so nothing about it looks like a quantity to check**, and a
+  pre-registration inherits the word without ever naming the observation under it. Before an
+  experiment is designed against a prior characterisation, re-derive the characterisation, and
+  prefer a derivation that is a *count* — a count has an instrument and a word does not. The
+  same re-derivation then retired the *next* design too: three of the seven relocations land
+  beside a component call, which is a node upstream locates, so the "restrict to spans that
+  mirror an upstream `loc`" fix would not have moved them either.
 
 ## Working with Subagents
 


### PR DESCRIPTION
One bullet appended to `## Measurement discipline`.

The #4517 prototype's residue had been written up as *"5 of 7 regression files are duplications, 2 are relocations"*. The next arm — a high-water clamp that stops a comment being written twice — was built and pre-registered against exactly that split, with the artifact named on both halves of the falsification condition.

Measured over the same 134,180-key two-arm sweep:

| | flush only | flush + clamp |
|---|---|---|
| `MISMATCH -> match` | 40 | **34** |
| `match -> MISMATCH` | 12 | **12** |

Identical regression set, fix set a proper subset — strictly worse than not having it. A per-arm comment-token count says why in one command with no build in it: official / off / on are equal on all seven files, so nothing was ever written twice and the clamp had nothing to clamp.

The generalisation is one step past the rule this file already carries about a recalled number: a *classification* is a word, so nothing about it looks like a quantity to check, and a pre-registration inherits the word without ever naming the observation under it. The same re-derivation then retired the next design too.

Docs-only. Measurements are in #4517 (comment 5606004339).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
