### PR TITLE
ci(lsp-gate): a corpus submodule bump pays for the gate it enrols files into

### DIFF
--- a/scripts/ci/corpus-compat-job-filter.mjs
+++ b/scripts/ci/corpus-compat-job-filter.mjs
@@ -20,6 +20,8 @@ import { appendFileSync, existsSync, readFileSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { CORPUS_REPOS } from '../compat-lsp/suites.mjs';
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, '..', '..');
 
@@ -154,11 +156,19 @@ export function decide(workspace, changedFiles, root = ROOT) {
 	// the jobs above default to `true` on an empty list and this one defaults
 	// to `false`, so a `--changed-files` argument that does not resolve closes
 	// the hatch on the only event that consults it.
+	// A corpus submodule bump enrols files nothing has measured, so the ratchet
+	// it is compared against describes a corpus that no longer exists and `main`
+	// is red until the next nightly (#4465). The four repositories are read from
+	// the gate's own declaration rather than transcribed.
+	const corpusPrefixes = CORPUS_REPOS.map((repo) => `submodules/${repo}`);
 	enabled['lsp-ratchet'] = changedFiles.some(
 		(file) =>
 			file.startsWith('scripts/compat-lsp/') ||
 			(file.startsWith('compatibility/lsp-known-failures') &&
-				file.endsWith('.json')),
+				file.endsWith('.json')) ||
+			corpusPrefixes.some(
+				(prefix) => file === prefix || file.startsWith(`${prefix}/`),
+			),
 	);
 	for (const file of changedFiles) {
 		const pkg = packageOf(workspace, file, root);

--- a/scripts/ci/test-corpus-compat-job-filter.mjs
+++ b/scripts/ci/test-corpus-compat-job-filter.mjs
@@ -8,6 +8,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { CORPUS_REPOS } from '../compat-lsp/suites.mjs';
 import {
 	JOB_TARGETS,
 	closure,
@@ -215,11 +216,26 @@ const tests = {
 				true,
 				`${file} must re-admit the full LSP gate`,
 			);
+		// A corpus submodule bump enrols files nothing has measured, so the PR
+		// that moves the pin is the second one that must pay for the gate (#4465).
+		// The repositories come from the gate's own `CORPUS_REPOS`, so this list
+		// is a control on the derivation and not a second copy of it.
+		for (const repo of CORPUS_REPOS)
+			for (const file of [`submodules/${repo}`, `submodules/${repo}/a.svelte`])
+				assert.equal(
+					decide(FAKE, [file])['lsp-ratchet'],
+					true,
+					`${file} must re-admit the full LSP gate`,
+				);
 		// …and only that PR: the hatch costs 950 job-minutes when it fires.
 		for (const file of [
 			'crates/rsvelte_core/src/lib.rs',
 			'compatibility/known-failures.client.json',
 			'pnpm-lock.yaml',
+			// a corpus submodule the LSP gate does not walk
+			'submodules/svelte.dev/x.svelte',
+			// a name that only shares a prefix with one it does
+			`submodules/${CORPUS_REPOS[0]}-extra/a.svelte`,
 		])
 			assert.equal(
 				decide(FAKE, [file])['lsp-ratchet'],

--- a/scripts/compat-lsp/artifacts.mjs
+++ b/scripts/compat-lsp/artifacts.mjs
@@ -99,7 +99,20 @@ function requireArtifact(value, label) {
       throw new Error(`${label} carries a mechanism for unlisted ${id}`);
 }
 
-export function mergeCurrentArtifacts(artifacts, populationFloor) {
+// `corpus-population.json` is an exact declaration, not a bound: it refuses a
+// GROWN corpus as loudly as a shrunken one, which is what a partial run looks
+// like. That is right for a verdict and wrong for a re-baseline — a corpus
+// submodule bump could not be baselined at all until someone edited the file by
+// hand (#4465). `allowPopulationChange` is the caller saying it is going to
+// rewrite that declaration from the measured population in the same command, so
+// the mismatch is reported rather than thrown. Completeness is still enforced,
+// by the shard-count and universe-hash checks above, which the declaration does
+// not participate in.
+export function mergeCurrentArtifacts(
+  artifacts,
+  populationFloor,
+  { allowPopulationChange = false } = {},
+) {
   if (!artifacts.length) throw new Error("zero current artifacts supplied");
   if (artifacts.length !== CORPUS_SHARDS + 1)
     throw new Error(`expected exactly ${CORPUS_SHARDS + 1} current artifacts`);
@@ -198,12 +211,14 @@ export function mergeCurrentArtifacts(artifacts, populationFloor) {
     throw new Error(
       "corpus shard union does not equal the declared file universe",
     );
+  const populationChanges = [];
   for (const repo of CORPUS_REPOS) {
     for (const field of ["files", "identifiers", "requests"]) {
-      if (population[repo][field] !== populationFloor[repo]?.[field])
-        throw new Error(
-          `${repo} ${field} population is ${population[repo][field]}, expected ${populationFloor[repo]?.[field]}`,
-        );
+      if (population[repo][field] !== populationFloor[repo]?.[field]) {
+        const message = `${repo} ${field} population is ${population[repo][field]}, expected ${populationFloor[repo]?.[field]}`;
+        if (!allowPopulationChange) throw new Error(message);
+        populationChanges.push(message);
+      }
     }
   }
   const current = artifacts.flatMap((artifact) => artifact.current).sort();
@@ -219,6 +234,7 @@ export function mergeCurrentArtifacts(artifacts, populationFloor) {
     current,
     mechanisms,
     population,
+    populationChanges,
     projectRevision: reference.projectRevision,
   };
 }

--- a/scripts/compat-lsp/artifacts.test.mjs
+++ b/scripts/compat-lsp/artifacts.test.mjs
@@ -151,6 +151,50 @@ test("revision, universe, and population drift cannot false-shrink", () => {
   );
 });
 
+test("a re-baseline may rewrite the population, and still not a partial run", () => {
+  // The declaration refuses a grown corpus as loudly as a shrunken one, which is
+  // right for a verdict and blocks the very command that could refresh it
+  // (#4465). Relaxing it must move exactly one guard: completeness is enforced
+  // by the shard set and the universe hash, neither of which reads the file.
+  const drifted = structuredClone(floor);
+  drifted["bits-ui"].files += 7;
+  const merged = mergeCurrentArtifacts(artifacts(), drifted, {
+    allowPopulationChange: true,
+  });
+  assert.equal(merged.populationChanges.length, 1);
+  assert.match(merged.populationChanges[0], /bits-ui files population is/);
+  assert.equal(merged.population["bits-ui"].files, CORPUS_SHARDS);
+
+  // Same call, unrelaxed: the default still refuses.
+  assert.throws(
+    () => mergeCurrentArtifacts(artifacts(), drifted),
+    /population is/,
+  );
+
+  // …and the relaxation buys a partial run nothing: drop a shard, corrupt the
+  // universe hash, and each still throws with the flag set.
+  assert.throws(
+    () =>
+      mergeCurrentArtifacts(artifacts().slice(0, -1), drifted, {
+        allowPopulationChange: true,
+      }),
+    /expected exactly/,
+  );
+  const universe = artifacts();
+  universe[2].universeHash = "other";
+  assert.throws(
+    () =>
+      mergeCurrentArtifacts(universe, drifted, { allowPopulationChange: true }),
+    /universe hashes differ/,
+  );
+  // An unchanged population reports nothing, so the writer stays quiet.
+  assert.deepEqual(
+    mergeCurrentArtifacts(artifacts(), floor, { allowPopulationChange: true })
+      .populationChanges,
+    [],
+  );
+});
+
 test("a deleted baseline file remains owned by one stable shard", () => {
   const id = "corpus/bits-ui/deleted.svelte";
   assert.equal(

--- a/scripts/compat-lsp/merge-current.mjs
+++ b/scripts/compat-lsp/merge-current.mjs
@@ -16,15 +16,15 @@ if (!directory)
   throw new Error(
     "usage: merge-current.mjs ARTIFACT_DIRECTORY [--update-baseline]",
   );
-const floor = JSON.parse(
-  fs.readFileSync(
-    path.join(ROOT, "scripts/compat-lsp/corpus-population.json"),
-    "utf8",
-  ),
+const populationPath = path.join(
+  ROOT,
+  "scripts/compat-lsp/corpus-population.json",
 );
+const floor = JSON.parse(fs.readFileSync(populationPath, "utf8"));
 const merged = mergeCurrentArtifacts(
   readArtifacts(path.resolve(directory)),
   floor,
+  { allowPopulationChange: UPDATE },
 );
 const baseline = path.join(ROOT, "compatibility/lsp-known-failures.json");
 const sidecar = path.join(ROOT, "compatibility/lsp-mechanisms.json");
@@ -59,6 +59,21 @@ if (UPDATE) {
   console.log(
     `[lsp-merge] wrote ${Object.keys(document.entries).length} mechanism sets over ${labels.size} labels to ${path.relative(ROOT, sidecar)}`,
   );
+  // Third file, same command, same reason: a population declaration refreshed
+  // apart from the ratchet describes a corpus the ratchet was not measured on.
+  if (merged.populationChanges.length) {
+    for (const change of merged.populationChanges)
+      console.log(`[lsp-merge] population changed: ${change}`);
+    const populationTemporary = `${populationPath}.${process.pid}.tmp`;
+    fs.writeFileSync(
+      populationTemporary,
+      JSON.stringify(merged.population, null, 2) + "\n",
+    );
+    fs.renameSync(populationTemporary, populationPath);
+    console.log(
+      `[lsp-merge] wrote ${merged.populationChanges.length} population change(s) to ${path.relative(ROOT, populationPath)}`,
+    );
+  }
 } else {
   const known = JSON.parse(fs.readFileSync(baseline, "utf8"));
   const knownSet = new Set(known);


### PR DESCRIPTION
Closes #4465.

`lsp-corpus` runs on a schedule, a dispatch, or the `lsp-ratchet` hatch. A corpus
submodule bump fires none of them, so #4407's 67 new shadcn files entered the gate's
population unmeasured, `main` went red, and every ratchet-touching PR inherited a
failure it did not cause.

## The hatch

`corpus-compat-job-filter.mjs` now opens `lsp-ratchet` for `submodules/<repo>` where
`<repo>` is one of the gate's own `CORPUS_REPOS`, imported rather than transcribed.

Replayed against the real carrier — `gh api repos/…/pulls/4407/files` returns exactly
one line, `submodules/shadcn-svelte`, with no trailing slash:

| input | `lsp-ratchet` |
|---|---|
| `submodules/shadcn-svelte` (#4407's actual file list) | **true** |
| `submodules/bits-ui/a.svelte` | true |
| `submodules/svelte.dev/x.svelte` (a corpus submodule this gate does not walk) | false |
| `submodules/bits-ui-extra/a.svelte` (shares a prefix only) | false |
| `crates/rsvelte_core/src/lib.rs`, `pnpm-lock.yaml` | false |

The hatch stays closed on ordinary PRs; a bump is rare and pays the 950 job-minutes
once instead of leaving `main` red until the nightly.

## The second half: the re-baseline could not run

`scripts/compat-lsp/corpus-population.json` is an exact declaration, not a bound —
`artifacts.mjs` asserts it with `!==` on all three fields per repo, so it refuses a
**grown** corpus as loudly as a shrunken one — and it is asserted inside the very
command that would refresh it. `mergeCurrentArtifacts` now takes
`allowPopulationChange`; `merge-current.mjs --update-baseline` passes it, reports each
change, and writes the measured population beside the ratchet and the sidecar, for the
reason that file already gives about the sidecar.

**The relaxation moves exactly one guard.** Completeness is enforced by the shard-count
check and by the union of measured ids hashing to the declared universe, neither of
which reads the population file. The new test asserts both still throw *with the flag
set*: a dropped shard gives `expected exactly`, a corrupted `universeHash` gives
`universe hashes differ`. It also pins that the default still refuses, and that an
unchanged population reports zero changes so the writer stays quiet.

## Controls

Both halves are ablated, and the tree is byte-identical afterwards:

- replace the prefix arm with `false` → `15 passed, 1 failed` (restored: 16/16)
- replace `if (!allowPopulationChange) throw` with `throw` → the new artifacts test is
  the only one that fails (restored: 81/81 across `scripts/compat-lsp/*.test.mjs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj