### PR TITLE
fix(client): a block comment opening the script slice is indented once, not twice

### DIFF
--- a/.changeset/erased-host-block-comment-indent.md
+++ b/.changeset/erased-host-block-comment-indent.md
@@ -1,0 +1,22 @@
+---
+"@rsvelte/compiler": patch
+---
+
+client: a block comment opening the instance-script slice is indented once, not twice
+
+When a block comment's host TypeScript construct is erased, the slice reaching
+`normalize_js_with_oxc_lead` is the comment alone, and esrap prints such a slice
+with a leading newline. The guard that stops the re-indent loop double-indenting
+a leading block comment tested `code.starts_with("/*")`, so the newline made it
+miss and every continuation line gained a tab: `\t\t * @typedef {Object} Props`
+where official prints `\t * @typedef {Object} Props`.
+
+Measured over the corpus, both arms, four targets: 38 of 135,560 units move,
+across 19 files, on `client` and `client-dev` only. Of the 98 lines that differ
+between the arms, 98 now equal official's and none went the other way; 12 units
+become byte-identical to official where none were before.
+
+No gate observes the class — `ast_equiv_batch` runs with `CommentPolicy::Ignore`
+and the normalized comparison runs both sides through oxfmt, which re-aligns a
+JSDoc body — so the guard is a unit test rather than a `pattern-corpus` repro,
+which would pin nothing.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/formatting.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/formatting.rs
@@ -1334,10 +1334,13 @@ pub(crate) fn normalize_js_with_oxc_lead(js: &str, indent_level: usize, lead: &s
     // preserve its original indentation exactly as-is.
     let mut result_lines = Vec::new();
     let indent_str: String = "\t".repeat(indent_level);
-    // A block comment opening on line 0 gets no indent on its opener line, so
+    // A block comment opening the slice gets no indent on its opener line, so
     // the final print cannot dedent one back off its continuation lines; leave
-    // them bare and let that print supply the indent once.
+    // them bare and let that print supply the indent once. esrap emits a leading
+    // newline when the slice is only a comment (its host construct was erased),
+    // so the test has to look past leading whitespace or the guard misses there.
     let leading_comment_last_line = code
+        .trim_start()
         .starts_with("/*")
         .then(|| {
             code.find_sub("*/")

--- a/crates/rsvelte_core/tests/erased_host_block_comment_indent_4515.rs
+++ b/crates/rsvelte_core/tests/erased_host_block_comment_indent_4515.rs
@@ -1,0 +1,92 @@
+//! A block comment whose host TypeScript construct is erased arrives at the
+//! client instance-script normalizer as a slice that is *only* the comment, and
+//! esrap prints such a slice with a leading newline. The double-indent guard
+//! tested `code.starts_with("/*")`, so that newline made it miss and the
+//! re-indent loop added one tab to every continuation line.
+//!
+//! No corpus gate observes this: `ast_equiv_batch` runs with
+//! `CommentPolicy::Ignore`, and the normalized byte comparison (the output
+//! family and the pattern-exact family alike) runs both sides through oxfmt,
+//! which re-aligns a JSDoc body. Measured on the cell below: raw
+//! `base == oracle` is false while normalized `base == oracle` is true. A
+//! `pattern-corpus` repro would therefore pin nothing, which README convention 6
+//! forbids — this test is the guard.
+//!
+//! Every expected string here is official Svelte 5.57.0's own output for the
+//! same source (`submodules/svelte`, pin `7bc0a70fe`), not a neighbouring cell's.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+/// The comment's host is erased, so the slice reaching the normalizer is the
+/// comment alone. Official indents its continuation lines one level.
+#[test]
+fn an_erased_host_block_comment_is_indented_once() {
+    let out = client(concat!(
+        "<script lang=\"ts\">\n",
+        "  interface P {\n",
+        "  /**\n",
+        "   * two\n",
+        "   */\n",
+        "    a: number\n",
+        "  }\n",
+        "  let { a }: P = $props()\n",
+        "</script>\n",
+        "<i>{a}</i>\n"
+    ));
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\n\t * two\n"), "{out}");
+    assert!(!out.contains("\n\t\t * two\n"), "{out}");
+}
+
+/// The control that a blanket "one tab" rule would break: the host survives, so
+/// the comment sits inside an object literal and official indents it *twice*.
+/// This cell agreed before the change and must still agree.
+#[test]
+fn a_surviving_host_keeps_its_own_nesting() {
+    let out = client(concat!(
+        "<script lang=\"ts\">\n",
+        "  const o = {\n",
+        "    /**\n",
+        "     * two\n",
+        "     */\n",
+        "    a: 1\n",
+        "  };\n",
+        "  let a = o.a;\n",
+        "</script>\n",
+        "<i>{a}</i>\n"
+    ));
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\n\t\t * two\n"), "{out}");
+}
+
+/// The second control: a comment that is already the script's first line took
+/// the same path before the change (its opener indent and `script_lead` are the
+/// same string) and must not move.
+#[test]
+fn a_script_leading_block_comment_does_not_move() {
+    let out = client(concat!(
+        "<script lang=\"ts\">\n",
+        "  /**\n",
+        "   * two\n",
+        "   */\n",
+        "  let a = 1;\n",
+        "</script>\n",
+        "<i>{a}</i>\n"
+    ));
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\n\t * two\n"), "{out}");
+    assert!(!out.contains("\n\t\t * two\n"), "{out}");
+}


### PR DESCRIPTION
Closes the indent half of #4515. The dedent half is still open there — see the bottom.

## Mechanism, instrumented end to end in one run

When a block comment's host TypeScript construct is erased, the slice handed to
`normalize_js_with_oxc_lead` is the comment **alone**, and esrap prints such a slice with a
leading newline:

```
[4515] normalize IN   indent_level=1 lead="  " js="/**\n     * two\n     */"
[4515] normalize POST-ESRAP code="\n/**\n   * two\n   */"
[4515] reindent guard leading_comment_last_line=None indent_str="\t"
[4515] normalize OUT  "\n\t/**\n\t   * two\n\t   */"
[4515] write_comment  value="*\n\t   * two\n\t   "
```

The guard whose entire job is to stop the re-indent loop double-indenting a leading block
comment tested `code.starts_with("/*")`. The leading newline makes that false, so the guard
misses and every continuation line gains a tab. The tab is then *inside the comment's value*,
which is why the final print adds its own on top.

The fix is that test: `code.trim_start().starts_with("/*")`.

## The issue thread said this was one defect; it is two, and they are independent

The comment's residual source columns (`   `) and this indent level are separate. That is
visible in a cell where the comment's opener indent **equals** `script_lead`, which removes the
column half and leaves this half alone:

| cell | official | base | this PR |
|---|---|---|---|
| erased host, opener 4 / lead 2 | `\t * two` | `\t\t   * two` | `\t   * two` (still DIFF) |
| erased host, opener 2 / lead 2 | `\t * two` | `\t\t * two` | **`\t * two`** |

A previous measurement on that thread implemented the column half alone and reported its result
as `\t\t * two` — which is exactly the second row's *base* value. Both halves are needed; each
one alone leaves the other.

## Grid — 7 cells x 4 targets, background DIFF 0

| | base | head |
|---|---:|---:|
| EQ | 18 | **20** |
| DIFF | 10 | 8 |

Moved: the `opener == lead` cell on `client` and `client-dev`. Nothing else moved in either
direction. The five control cells (object-literal member, function body, script-leading comment,
plain-JS object member, and the same shapes without `lang="ts"`) are EQ on both arms across all
four targets.

The first run of that grid reported every `*-dev` cell DIFF including the controls. That was the
instrument: `compile_one` uses the file's full path as `filename` and I had handed the oracle the
basename, so `E_toplevel[$.FILENAME]` differed on one line. Matching them takes the background to
zero.

## Corpus — 135,560 units, both arms, four targets

```
client      rows=33890 distinct=33890 MOVED=19
client-dev  rows=33890 distinct=33890 MOVED=19
server      rows=33890 distinct=33890 MOVED=0
server-dev  rows=33890 distinct=33890 MOVED=0
TOTAL units=135560 MOVED=38 misaligned=0 distinct files moved=19
```

Under the gate's own normalization (`flattenTemplateHoles` → oxfmt with
`compatibility/.oxfmtrc.json` → `stripBlankLines`), on those 38 units:

```
live units 38   dead units 0
MISMATCH -> match: 0     match -> MISMATCH: 0
still match: 12          still MISMATCH: 26
```

Raw, which is where the class lives:

```
units 38   raw byte-equal to official: base 0 / head 12
lines where base != head: 98
  of those, equal to official: base 0 / head 98
```

98 of 98 differing lines now equal official's and none went the other way. The carriers are the
string `GATES.md` blind spot 1a names:

```
off  "\t * @typedef {Object} Props"
base "\t\t * @typedef {Object} Props"
head "\t * @typedef {Object} Props"
```

Keying those hash files on the first space silently collapsed 21 rows — 21 corpus paths contain
one (`threlte/.../examples/01 …`) — so the key splits from the right and `distinct == rows` is
printed beside every count.

## Why a unit test and not a `pattern-corpus` repro

Measured on the fixture rather than argued:

| cell | raw `base == oracle` | normalized `base == oracle` |
|---|---|---|
| erased host, opener 4 | false | **true** |
| erased host, opener 2 | false | **true** |
| `/* */` with no leading `*` | false | false |

Both erased-host shapes collapse under oxfmt, so a repro file would be green on both arms and
pin nothing, which README convention 6 forbids. (The third row does survive normalization — that
one is a legitimate repro for the dedent half, which this PR does not fix.)

The test's negative control: reverting the one-line change fails **exactly** the target test and
neither control.

```
test a_script_leading_block_comment_does_not_move ... ok
test a_surviving_host_keeps_its_own_nesting ... ok
test an_erased_host_block_comment_is_indented_once ... FAILED
```

The surviving-host control is the cell a blanket "one tab" rule would break: official prints
`\t\t * two` there, so it is a cell that can kill the hypothesis by passing.

## Not in this PR

The dedent base. `dedent_block_comment` is given `script_lead` — the *script's* first-line indent
— where upstream's `onComment` uses the **comment's own opener line** indent. Those two strings
are equal only when the comment is the script's first line. Recovering the right one means
dedenting at copy time in `emit_pending_comment`, which changes `push_source_range`'s one-chunk-
per-comment invariant into one per line and is therefore source-map visible. #4515 stays open for
it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
