### PR TITLE
chore(pattern-corpus): a fix with no admissible repro is recorded as a doc with no file

### DIFF
--- a/compatibility/pattern-corpus/README.md
+++ b/compatibility/pattern-corpus/README.md
@@ -49,6 +49,16 @@ Ids are `pattern/issues/<file>`, `pattern/matrix/<axis>/<file>` and
    divergence would mean seeding a `known-failures` entry, and the seed then has
    to be tracked and burned down separately from the fix. Add the repro in the
    fix PR (or immediately after it merges) so it lands green.
+8. **A fix with no admissible repro is still recorded — as a doc with no file.**
+   Convention 6 rules out a file for a comment-only divergence: `verify.mjs` calls
+   `ast_equiv_batch` with no arguments, so `CommentPolicy::Ignore` applies and a
+   comment-only difference is byte-different, AST-equivalent and scored a **pass**
+   by every entry and every target. Such a file would be green on both arms. Write
+   an `issues/<name>.md` with no `issues/<name>` beside it, carrying a
+   `**Repro:** none — ` line that names the guard in backticks; the checker
+   requires that path to exist, so the record cannot outlive what it points at.
+   The relaxation is one-directional — a file on disk still owes its doc, and a
+   doc whose file exists may not claim there is none (#4449).
 
 ## `issues/` — one minimal repro per fixed divergence
 
@@ -67,13 +77,21 @@ The table shape also let two defects be spelled that a per-file layout cannot:
 prose (the checker compares sets, so a repeated id was invisible to it), and one row was
 missing its trailing pipe. Both are unrepresentable now rather than merely detected.
 
+Some fixed divergences have no admissible repro at all (convention 8). Those are
+`issues/<name>.md` files with **no** sibling file, and they carry a
+`**Repro:** none — ` line naming the test that guards the fix instead. Without them
+a comment-only fix left no trace here, and a file-driven index makes an omission
+produce neither a conflict nor a red — the branch that stays green does not
+self-report.
+
 To read them all in one place:
 
 ```sh
 node scripts/ci/check-pattern-corpus-docs.mjs --index
 ```
 
-which prints the old table to stdout, generated from the sibling docs.
+which prints the old table to stdout, generated from the sibling docs, with the
+no-repro records last.
 
 ## `matrix/` — the axes around those repros
 

--- a/compatibility/pattern-corpus/issues/4453-comment-in-removed-props-pattern.md
+++ b/compatibility/pattern-corpus/issues/4453-comment-in-removed-props-pattern.md
@@ -1,0 +1,14 @@
+# comment in a removed `$props()` destructuring pattern
+
+**Issue:** [#4453](https://github.com/baseballyama/rsvelte/issues/4453)
+**Repro:** none — `crates/rsvelte_core/tests/props_pattern_comment_4453.rs`
+
+A comment inside a destructured `$props()` pattern was dropped, or overtook an
+earlier comment, when the client transform removed the declaration the comment
+sat in. Fixed by #4447.
+
+No repro can live here. The divergence is comment-only, so it is byte-different,
+AST-equivalent, and scored a **pass** by every corpus entry and every target —
+`verify.mjs` calls `ast_equiv_batch` with no arguments, which means
+`CommentPolicy::Ignore`. A file placed here would therefore be green on both
+arms, which convention 6 forbids: it would pin nothing and could not regress.

--- a/compatibility/pattern-corpus/issues/4517-instance-script-comment-dropped.md
+++ b/compatibility/pattern-corpus/issues/4517-instance-script-comment-dropped.md
@@ -1,0 +1,17 @@
+# instance-script comment dropped before a component call with children
+
+**Issue:** [#4517](https://github.com/baseballyama/rsvelte/issues/4517)
+**Repro:** none — `crates/rsvelte_core/tests/instance_script_dropped_comment_4517.rs`
+
+A comment at the end of the instance script was dropped when the first template
+statement was a component call with children: under split coordinates a real
+source offset sits *below* `loc_base`, so `Printer::has_loc` read it as "no
+location", the located flush declined it, and a comment with no comment-space
+node after it was never emitted. `print_split` now prints once and prints again
+only when the first pass dropped something.
+
+No repro can live here, for the same reason as
+`4453-comment-in-removed-props-pattern.md`: a comment-only divergence is
+AST-equivalent, so the corpus scores it a pass on both arms. The guard's own
+discriminating shape — comments the first pass already places, which a broader
+rule would *move* — is likewise invisible to the corpus and lives in the test.

--- a/scripts/ci/check-pattern-corpus-docs.mjs
+++ b/scripts/ci/check-pattern-corpus-docs.mjs
@@ -23,7 +23,7 @@
 // script expects (a new sub-corpus, or a missing directory) — a failure rather
 // than a pass, because a check that silently stops looking is worse than none.
 
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -85,6 +85,13 @@ function bijection(label, ids, names, problems) {
 
 const DOC_SUFFIX = '.md';
 const ISSUE_LINE = '**Issue:** ';
+// A fix whose divergence cannot be written as a repro is recorded as a doc with
+// no file (#4449). The line has to name what does guard it, or the record is a
+// claim with nothing behind it — which is the state this replaced.
+const REPRO_NONE = '**Repro:** none';
+const BACKTICKED = /`([^`]+)`/g;
+
+export const ROOT = join(HERE, '..', '..');
 
 /** `{ repros, docs }` for `issues/`, split on the doc suffix. */
 function issueEntries(corpus) {
@@ -95,14 +102,32 @@ function issueEntries(corpus) {
   };
 }
 
-/** Read one sibling doc into the two cells the README table used to hold. */
+/**
+ * Read one sibling doc into the cells the README table used to hold, plus the
+ * `**Repro:** none` line when there is one. That line is excluded from `body`
+ * on purpose: otherwise its presence alone would satisfy "says something".
+ */
 export function readIssueDoc(corpus, repro) {
   const text = readFileSync(join(corpus, 'issues', `${repro}${DOC_SUFFIX}`), 'utf8');
   const lines = text.split('\n');
   const at = lines.findIndex((line) => line.startsWith(ISSUE_LINE));
   if (at < 0) return null;
-  const body = lines.slice(at + 1).join('\n').trim();
-  return { issue: lines[at].slice(ISSUE_LINE.length).trim(), body };
+  const rest = lines.slice(at + 1);
+  const reproAt = rest.findIndex((line) => line.startsWith(REPRO_NONE));
+  const body = rest
+    .filter((_, i) => i !== reproAt)
+    .join('\n')
+    .trim();
+  return {
+    issue: lines[at].slice(ISSUE_LINE.length).trim(),
+    body,
+    reproNone: reproAt < 0 ? null : rest[reproAt],
+  };
+}
+
+/** Every backticked path on the `**Repro:** none` line. */
+function guardPaths(line) {
+  return [...line.matchAll(BACKTICKED)].map((m) => m[1]);
 }
 
 /**
@@ -110,7 +135,7 @@ export function readIssueDoc(corpus, repro) {
  * decoration: a bijection alone is satisfied by 666 empty files, which is the
  * shape a bulk migration produces when it goes wrong.
  */
-function issueDocs(corpus, problems) {
+function issueDocs(corpus, problems, root) {
   const { repros, docs } = issueEntries(corpus);
   const have = new Set(docs);
   for (const repro of repros) {
@@ -121,28 +146,61 @@ function issueDocs(corpus, problems) {
     const doc = readIssueDoc(corpus, repro);
     if (!doc) problems.push(`issues/${repro}${DOC_SUFFIX} has no \`${ISSUE_LINE.trim()}\` line`);
     else if (!doc.body) problems.push(`issues/${repro}${DOC_SUFFIX} says nothing about what the repro pins`);
+    else if (doc.reproNone) {
+      problems.push(
+        `issues/${repro}${DOC_SUFFIX} says \`${REPRO_NONE}\` while \`${repro}\` is on disk`,
+      );
+    }
   }
   for (const doc of docs) {
     const repro = doc.slice(0, -DOC_SUFFIX.length);
-    if (!repros.includes(repro)) {
+    if (repros.includes(repro)) continue;
+    const parsed = readIssueDoc(corpus, repro);
+    if (!parsed) {
+      problems.push(`issues/${doc} has no \`${ISSUE_LINE.trim()}\` line`);
+      continue;
+    }
+    if (!parsed.reproNone) {
       problems.push(`issues/${doc} describes \`${repro}\`, which is not on disk`);
+      continue;
+    }
+    if (!parsed.body) problems.push(`issues/${doc} says nothing about what the fix restored`);
+    const guards = guardPaths(parsed.reproNone);
+    if (guards.length === 0) {
+      problems.push(`issues/${doc} says \`${REPRO_NONE}\` but names no guard in backticks`);
+      continue;
+    }
+    for (const guard of guards) {
+      if (!existsSync(join(root, guard))) {
+        problems.push(`issues/${doc} names the guard \`${guard}\`, which is not on disk`);
+      }
     }
   }
 }
 
 /** The old README table, generated — `--index`. */
 export function index(corpus) {
-  const { repros } = issueEntries(corpus);
+  const { repros, docs } = issueEntries(corpus);
   const out = ['| File | Issue | What it pins |', '|---|---|---|'];
   for (const repro of repros) {
     const doc = readIssueDoc(corpus, repro);
     if (!doc) continue;
     out.push(`| \`${repro}\` | ${doc.issue} | ${doc.body.replace(/\n/g, ' ')} |`);
   }
+  // Records with no repro read the same way and must not be invisible here —
+  // being unlisted is the state #4449 was about.
+  for (const doc of docs) {
+    const repro = doc.slice(0, -DOC_SUFFIX.length);
+    if (repros.includes(repro)) continue;
+    const parsed = readIssueDoc(corpus, repro);
+    if (!parsed?.reproNone) continue;
+    const guards = guardPaths(parsed.reproNone).map((g) => `\`${g}\``).join(', ');
+    out.push(`| none — guarded by ${guards} | ${parsed.issue} | ${parsed.body.replace(/\n/g, ' ')} |`);
+  }
   return out.join('\n');
 }
 
