### PR TITLE
fix(client): a removed `$props()` declaration no longer takes its comments with it

### DIFF
--- a/.changeset/props-only-script-comment.md
+++ b/.changeset/props-only-script-comment.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/compiler": patch
+---
+
+client: a `$props()` declaration the transform removes outright no longer takes its comments with it
+
+When the destructured `$props()` declaration is the script's only statement, the
+transform empties the instance script, and the re-emission loop that puts a
+dropped declaration comment back is inside `if !trimmed.is_empty()`. The comment
+was therefore dropped from the client output entirely. Re-entering the comments
+as the script's own text puts them in the comment buffer, where the template
+root's declarator — which already carries the source anchor upstream stamps on
+it — picks them up, so the output is `var /* c */ i = root();` the way upstream
+writes it.
+
+The line break rsvelte still adds after a block comment in this position when
+`</script>` and the first element share a source line is #4500 and is unchanged
+here.

--- a/compatibility/KNOWN-FAILURES.md
+++ b/compatibility/KNOWN-FAILURES.md
@@ -7280,10 +7280,11 @@ over the `pattern/issues/` prefix alone, with the AST rescue removed. Its unit i
 `(id, target)`, folded to one entry per id carrying a `details` array naming each diverging
 target, so an id that diverges on all four targets is one ratchet entry rather than four.
 
-**Current baseline**, measured by the enrolling CI run (`Corpus Compat` 34430947366, tree
-`7b270ecbc`, 668 `pattern/issues/` manifest entries per target): 11 distinct ids, 30 `(id, target)`
-pairs, filed as `pattern-exact-known-failures.client.json`, 6 entries;
-`pattern-exact-known-failures.client-dev.json`, 6 entries;
+**Current baseline**, from the enrolling CI run (`Corpus Compat` 34430947366, tree
+`7b270ecbc`, 668 `pattern/issues/` manifest entries per target) less the two client entries of
+`008-comment-props-destructure.svelte`, which #4563 retired: 11 distinct ids, 28 `(id, target)`
+pairs, filed as `pattern-exact-known-failures.client.json`, 5 entries;
+`pattern-exact-known-failures.client-dev.json`, 5 entries;
 `pattern-exact-known-failures.server.json`, 9 entries; and
 `pattern-exact-known-failures.server-dev.json`, 9 entries. The two client targets and the two dev
 targets agree entry for entry, which is what makes the server/client split the real axis here.
@@ -7322,7 +7323,7 @@ same comment on both sides in a different place.**
 
 | id | targets | direction |
 |---|---|---|
-| `008-comment-props-destructure.svelte` | all 4 | **misplaced.** Client wants `var /* ) scanner payload */ div = root();` and rsvelte drops it; server puts the same comment after `= $$props;` where official has none. One comment, two verdicts — a relocation, not a loss. |
+| `008-comment-props-destructure.svelte` | server, server-dev | **rsvelte emits extra**, on the server only: the comment lands after `= $$props;` where official has none. The client half — official writing `var /* ) scanner payload */ div = root();` where rsvelte dropped the comment — was the enrolling baseline's other verdict and retired in #4563, so the entry that once read as a relocation is now a one-sided extra. |
 | `3515-props-default-line-comment.svelte` | server, server-dev | **rsvelte emits extra.** `let { a = 1 } = $$props; // initializer` against official's bare statement. |
 | `3515-props-default-multiline-comment.svelte` | all 4 | **mixed.** Server is the same extra `/* initializer` as the line-comment sibling; client is an indentation difference *inside* a kept block comment (`\t\t` vs `\t\t\t\t`), which is the continuation-line half of the same divergence. |
 | `3515-props-plain-line-comment.svelte` | server, server-dev | **rsvelte emits extra**, as the `default` sibling. |

