### PR TITLE
fix(client): a dropped instance-script comment is flushed from source space

### DIFF
--- a/.changeset/instance-script-dropped-comment.md
+++ b/.changeset/instance-script-dropped-comment.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/compiler": patch
+---
+
+client: emit an instance-script comment the located flush drops entirely
+
+Under split coordinates a comment lives above `loc_base` and an original source
+position lives below it, so `has_loc` — which answers "may this node carry
+comments" — reads a real source offset as "no location" and
+`flush_comments_until` returns before writing anything. A comment with no
+comment-space node after it is therefore never emitted at all, which is what a
+`<script>` whose template lowers to a component call produces.
+
+The printer now runs a second pass when the first one dropped a comment, and
+that pass may flush **only** the dropped set from source space. Restricting it
+to what the ordinary path loses is what separates a recovery from a relocation:
+measured over the corpus, the rule fixes 22 units and moves none. The second
+pass runs on 0.86% of compiles.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.40"
+version = "0.10.41"
 dependencies = [
  "compact_str",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.146", features = ["serialize"] }
 oxc_span = "0.146"
 oxc_diagnostics = "0.146"
 oxc_codegen = "0.146"
-rsvelte_esrap = { version = "=0.10.40", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.41", path = "../rsvelte_esrap" }
 oxc_syntax = "0.146"
 oxc_semantic = "0.146"
 

--- a/crates/rsvelte_core/tests/instance_script_dropped_comment_4517.rs
+++ b/crates/rsvelte_core/tests/instance_script_dropped_comment_4517.rs
@@ -1,0 +1,113 @@
+//! The control for the instance-script comment the located flush cannot reach.
+//!
+//! Under split coordinates a real source offset sits *below* `loc_base`, so
+//! `Printer::has_loc` reads it as "no location" and the located flush declines
+//! it — a comment with no comment-space node after it is then never emitted at
+//! all. `print_split` recovers exactly those by printing once and printing
+//! again only when the first pass dropped something.
+//!
+//! The pair is what makes this discriminating. `drop_*` are comments the first
+//! pass loses, so they exercise the recovery; `keep_*` and `plain_element` are
+//! comments the first pass already places, and a rule that claimed those too
+//! would *move* a comment that was already correct — which no corpus gate can
+//! observe, because `ast_equiv_batch` runs under `CommentPolicy::Ignore` and
+//! scores any comment-only divergence a pass (`verify.mjs:607-611`). Unit tests
+//! are the only guard this class has.
+//!
+//! `keep_selfclose` is the other half of the same issue and is deliberately
+//! pinned to rsvelte's own bytes: the comment is emitted *after* the call where
+//! official emits it before. The first pass does write it, so it is a
+//! relocation rather than a loss and this recovery declines it on purpose.
+//! When that half is fixed the expectation here becomes official's.
+//!
+//! Every other expectation is the official compiler's bytes (client, prod),
+//! taken from `submodules/svelte/packages/svelte/src/compiler/index.js` — not
+//! the npm build, which disagrees with it on other shapes.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(script: &str, template: &str) -> String {
+    let src = format!("<script>\n{script}\n</script>\n{template}\n");
+    let code = compile(
+        &src,
+        CompileOptions {
+            filename: Some("C.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    let lines: Vec<&str> = code
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+    let start = lines
+        .iter()
+        .position(|line| line.starts_with("export default function"))
+        .expect("component function");
+    lines[start..].join("\n")
+}
+
+const CHILDREN_CALL: &str = "\tX($$anchor, {\n\
+     \t\tchildren: ($$anchor, $$slotProps) => {\n\
+     \t\t\t$.next();\n\
+     \t\t\tvar text = $.text('t');\n\
+     \t\t\t$.append($$anchor, text);\n\
+     \t\t},\n\
+     \t\t$$slots: { default: true }\n\
+     \t});";
+
+#[test]
+fn a_comment_alone_in_the_instance_script_precedes_the_component_call() {
+    assert_eq!(
+        client("\t// c", "<X>t</X>"),
+        format!("export default function C($$anchor) {{\n\t// c\n{CHILDREN_CALL}\n}}")
+    );
+}
+
+#[test]
+fn a_comment_after_the_last_statement_precedes_the_component_call() {
+    assert_eq!(
+        client("\tlet a = 1;\n\t// c", "<X>t</X>"),
+        format!(
+            "export default function C($$anchor) {{\n\tlet a = 1;\n\t// c\n{CHILDREN_CALL}\n}}"
+        )
+    );
+}
+
+/// A comment the located flush already places must not move: it is followed by
+/// a statement, so the first pass writes it and the recovery declines it.
+#[test]
+fn a_comment_before_a_statement_stays_where_the_located_flush_put_it() {
+    assert_eq!(
+        client("\t// c\n\tlet a = 1;", "<X>t</X>"),
+        format!(
+            "export default function C($$anchor) {{\n\t// c\n\tlet a = 1;\n{CHILDREN_CALL}\n}}"
+        )
+    );
+}
+
+/// An element template reaches a different lowering, and official itself writes
+/// the comment inside the declarator. Nothing here may change that.
+#[test]
+fn a_plain_element_template_keeps_officials_declarator_placement() {
+    assert_eq!(
+        client("\t// c", "<p>x</p>"),
+        "export default function C($$anchor) {\n\tvar // c\n\tp = root();\n\t$.append($$anchor, p);\n}"
+    );
+}
+
+/// The unfixed half of the issue. Official emits `// c` *before* the call; the
+/// first pass writes it after, so this is a relocation and out of scope here.
+/// A recovery that claimed relocations too would pass this by accident while
+/// breaking the `keep_*` cells above.
+#[test]
+fn a_self_closing_component_still_trails_its_comment() {
+    assert_eq!(
+        client("\t// c", "<X />"),
+        "export default function C($$anchor) {\n\tX($$anchor, {});\n\t// c\n}"
+    );
+}

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.40"
+version = "0.10.41"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -197,7 +197,7 @@ pub fn print_split(
     let (comments, line_starts) = comments_and_line_starts(program, comment_source);
     let map_line_starts = map_source.map(printer::line_starts).unwrap_or_default();
     if comments.is_empty() {
-        print_split_impl::<false>(
+        return print_split_impl::<false>(
             program,
             loc_base,
             comment_source,
@@ -208,21 +208,60 @@ pub fn print_split(
             comments,
             line_starts,
             map_line_starts,
-        )
-    } else {
-        print_split_impl::<true>(
-            program,
-            loc_base,
-            comment_source,
-            map_source,
-            loc_map,
-            brace_mappings,
-            options,
-            comments,
-            line_starts,
-            map_line_starts,
-        )
+            Vec::new(),
+            None,
+        );
     }
+    // Under split coordinates a source position sits below `loc_base`, so the
+    // located flush declines it and a comment with no comment-space node after
+    // it is never emitted. Recovering it needs to know which comments the
+    // located pass drops, which only a print can answer — so print once, and
+    // print again only when that pass dropped something.
+    let total = comments.len();
+    let mut written = Vec::new();
+    let first = print_split_impl::<true>(
+        program,
+        loc_base,
+        comment_source,
+        map_source,
+        loc_map,
+        brace_mappings,
+        options,
+        comments,
+        line_starts,
+        map_line_starts,
+        Vec::new(),
+        Some(&mut written),
+    );
+    written.sort_unstable();
+    written.dedup();
+    if written.len() == total {
+        return first;
+    }
+    let (comments, line_starts) = comments_and_line_starts(program, comment_source);
+    let map_line_starts = map_source.map(printer::line_starts).unwrap_or_default();
+    let dropped: Vec<u32> = comments
+        .iter()
+        .map(|cmt| cmt.start)
+        .filter(|start| written.binary_search(start).is_err())
+        .collect();
+    if dropped.is_empty() {
+        return first;
+    }
+    print_split_impl::<true>(
+        program,
+        loc_base,
+        comment_source,
+        map_source,
+        loc_map,
+        brace_mappings,
+        options,
+        comments,
+        line_starts,
+        map_line_starts,
+        dropped,
+        None,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -237,14 +276,20 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
     comments: Vec<printer::Cmt>,
     line_starts: Vec<u32>,
     map_line_starts: Vec<u32>,
+    src_flushable: Vec<u32>,
+    written_out: Option<&mut Vec<u32>>,
 ) -> PrintWithMap {
     if !HAS_COMMENTS && map_source.is_none() {
         let mut printer =
             printer::Printer::<HAS_COMMENTS, true>::with_comments(options, comments, line_starts)
                 .with_placement_source(comment_source)
-                .with_split_coordinates(map_line_starts, loc_base, loc_map, brace_mappings, false);
+                .with_split_coordinates(map_line_starts, loc_base, loc_map, brace_mappings, false)
+                .with_src_flushable(src_flushable);
         let mut ctx = context::Context::new_direct(&options.indent, program.source_text.len());
         printer.print_program(program, &mut ctx);
+        if let Some(out) = written_out {
+            *out = printer.take_written();
+        }
         let (buffer, returned, indent, dirty) = ctx.into_direct_parts();
         let (code, buffer) = command::finish_direct(buffer, &indent, dirty);
         pool::give(buffer, returned);
@@ -262,9 +307,13 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
                 loc_map,
                 brace_mappings,
                 map_source.is_some(),
-            );
+            )
+            .with_src_flushable(src_flushable);
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
+    if let Some(out) = written_out {
+        *out = printer.take_written();
+    }
     let capacity = ctx.measure();
     let (buffer, returned) = ctx.into_parts();
     let output = if map_source.is_some() {

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -123,6 +123,11 @@ pub struct Printer<'opt, const HAS_COMMENTS: bool = true, const DIRECT: bool = f
     /// Source-backed brace ranges for default-exported wrapper functions whose
     /// ordinary body span must remain in comment space.
     brace_mappings: Vec<BraceMapping>,
+    /// Comment-space starts this print is allowed to emit from source space.
+    /// Empty on the first pass, so nothing is; see [`crate::print_split`].
+    src_flushable: Vec<u32>,
+    /// Comment-space starts this print has emitted, in emission order.
+    written: Vec<u32>,
     /// Decorator expressions have no esrap mapping visitor, so their nested
     /// tokens must stay unmapped too.
     map_nodes: bool,
@@ -736,6 +741,8 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             loc_base: None,
             loc_map: Vec::new(),
             brace_mappings: Vec::new(),
+            src_flushable: Vec::new(),
+            written: Vec::new(),
             map_nodes: true,
         }
     }
@@ -761,6 +768,8 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             loc_base: None,
             loc_map: Vec::new(),
             brace_mappings: Vec::new(),
+            src_flushable: Vec::new(),
+            written: Vec::new(),
             map_nodes: true,
         }
     }
@@ -800,6 +809,18 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         self.loc_map = loc_map.to_vec();
         self.brace_mappings = brace_mappings.to_vec();
         self
+    }
+
+    /// The comment-space starts this print may emit from source space. Only the
+    /// second pass of [`crate::print_split`] passes a non-empty set.
+    pub fn with_src_flushable(mut self, starts: Vec<u32>) -> Self {
+        self.src_flushable = starts;
+        self
+    }
+
+    /// The comment-space starts this print emitted, in emission order.
+    pub fn take_written(&mut self) -> Vec<u32> {
+        std::mem::take(&mut self.written)
     }
 
     /// Enable source-map anchor events for this print.
@@ -1136,13 +1157,78 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         )
     }
 
