### PR TITLE
fix(client): a comment-buffer region holding only a chunk separator is not a location

### DIFF
--- a/.changeset/consumed-span-whitespace-only.md
+++ b/.changeset/consumed-span-whitespace-only.md
@@ -1,0 +1,17 @@
+---
+"@rsvelte/compiler": patch
+---
+
+client: a comment-buffer region that holds only a chunk separator is not a location
+
+`to_oxc::consumed` gives a container the slice of the synthetic comment buffer
+its children consumed. When they consumed only the `'\n'` each chunk is appended
+with, that slice sits just past a *neighbouring* chunk's trailing comment, and
+`has_loc` reads it as a real source position — so the arrow printer hands it to
+the parameter list as the `until` bound and flushes an unrelated script comment
+inside the parens.
+
+A region with no non-whitespace byte holds neither a token nor a comment, so it
+no longer becomes a span. `<svelte:boundary>` now drops the trailing script
+comment as upstream does, and `{#key}` keeps it in the second argument's
+parameter list where upstream puts it.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -711,12 +711,31 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
         let before = self.synth.borrow().cursor();
         let value = f()?;
         let after = self.synth.borrow().cursor();
-        let span = if after > before {
+        // A region with no non-whitespace byte holds neither a token nor a
+        // comment, so it is not a location anything can be anchored to: it is
+        // the `'\n'` each chunk is appended with, belonging to a NEIGHBOURING
+        // chunk. Handing it to a builder-made node makes that node a comment
+        // flush boundary sitting just past an unrelated chunk's trailing
+        // comment (#4492, #4481's `{#key}` cell). The scan stops at the first
+        // code byte, so a region that has one costs O(1).
+        let span = if after > before && self.region_has_content(before, after) {
             Span::new(before, after)
         } else {
             SPAN
         };
         Some((value, span))
+    }
+
+    /// Whether `[start, end)` of the comment buffer holds anything but ASCII
+    /// whitespace. Non-ASCII whitespace counts as content, which keeps the
+    /// pre-existing span rather than dropping one this cannot classify.
+    fn region_has_content(&self, start: u32, end: u32) -> bool {
+        let synth = self.synth.borrow();
+        synth
+            .source
+            .as_bytes()
+            .get(start as usize..end as usize)
+            .is_some_and(|bytes| bytes.iter().any(|byte| !byte.is_ascii_whitespace()))
     }
 
     /// Record a span the printer must NOT read as a chunk location.

