### PR TITLE
fix(compiler): a block comment whose host is erased keeps its own column

### DIFF
--- a/.changeset/erased-host-block-comment-indent.md
+++ b/.changeset/erased-host-block-comment-indent.md
@@ -1,0 +1,19 @@
+---
+"@rsvelte/compiler": patch
+---
+
+compiler: a block comment whose host TypeScript construct is erased keeps its own column
+
+A multi-line block comment re-emitted out of an erased construct is re-indented
+downstream by the distance between its opener's column and its continuation
+lines'. The opener arrived at whatever indentation the erased construct left
+behind — the script's, not the comment's — so a comment nested deeper than the
+script kept the difference on every continuation line (#4515).
+
+The opener now arrives at the column it had in the source, which makes the two
+quantities the same one again. Measured on six cells against Svelte 5.57.0, both
+targets: the three where the comment is nested deeper than the script (spaces,
+tabs, and with a surviving statement beside the erased construct) go from
+divergent to byte-equal, and the three that already agreed — an opener at the
+script's own indentation, a surviving host, a script-leading comment — are
+unchanged.

--- a/compatibility/pattern-corpus/issues/4515-erased-host-block-comment-indent.md
+++ b/compatibility/pattern-corpus/issues/4515-erased-host-block-comment-indent.md
@@ -1,0 +1,15 @@
+# a block comment whose erased host nested it deeper than the script
+
+**Issue:** [#4515](https://github.com/baseballyama/rsvelte/issues/4515)
+**Repro:** none — `crates/rsvelte_core/tests/erased_host_block_comment_indent_4515.rs`
+
+A multi-line block comment re-emitted out of an erased TypeScript construct kept
+the source's inner columns on its continuation lines; upstream re-indents them to
+the enclosing level. The comment's opener now arrives at the column it had in the
+source, so the downstream re-indent measures the distance the source really has.
+
+No repro can live here. `ast_equiv_batch` runs with `CommentPolicy::Ignore`, so a
+comment-only divergence is a pass on both arms, and the normalized byte
+comparison runs both sides through oxfmt, which re-aligns a JSDoc body — measured
+on this cell, raw `base == oracle` is false while normalized `base == oracle` is
+true. A file placed here would pin nothing.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -962,9 +962,45 @@ fn emit_pending_comment(
     comment_start: u32,
     comment_end: u32,
     output: &mut String,
-    copied_chunks: Option<&mut Vec<CopiedSourceChunk>>,
+    mut copied_chunks: Option<&mut Vec<CopiedSourceChunk>>,
     reemitted: Option<&mut Vec<Range<u32>>>,
 ) {
+    // A multi-line block comment is re-indented downstream by the distance
+    // between its opener's column and its continuation lines', so the opener
+    // has to arrive at the column it had in the source. What precedes it here
+    // is whatever indentation the erased construct left behind, which is the
+    // script's and not the comment's (#4515).
+    if source[comment_start as usize..comment_end as usize].contains('\n') {
+        let line_start = source[..comment_start as usize]
+            .rfind('\n')
+            .map_or(0, |at| at + 1);
+        let indent = &source[line_start..comment_start as usize];
+        let kept = output.trim_end_matches([' ', '\t']).len();
+        // The whitespace being replaced was copied from the source, so the
+        // chunk that claims it has to give back exactly as much as is dropped
+        // or every later projection offset shifts.
+        let cut = output.len() - kept;
+        let claimed = copied_chunks.as_ref().is_none_or(|chunks| {
+            chunks.last().is_none_or(|last| {
+                last.output.end as usize == output.len()
+                    && cut as u32 <= last.output.end - last.output.start
+            })
+        });
+        if indent.bytes().all(|byte| byte == b' ' || byte == b'\t') && claimed {
+            output.truncate(kept);
+            if cut > 0
+                && let Some(chunks) = copied_chunks.as_deref_mut()
+                && let Some(last) = chunks.last_mut()
+            {
+                last.output.end -= cut as u32;
+                last.source.end -= cut as u32;
+                if last.output.start == last.output.end {
+                    chunks.pop();
+                }
+            }
+            output.push_str(indent);
+        }
+    }
     let output_start = output.len() as u32;
     push_source_range(source, comment_start..comment_end, output, copied_chunks);
     if let Some(reemitted) = reemitted {

--- a/crates/rsvelte_core/tests/erased_host_block_comment_indent_4515.rs
+++ b/crates/rsvelte_core/tests/erased_host_block_comment_indent_4515.rs
@@ -51,6 +51,74 @@ fn an_erased_host_block_comment_is_indented_once() {
     assert!(!out.contains("\n\t\t * two\n"), "{out}");
 }
 
+/// The opener nested deeper than the script's own indentation. The re-emitted
+/// slice is re-indented downstream by the distance between the opener's column
+/// and the continuation lines', so the opener has to arrive at the column it
+/// had in the source rather than at whatever the erased construct left behind.
+#[test]
+fn an_opener_nested_deeper_than_the_script_is_still_indented_once() {
+    let out = client(concat!(
+        "<script lang=\"ts\">\n",
+        "  interface P {\n",
+        "    /**\n",
+        "     * two\n",
+        "     */\n",
+        "    a: number\n",
+        "  }\n",
+        "  let { a }: P = $props()\n",
+        "</script>\n",
+        "<i>{a}</i>\n"
+    ));
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\n\t * two\n"), "{out}");
+    assert!(!out.contains("\n\t   * two\n"), "{out}");
+}
+
+/// The same nesting written with tabs: the opener's column is a byte count of
+/// whatever whitespace the source used, so a space-only rule would miss here.
+#[test]
+fn a_tab_indented_opener_is_indented_once() {
+    let out = client(concat!(
+        "<script lang=\"ts\">\n",
+        "\tinterface P {\n",
+        "\t\t/**\n",
+        "\t\t * two\n",
+        "\t\t */\n",
+        "\t\ta: number\n",
+        "\t}\n",
+        "\tlet { a }: P = $props()\n",
+        "</script>\n",
+        "<i>{a}</i>\n"
+    ));
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\n\t * two\n"), "{out}");
+    assert!(!out.contains("\n\t\t * two\n"), "{out}");
+}
+
+/// A surviving statement beside the erased construct: the comment is no longer
+/// the script's first non-blank line, so `script_lead` is that statement's
+/// indentation and not the comment's — the cell that says the fix reads the
+/// comment's own column rather than the script's.
+#[test]
+fn a_statement_beside_the_erased_construct_does_not_change_the_column() {
+    let out = client(concat!(
+        "<script lang=\"ts\">\n",
+        "  const k = 1;\n",
+        "  interface P {\n",
+        "    /**\n",
+        "     * two\n",
+        "     */\n",
+        "    a: number\n",
+        "  }\n",
+        "  let { a }: P = $props()\n",
+        "</script>\n",
+        "<i>{a}{k}</i>\n"
+    ));
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\n\t * two\n"), "{out}");
+    assert!(!out.contains("\n\t   * two\n"), "{out}");
+}
+
 /// The control that a blanket "one tab" rule would break: the host survives, so
 /// the comment sits inside an object literal and official indents it *twice*.
 /// This cell agreed before the change and must still agree.


### PR DESCRIPTION
Closes #4515.

## What was wrong

A multi-line block comment whose host TypeScript construct is erased is re-emitted as a slice of
the source, and the client normalizer re-indents it by the distance between its **opener's column**
and its **continuation lines'**. The opener arrived at whatever indentation the erased construct
left behind in the output — the script's — while the continuation lines still carried the comment's
own. A comment nested deeper than the script therefore kept the difference on every continuation
line.

`AGENTS.md` already records the half of this that was ported: *"Upstream dedents a block comment by
its opener line's indentation."* `script_lead` supplies that for a comment at the script's own
level, which is why the cell already in
`crates/rsvelte_core/tests/erased_host_block_comment_indent_4515.rs` agreed — its opener and
`script_lead` are the same string. One nested level deeper and they are not.

## The fix

`emit_pending_comment` puts the opener back at the column it had in the source: the indentation
that the erased construct left on that line is replaced by the comment's own. Both quantities the
re-indent measures then come from the same place.

The replaced whitespace was copied from the source, so the `CopiedSourceChunk` that claims it gives
back exactly as much as is dropped (and is removed if that empties it). Without that, every later
projection offset shifts — the change is in `2_analyze/types.rs`, which feeds svelte2tsx as well as
the compiler.

## Measured

Six cells, three arms (official at `submodules/svelte` pin `7bc0a70fe`, `VERSION 5.57.0`; `main`;
this branch), verdict full `js.code` byte equality, **both targets**:

| cell | `main` | head |
|---|---|---|
| opener nested deeper than the script (4 spaces vs 2) — this issue's repro | DIFF | **EQ** |
| the same nesting written with tabs | DIFF | **EQ** |
| a surviving statement beside the erased construct | DIFF | **EQ** |
| opener at the script's own indentation (the existing pin) | EQ | EQ |
| a surviving host — the comment sits in an object literal | EQ | EQ |
| a script-leading block comment | EQ | EQ |

Three move, all one way; none of the three that already agreed is lost. `client` and `server`
produce the same table, which is what says the fix is in the shared erasure and not in one
target's printer.

### Not moved

#4396 and #4397's repros are byte-identical between `main` and this branch and remain DIFF against
official under both arms — a negative result with its own liveness control.

## Pins

Three tests added to `erased_host_block_comment_indent_4515.rs` beside its existing three. The
spaces and tabs cells assert the continuation line renders as `\t * two` **and** that it does not
render as the source-column form, so a rule that merely shifted the columns some other distance
fails. The third holds a surviving statement beside the erased construct, which makes
`script_lead` that statement's indentation rather than the comment's — the cell that separates
"reads the comment's own column" from "reads the script's".

A repro cannot live in `compatibility/pattern-corpus/`: `ast_equiv_batch` runs with
`CommentPolicy::Ignore`, and the normalized byte comparison runs both sides through oxfmt, which
re-aligns a JSDoc body — raw `base == oracle` is false on this cell while normalized
`base == oracle` is true. Recorded as a no-repro doc under the convention #4556 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