-    fn write_comment_at(&self, index: usize, ctx: &mut Context<DIRECT>) {
+    fn write_comment_at(&mut self, index: usize, ctx: &mut Context<DIRECT>) {
+        if let Some(comment) = self.comment_at(index) {
+            self.written.push(comment.start);
+        }
         if let Some(source) = self.comment_source {
             let comment = self.comment_at(index).expect("pending comment");
             write_borrowed_comment_span(comment.start, comment.end, comment.block, source, ctx);
         } else {
             write_comment(&self.comments[index], ctx);
         }
+    }
+
+    /// Under split coordinates a real source offset is *below* `loc_base`, so
+    /// [`Self::has_loc`] reads it as "no location" and the located flush above
+    /// declines it. esrap has one coordinate space, so the same offset flushes
+    /// there. Compare each pending comment's own source position instead of its
+    /// buffer position — and only for the comments the located pass has been
+    /// shown to drop, because claiming one it would have placed moves a comment
+    /// that was already correct.
+    fn flush_comments_before_source(&mut self, ctx: &mut Context<DIRECT>, to: u32, pad: bool) {
+        if to == 0 || to == u32::MAX || self.src_flushable.is_empty() {
+            return;
+        }
+        let to_line = self.map_position(to).map(|(line, _)| line);
+        while self.comment_index < self.comment_len() {
+            let cmt = self
+                .comment_at(self.comment_index)
+                .expect("pending comment");
+            let Some((_, _)) = self.map_position(cmt.start) else {
+                break;
+            };
+            let Some((cmt_end_line, _)) = self.map_position(cmt.end) else {
+                break;
+            };
+            if self
+                .comment_source_offset(cmt.start)
+                .is_none_or(|source| source >= to)
+            {
+                break;
+            }
+            // Advancing past a comment this pass may not claim would drop it
+            // from the located pass too, so stop rather than skip.
+            if self.src_flushable.binary_search(&cmt.start).is_err() {
+                break;
+            }
+            self.write_comment_at(self.comment_index, ctx);
+            if !cmt.block || to_line.is_none_or(|line| cmt_end_line < line) {
+                ctx.newline();
+            } else if pad {
+                ctx.write_ascii(b' ');
+            }
+            self.comment_index += 1;
+        }
+    }
+
+    /// Resolve a comment-space offset back to an original-source offset through
+    /// `loc_map`, so a comment can be compared against a source position.
+    fn comment_source_offset(&self, offset: u32) -> Option<u32> {
+        let index = self
+            .loc_map
+            .partition_point(|range| range.start <= offset)
+            .checked_sub(1)?;
+        let range = self.loc_map.get(index)?;
+        if offset >= range.end {
+            return None;
+        }
+        let source = range.source?;
+        Some(if range.linear {
+            source + (offset - range.start)
+        } else {
+            source
+        })
     }
 
     /// esrap's `flush_comments_until`: emit every pending comment that starts
@@ -1159,6 +1245,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             return;
         }
         if !self.has_loc(to) {
+            self.flush_comments_before_source(ctx, to, pad);
             return;
         }
         let Some(next_comment) = self.comment_at(self.comment_index) else {

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.40"
+version = "0.10.41"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
Closes #4517 (one of its two defects).

## The defect

Under split coordinates a comment offset sits at or above `loc_base` and an
original source offset deliberately below it. `has_loc` answers *"may this node
carry comments"*, so a **real source position reads as "no location"** and
`flush_comments_until` returns before writing anything. A comment with no
comment-space node after it is therefore never emitted at all — which is exactly
what an instance script whose template lowers to a component call produces:

```svelte
<script>
  // c
</script>
<X>t</X>
```

official keeps `// c`; rsvelte drops it.

## The fix, and the rule that separates it from a regression

The printer prints once with nothing flushable from source space, records the
comment starts it wrote, and prints again allowing **only** the ones the first
pass dropped.

Restricting the second pass to that set is the whole of it, and it was measured
rather than argued. Classifying the two candidate populations by the comment
**TEXT multiset** (not position):

| population | LOSS | RELOCATION-ONLY | MIXED |
|---|---:|---:|---:|
| candidate fixes | 14 | 6 | **0** |
| candidate regressions | 0 | 7 | **0** |

A regression is never a comment official has that rsvelte lacks — it is a
comment rsvelte already emits, somewhere else. So "flush from source space only
what the ordinary path drops entirely" takes every loss and no relocation, and
`MIXED = 0` on both sides is what says the rule is exact rather than a good
trade.

## Measurements

- **Corpus A/B**, 134,180 keys, both arms at this PR's base
  (`0e71c9ebbaa9e9c2` vs `c12a734d203bb467`, two-sided arm probe
  `comment-before-call=false` / `=true`): **22 `MISMATCH -> match`, 0
  `match -> MISMATCH`**. OFF-identity control `differing=0`.
- **The issue's own 12-cell grid**: 7 EQ → **9 EQ** per target. Both `drop`
  cells fixed byte-exactly; the three `move` cells untouched; no EQ cell lost.
- **Cost**: the second pass runs on **1,149 of 134,180 compiles (0.86%)**. The
  `comments` / `line_starts` recompute stays off the common path.

## Why the tests are the only guard

`verify.mjs` calls `ast_equiv_batch` without `--comments`, so it runs under
`CommentPolicy::Ignore`: a divergence living only in comments is byte-different,
AST-equivalent, and **scored a pass — for every entry and every target**.
`known-failures.client.json` and `known-failures.client-dev.json` are both empty.
No corpus gate observes any of this, so the unit tests are it.

The pair discriminates: ablating `crates/rsvelte_esrap` fails exactly the two
`drop_*` tests and leaves the other three green.
`a_self_closing_component_still_trails_its_comment` deliberately pins rsvelte's
own (unfixed) bytes, so the residue is recorded rather than silent.

## What is left

The three `move` cells — where the ordinary path writes the comment *after* the
component call instead of before it — are #4517's second defect and get their
own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyoUh3fjAQiDBpiHA9sHXA