-export function check(corpus, sources = SOURCES) {
+export function check(corpus, sources = SOURCES, root = ROOT) {
   const problems = [];
   const layout = entries(corpus, true);
   const unexpected = layout.filter((entry) => !SUBDIRS.includes(entry));
@@ -162,7 +220,7 @@ export function check(corpus, sources = SOURCES) {
 
   const issues = sectionBounds(lines, 2, '`issues/`');
   if (!issues) return { fatal: 'README has no `## `issues/`` section', problems };
-  issueDocs(corpus, problems);
+  issueDocs(corpus, problems, root);
 
   // Every sibling doc is safe from being collected as a corpus unit only
   // because `pattern` carries `markdown: false` — `collectRepo`'s own default
@@ -246,5 +304,10 @@ function main() {
 }
 
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
-  process.exit(main());
+  // `process.exit` truncates a piped stdout: writes to a pipe are async, and
+  // exiting drops whatever has not drained. `--index` prints ~675 rows, and
+  // through a pipe that arrived as the first 162 with no marker — the exact
+  // shape of a cap that reads as a complete answer. Setting the code instead
+  // lets Node drain first.
+  process.exitCode = main();
 }

--- a/scripts/ci/test-check-pattern-corpus-docs.mjs
+++ b/scripts/ci/test-check-pattern-corpus-docs.mjs
@@ -9,6 +9,7 @@
 // that case while the section-scoped check fails it.
 
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -101,13 +102,21 @@ function clean(overrides = {}) {
   });
 }
 