--- a/crates/rsvelte_core/tests/whitespace_only_chunk_region_4492.rs
+++ b/crates/rsvelte_core/tests/whitespace_only_chunk_region_4492.rs
@@ -1,0 +1,151 @@
+//! The comment-buffer region a builder-made node is given must hold something.
+//!
+//! `to_oxc::consumed` gives a container the slice of the synthetic comment
+//! buffer its children consumed. When they consumed only the `'\n'` a chunk is
+//! appended with, that slice sits just past a NEIGHBOURING chunk's trailing
+//! comment, and `has_loc` reads it as a real location — so
+//! `arrow_function_with_owned_comments` hands it to the parameter list as the
+//! `until` bound and the comment is flushed inside the parens (#4492, and
+//! #4481's `{#key}` cell).
+//!
+//! The four cells are the pair that makes the rule discriminating. Two of them
+//! move under the fix, in OPPOSITE directions — `<svelte:boundary>` must lose
+//! the comment and `{#key}` must keep it, one argument earlier than rsvelte put
+//! it — and two must not move at all while still carrying the comment through,
+//! so a fix that simply stops flushing at builder-made nodes fails them.
+//!
+//! Every expectation is the official compiler's bytes at the recorded submodule
+//! pin, `submodules/svelte/packages/svelte/src/compiler/index.js`, `client`,
+//! `dev: false` — generated from it rather than transcribed.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// One instance script — `let c = 1;` then a trailing `// x` — under one template.
+fn client(template: &str) -> String {
+    let source = format!("<script>\n\tlet c = 1;\n\t// x\n</script>\n{template}\n");
+    compile(
+        &source,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn a_svelte_boundary_drops_it_as_upstream_does() {
+    assert_eq!(
+        client(r#"<svelte:boundary><b>{c}</b></svelte:boundary>"#),
+        r#"import 'svelte/internal/disclose-version';
+import 'svelte/internal/flags/legacy';
+import * as $ from 'svelte/internal/client';
+
+var root = $.from_html(`<b></b>`);
+
+export default function T($$anchor) {
+	let c = 1;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+
+	$.boundary(node, {}, ($$anchor) => {
+		var b = root();
+
+		b.textContent = '1';
+		$.append($$anchor, b);
+	});
+
+	$.append($$anchor, fragment);
+}"#
+    );
+}
+
+#[test]
+fn a_key_block_keeps_it_in_the_second_arguments_parameter_list() {
+    assert_eq!(
+        client(r#"{#key c}<b>{c}</b>{/key}"#),
+        r#"import 'svelte/internal/disclose-version';
+import 'svelte/internal/flags/legacy';
+import * as $ from 'svelte/internal/client';
+
+var root = $.from_html(`<b></b>`);
+
+export default function T($$anchor) {
+	let c = 1;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+
+	$.key(
+		node,
+		(// x
+		) => c,
+		($$anchor) => {
+			var b = root();
+
+			b.textContent = '1';
+			$.append($$anchor, b);
+		}
+	);
+
+	$.append($$anchor, fragment);
+}"#
+    );
+}
+
+#[test]
+fn a_plain_element_still_keeps_it_on_the_var() {
+    assert_eq!(
+        client(r#"<p>{c}</p>"#),
+        r#"import 'svelte/internal/disclose-version';
+import 'svelte/internal/flags/legacy';
+import * as $ from 'svelte/internal/client';
+
+var root = $.from_html(`<p></p>`);
+
+export default function T($$anchor) {
+	let c = 1;
+
+	var // x
+	p = root();
+
+	p.textContent = '1';
+	$.append($$anchor, p);
+}"#
+    );
+}
+
+#[test]
+fn an_await_block_still_keeps_it_in_a_parameter_list() {
+    assert_eq!(
+        client(r#"{#await Promise.resolve(c)}<b>{c}</b>{/await}"#),
+        r#"import 'svelte/internal/disclose-version';
+import 'svelte/internal/flags/legacy';
+import * as $ from 'svelte/internal/client';
+
+var root = $.from_html(`<b></b>`);
+
+export default function T($$anchor) {
+	let c = 1;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+
+	$.await(
+		node,
+		(// x
+		) => Promise.resolve(c),
+		($$anchor) => {
+			var b = root();
+
+			b.textContent = '1';
+			$.append($$anchor, b);
+		}
+	);
+
+	$.append($$anchor, fragment);
+}"#
+    );
+}


### PR DESCRIPTION
Closes #4492. Closes the `{#key}` cell of #4481.

## Mechanism

`to_oxc::consumed` gives a container the slice of the synthetic comment buffer its
children consumed — `(synth.cursor before, synth.cursor after)`. That is not a source
position: it is wherever the cursor happened to be. Instrumented on `842278fb0` with the
issue's own cell:

```
[to_oxc arrow] span=Span { start: 83, end: 84 }  text=Some("\n")
[arrow]        body_start=83 has_loc=true until=Some(83) owned=None
[cmt]          idx=0 meta=Some((78, 82, false)) loc_base=Some(66) caller=printer.rs:1278
```

The arrow's `FunctionBody` span is **one byte**, and that byte is the `'\n'`
`parse_chunk` appends each chunk with. `has_loc` reads 83 as a real location, so
`arrow_function_with_owned_comments` passes it to `formal_parameters_with_this` as the
`until` bound, and `flush_comments_until` writes the *instance script's* comment
(78..82, a different chunk) inside the parameter list. Upstream's `b.arrow` carries no
`loc`, so its `until` is null and the parameter list bounds nothing.

A region with no non-whitespace byte holds neither a token nor a comment, so it is not a
location anything can anchor to. It no longer becomes a span. The scan stops at the first
code byte, so a region that has one costs O(1); non-ASCII whitespace counts as content,
which keeps the pre-existing span rather than dropping one the test cannot classify.

## Grid — 17 templates x 4 targets, all attributable

A cell counts only when its comment-free sibling is byte-equal to the oracle **on both
arms**, so a background divergence cannot be read as this one (#4481 excludes `f_each`
for exactly that reason).

| target | attributable | base EQ | head EQ | DIFF→EQ | EQ→DIFF | comment-free cells that moved |
|---|---:|---:|---:|---:|---:|---:|
| client | 17/17 | 8 | 10 | 2 | **0** | 0 |
| client-dev | 17/17 | 11 | 13 | 2 | **0** | 0 |
| server | 17/17 | 10 | 10 | 0 | **0** | 0 |
| server-dev | 17/17 | 10 | 10 | 0 | **0** | 0 |

The two that move go in **opposite directions**, which is what makes the rule
discriminating rather than "flush less": `<svelte:boundary>` must *drop* the comment
(upstream does) and `{#key}` must *keep* it, one argument earlier than rsvelte was
putting it.

## Corpus — 33,890 units x 4 targets = 135,560

```
stage 1   client 82 MOVED   server 0   client-dev 82 MOVED   server-dev 0
          row misalignment 0, warning field changed on 0, ERR rows byte-identical
          between arms (client 1244, server 1243) — the accepted/rejected sets are equal
stage 2   client      fixes=5  regressions=0  both-DIFF=77
          client-dev  fixes=0  regressions=0  both-DIFF=82
```

The five real-world files that become byte-equal to the oracle:

```
cnblocks/src/lib/components/layout/nav-user.svelte
cnblocks/src/routes/(app)/v2-docs/mcp/+page.svelte
primo/src/routes/dashboard/marketplace/blocks/+page.svelte
shadcn-svelte/docs/src/lib/components/block-viewer-iframe.svelte
trakt-web/projects/client/src/lib/components/dialogs/Modal.svelte
```

Two populations the component sweep structurally cannot see, measured separately:

- `compatibility/pattern-corpus`, 1,386 x 4: **MOVED 0**. Positive control on the same
  instrument — the two grid cells put through it read `MOVED / MOVED / same / same`, so
  the zero is an absence of carriers and not a silent instrument.
- modules (`.svelte.js` / `.svelte.ts`), 923 x 4: **MOVED 0**, on a live denominator of
  **200 files** — 723 are rejected on both arms by `compile_one --module`, so read this
  as "no movement over 800 units", not as a statement about the whole module population.

## Arms

Both built at `842278fb0`, four distinct `sha256`
(`d483f927…` / `36648d3a…` base, `cb68c437…` / `1c78dce8…` head binaries). The
discriminating probe is the issue's own cell: base prints `($$anchor// x`, head prints
`($$anchor)`.

## Test

`crates/rsvelte_core/tests/whitespace_only_chunk_region_4492.rs`, four cells whose
expectations are **generated from** the oracle rather than transcribed. Two of them do
not move under this change and still carry the comment through — `<p>` keeps `var // x`,
`{#await}` keeps `(// x` — so a fix that simply stopped flushing at builder-made nodes
fails them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