--- a/compatibility/pattern-corpus/issues/4501-props-only-script-comment-dropped.md
+++ b/compatibility/pattern-corpus/issues/4501-props-only-script-comment-dropped.md
@@ -1,0 +1,18 @@
+# value-position comment dropped when `$props()` is the script's only statement
+
+**Issue:** [#4501](https://github.com/baseballyama/rsvelte/issues/4501)
+**Repro:** none — `crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs`
+
+A block comment in the value position of a destructured `$props()` declaration
+was dropped from the client output when that declaration was the script's only
+statement. The transform removes the declaration, the instance script becomes
+empty, and the loop that re-emits a dropped declaration comment is inside
+`if !trimmed.is_empty()`. Re-entering the comments as the script's text puts
+them in the comment buffer, so the template root's declarator — which already
+carries the source anchor upstream stamps on it — picks them up.
+
+No repro can live here, for the same reason as
+`4453-comment-in-removed-props-pattern.md`: a comment-only divergence is
+AST-equivalent, so the corpus scores it a pass on both arms. The corpus also has
+no instance of the shape at all — the issue's screen over 35,723 files finds 0 —
+so a repro added here would be guarded by nothing.

--- a/compatibility/pattern-exact-known-failures.client-dev.json
+++ b/compatibility/pattern-exact-known-failures.client-dev.json
@@ -1,5 +1,4 @@
 [
-	"pattern/issues/008-comment-props-destructure.svelte",
 	"pattern/issues/3515-props-default-multiline-comment.svelte",
 	"pattern/issues/3515-props-plain-multiline-comment.svelte",
 	"pattern/issues/3515-props-rest-line-comment.svelte",

--- a/compatibility/pattern-exact-known-failures.client.json
+++ b/compatibility/pattern-exact-known-failures.client.json
@@ -1,5 +1,4 @@
 [
-	"pattern/issues/008-comment-props-destructure.svelte",
 	"pattern/issues/3515-props-default-multiline-comment.svelte",
 	"pattern/issues/3515-props-plain-multiline-comment.svelte",
 	"pattern/issues/3515-props-rest-line-comment.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -1442,6 +1442,18 @@ pub(crate) fn transform_client(
         // adds indent to the first line, but subsequent lines of Raw content
         // need explicit indentation. We always use 1 because instance script
         // content is always emitted at the function body level.
+        // A `$props()` declaration the transform removes outright takes its own
+        // comments with it. Re-entering them as the script's text is what puts
+        // them in the comment buffer, so the first generated declarator can
+        // carry them the way upstream does; the re-emission loop below prints a
+        // statement instead, which is a different position (#4501).
+        if transformed_script.trim().is_empty() && !props_comments.is_empty() {
+            transformed_script = props_comments
+                .iter()
+                .map(|(_, comment)| comment.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+        }
         let script_indent = 1usize;
         let trimmed = transformed_script.trim();
         // Upstream dedents a block comment by its opener line's indentation,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -680,6 +680,70 @@ fn comments_in_removed_props_declarations_are_retained() {
 }
 
 #[test]
+fn a_props_only_script_keeps_its_value_position_comment_on_the_template_root() {
+    // Expected text is the oracle's own output for this input, not a
+    // neighbouring cell's. The trailing newline inside the script is what makes
+    // upstream break the line here; without it upstream writes
+    // `var /* c */ i = root();` and rsvelte still breaks — that residue is
+    // #4500, and it is why the sibling case below asserts the declarator rather
+    // than the whole file.
+    let source = "<script>let { a } = /* c */ $props();\n</script><i>{a}</i>";
+    let result = crate::compiler::compile(
+        source,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            name: Some("C6".into()),
+            ..Default::default()
+        },
+    )
+    .expect("compiles");
+    assert_eq!(
+        result.js.code,
+        "import 'svelte/internal/disclose-version';\n\
+         import * as $ from 'svelte/internal/client';\n\
+         \n\
+         var root = $.from_html(`<i> </i>`);\n\
+         \n\
+         export default function C6($$anchor, $$props) {\n\
+         \tvar /* c */\n\
+         \ti = root();\n\
+         \n\
+         \tvar text = $.only_child(i, true);\n\
+         \n\
+         \t$.template_effect(() => $.set_text(text, $$props.a));\n\
+         \t$.append($$anchor, i);\n\
+         }"
+    );
+}
+
+#[test]
+fn a_removed_props_declaration_does_not_take_its_comment_with_it() {
+    // The declaration is the script's only statement, so the transform empties
+    // the script and the comment leaves with it unless it is re-entered as the
+    // script's text (#4501). `var /* c */` is the position upstream writes it
+    // at; a bare `contains("/* c */")` would also pass on the statement-shaped
+    // re-emission this replaces.
+    for source in [
+        "<script>let { a } = /* c */ $props();</script><i>{a}</i>",
+        "<script>\nlet { a } = /* c */ $props();</script><i>{a}</i>",
+    ] {
+        let result = crate::compiler::compile(
+            source,
+            crate::compiler::CompileOptions {
+                generate: crate::compiler::GenerateMode::Client,
+                ..Default::default()
+            },
+        )
+        .expect("compiles");
+        assert!(
+            result.js.code.contains("var /* c */"),
+            "{source}\n{}",
+            result.js.code
+        );
+    }
+}
+
+#[test]
 fn legacy_prop_trailing_comment_stays_inside_generated_prop_call() {
     let source = r#"<script lang="ts">
 	export let value: string | null = null; // trailing prop comment

--- a/crates/rsvelte_core/tests/repeated_type_head_comment_runs_4373.rs
+++ b/crates/rsvelte_core/tests/repeated_type_head_comment_runs_4373.rs
@@ -96,7 +96,11 @@ let { a }: P = $props();
 
 /// The same head, written inline on the declarator instead of behind an alias.
 /// This is the host that reaches the held-back (`pending`) re-emission path,
-/// where the comments are flushed at the initializer rather than in place.
+/// where the comments are flushed at the initializer rather than in place. The
+/// declaration is the script's only statement, so the transform empties the
+/// script and the comments reach the client only because they are re-entered as
+/// its text (#4501); with another statement beside it the count is still right
+/// and the placement is not, which is why the table's key cannot own that cell.
 const INLINE_TWO: &str = "<script lang=\"ts\">
 let { a }: {
   // c
@@ -197,6 +201,18 @@ fn cells() -> Vec<(&'static str, String, &'static str, &'static str)> {
             "",
             "",
         ),
+        (
+            "an inline head on a destructured `$props()`",
+            INLINE_TWO.to_string(),
+            "c d c d",
+            "c d c d",
+        ),
+        (
+            "one comment in an inline head on a destructured `$props()`",
+            INLINE_ONE.to_string(),
+            "c c",
+            "c c",
+        ),
     ]
 }
 
@@ -252,14 +268,6 @@ fn the_extractor_and_the_compile_are_live() {
 /// moves into the table above.
 #[test]
 fn the_blocked_hosts_are_pinned_rather_than_matched() {
-    // An inline annotation on a destructured `$props()` loses its comment on the
-    // CLIENT before the repeat can apply (#4398) — the declaration is rebuilt
-    // from the pattern. The server keeps it and repeats the run correctly.
-    assert_eq!(sequence(INLINE_TWO, GenerateMode::Client), "");
-    assert_eq!(sequence(INLINE_TWO, GenerateMode::Server), "c d c d");
-    assert_eq!(sequence(INLINE_ONE, GenerateMode::Client), "");
-    assert_eq!(sequence(INLINE_ONE, GenerateMode::Server), "c c");
-
     // An annotation on an UNINITIALIZED declarator is dropped on both targets
     // (#4396): upstream ends the declaration at the identifier and floats the
     // comment to the next located node, which rsvelte has no channel for. The


### PR DESCRIPTION
Closes #4501.

## What was wrong

A block comment in the value position of a destructured `$props()` declaration was dropped from
the client output when that declaration was the instance script's **only** statement.

The transform removes the declaration, so `transformed_script` is empty; the loop that puts a
dropped declaration comment back (`client/mod.rs`) sits inside `if !trimmed.is_empty()`, so it
never runs. Nothing else carries the comment, and it is gone.

## The fix

Re-enter the dropped comments as the script's own text when the transform emptied it. That is
what puts them in the comment buffer, and the template root's declarator — built by
`b::var_decl_anchored`, which already stamps it with the source offset upstream anchors to —
picks them up. The re-emission loop below then sees them live (`kept == had`) and does not push
a second copy, so the two paths do not fight.

Emitting them as a `RawMapped` statement instead, which is what the existing loop does, puts the
comment on its own line before the first surviving statement. That is a different position from
upstream's, and it is why the fix is upstream of the loop rather than inside it.

## Measured

The issue's nine cells plus two controls, three arms — official (`submodules/svelte`, `VERSION
5.57.0`), `main`, and this branch — verdict full `js.code` byte equality:

| cell | official vs `main` | official vs head | `main` vs head |
|---|---|---|---|
| 1 `let { a } = /* c */ $props();` | DIFF | DIFF | **MOVED** |
| 2 statement before | DIFF | DIFF | same |
| 3 statement after | EQ | EQ | same |
| 4 both | DIFF | DIFF | same |
| 5 leading newline | DIFF | DIFF | **MOVED** |
| 6 trailing newline | DIFF | **EQ** | **MOVED** |
| 7 same-line `const` | DIFF | DIFF | same |
| 8 same-line `$state` | DIFF | DIFF | same |
| 9 rest element | DIFF | DIFF | same |
| n1 comment-only script (#4500's repro) | DIFF | DIFF | same |
| n2 no comment | EQ | EQ | same |

Three cells move and all move one way: **no EQ cell is lost**, cell 6 becomes byte-equal, and
cells 1 and 5 go from the comment being absent to

```js
	var /* c */
	i = root();
```

where official writes `var /* c */ i = root();`. The remaining difference is the line break after
the block comment, which is **#4500** — n1 is #4500's own repro and is byte-identical between
`main` and this branch, so this PR neither fixes nor worsens it.

The issue's own rule needs correcting on one point: it lists cells 7 and 8 as dropped, and they
are not dropped on `main` today. #4528 landed between the filing and now. The live rule is
"dropped iff the declaration is the only statement and there is no rest element", which is cells
1, 5 and 6 — exactly the three this PR moves. The issue's count key also could not see that the
*kept* cells put the comment in the wrong place; the table above is byte equality, which can.

### Not moved

`#4448`, `#4500` and `#4516`'s repros are byte-identical between `main` and this branch, and all
three remain DIFF against official under **both** arms — so this is a negative result with its
own liveness control rather than a silent zero.

## Pins

Two tests in `client/tests.rs`. The first asserts cell 6's **whole** output against the oracle's
own bytes for that input. The second asserts `var /* c */` for cells 1 and 5 — the declarator
position — rather than `contains("/* c */")`, which the statement-shaped re-emission this
replaces would also satisfy.

A repro cannot live in `compatibility/pattern-corpus/`: a comment-only divergence is
AST-equivalent, so the corpus scores it a pass on both arms, and the issue's screen over 35,723
files finds **0** instances of the shape anyway. It is recorded as a no-repro doc under the
convention #4556 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