-function run(dir) {
+function run(dir, root = ROOT) {
   try {
-    return check(dir, join(dir, 'corpus-sources.json'));
+    return check(dir, join(dir, 'corpus-sources.json'), root);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 }
+
+// A guard path is resolved against the repo root, so the present/absent pair is
+// drawn from the real tree. The present one is this guard's own script: it
+// cannot disappear without taking these controls with it.
+const GUARD = 'scripts/ci/check-pattern-corpus-docs.mjs';
+const MISSING_GUARD = 'crates/rsvelte_core/tests/no-such-guard-4449.rs';
+const recordDoc = (guard = GUARD, body = 'what the fix restored') =>
+  `# \`ghost.svelte\`\n\n**Issue:** [#1](x)\n**Repro:** none — \`${guard}\`\n\n${body}\n`;
 
 const tests = {
   'a fully documented corpus reports nothing'() {
@@ -126,6 +135,56 @@ const tests = {
     const { problems } = run(clean({ orphanDocs: { 'ghost.svelte.md': '**Issue:** x\n\nwhy\n' } }));
     assert.equal(problems.length, 1, problems.join('; '));
     assert.match(problems[0], /issues\/ghost\.svelte\.md describes `ghost\.svelte`, which is not on disk/);
+  },
+
+  // #4449: a fix whose divergence cannot be written as a repro — a comment-only
+  // divergence is byte-different, AST-equivalent, and scored a pass by every
+  // corpus target — had nowhere to be recorded, and the absence was silent. A
+  // doc with no file is now legal, but only when it names a guard that exists.
+  'a doc with no file that names an existing guard is accepted'() {
+    const { fatal, problems } = run(clean({ orphanDocs: { 'ghost.svelte.md': recordDoc() } }));
+    assert.equal(fatal, null);
+    assert.deepEqual(problems, []);
+  },
+
+  'a doc with no file that names a missing guard is reported'() {
+    const { problems } = run(clean({ orphanDocs: { 'ghost.svelte.md': recordDoc(MISSING_GUARD) } }));
+    assert.equal(problems.length, 1, problems.join('; '));
+    assert.match(problems[0], /names the guard `[^`]*no-such-guard-4449\.rs`, which is not on disk/);
+  },
+
+  'a doc with no file whose guard line names nothing is reported'() {
+    const { problems } = run(
+      clean({
+        orphanDocs: {
+          'ghost.svelte.md': '# x\n\n**Issue:** [#1](x)\n**Repro:** none, a unit test covers it\n\nwhy\n',
+        },
+      }),
+    );
+    assert.equal(problems.length, 1, problems.join('; '));
+    assert.match(problems[0], /names no guard in backticks/);
+  },
+
+  'a doc with no file that says nothing is reported'() {
+    const { problems } = run(
+      clean({ orphanDocs: { 'ghost.svelte.md': recordDoc(GUARD, '') } }),
+    );
+    assert.equal(problems.length, 1, problems.join('; '));
+    assert.match(problems[0], /says nothing about what the fix restored/);
+  },
+
+  // The relaxation is one-directional: a file on disk still owes a repro, so a
+  // doc cannot claim there is none while its own repro sits beside it.
+  'a doc that claims no repro while its file is on disk is reported'() {
+    const { problems } = run(
+      clean({
+        issues: {
+          'a.svelte': `# \`a.svelte\`\n\n**Issue:** [#1](x)\n**Repro:** none — \`${GUARD}\`\n\nwhy\n`,
+        },
+      }),
+    );
+    assert.equal(problems.length, 1, problems.join('; '));
+    assert.match(problems[0], /says `\*\*Repro:\*\* none` while `a\.svelte` is on disk/);
   },
 
   // A bijection alone is satisfied by 666 empty files, which is what a bulk
