### PR TITLE
ci(coverage): bound the instrumented build peak disk by batching the report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     # Run unconditionally on push-to-main and manual dispatch. On PRs run
     # only when the author opts in by labeling the PR `coverage` —
     # llvm-cov instrumentation roughly doubles test runtime and the
@@ -130,20 +130,95 @@ jobs:
         timeout-minutes: 15
 
       - name: Generate coverage
-        # Skip the coverage instrumentation hit for the SSR / runtime suites if
-        # they get too noisy — initially we measure everything, and we can prune
-        # in `--ignore-filename-regex` later if needed.
-        # The disk watcher streams, and a streamed line survives the runner
-        # dying mid-step: when this job last failed, `Generate coverage` ended
-        # with a null conclusion and every later step — `if: always()` included —
-        # never ran, so a df placed after it reports nothing.
+        # `cargo llvm-cov --workspace` links every instrumented test binary and
+        # keeps them all until it reports, so peak disk is the SUM over every
+        # test target in the workspace — the large majority of them
+        # rsvelte_core's — and the runner's disk is not enough (#4474).
+        # Reporting per batch and reclaiming after each makes the peak the MAX
+        # over batches. The step prints its own counts; they are not written
+        # here, because a target count only ever grows.
+        # `CARGO_PROFILE_DEV_DEBUG` is deliberately not set: cargo-llvm-cov
+        # already pins `-C debuginfo=line-tables-only` and overrides the profile
+        # in both directions, measured on 0/2/line-tables-only.
         run: |
+          set -euo pipefail
           ( while true; do printf 'DISK %s ' "$(date -u +%H:%M:%S)"; df -h / | tail -1; sleep 30; done ) &
           watcher=$!
           trap 'kill "$watcher" 2>/dev/null || true' EXIT
