### PR TITLE
test: allow slow Chrome startup in wasm browser gate

### DIFF
--- a/scripts/dev/test-wasm-browser.mjs
+++ b/scripts/dev/test-wasm-browser.mjs
@@ -63,7 +63,7 @@ chrome.on('error', (error) => { launchError = error; });
 let socket;
 try {
 	let port;
-	for (let attempt = 0; attempt < 150; attempt++) {
+	for (let attempt = 0; attempt < 600; attempt++) {
 		if (launchError) throw launchError;
 		try { port = (await readFile(join(profile, 'DevToolsActivePort'), 'utf8')).split('\n')[0]; break; }
 		catch (error) { if (error.code !== 'ENOENT') throw error; }


### PR DESCRIPTION
The WASM browser gate allowed only 15 seconds for Chrome to create its DevTools port file. On a busy release runner, Chrome started after that deadline and failed the gate before any compiler assertions ran. Allow up to 60 seconds for startup; browser and Worker compilation assertions are unchanged.

Validation: a wrapper delaying Chrome startup by 16 seconds fails with the previous deadline and passes with this change, including the pinned Svelte source oracle comparisons in the browser and Worker. `cargo fmt` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` pass.