@@ -278,6 +337,20 @@ const tests = {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  },
+
+  // `--index` is the "read them all in one place" command the README points at,
+  // and through a PIPE `process.exit` dropped everything that had not drained:
+  // 162 of 675 rows, deterministically, with no marker. Compared against the
+  // in-process value rather than against a literal, so it cannot go stale.
+  '--index survives a pipe'() {
+    const inProcess = index(join(ROOT, 'compatibility', 'pattern-corpus'));
+    const piped = execFileSync(
+      process.execPath,
+      [join(ROOT, 'scripts/ci/check-pattern-corpus-docs.mjs'), '--index'],
+      { encoding: 'utf8', maxBuffer: 1 << 28, stdio: ['ignore', 'pipe', 'inherit'] },
+    );
+    assert.equal(piped.trimEnd(), inProcess.trimEnd());
   },
 
   // A guard nothing calls is worth nothing.


### PR DESCRIPTION
Closes #4449.

## What was wrong

`compatibility/pattern-corpus`'s provenance index is a **bijection with the file set** —
`check-pattern-corpus-docs.mjs` reports `issues/<doc> describes <repro>, which is not on disk` and its
own control `a sibling doc with no file is reported` pins that. So a fixed divergence that cannot be
written as a repro had nowhere to be written down.

That is not hypothetical. A comment-only divergence is byte-different, AST-equivalent, and scored a
**pass** by every entry and every target, because `verify.mjs:607-611` calls `ast_equiv_batch` with no
arguments and `CommentPolicy::Ignore` applies. A file placed here would be green on both arms, which
convention 6 forbids: it pins nothing and cannot regress. #4453 and #4517 are two such fixes, both
correctly guarded by unit tests, and both left **no line** in this record.

The asymmetry the repo already documents shows up here: a branch that goes red when `main` moves
self-reports; a branch that stays green does not. In an append-only table a missing entry eventually
collides with someone's append. In a file-driven index it produces neither a conflict nor a red.

## The choice

Of the three candidates the issue names, this takes **1** — relax the bijection in the doc → file
direction only, and make the relaxation carry its own evidence.

An `issues/<name>.md` with no sibling `issues/<name>` is legal when it carries

```
**Repro:** none — `crates/rsvelte_core/tests/props_pattern_comment_4453.rs`
```

and the checker requires that path to **exist**, so the record cannot outlive what it points at. The
`**Repro:** none` line is excluded from the doc's body before the "says nothing" check, or its presence
alone would satisfy it. One direction only: a file on disk still owes its doc, and a doc whose file
exists may not claim there is none.

Two real records land with it — #4453 and #4517, the cases that motivated the issue.

## `--index` was silently dropping 76% of its own output

Found while checking the new rows appear. `--index` is the "read them all in one place" command the
README points at. Through a **pipe** it printed 162 of 675 lines, deterministically, with no marker —
`process.exit` drops whatever has not drained, and writes to a pipe are async. To a file: all 675. On
`main` the same command gives 341 lines piped. It sets `process.exitCode` now.

This is the same failure as the issue one layer down — a record that reads as complete and is not — so
it is fixed here rather than filed.

## Controls

Five new fixture controls plus one for the pipe, and all six are **red against `main`'s checker** while
the 17 pre-existing ones stay green (`17 passed, 5 failed` on the unpatched script for the fixture set,
`22 passed, 1 failed` when only `process.exit` is restored):

| control | pins |
|---|---|
| a doc with no file that names an existing guard is accepted | the relaxation exists |
| a doc with no file that names a missing guard is reported | the guard path is checked, not just present |
| a doc with no file whose guard line names nothing is reported | `**Repro:** none, a unit test covers it` is not enough |
| a doc with no file that says nothing is reported | the emptiness check still applies |
| a doc that claims no repro while its file is on disk is reported | one direction only |
| `--index` survives a pipe | compared to the in-process value, so it cannot go stale |

The present/absent guard pair is drawn from the real tree, and the present one is the guard script's
own path — it cannot disappear without taking these controls with it.

Injection control on the shipped records: replacing #4453's guard path with a non-existent one makes
`check-pattern-corpus-docs.mjs` exit 1 and name it; restoring returns exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj