### PR TITLE
fix(client): the comment coordinate boundary clears the source, so a source offset cannot read as comment space

### DIFF
--- a/.changeset/loc-base-source-upper-bound.md
+++ b/.changeset/loc-base-source-upper-bound.md
@@ -1,0 +1,28 @@
+---
+"@rsvelte/compiler": patch
+---
+
+client: the comment coordinate boundary clears the source, so a source offset cannot read as comment space
+
+`loc_base` separates the two coordinate spaces the client printer works in:
+below it, an offset is a real source position with no comment-space location;
+at or above it, an offset indexes the synthetic comment buffer. It was computed
+as `synth.max_span + 2`, and `max_span` is the running max of whatever the probe
+pass happened to note — chunk text lengths, some statement ends, some
+`RawMapped` source offsets. Nothing made that an upper bound on the source
+offsets the printer actually resolves, so on a file whose template outgrew its
+largest chunk a genuine source offset sat above `loc_base` and was
+indistinguishable from a buffer offset by the only test either consumer has
+(#4521).
+
+The quantity that *is* an upper bound is the source length, and
+`program_to_oxc_with_islands` now takes it. `has_loc` therefore means what it
+says, and the printer stops treating a template identifier's position as a
+comment-space one.
+
+Over 34,930 real-world components, `js.code` moves on one file and moves toward
+official (18 differing lines to 11; the `var … = $.sibling(…)` region becomes
+byte-identical, where before four comments were parked on the wrong declarator).
+Pairing map segments by generated position across 1,016 files whose maps move:
+256 segments go from pointing at the wrong identifier to the right one, and none
+goes the other way.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -403,7 +403,7 @@ pub fn transform_client_module(
         }
     }
 
-    print_module_program(body, &header)
+    print_module_program(body, &header, source.len() as u32)
 }
 
 /// Print a `.svelte.(js|ts)` module body the way upstream's `client_module` /
@@ -434,6 +434,7 @@ fn expand_module_inspect_holes(code: String) -> String {
 pub(crate) fn print_module_program(
     body: Vec<JsStatement>,
     header: &str,
+    source_len: u32,
 ) -> Result<String, TransformError> {
     use super::js_ast::codegen::generate;
 
@@ -443,8 +444,8 @@ pub(crate) fn print_module_program(
     };
     let arena = super::js_ast::arena::JsArena::new();
     let alloc = oxc_allocator::Allocator::default();
-    if let Some(code) =
-        super::js_ast::to_oxc::program_to_oxc(&program, &arena, &alloc).map(|converted| {
+    if let Some(code) = super::js_ast::to_oxc::program_to_oxc(&program, &arena, &alloc, source_len)
+        .map(|converted| {
             let print_opts = rsvelte_esrap::PrintOptions::default().with_unlocated_program(true);
             match &converted.comment_source {
                 Some(cs) => {
@@ -2807,6 +2808,7 @@ pub(crate) fn transform_client(
                     &context.arena,
                     &alloc,
                     &ast_islands,
+                    source.len() as u32,
                 )
             })
             .map(|converted| {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -3560,7 +3560,7 @@ mod tests {
 
         let handwritten = generate(&prog, &arena).unwrap();
         let allocator = oxc_allocator::Allocator::default();
-        let converted = super::super::to_oxc::program_to_oxc(&prog, &arena, &allocator).unwrap();
+        let converted = super::super::to_oxc::program_to_oxc(&prog, &arena, &allocator, 0).unwrap();
         let esrap = rsvelte_esrap::print(&converted.program, "");
 
         for (printer, code) in [("handwritten", handwritten), ("oxc/esrap", esrap)] {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -179,23 +179,32 @@ pub fn program_to_oxc<'a>(
     program: &JsProgram,
     arena: &JsArena,
     allocator: &'a oxc_allocator::Allocator,
+    source_len: u32,
 ) -> Option<Converted<'a>> {
-    program_to_oxc_with_islands(program, arena, allocator, &[])
+    program_to_oxc_with_islands(program, arena, allocator, &[], source_len)
 }
 
 /// Convert an IR program while inserting retained source ASTs directly.
+/// `source_len` is the byte length of the original file this program was
+/// generated from, and it is the only quantity here that is genuinely an upper
+/// bound on the source offsets the printer can be asked to resolve. `max_span`
+/// is not: it is the running max of whatever the probe pass happens to note,
+/// so a template identifier's span could sit above a `max_span`-derived
+/// `loc_base` and read as comment space (#4521). Pass `0` when the program has
+/// no original source (a synthetic program in a test).
 pub fn program_to_oxc_with_islands<'a, 'source>(
     program: &JsProgram,
     arena: &JsArena,
     allocator: &'a oxc_allocator::Allocator,
     islands: &[AstIsland<'source>],
+    source_len: u32,
 ) -> Option<Converted<'a>> {
     note_fallback(UNSUPPORTED);
     let (probe, synth) = convert_once(program, arena, allocator, islands, None)?;
     if !synth.saw_comments {
         return Some(probe);
     }
-    let loc_base = synth.max_span.saturating_add(2);
+    let loc_base = synth.max_span.max(source_len).saturating_add(2);
     let (converted, synth) = convert_once(program, arena, allocator, islands, Some(loc_base))?;
     // Every span the pass produced outside a chunk region must stay below
     // `loc_base`, or the printer would mistake it for a real location.
@@ -3305,7 +3314,7 @@ mod tests {
         let program = JsProgram::with_body(vec![b::stmt(&arena, b::id("div"))]);
         let allocator = Allocator::default();
         let converted =
-            program_to_oxc(&program, &arena, &allocator).expect("identifier is supported");
+            program_to_oxc(&program, &arena, &allocator, 0).expect("identifier is supported");
 
         let oxc_ast::ast::Statement::ExpressionStatement(statement) = &converted.program.body[0]
         else {
@@ -3313,6 +3322,28 @@ mod tests {
         };
         assert_eq!(statement.expression.span().start, 7);
         assert_eq!(statement.expression.span().end, 10);
+    }
+
+    /// With a declared source length the boundary clears every source offset,
+    /// which is what makes "at or above `loc_base`" mean "comment space" (#4521).
+    #[test]
+    fn a_declared_source_length_lifts_the_comment_boundary_over_every_source_offset() {
+        let arena = JsArena::new();
+        arena.note_identifier_span("div", 1_000, 1_003);
+        let program = JsProgram::with_body(vec![
+            JsStatement::Raw("/* comment */ value;".into()),
+            b::stmt(&arena, b::id("div")),
+        ]);
+        let allocator = Allocator::default();
+        let converted = program_to_oxc(&program, &arena, &allocator, 1_200)
+            .expect("commented chunk is supported");
+
+        assert!(converted.comment_source.is_some());
+        assert!(
+            converted.loc_base > 1_200,
+            "loc_base {} must clear the source",
+            converted.loc_base
+        );
     }
 
     #[test]
@@ -3325,7 +3356,7 @@ mod tests {
         ]);
         let allocator = Allocator::default();
         let converted =
-            program_to_oxc(&program, &arena, &allocator).expect("commented chunk is supported");
+            program_to_oxc(&program, &arena, &allocator, 0).expect("commented chunk is supported");
 
         assert!(converted.comment_source.is_some());
         assert!(converted.loc_base < 1_000);
@@ -3357,7 +3388,7 @@ mod tests {
         let program =
             JsProgram::with_body(vec![b::stmt(&arena, assignment), b::stmt(&arena, update)]);
         let allocator = Allocator::default();
-        let converted = program_to_oxc(&program, &arena, &allocator)
+        let converted = program_to_oxc(&program, &arena, &allocator, 0)
             .expect("spanned assignment targets are supported");
 
         let Statement::ExpressionStatement(assignment) = &converted.program.body[0] else {
@@ -3403,7 +3434,7 @@ mod tests {
             crate::compiler::phases::phase3_transform::js_ast::JsExpr::Spanned(call_id, 0, 0),
         )]);
         let allocator = Allocator::default();
-        let converted = program_to_oxc(&program, &arena, &allocator).expect("call is supported");
+        let converted = program_to_oxc(&program, &arena, &allocator, 0).expect("call is supported");
 
         let oxc_ast::ast::Statement::ExpressionStatement(statement) = &converted.program.body[0]
         else {
@@ -3436,6 +3467,7 @@ mod tests {
                 source_offset: 12,
                 statement_indices: vec![1],
             }],
+            0,
         )
         .expect("retained AST is supported");
 
@@ -3463,7 +3495,7 @@ mod tests {
         )]);
         let allocator = Allocator::default();
         let converted =
-            program_to_oxc(&program, &arena, &allocator).expect("mapped raw chunk is supported");
+            program_to_oxc(&program, &arena, &allocator, 0).expect("mapped raw chunk is supported");
         let printed = rsvelte_esrap::print_with_map(
             &converted.program,
             "let value = 1;",
@@ -3490,7 +3522,8 @@ mod tests {
         });
         let program = JsProgram::with_body(vec![b::stmt(&arena, member)]);
         let allocator = Allocator::default();
-        let converted = program_to_oxc(&program, &arena, &allocator).expect("member is supported");
+        let converted =
+            program_to_oxc(&program, &arena, &allocator, 0).expect("member is supported");
 
         let Statement::ExpressionStatement(statement) = &converted.program.body[0] else {
             panic!("expected expression statement");

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
@@ -211,7 +211,7 @@ pub fn transform_server_module(
         }
     }
 
-    super::client::print_module_program(body, &header)
+    super::client::print_module_program(body, &header, source.len() as u32)
 }
 
 /// Safety cap on the fixed-point iteration for the server-module call rewrites

--- a/crates/rsvelte_core/tests/ast_handoff_coordinate_free.rs
+++ b/crates/rsvelte_core/tests/ast_handoff_coordinate_free.rs
@@ -68,8 +68,8 @@ fn stripping_leaves_no_span_and_no_comment_behind() {
 
     compile_client_with_program_sink(SOURCE, options, &mut |program, arena| {
         let allocator = oxc_allocator::Allocator::default();
-        let converted =
-            program_to_oxc(program, arena, &allocator).expect("fixture must convert to OXC");
+        let converted = program_to_oxc(program, arena, &allocator, SOURCE.len() as u32)
+            .expect("fixture must convert to OXC");
         before = located(&converted.program);
         before_comments = converted.program.comments.len();
 

--- a/crates/rsvelte_devtools/src/bin/ast_handoff_sizing.rs
+++ b/crates/rsvelte_devtools/src/bin/ast_handoff_sizing.rs
@@ -126,7 +126,7 @@ fn measure(source: &str, path: &str) -> Option<Row> {
     let output = compile_client_with_program_sink(source, options, &mut |program, arena| {
         let allocator = oxc_allocator::Allocator::default();
         let at = Instant::now();
-        let converted = program_to_oxc(program, arena, &allocator);
+        let converted = program_to_oxc(program, arena, &allocator, source.len() as u32);
         convert = at.elapsed();
         match converted {
             None => {
@@ -146,7 +146,7 @@ fn measure(source: &str, path: &str) -> Option<Row> {
                 // Same conversion again, then stripped: the question is not
                 // "does the strip run" but "does its result pass the gate that
                 // rejected the unstripped program".
-                let again = program_to_oxc(program, arena, &allocator)
+                let again = program_to_oxc(program, arena, &allocator, source.len() as u32)
                     .expect("second conversion of a program that already converted");
                 let at = Instant::now();
                 let stripped = again.into_coordinate_free_program();


### PR DESCRIPTION
Closes #4521.

## What was wrong

`loc_base` is the boundary between the two coordinate spaces the client printer works in — below it an
offset is a real source position carrying no comment-space location, at or above it an offset indexes
the synthetic comment buffer. It was `synth.max_span + 2`, and `max_span` is the running max of
whatever the probe pass happens to `note_span`: chunk text lengths, some statement ends, some
`RawMapped` source offsets. Nothing made that an upper bound on the source offsets the printer
actually resolves, so on a file whose template outgrew its largest chunk a genuine source offset sat
**above** `loc_base` and was indistinguishable from a buffer offset by the only test either consumer
has (`has_loc`).

The guard at `to_oxc.rs` could not see it because it re-reads the same under-counting `max_span`.

## The fix

The quantity that genuinely bounds every source offset is the **source length**, and
`program_to_oxc_with_islands` did not receive it. It does now, and `loc_base` is
`max(max_span, source_len) + 2`. `program_to_oxc`, `print_module_program` (the `compileModule` path,
both client and server) and the devtools sink thread it through; the synthetic-program unit tests pass
`0`, which is what "this program has no original source" means.

Adding the missing `note_span` calls one at a time was the alternative and is the enumeration hazard
this repo already records — the list would come from the offsets someone hit, not from the offsets the
printer can resolve.

## Measured, two arms

Arms are distinct binaries (`sha256 048d8c2e5603…` base, `bec6ddc9579a…` head) and are separated
behaviourally, not by label: an env-gated probe present in **both** builds prints `source_len=` only on
the head arm (`loc_base=56 max_span=54` vs `loc_base=57 max_span=54 source_len=55`). The probe is not
in the shipped diff.

Population: 34,930 real-world `.svelte` files under `submodules/`, `generate: client`, `dev: false`.
`rows == distinct keys == 34,930` on both arms, 1,269 throw identically on both. `js.map` is an
**object** across NAPI, so it is hashed as `JSON.stringify`, with the runtime type printed
(`TYPES code=string map=object`) before any hash is believed.

### `js.code` — one file moves, and it moves toward official

`submodules/svelte-eslint-parser/tests/fixtures/parser/ast/svelte5/ts-event03-type-output.svelte`,
the file #4521 names. Differing lines against official (`submodules/svelte` at the pinned
`7bc0a70fe`, `VERSION 5.57.0`): **18 → 11**. The region official writes as

```js
	var button = $.first_child(fragment);

	var // e: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement; }
	// e.currentTarget: EventTarget & HTMLButtonElement
	input = $.sibling(button, 2);
```

is now byte-identical. On `main` all four comments are parked on `button` — the wrong declarator — and
`var button` and `var input` are in the wrong order. The head arm drops two of the four (official puts
them inside the `$.delegated('input', …)` arrow, which is #4481's shape); the two it keeps are on the
node official keeps them on. So the arm with *fewer* comments is the one that places them correctly,
which a count-keyed comparison would have scored the other way.

### `js.map` — 1,016 files move; segments paired by generated position

`js.code` is byte-identical between the arms on 1,015 of those, so segments pair exactly. Verdicts are
oracle-free properties of (map, source, generated text): a segment is `ID-CORRECT` when the generated
position starts an identifier and the original position starts the same identifier, `OUT-OF-RANGE`
when the original column exceeds that source line's length.

```
paired-segments=460655  MOVED=3381
  1912  OUT-OF-RANGE -> OUT-OF-RANGE
  1070  NEW-IN-HEAD
   926  non-identifier-site -> non-identifier-site
   256  id-wrong -> ID-CORRECT
   169  non-identifier-site -> OUT-OF-RANGE
   117  id-wrong -> id-wrong
     1  ID-CORRECT -> ID-CORRECT
```

**256 repaired, 0 regressed** on the identifier verdict.

### The 169, with their raw values

Out-of-range rises by 169, and that number is a leak becoming visible rather than a leak being created.
Every one of them is a comment-space offset that reaches the map untranslated (`map_position`'s
`None => offset` fallback); raising `loc_base` moves where the untranslated value lands. Printing the
underlying values rather than tallying the bucket:

```
gen 150:6  "\t\t\t\t\t\t}"   base -> src 112:0   "        }}>"
gen 648:2  "\t}"             base -> src 1400:23 "ansform: uppercase;"     <- a CSS line
gen  14:1  "};"              base -> src 15:3    "</script>"
gen  39:2  "\t}"             base -> src 103:1   "    .popup-title {"      <- a CSS line
gen 124:3  "\t\t\t},"        base -> src 169:14  "h: fit-content;"         <- a CSS line
gen  51:2  "\t\t},"          base -> src 20:17   inside a template literal
```

The base positions are wrong in every case — they are in range by accident, pointing at CSS or template
text with no relation to the generated brace. The head positions are past the source end and therefore
countable. Fixing the fallback is #4466's subject, not this one; the measurement above is posted there.

### What this does NOT move

The five open sibling comment defects, run through both arms and against official:

| cell | base == official | head == official | base == head |
|---|---|---|---|
| #4500 `<script>/* c */ let { a } = $props();</script><b>{a}</b>` | false | false | **true** |
| #4448 `let p = /* c */ $props();` | false | false | **true** |
| #4516 `let a = $state(1); // c` + `<C bind:value={a} />` | false | false | **true** |
| #4481 trailing `// x` + `<svelte:window>` | false | false | **true** |
| #4489 trailing `// x` + top-level `{#snippet}` | false | false | **true** |

All five are live divergences under both arms, so this is a negative result with its own liveness
control, not a silent zero. This PR fixes the boundary and nothing downstream of it.

## Pin

`a_declared_source_length_lifts_the_comment_boundary_over_every_source_offset` in `to_oxc.rs`'s test
module: a program with a noted identifier span at 1,000 and a declared source length of 1,200 must have
`loc_base > 1_200`. Negative control — deleting `.max(source_len)` fails **that test and only that
test**, with its sibling
`generated_identifier_source_span_does_not_raise_comment_boundary` (source length `0`) still passing,
so the pin reads the new invariant rather than the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
