### PR TITLE
fix(release): the changeset self-test's live control is unmeasured on a tree with no pending changeset, not failed

### DIFF
--- a/scripts/release/test-core-consumer-changesets.mjs
+++ b/scripts/release/test-core-consumer-changesets.mjs
@@ -25,12 +25,22 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const CONFIG = JSON.parse(readFileSync(join(ROOT, '.changeset/config.json'), 'utf8'));
 
 let failures = 0;
+let unmeasured = 0;
+
+// A control whose population is empty on this tree has nothing to say; it is
+// printed as such rather than as a pass or a failure.
+class Unmeasured extends Error {}
 
 function check(name, fn) {
 	try {
 		fn();
 		console.log(`  ok   ${name}`);
 	} catch (err) {
+		if (err instanceof Unmeasured) {
+			unmeasured += 1;
+			console.log(`  skip ${name}\n       ${err.message}`);
+			return;
+		}
 		failures += 1;
 		console.log(`  FAIL ${name}\n       ${err.message}`);
 	}
@@ -164,18 +174,26 @@ check('packagesIn reads the frontmatter only', () => {
 // A live control on the tree: the guard's verdict is computed from these files,
 // so a reader that silently matches none of them would make every requirement
 // look unmet -- or, with the tick logic, every one look borrowed.
+// Right after a Release PR merges the tree carries no pending changeset, so the
+// population is empty and the two fixture controls above are what carry
+// packagesIn; failing here would turn every PR red until the next fix lands.
 check('every pending changeset names at least one @rsvelte package', () => {
 	const dir = join(ROOT, '.changeset');
 	const files = readdirSync(dir).filter((f) => f.endsWith('.md') && f !== 'README.md');
-	assert.ok(files.length > 0, 'no pending changesets -- this control cannot fire');
+	if (files.length === 0) {
+		throw new Unmeasured(
+			'0 pending changesets on this tree -- a state of main right after a release, not a verdict on this PR; the fixture controls above carry packagesIn',
+		);
+	}
 	const silent = files.filter((f) => packagesIn(readFileSync(join(dir, f), 'utf8')).size === 0);
 	assert.deepEqual(silent, [], 'these changesets parse to no package');
 });
 
+const tail = unmeasured ? ` (${unmeasured} unmeasured on this tree)` : '';
 console.log(
 	failures === 0
-		? '\ncore-consumer-changesets self-test: all checks passed'
-		: `\ncore-consumer-changesets self-test: ${failures} failure(s)`,
+		? `\ncore-consumer-changesets self-test: all checks passed${tail}`
+		: `\ncore-consumer-changesets self-test: ${failures} failure(s)${tail}`,
 );
 
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## What

`scripts/release/test-core-consumer-changesets.mjs` (run by the `Changeset` job) has a live control that reads the tree's pending changesets and asserts that `packagesIn` names a package in each. It also asserted the set is **non-empty** — and right after a Release PR merges the set is empty by construction, so every PR whose merge ref lands on that main is red on `Changeset` until the next fix lands a changeset. #4552 hit it on the tree after #4551 (`FAIL every pending changeset names at least one @rsvelte package — no pending changesets -- this control cannot fire`).

An empty population is now printed as `skip … 0 pending changesets on this tree -- no population` and counted in the summary line (`all checks passed (1 unmeasured on this tree)`), neither a pass nor a failure. The two fixture controls above it (`packagesIn reads every quote style…`, `…reads the frontmatter only`) carry the reader in both directions on every tree.

## Measured on this branch (0 pending changesets)

| tree | result |
|---|---|
| as is (0 pending) | `skip`, exit 0 |
| + a changeset naming `@rsvelte/fmt` | `ok`, exit 0 |
| + a changeset naming nothing | `FAIL … these changesets parse to no package`, exit 1 |

No Changeset needed: no package ships from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQAqKJWyJNQss6cDCTnt8U