-          cargo llvm-cov --workspace --lcov --output-path lcov.info \
-            --ignore-filename-regex '(tests/|benches/|src/bin/)' \
-            -- --test-threads=2
+
+          mkdir -p cov
+          # A restored target cache can carry stale counters; clean once, then
+          # own the reclamation ourselves for the rest of the job.
+          cargo llvm-cov clean --workspace
+
+          reclaim() {
+            # Test executables only. `.rlib`/`.rmeta`/`.so` stay so the next
+            # batch reuses the dependency build instead of recompiling it.
+            find target/llvm-cov-target/debug/deps -maxdepth 1 -type f -perm -u+x \
+              ! -name '*.so' ! -name '*.rlib' ! -name '*.rmeta' ! -name '*.d' -delete 2>/dev/null || true
+            rm -f target/llvm-cov-target/*.profraw
+            df -h / | tail -1
+          }
+
+          run() {
+            label=$1; shift
+            cargo llvm-cov --no-clean --lcov --output-path "cov/${label}.info" \
+              --ignore-filename-regex '(tests/|benches/|src/bin/)' "$@" -- --test-threads=2
+            reclaim
+          }
+
+          # Disjoint by construction: everything except rsvelte_core in one
+          # batch, then rsvelte_core's lib, then its test targets in batches.
+          run rest --workspace --exclude rsvelte_core
+          run core-lib -p rsvelte_core --lib --bins
+
+          # Derived, not transcribed: a new rsvelte_core test target is picked up
+          # without editing this file.
+          # `read` rather than `mapfile`: the loop is identical on bash 3.2, so
+          # this step can be dry-run outside CI. The `|| [ -n "$t" ]` arm keeps
+          # the last element when a producer omits its trailing newline.
+          CORE=()
+          while IFS= read -r t || [ -n "$t" ]; do
+            [ -n "$t" ] && CORE+=("$t")
+          done < <(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name=="rsvelte_core") | .targets[] | select(.kind==["test"]) | .name' | sort)
+          # An empty or truncated enumeration would report a partial measurement
+          # and exit 0, which reads exactly like full coverage.
+          if [ "${#CORE[@]}" -lt 500 ]; then
+            echo "rsvelte_core test enumeration returned ${#CORE[@]}, expected >=500; refusing to publish a partial report"
+            exit 1
+          fi
+          echo "rsvelte_core integration test targets: ${#CORE[@]}"
+
+          BATCH=100
+          i=0; n=0
+          while [ "$i" -lt "${#CORE[@]}" ]; do
+            n=$((n + 1))
+            args=()
+            for t in "${CORE[@]:$i:$BATCH}"; do args+=(--test "$t"); done
+            echo "=== batch $n: ${#args[@]} args starting at $i ==="
+            run "core-${n}" -p rsvelte_core "${args[@]}"
+            i=$((i + BATCH))
+          done
+
+          # Concatenated lcov: each batch emits complete `SF:`/`end_of_record`
+          # records, and both Codecov and lcov read a stream of them. A file
+          # covered by several batches appears once per batch, which is how its
+          # counters get summed rather than replaced.
+          # The explicit `echo` is load-bearing: cargo-llvm-cov's lcov output
+          # ends WITHOUT a trailing newline, so a plain `cat` welds one batch's
+          # `end_of_record` onto the next batch's `SF:` and silently loses a
+          # record per boundary while still exiting 0.
+          for f in cov/*.info; do cat "$f"; echo; done > lcov.info
+          test -s lcov.info
+          sf=$(grep -c '^SF:' lcov.info)
+          eor=$(grep -c '^end_of_record' lcov.info)
+          echo "batches=$(ls -1 cov/*.info | wc -l) SF=${sf} end_of_record=${eor}"
+          # A welded boundary shows up here and nowhere else in the job.
+          if [ "$sf" -ne "$eor" ]; then
+            echo "lcov.info has ${sf} SF records against ${eor} end_of_record; a record boundary was corrupted"
+            exit 1
+          fi
         env:
           RUST_MIN_STACK: '33554432'
           # Match CI's tsc pin; see .github/workflows/ci.yml for the


### PR DESCRIPTION
Closes #4474 — `Coverage` has failed on **every** `main` run since
2026-09-08T02:24Z (35 failures, 0 successes), because
`cargo llvm-cov --workspace` links every instrumented test binary and keeps them
all until it reports. Peak disk is therefore the **sum** over every test target
in the workspace; the runner's 145 GB is not enough, and `gh run rerun` cannot
recover it.

This reports **per batch** and reclaims the executables after each, so peak disk
becomes the **max** over batches instead of the sum.

## The issue's recommended lever is unavailable — measured

#4474 lists `CARGO_PROFILE_DEV_DEBUG=line-tables-only` as "the cheapest lever if
it holds". It does not hold. `cargo-llvm-cov 0.9.1` already pins
`-C debuginfo=line-tables-only` and **overrides the profile in both
directions**:

```
unset                                    -> -C debuginfo=line-tables-only  (60 invocations)
CARGO_PROFILE_DEV_DEBUG=line-tables-only -> -C debuginfo=line-tables-only
CARGO_PROFILE_DEV_DEBUG=2                -> -C debuginfo=line-tables-only   <- ignored
CARGO_PROFILE_DEV_DEBUG=0                -> -C debuginfo=line-tables-only   <- ignored
```

Negative control: the same crate under plain `cargo build --tests -vv` shows
`-C debuginfo=2` on all 60, so the probe discriminates. The sizes agree —
`llvm-cov-target/debug/deps` is byte-identical at 317,440 KB across all three
settings, while a plain build moves 379,152 → 299,064 → 234,332 KB. The ~20%
debug info is worth has already been taken before the job starts.

(Incidental, recorded so nobody loses time: `CARGO_PROFILE_TEST_DEBUG` is a
silent no-op — `profile.test` inherits `profile.dev` and the `TEST` spelling
leaves rustc at `debuginfo=2`.)

## Three guards, each with a control

**The enumeration cannot silently shrink.** `rsvelte_core`'s test targets are
read from `cargo metadata`, not transcribed, and the step refuses below 500 —
an empty or truncated list would otherwise report a partial measurement and
exit 0, which reads exactly like full coverage. Control: truncating the
enumeration to 3 makes it exit 1 with the count named.

**The batching covers every target exactly once.** Dry-run against real
`cargo metadata` output: 723 targets → 8 batches, and the emitted set `diff`s
clean against the enumerated set — no omissions, no duplicates.

**A welded record boundary fails the step.** This one was a real defect found
by testing the design end-to-end at small scale: cargo-llvm-cov's lcov output
**ends without a trailing newline**, so a plain `cat cov/*.info` welds one
batch's `end_of_record` onto the next batch's `SF:` and loses one record per
boundary — while exiting 0. Measured on a two-batch run: **9 `SF:` against 10
`end_of_record`**. Fixed by emitting an explicit newline between files, and the
step now asserts the two counts are equal. The assertion is two-sided: it fires
on the welded file and passes on the fixed one.

## Also

`read` rather than `mapfile`, so the step can be dry-run on bash 3.2 outside
CI — which is how the batching and guard controls above were run at all.
Timeout 60 → 90, because the same compile and test work now spans several
cargo invocations.

## What is NOT established, and how this PR settles it

I cannot reproduce a 145 GB runner locally, so **the peak actually falling
below the limit is unmeasured here**. That is exactly what this PR's own CI run
answers: it carries the `coverage` label, so the workflow runs on the PR, and
the step streams `DISK` lines plus a reclaim delta after every batch. If the
peak still exceeds the disk, the trace will say so and the batch size is the
knob.

Two things I am deliberately not claiming. **Per-crate would not have been
enough** — `rsvelte_core` alone is the large majority of the workspace's test
targets, so splitting by crate is headroom, not a bound; splitting by target
batch is. And **the shortfall was never measured**: the trace in #4474 ends at
`144G used / 944M avail` and dies, so it records that 109 GB was not enough and
not how much would have been — which is why "free ~12-15 GB more" was not the
fix taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
