### PR TITLE
fix(napi): reject a non-object options argument

### DIFF
--- a/.changeset/napi-options-non-object.md
+++ b/.changeset/napi-options-non-object.md
@@ -1,0 +1,9 @@
+---
+'@rsvelte/vite-plugin-svelte-native': patch
+---
+
+Reject a non-object options argument at the `compile` / `compileModule` native
+boundary. Upstream's `object()` validator opens with a shape guard that runs
+before its key loop; without it a string, number, boolean, function or array
+decoded to all-`None` and the component compiled with silent defaults, so
+`compile(src, '{"generate":"server"}')` returned client output and no error.

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -951,6 +951,15 @@ fn unrecognised_option(keypath: &str) -> OptionError {
     }
 }
 
+/// `object()`'s shape guard runs before the key loop, and its keypath is empty at
+/// the top level — hence upstream's doubled space, reproduced here.
+fn shape_error(not_object: bool) -> OptionResult<()> {
+    if not_object {
+        return Err(invalid_option(" should be an object"));
+    }
+    Ok(())
+}
+
 /// A value upstream accepts that this entry point cannot honour. There is no
 /// upstream code for it because upstream never raises it.
 fn unsupported_option(detail: impl std::fmt::Display) -> OptionError {
@@ -1509,6 +1518,7 @@ impl NapiModuleCompileOptions {
 pub struct NapiCompileOptionsArg {
     inner: NapiCompileOptions,
     unrecognised: Option<String>,
+    not_object: bool,
 }
 
 /// The module entry's counterpart. Its recognised set is the same one: upstream
@@ -1516,6 +1526,32 @@ pub struct NapiCompileOptionsArg {
 pub struct NapiModuleCompileOptionsArg {
     inner: NapiModuleCompileOptions,
     unrecognised: Option<String>,
+    not_object: bool,
+}
+
+/// Upstream's `object()` opens with `(input && typeof input !== 'object') || Array.isArray(input)`.
+/// `null`/`undefined` never reach here: the parameter is an `Option`, so napi maps them to `None`.
+unsafe fn is_not_object(
+    env: napi::sys::napi_env,
+    napi_val: napi::sys::napi_value,
+) -> napi::Result<bool> {
+    let mut val_type = 0;
+    // SAFETY: `env`/`napi_val` are valid handles from Node-API; `napi_typeof`
+    // only reads them and writes the type tag.
+    let status = unsafe { napi::sys::napi_typeof(env, napi_val, &raw mut val_type) };
+    if status != napi::sys::Status::napi_ok {
+        return Err(napi::Error::from_status(napi::Status::from(status)));
+    }
+    if val_type != napi::sys::ValueType::napi_object {
+        return Ok(true);
+    }
+    let mut is_array = false;
+    // SAFETY: same valid handles; `napi_is_array` only reads them.
+    let status = unsafe { napi::sys::napi_is_array(env, napi_val, &raw mut is_array) };
+    if status != napi::sys::Status::napi_ok {
+        return Err(napi::Error::from_status(napi::Status::from(status)));
+    }
+    Ok(is_array)
 }
 
 /// Upstream's `object()` walks `for (const key in input)`, so an inherited
@@ -1561,6 +1597,8 @@ macro_rules! option_arg_wrapper {
                 env: napi::sys::napi_env,
                 napi_val: napi::sys::napi_value,
             ) -> napi::Result<Self> {
+                // SAFETY: valid handles from Node-API, forwarded to the shape check.
+                let not_object = unsafe { is_not_object(env, napi_val)? };
                 // SAFETY: valid handles from Node-API, forwarded to the key scan.
                 let unrecognised = unsafe { first_unrecognised_key(env, napi_val)? };
                 // SAFETY: the same valid handles, forwarded to the field decoder
@@ -1569,6 +1607,7 @@ macro_rules! option_arg_wrapper {
                 Ok(Self {
                     inner,
                     unrecognised,
+                    not_object,
                 })
             }
         }
@@ -1607,9 +1646,12 @@ fn options_to_compile(
     // Upstream seeds `state.filename` from the raw option before validating, so
     // the option error carries it even when a *later* option is what failed.
     let filename = raw_filename(opts.inner.filename.as_ref());
-    opts.unrecognised
-        .as_deref()
-        .map_or(Ok(()), |key| Err(unrecognised_option(key)))
+    shape_error(opts.not_object)
+        .and_then(|()| {
+            opts.unrecognised
+                .as_deref()
+                .map_or(Ok(()), |key| Err(unrecognised_option(key)))
+        })
         .and_then(|()| opts.inner.into_compile_options())
         .map_err(|e| e.into_napi(env, filename.as_deref()))
 }
@@ -1622,9 +1664,12 @@ fn options_to_module_compile(
         return Ok(ModuleCompileOptions::default());
     };
     let filename = raw_filename(opts.inner.filename.as_ref());
-    opts.unrecognised
-        .as_deref()
-        .map_or(Ok(()), |key| Err(unrecognised_option(key)))
+    shape_error(opts.not_object)
+        .and_then(|()| {
+            opts.unrecognised
+                .as_deref()
+                .map_or(Ok(()), |key| Err(unrecognised_option(key)))
+        })
         .and_then(|()| opts.inner.into_module_compile_options())
         .map_err(|e| e.into_napi(env, filename.as_deref()))
 }

--- a/scripts/dev/test-napi-compile-options.mjs
+++ b/scripts/dev/test-napi-compile-options.mjs
@@ -1105,6 +1105,94 @@ for (const [label, opts] of VALID_OPTIONS) {
 	);
 }
 
+// Upstream's `object()` opens with a shape guard — `(input && typeof input !==
+// 'object') || Array.isArray(input)` — that runs before the key loop. Without it
+// a non-object decodes to all-`None` and compiles with silent defaults (#4534):
+// the failure is an ACCEPTED call, not a wrong error, so a row asserting only
+// that both sides agree on some error would never have been reached.
+function rawErrorShape(compile, src, opts) {
+	try {
+		compile(src, opts);
+		return { threw: false };
+	} catch (e) {
+		return {
+			threw: true,
+			code: e.code === undefined ? '(absent)' : String(e.code),
+			name: String(e.name),
+			filename: e.filename === undefined ? '(absent)' : String(e.filename),
+			message: String(e.message),
+		};
+	}
+}
+
+// Truthy non-objects and arrays: upstream's guard fires, so every field matches.
+const NON_OBJECT_EXACT = [
+	['string', '{"generate":"server"}'],
+	['number', 42],
+	['true', true],
+	['function', () => {}],
+	['array', ['generate']],
+	['array-empty', []],
+];
+
+// The falsy scalars are rejected by both sides with the same CODE for different
+// reasons: `input &&` short-circuits, so upstream skips its own guard and hands
+// the scalar to each per-option validator, reporting against whichever option is
+// declared first. rsvelte names the actual fault, so the message is deliberately
+// not upstream's — see the PR for #4534.
+const NON_OBJECT_FALSY = [
+	['empty-string', ''],
+	['zero', 0],
+	['false', false],
+];
+
+console.log('\n# non-object options argument');
+for (const [entry, compileSv, compileRs, src] of [
+	['compile', officialCompile, napi.compile, CSS_SRC],
+	['compileModule', officialCompileModule, napi.compileModule, MODULE_OPT_SRC],
+]) {
+	for (const [label, opts] of NON_OBJECT_EXACT) {
+		const sv = rawErrorShape(compileSv, src, opts);
+		const rs = rawErrorShape(compileRs, src, opts);
+		if (!sv.threw) {
+			assert(`non-object.${entry}.${label}: official rejects it`, false, 'the oracle accepted');
+			continue;
+		}
+		if (!rs.threw) {
+			assert(`non-object.${entry}.${label}: rsvelte rejects it too`, false, 'rsvelte compiled it');
+			continue;
+		}
+		for (const field of ['code', 'name', 'filename', 'message']) {
+			assert(
+				`non-object.${entry}.${label}: ${field}`,
+				rs[field] === sv[field],
+				`official ${JSON.stringify(sv[field])} vs rsvelte ${JSON.stringify(rs[field])}`
+			);
+		}
+	}
+	for (const [label, opts] of NON_OBJECT_FALSY) {
+		const sv = rawErrorShape(compileSv, src, opts);
+		const rs = rawErrorShape(compileRs, src, opts);
+		assert(
+			`non-object-falsy.${entry}.${label}: both reject with options_invalid_value`,
+			sv.threw && rs.threw && sv.code === 'options_invalid_value' && rs.code === sv.code,
+			`official ${sv.threw ? sv.code : 'accepted'} vs rsvelte ${rs.threw ? rs.code : 'accepted'}`
+		);
+		assert(
+			`non-object-falsy.${entry}.${label}: rsvelte names the shape`,
+			rs.threw && rs.message.includes('should be an object'),
+			rs.threw ? rs.message : 'rsvelte compiled it'
+		);
+		// Expiry condition rather than decoration: if upstream ever drops the
+		// `input &&` short-circuit these become exact rows, and this is what says so.
+		assert(
+			`non-object-falsy.${entry}.${label}: upstream still short-circuits its own guard`,
+			sv.threw && !sv.message.includes('should be an object'),
+			`upstream now reports the shape — promote ${label} to NON_OBJECT_EXACT`
+		);
+	}
+}
+
 function moduleErrorShape(compileModule, opts) {
 	try {
 		compileModule(MODULE_OPT_SRC, { filename: 'a.svelte.js', ...opts });


### PR DESCRIPTION
Closes #4534.

## What

Upstream's `object()` validator (`validate-options.js:234-241`) opens with a shape guard that runs **before** its key loop:

```js
if ((input && typeof input !== 'object') || Array.isArray(input)) {
    throw_error(`${keypath} should be an object`);
}
```

rsvelte had no counterpart. `first_unrecognised_key` returned `Ok(None)` for anything whose `napi_typeof` is not `napi_object`, and the derived `#[napi(object)]` decoder then succeeded with every field `None` — so a non-object compiled the component with silent defaults and returned success.

```js
compile(src, '{"generate":"server"}')  // 287 chars — client output, no error
compile(src, { generate: 'server' })   // 138 chars
```

The failure is an **accepted call**, not a wrong error, which is why no existing row reached it: a test asserting "both sides agree on some error" is never entered when one side does not error.

## Measured

12 shapes × 2 entry points, against the pinned oracle (`submodules/svelte`, 5.57.0). Before → after:

| shape | official | rsvelte before | rsvelte after |
|---|---|---|---|
| `'{"generate":"server"}'`, `42`, `true`, `fn`, `[]`, `['generate']` | `options_invalid_value` | **accepted** (or `options_unrecognised` for the non-empty array) | `options_invalid_value` |
| `''`, `0`, `false` | `options_invalid_value` | **accepted** | `options_invalid_value` |
| `{ generate: 'server' }` | ok, 138 | ok, 138 | ok, 138 |
| `null`, `undefined` | bare `TypeError` | accepted | accepted (unchanged) |

Nine rows close on the code axis. `{ generate: 'server' }` is the negative control — a guard that rejected valid objects would show up there.

`null` / `undefined` are deliberately untouched. They never reach `from_napi_value` at all (the parameter is `Option<NapiCompileOptionsArg>`, so napi maps them to `None` first), and official's rejection is an incidental `TypeError` from `.replace` rather than a designed diagnostic — reproducing it is a product decision I am not making here.

## The message on three rows is deliberately not upstream's

`''`, `0` and `false` are falsy, so `input &&` short-circuits and upstream **skips its own guard**. They reach the per-option validators as `input && input[key]` — the scalar itself, for every key — and are reported against whichever option is declared first:

```
official: Invalid compiler option: dev should be true or false, if specified     // for ''
official: Invalid compiler option: filename should be a string, if specified     // for 0
```

Both name an option the caller never passed. rsvelte reports the shape instead. The **code** matches on all nine rows; only these three messages differ, and reproducing upstream's would mean porting a short-circuit artifact whose text depends on the declaration order of an object literal in upstream's source.

That is a claim about upstream's current behaviour, so the test carries an expiry condition rather than a comment: each falsy row asserts that official's message does **not** contain `should be an object`. If upstream ever drops the short-circuit, that assertion fires and says to promote the row to the exact-parity set.

## Test

`scripts/dev/test-napi-compile-options.mjs` (already in CI as `test:napi-options`), 67 new rows across both entry points — six exact-parity shapes compared on all four of `code`/`name`/`filename`/`message`, plus the three falsy rows with their expiry condition.

Ablation: with the pre-fix binary staged in place of the fixed one, the suite reports **26 failures, all 26 inside the two new sections and none elsewhere**. Restored, 477 passed / 0 failed.

Per-field validation was measured on the same pass and is not affected — 8 of 9 field-type cells already agree, and the ninth is rsvelte being the more correct side (`{ filename: 42 }` makes official throw a bare `TypeError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj