### PR TITLE
fix(parse): `super` is legal wherever acorn enters `SCOPE_SUPER`

### DIFF
--- a/.changeset/class-field-super.md
+++ b/.changeset/class-field-super.md
@@ -1,0 +1,28 @@
+---
+"@rsvelte/compiler": patch
+---
+
+parse: `super` is legal wherever acorn enters `SCOPE_SUPER`, not only in a method
+
+`super.x` was rejected with `'super' keyword outside a method` inside a class field
+initializer, a class static block, and an object literal getter or setter — all
+valid JavaScript, all accepted by official Svelte, and all reported by a user
+against `compileModule` and `compile` alike (#4549).
+
+The site is `expression.rs`'s own `Scan`, not the OXC allow-list in
+`early_errors.rs`: `SemanticBuilder` reports nothing for any of these cells. The
+scan set `super_allowed` from method definitions and object-literal shorthand
+methods only, where acorn enters `SCOPE_SUPER` from `parseMethod` (which
+getters and setters also go through), from `parseClassField` around the
+**initializer only**, and from `parseClassStaticBlock`.
+
+`SCOPE_DIRECT_SUPER` is ported with it, so a `super()` call in a field
+initializer or a static block now says `super() call outside constructor of a
+subclass` where it said `'super' keyword outside a method`. acorn checks
+`allowSuper` at the `super` token and `allowDirectSuper` only after the `(`, so
+a bare `super()` in a plain function keeps the first message.
+
+Over the 20 shapes acorn's own list generates, rsvelte agreed with official on
+12 and now agrees on all 20. A computed key still rejects, because acorn enters
+the scope for a field's value and not for its key, and a `function` expression
+still rejects everywhere — it makes its own `[[HomeObject]]`.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -8202,6 +8202,12 @@ fn acorn_only_violation(
         await_at: Option<u32>,
         super_allowed: bool,
         next_function_is_method: bool,
+        /// acorn's `SCOPE_DIRECT_SUPER`: only a derived class's constructor gets
+        /// it, and only `super()` reads it. Arrows are transparent to both.
+        direct_super_allowed: bool,
+        next_function_is_direct_super: bool,
+        direct_super_at: Option<u32>,
+        class_is_derived: bool,
     }
     impl Scan<'_> {
         fn record_ts_modifier(&mut self, carries_modifier: bool, span: oxc_span::Span) {
@@ -8246,16 +8252,81 @@ fn acorn_only_violation(
             func: &oxc_ast::ast::Function<'a>,
             flags: oxc_syntax::scope::ScopeFlags,
         ) {
-            let saved = self.super_allowed;
+            let saved = (self.super_allowed, self.direct_super_allowed);
             self.super_allowed = std::mem::take(&mut self.next_function_is_method);
+            self.direct_super_allowed = std::mem::take(&mut self.next_function_is_direct_super);
             oxc_ast_visit::walk::walk_function(self, func, flags);
-            self.super_allowed = saved;
+            (self.super_allowed, self.direct_super_allowed) = saved;
         }
         fn visit_object_property(&mut self, prop: &oxc_ast::ast::ObjectProperty<'a>) {
             let saved = self.next_function_is_method;
-            self.next_function_is_method = prop.method;
+            // acorn routes a getter/setter through `parseMethod` like a shorthand
+            // method, so all three enter `SCOPE_SUPER`; oxc's `method` flag is set
+            // for the shorthand only.
+            self.next_function_is_method = prop.method
+                || matches!(
+                    prop.kind,
+                    oxc_ast::ast::PropertyKind::Get | oxc_ast::ast::PropertyKind::Set
+                );
             oxc_ast_visit::walk::walk_object_property(self, prop);
             self.next_function_is_method = saved;
+        }
+        /// acorn's `parseClassField` enters `SCOPE_CLASS_FIELD_INIT | SCOPE_SUPER`
+        /// around the initializer **only**, so `super` is legal there (the field
+        /// carries the class's `[[HomeObject]]`) and still illegal in a computed
+        /// key. `SCOPE_DIRECT_SUPER` is not entered, so `super()` stays rejected.
+        fn visit_property_definition(&mut self, def: &oxc_ast::ast::PropertyDefinition<'a>) {
+            self.record_ts_modifier(
+                def.accessibility.is_some()
+                    || def.r#override
+                    || def.readonly
+                    || def.declare
+                    || def.r#type
+                        == oxc_ast::ast::PropertyDefinitionType::TSAbstractPropertyDefinition,
+                def.span,
+            );
+            self.visit_decorators(&def.decorators);
+            self.visit_property_key(&def.key);
+            if let Some(annotation) = &def.type_annotation {
+                self.visit_ts_type_annotation(annotation);
+            }
+            if let Some(value) = &def.value {
+                let saved = (self.super_allowed, self.direct_super_allowed);
+                self.super_allowed = true;
+                self.direct_super_allowed = false;
+                self.visit_expression(value);
+                (self.super_allowed, self.direct_super_allowed) = saved;
+            }
+        }
+        /// acorn's `parseClassStaticBlock` enters `SCOPE_CLASS_STATIC_BLOCK |
+        /// SCOPE_SUPER`, same as a field initializer.
+        fn visit_static_block(&mut self, block: &oxc_ast::ast::StaticBlock<'a>) {
+            let saved = (self.super_allowed, self.direct_super_allowed);
+            self.super_allowed = true;
+            self.direct_super_allowed = false;
+            oxc_ast_visit::walk::walk_static_block(self, block);
+            (self.super_allowed, self.direct_super_allowed) = saved;
+        }
+        /// `SCOPE_DIRECT_SUPER` is a property of the class the method is in, so the
+        /// flag has to be readable when its constructor is reached.
+        fn visit_class(&mut self, class: &oxc_ast::ast::Class<'a>) {
+            let saved = self.class_is_derived;
+            self.class_is_derived = class.heritage.is_some();
+            oxc_ast_visit::walk::walk_class(self, class);
+            self.class_is_derived = saved;
+        }
+        /// acorn checks `allowSuper` at the `super` token and `allowDirectSuper`
+        /// only after seeing the `(`, so a `super()` where neither holds reports
+        /// the first message, not this one.
+        fn visit_call_expression(&mut self, call: &oxc_ast::ast::CallExpression<'a>) {
+            if matches!(call.callee, oxc_ast::ast::Expression::Super(_))
+                && self.super_allowed
+                && !self.direct_super_allowed
+                && self.direct_super_at.is_none()
+            {
+                self.direct_super_at = Some(call.span.start);
+            }
+            oxc_ast_visit::walk::walk_call_expression(self, call);
         }
         fn visit_decorator(&mut self, dec: &oxc_ast::ast::Decorator<'a>) {
             if self.check_decorator && self.decorator_at.is_none() {
@@ -8285,22 +8356,18 @@ fn acorn_only_violation(
                     || def.r#type == oxc_ast::ast::MethodDefinitionType::TSAbstractMethodDefinition,
                 def.span,
             );
-            let saved = self.next_function_is_method;
-            self.next_function_is_method = true;
-            oxc_ast_visit::walk::walk_method_definition(self, def);
-            self.next_function_is_method = saved;
-        }
-        fn visit_property_definition(&mut self, def: &oxc_ast::ast::PropertyDefinition<'a>) {
-            self.record_ts_modifier(
-                def.accessibility.is_some()
-                    || def.r#override
-                    || def.readonly
-                    || def.declare
-                    || def.r#type
-                        == oxc_ast::ast::PropertyDefinitionType::TSAbstractPropertyDefinition,
-                def.span,
+            let saved = (
+                self.next_function_is_method,
+                self.next_function_is_direct_super,
             );
-            oxc_ast_visit::walk::walk_property_definition(self, def);
+            self.next_function_is_method = true;
+            self.next_function_is_direct_super = self.class_is_derived
+                && def.kind == oxc_ast::ast::MethodDefinitionKind::Constructor;
+            oxc_ast_visit::walk::walk_method_definition(self, def);
+            (
+                self.next_function_is_method,
+                self.next_function_is_direct_super,
+            ) = saved;
         }
         fn visit_accessor_property(&mut self, def: &oxc_ast::ast::AccessorProperty<'a>) {
             // acorn has no auto-accessor plugin, so `accessor` itself is the violation.
@@ -8326,6 +8393,10 @@ fn acorn_only_violation(
         await_at: None,
         super_allowed: false,
         next_function_is_method: false,
+        direct_super_allowed: false,
+        next_function_is_direct_super: false,
+        direct_super_at: None,
+        class_is_derived: false,
     };
     // The TypeScript-only rule below needs a token that is cheap to rule out, so
     // a plain-JS script keeps the walk it had.
@@ -8364,6 +8435,12 @@ fn acorn_only_violation(
         finder
             .super_at
             .map(|at| (at, "'super' keyword outside a method".to_string())),
+        finder.direct_super_at.map(|at| {
+            (
+                at,
+                "super() call outside constructor of a subclass".to_string(),
+            )
+        }),
         finder
             .await_at
             .map(|at| (at, "Unexpected token".to_string())),

--- a/crates/rsvelte_core/tests/class_field_super_4549.rs
+++ b/crates/rsvelte_core/tests/class_field_super_4549.rs
@@ -1,0 +1,203 @@
+//! `super` was rejected wherever acorn's `SCOPE_SUPER` is entered by something
+//! other than a method: a class field initializer, a class static block, and an
+//! object literal getter/setter (#4549, reported against `compileModule` and
+//! `compile` alike).
+//!
+//! `expression.rs`'s `Scan` is the site — OXC's `SemanticBuilder` reports
+//! nothing for any of these, so the allow-list in `early_errors.rs` was never
+//! involved. The rows below are enumerated from acorn 8.18.0's own list of the
+//! places that enter the scope (`parseMethod`, `parseClassField` — the
+//! initializer only — and `parseClassStaticBlock`) rather than from the shapes
+//! the report happened to carry, and every expected value is official Svelte
+//! 5.57.0's answer for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_module};
+
+const BASE: &str = "class B { load(){} constructor(){} }\n";
+
+/// `None` = accepted; `Some(message)` = the `js_parse_error` official raises.
+struct Row {
+    what: &'static str,
+    body: String,
+    expected: Option<&'static str>,
+}
+
+const OUTSIDE_METHOD: &str = "'super' keyword outside a method";
+const OUTSIDE_CTOR: &str = "super() call outside constructor of a subclass";
+
+fn rows() -> Vec<Row> {
+    let row = |what: &'static str, body: String, expected: Option<&'static str>| Row {
+        what,
+        body,
+        expected,
+    };
+    vec![
+        // Entered the scope before this change and must still.
+        row(
+            "class method",
+            format!("{BASE}class C extends B {{ m(){{ super.load(); }} }}"),
+            None,
+        ),
+        row(
+            "derived ctor super()",
+            format!("{BASE}class C extends B {{ constructor(){{ super(); }} }}"),
+            None,
+        ),
+        row(
+            "arrow in derived ctor super()",
+            format!("{BASE}class C extends B {{ constructor(){{ (() => {{ super(); }})(); }} }}"),
+            None,
+        ),
+        row(
+            "object literal method",
+            "const o = { m(){ super.toString(); } };".into(),
+            None,
+        ),
+        // Newly entered.
+        row(
+            "field initializer, arrow",
+            format!("{BASE}class C extends B {{ f = () => super.load(); }}"),
+            None,
+        ),
+        row(
+            "field initializer, no arrow",
+            format!("{BASE}class C extends B {{ f = super.load; }}"),
+            None,
+        ),
+        row(
+            "static field initializer",
+            format!("{BASE}class C extends B {{ static f = () => super.load(); }}"),
+            None,
+        ),
+        row(
+            "static block",
+            format!("{BASE}class C extends B {{ static {{ super.load(); }} }}"),
+            None,
+        ),
+        row(
+            "object literal getter",
+            "const o = { get m(){ return super.toString(); } };".into(),
+            None,
+        ),
+        row(
+            "object literal setter",
+            "const o = { set m(v){ super.toString(); } };".into(),
+            None,
+        ),
+        // `SCOPE_DIRECT_SUPER` is NOT entered with it, so `super()` stays illegal
+        // — and with a different message from a bare `super` in the same place.
+        row(
+            "field initializer super()",
+            format!("{BASE}class C extends B {{ f = () => {{ super(); }}; }}"),
+            Some(OUTSIDE_CTOR),
+        ),
+        row(
+            "static block super()",
+            format!("{BASE}class C extends B {{ static {{ super(); }} }}"),
+            Some(OUTSIDE_CTOR),
+        ),
+        row(
+            "non-derived ctor super()",
+            "class C { constructor(){ super(); } }".into(),
+            Some(OUTSIDE_CTOR),
+        ),
+        // Rejections that must survive: the cells a blanket "allow super in a
+        // class" rule would wrongly accept.
+        row(
+            "computed key",
+            format!("{BASE}class C extends B {{ [super.load()] = 1; }}"),
+            Some(OUTSIDE_METHOD),
+        ),
+        row(
+            "object literal plain property",
+            "const o = { m: super.toString };".into(),
+            Some(OUTSIDE_METHOD),
+        ),
+        row(
+            "function expression in a field initializer",
+            format!("{BASE}class C extends B {{ f = function(){{ super.load(); }}; }}"),
+            Some(OUTSIDE_METHOD),
+        ),
+        row(
+            "function expression returned from a field initializer's arrow",
+            format!("{BASE}class C extends B {{ f = () => function(){{ super.load(); }}; }}"),
+            Some(OUTSIDE_METHOD),
+        ),
+        row(
+            "function expression in a static block",
+            format!("{BASE}class C extends B {{ static {{ (function(){{ super.load(); }}); }} }}"),
+            Some(OUTSIDE_METHOD),
+        ),
+        row(
+            "function expression in a method",
+            format!("{BASE}class C extends B {{ m(){{ return function(){{ super.load(); }}; }} }}"),
+            Some(OUTSIDE_METHOD),
+        ),
+        row(
+            "top level",
+            "super.toString();".into(),
+            Some(OUTSIDE_METHOD),
+        ),
+    ]
+}
+
+fn module_verdict(src: &str) -> Option<String> {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("m.svelte.js".into()),
+            ..Default::default()
+        },
+    )
+    .err()
+    .map(|e| format!("{e:?}"))
+}
+
+fn component_verdict(body: &str) -> Option<String> {
+    compile(
+        &format!("<script>\n{body}\n</script>\n<i>x</i>\n"),
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .err()
+    .map(|e| format!("{e:?}"))
+}
+
+fn check(what: &str, entry: &str, expected: Option<&str>, actual: Option<String>) -> bool {
+    match (expected, &actual) {
+        (None, None) => true,
+        (Some(message), Some(text)) if text.contains(message) => true,
+        _ => {
+            println!(
+                "  MISMATCH {entry:9} {what}\n    expected {expected:?}\n    actual   {actual:?}"
+            );
+            false
+        }
+    }
+}
+
+/// Both entry points are asserted: the report names `compileModule` and
+/// `compile`, and the module surface is a separate code path with almost no
+/// corpus population.
+#[test]
+fn super_is_legal_exactly_where_acorn_enters_scope_super() {
+    let mut bad = 0;
+    let all = rows();
+    for row in &all {
+        if !check(row.what, "module", row.expected, module_verdict(&row.body)) {
+            bad += 1;
+        }
+        if !check(
+            row.what,
+            "component",
+            row.expected,
+            component_verdict(&row.body),
+        ) {
+            bad += 1;
+        }
+    }
+    assert_eq!(bad, 0, "{bad} of {} cells diverge", all.len() * 2);
+}


### PR DESCRIPTION
Closes #4549.

## The site is ours, and it is not the one the file header points at

`super.x` was rejected with `'super' keyword outside a method` in a class field initializer, a
class static block, and an object literal getter or setter. `early_errors.rs` maps OXC's semantic
diagnostics onto acorn's wording, so that looked like the place — it is not. Instrumented,
`SemanticBuilder` reports **nothing** for the failing cells, and the right thing for their
`function`-expression siblings:

```
=== field-arrow-member      SEM (none)
=== field-plain-member      SEM (none)
=== nonderived-field-arrow  SEM (none)
=== static-field-arrow      SEM (none)
=== field-fn-member         SEM 'super' can only be referenced in members of derived classes…
=== field-arrow-call        SEM Super calls are not permitted outside constructors…
```

The rejection is `expression.rs`'s own `Scan`, whose `super_allowed` was set from method
definitions and object-literal **shorthand** methods only.

## Rows taken from the oracle's list, not from the report

acorn 8.18.0 enters `SCOPE_SUPER` in exactly three places — `parseMethod` (`:3562`), which a
getter and a setter also go through; `parseClassField` (`:1715`), around the **initializer only**;
and `parseClassStaticBlock` (`:1731`). `allowSuper` reads `currentThisScope()`, so arrows are
transparent and a `function` expression is not. All three are ported here.

`SCOPE_DIRECT_SUPER` comes with them: once `super` is allowed in a field initializer, a `super()`
there needs acorn's *second* message. acorn checks `allowSuper` at the `super` token and
`allowDirectSuper` only after the `(` (`:3046` then `:3050`), so a bare `super()` in a plain
function still reports the first one — which is what the two pinned rows in
`early_errors_3243.rs` assert, and they do not move.

The issue's title says "arrow function"; the axis is the **field initializer**. `f = super.load;`
with no arrow fails identically, and an arrow inside a *method* was always fine.

## Grid — 20 shapes x 2 entry points, official as the oracle

| | base | head |
|---|---:|---:|
| agree | 12 | **20** |
| disagree | 8 | **0** |

Both `compileModule` (`.svelte.js`) and `compile` are asserted, because the report named both and
the module surface is a separate code path with almost no corpus population.

The eight that moved: field initializer (arrow / no arrow / static), static block, object literal
getter, object literal setter — over-rejections; and `super()` in a field initializer or a static
block — right verdict, wrong message.

The twelve that did not are the cells a blanket "allow `super` inside a class" rule would break,
and they pass on both arms:

- a **computed key** (`[super.load()] = 1`) still rejects — acorn enters the scope for a field's
  value, not for its key;
- a **`function` expression** still rejects in each of the four places one can sit (in a field
  initializer, returned from a field initializer's arrow, in a static block, in a method), since
  it makes its own `[[HomeObject]]`;
- an object literal **plain property** and top level still reject;
- a derived constructor's `super()`, including through an arrow, still passes.

## Guards

`crates/rsvelte_core/tests/class_field_super_4549.rs` is that grid, 40 cells, every expected value
official Svelte 5.57.0's own answer for the same source.

Negative control: reverting the change fails **exactly** the 16 cells the eight new rows own and
leaves the other 24 passing, while `early_errors_3243.rs` stays 7/7 — so the pinned rows and the
new ones are independent.

Local suites, all green with the change: `compiler_errors` 2/2, `early_errors_3243` 7/7,
`parser_fixtures` 3/3, `validator` 3/3, `class_field_super_4549` 40/40.

(Two earlier readings in this worktree were instrument failures rather than regressions and are
worth naming: a fresh `git worktree` populates no submodules, so `compiler_errors` failed with
"no sample directories" and cargo's fail-fast then left three suites unrun; and `validator` failed
with "Fixtures not found" until `fixtures/` was linked. Both were re-run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
