### PR TITLE
ci(lsp-gate): record the verdict and the arm in the uploaded artifact

### DIFF
--- a/scripts/compat-lsp/artifacts.mjs
+++ b/scripts/compat-lsp/artifacts.mjs
@@ -7,7 +7,10 @@ import { CORPUS_REPOS } from "./suites.mjs";
 
 // 2 adds `mechanisms`: an artifact that predates it cannot populate the sidecar,
 // and a merge that silently accepted one would write a short map rather than fail.
-export const ARTIFACT_SCHEMA = 2;
+// 3 adds `added`/`removed` and `arms` for the same reason: a consumer reading the
+// verdict or the arm off an older artifact gets `undefined`, i.e. an empty stale
+// list and an unnamed binary, both of which read as an answer.
+export const ARTIFACT_SCHEMA = 3;
 export const CORPUS_SHARDS = 16;
 export const FIXTURE_SUITES = [
   "fixtures",
@@ -22,6 +25,33 @@ export const hashValues = (values) =>
   createHash("sha256")
     .update([...values].sort().join("\n"))
     .digest("hex");
+
+// The arm is resolved by path, so the tree revisions say nothing about which
+// binary ran. `bin/server.js` is a 93-byte stub that requires `../dist/src/server`,
+// so hashing the command's own first element identifies the official arm not at
+// all — the caller names the files that actually constitute each arm. For rsvelte
+// the static binary is the whole closure; for official the built entry says
+// whether `dist` was rebuilt from the recorded submodule revision, and is not the
+// transitive closure of what that entry requires.
+export function describeArm(command, extraPaths = []) {
+  const files = [...command, ...extraPaths]
+    .filter(
+      (candidate) =>
+        typeof candidate === "string" &&
+        candidate.includes(path.sep) &&
+        fs.existsSync(candidate) &&
+        fs.statSync(candidate).isFile(),
+    )
+    .map((file) => {
+      const contents = fs.readFileSync(file);
+      return {
+        path: file,
+        bytes: contents.length,
+        sha256: createHash("sha256").update(contents).digest("hex"),
+      };
+    });
+  return { command: [...command], files };
+}
 
 function revision(directory) {
   return execFileSync("git", ["rev-parse", "HEAD"], {
@@ -42,6 +72,9 @@ export function createCurrentArtifact({
   counts,
   mechanisms = {},
   diagnosticDetails = {},
+  added,
+  removed,
+  arms,
 }) {
   const sourceRevisions = {
     "language-tools": revision(path.join(root, "submodules/language-tools")),
@@ -61,6 +94,11 @@ export function createCurrentArtifact({
     population,
     counts,
     current: [...current].sort(),
+    // The verdict, not only the measurement: the printed lists are capped for
+    // display, so this is the only complete record of what the run decided.
+    added: [...added].sort(),
+    removed: [...removed].sort(),
+    arms,
     // Always written, even when empty: an absent map and an unclassified run
     // are different facts, and only one of them is a wiring failure.
     mechanisms: Object.fromEntries(
@@ -84,11 +122,21 @@ function requireArtifact(value, label) {
   for (const field of ["projectRevision", "configurationId", "universeHash"])
     if (typeof value[field] !== "string" || !value[field])
       throw new Error(`${label} lacks ${field}`);
-  for (const field of ["suites", "repos", "measuredIds", "current"])
+  for (const field of [
+    "suites",
+    "repos",
+    "measuredIds",
+    "current",
+    "added",
+    "removed",
+  ])
     if (!Array.isArray(value[field]))
       throw new Error(`${label} lacks ${field}`);
   if (!value.mechanisms || typeof value.mechanisms !== "object")
     throw new Error(`${label} lacks mechanisms`);
+  for (const arm of ["official", "rsvelte"])
+    if (!Array.isArray(value.arms?.[arm]?.command))
+      throw new Error(`${label} lacks the ${arm} arm`);
   // Coverage is asserted per artifact rather than on the union: a shard that
   // classified nothing is otherwise invisible once sixteen maps are merged.
   for (const id of value.current)

--- a/scripts/compat-lsp/artifacts.test.mjs
+++ b/scripts/compat-lsp/artifacts.test.mjs
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
   ARTIFACT_SCHEMA,
   CONFIGURATION_ID,
   CORPUS_SHARDS,
   FIXTURE_SUITES,
+  describeArm,
   hashValues,
   mergeCurrentArtifacts,
   recordsFixtureControls,
@@ -31,6 +35,12 @@ function artifacts() {
     sourceRevisions: {
       "language-tools": "language-tools",
       ...Object.fromEntries(CORPUS_REPOS.map((repo) => [repo, `${repo}-sha`])),
+    },
+    added: [],
+    removed: [],
+    arms: {
+      official: { command: ["node", "server.js"], files: [] },
+      rsvelte: { command: ["rsvelte-language-server"], files: [] },
     },
   };
   return [
@@ -192,4 +202,55 @@ test("the merged mechanism map is the union over the artifact set", () => {
     merged.mechanisms["differential:fixtures/a|initialize|/capabilities:value"],
     ["unclassified"],
   );
+});
+
+test("an artifact missing the verdict or an arm is refused", () => {
+  for (const drop of ["added", "removed"]) {
+    const set = artifacts();
+    delete set[0][drop];
+    assert.throws(
+      () => mergeCurrentArtifacts(set, floor),
+      new RegExp(`lacks ${drop}`),
+    );
+  }
+  for (const arm of ["official", "rsvelte"]) {
+    const set = artifacts();
+    delete set[0].arms[arm];
+    assert.throws(
+      () => mergeCurrentArtifacts(set, floor),
+      new RegExp(`lacks the ${arm} arm`),
+    );
+  }
+  // The positive control: the unmodified set still merges, so the four
+  // rejections above are the deletions and not a broken fixture.
+  assert.ok(mergeCurrentArtifacts(artifacts(), floor));
+});
+
+test("describeArm identifies the files an arm is made of, not its command", () => {
+  const self = fileURLToPath(import.meta.url);
+  const sibling = path.join(path.dirname(self), "artifacts.mjs");
+
+  // The official arm's spelling is `node bin/server.js`, where bin/server.js is a
+  // stub; the file that identifies the build is passed as an extra path. Both are
+  // recorded, and the extra one is what a rebuild moves.
+  const described = describeArm(["node", self, "--stdio"], [sibling]);
+  assert.deepEqual(
+    described.files.map((file) => file.path),
+    [self, sibling],
+  );
+  assert.equal(described.files[0].bytes, fs.readFileSync(self).length);
+  for (const file of described.files) assert.match(file.sha256, /^[0-9a-f]{64}$/);
+  // Distinct files must not collapse to one hash — the failure this guards is a
+  // recorded identity that is the same for every build.
+  assert.notEqual(described.files[0].sha256, described.files[1].sha256);
+
+  // A command naming nothing on disk records no file rather than hashing whatever
+  // it finds: an empty list and a wrong hash are not the same answer.
+  assert.deepEqual(describeArm(["rsvelte-language-server"]).files, []);
+  assert.deepEqual(
+    describeArm([path.join(path.dirname(self), "no-such-binary")]).files,
+    [],
+  );
+  // A directory is not a file, so it must not be hashed.
+  assert.deepEqual(describeArm([path.dirname(self)]).files, []);
 });

--- a/scripts/compat-lsp/verify.mjs
+++ b/scripts/compat-lsp/verify.mjs
@@ -24,6 +24,7 @@ import {
 import {
   CORPUS_SHARDS,
   createCurrentArtifact,
+  describeArm,
   recordsFixtureControls,
 } from "./artifacts.mjs";
 import { EDIT_PHASES, OPEN_PHASE, editChanges } from "./edits.mjs";
@@ -184,12 +185,14 @@ function requireExecutable(command, label) {
 const TRUSTED = !selectedSuites.includes("corpus");
 requireExecutable(officialCommand, "official language server");
 requireExecutable(rsvelteCommand, "rsvelte language server");
+// Named here rather than inside the guard: the artifact records it as part of the
+// official arm's identity, and `bin/server.js` is a stub that identifies nothing.
+const officialBuiltServer = path.join(
+  ROOT,
+  "submodules/language-tools/packages/language-server/dist/src/server.js",
+);
 if (!process.env.OFFICIAL_LSP_COMMAND) {
-  const builtServer = path.join(
-    ROOT,
-    "submodules/language-tools/packages/language-server/dist/src/server.js",
-  );
-  if (!fs.existsSync(builtServer)) {
+  if (!fs.existsSync(officialBuiltServer)) {
     throw new Error(
       "official language server is not built; run `pnpm --dir submodules/language-tools --filter svelte-language-server build`",
     );
@@ -1045,6 +1048,18 @@ async function main() {
   // must leave nothing that `merge-current.mjs` could accept.
   assertOracleCalibration(calibration);
 
+  const known = knownBaseline;
+  const currentSet = new Set(current);
+  const knownSet = new Set(known);
+  const selectedKnown = selectKnownForScope(
+    known,
+    selectedSuites,
+    selectedRepos,
+    SHARD,
+  );
+  const added = current.filter((entry) => !knownSet.has(entry));
+  const removed = selectedKnown.filter((entry) => !currentSet.has(entry));
+
   if (WRITE_CURRENT) {
     const artifact = createCurrentArtifact({
       root: ROOT,
@@ -1060,6 +1075,12 @@ async function main() {
         [...mechanismsById].map(([id, labels]) => [id, [...labels]]),
       ),
       diagnosticDetails: Object.fromEntries(newDiagnosticDetails),
+      added,
+      removed,
+      arms: {
+        official: describeArm(officialCommand, [officialBuiltServer]),
+        rsvelte: describeArm(rsvelteCommand),
+      },
     });
     fs.mkdirSync(path.dirname(path.resolve(WRITE_CURRENT)), {
       recursive: true,
@@ -1078,17 +1099,6 @@ async function main() {
     );
   }
 
-  const known = knownBaseline;
-  const currentSet = new Set(current);
-  const knownSet = new Set(known);
-  const selectedKnown = selectKnownForScope(
-    known,
-    selectedSuites,
-    selectedRepos,
-    SHARD,
-  );
-  const added = current.filter((entry) => !knownSet.has(entry));
-  const removed = selectedKnown.filter((entry) => !currentSet.has(entry));
   const report = JSON.parse(fs.readFileSync(REPORT, "utf8"));
   report.ratchet = { current, added, removed };
   fs.writeFileSync(REPORT, JSON.stringify(report, null, "\t") + "\n");
@@ -1103,6 +1113,10 @@ async function main() {
   if (added.length) {
     console.error(`\n[lsp-verify] ${added.length} NEW divergence(s):`);
     for (const entry of added.slice(0, SHOW)) console.error(`  ${entry}`);
+    if (added.length > SHOW)
+      console.error(
+        `  … and ${added.length - SHOW} more (raise --show, or read \`added\` in the uploaded artifact)`,
+      );
     for (const entry of added.slice(0, SHOW)) {
       const details = newDiagnosticDetails.get(entry);
       if (!details) continue;
@@ -1116,6 +1130,10 @@ async function main() {
       `\n[lsp-verify] ${removed.length} stale ratchet entry/entries:`,
     );
     for (const entry of removed.slice(0, SHOW)) console.error(`  ${entry}`);
+    if (removed.length > SHOW)
+      console.error(
+        `  … and ${removed.length - SHOW} more (raise --show, or read \`removed\` in the uploaded artifact)`,
+      );
   }
   if (added.length || removed.length) process.exitCode = 1;
   else


### PR DESCRIPTION
Closes #4484. Closes #4479.

Bundled deliberately: both are reporting defects in the same file, neither moves a ratchet entry, and #4484's own text gives the reason — any diff touching `scripts/compat-lsp/**` sets `lsp-ratchet=true` and re-admits the ~950 job-minute `lsp-corpus` job, so two PRs would pay that twice for one file's reporting. I checked with rsvelte-40 before taking these.

## #4484 — a list truncated for display became a population

`added` and `removed` printed through `slice(0, SHOW)` with `SHOW = 30` and **no trailing count**. `--show` appears 0 times in `.github/workflows/` (positive control: `compat-lsp` appears on 8 lines there), so 30 is what CI runs. The header carries the true count, so the output is self-contradicting rather than silent — but only for a reader who compares the header against the number of lines they collected, which is not what "copy the list" looks like.

Two halves:

1. Each truncated loop now prints `… and N more`, so the list cannot look complete.
2. **The half that matters**: `added` and `removed` now go into the uploaded `lsp-current-*` artifact. They previously lived only in `report.ratchet`, which is *not* uploaded, so a consumer had to reconstruct the stale set by re-running `selectKnownForScope` against `current`.

The computation moved above the artifact write. The write stays above the `transportTimeouts` throw, which a comment there pins deliberately ("the artifact is the only record of how far off the deadline was").

## #4479 — the arm was resolved by path and never recorded

`projectRevision`, `sourceRevisions`, `universeHash` and `configurationId` all describe the **source tree**. The arm was whatever binary happened to sit at `ROOT/target/debug/`, and `requireExecutable` only checked that a file was there.

`describeArm(command, extraPaths)` records the command plus the hash and size of each file that constitutes the arm.

**It takes the constituting files from the caller, and that is not incidental.** The official arm's command names `bin/server.js`:

```
bin/server.js         93 bytes   #! /usr/bin/env node
                                 const { startServer } = require('../dist/src/server');
dist/src/server.js  24470 bytes
```

Hashing the command's own first element would have recorded a 93-byte stub that is byte-identical for every build of language-tools — a recorded "identity" that cannot distinguish two arms, which is the defect being fixed rather than a fix for it. `verify.mjs` passes the built entry, which is what a rebuild moves. Stated honestly in the code comment: for rsvelte the static binary is the whole closure; for official the built entry says whether `dist` was rebuilt from the recorded submodule revision and is **not** the transitive closure of what it requires.

An arm the gate cannot locate on disk (a bare `RSVELTE_LSP_COMMAND` resolved through `PATH`) records `files: []` rather than hashing whatever it finds — an empty list and a wrong hash are not the same answer. Verified against the real commands: official records both files with distinct hashes; rsvelte records `[]` in a checkout with no debug binary.

## Schema

`ARTIFACT_SCHEMA` 2 → 3, on the criterion the schema-2 comment already states. A consumer reading `removed` or `arms` off an older artifact gets `undefined` — an empty stale list and an unnamed binary — and both read as an answer rather than as an absence. `requireArtifact` now asserts all three, so such an artifact fails at the merge instead of merging short.

Safe to bump: no checked-in file carries schema 2 (`git ls-files | grep lsp-current` → empty), the only validating reader is `merge-current.mjs`, and its 17 artifacts always come from a single run, so a mixed-schema set cannot arise.

## Tests

`node --test scripts/compat-lsp/*.test.mjs` — 82 pass, 0 fail (`test:lsp-ratchet`).

Two new tests, both two-sided:

- **an artifact missing the verdict or an arm is refused** — deletes each of `added`, `removed`, `arms.official`, `arms.rsvelte` in turn and requires the named rejection, then merges the unmodified set as the positive control, so the four rejections are the deletions and not a broken fixture.
- **describeArm identifies the files an arm is made of, not its command** — asserts both files are recorded in order, that their hashes **differ** (the failure guarded against is a recorded identity that is the same for every build), and that a missing path, a nonexistent file and a directory each record nothing.

Not covered by a unit test: the `… and N more` print, because `verify.mjs` is a script with no exported print path. That is why the artifact half exists — the cap stops being load-bearing once the complete verdict is in the artifact, and the new line points the reader at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj