### PR TITLE
fix(client): a `$props()` declaration's inline comment stays on the declaration it lowered to

### DIFF
--- a/.changeset/props-comment-trailing.md
+++ b/.changeset/props-comment-trailing.md
@@ -1,0 +1,26 @@
+---
+"@rsvelte/compiler": patch
+---
+
+client: a `$props()` declaration's inline comment stays on the declaration it lowered to
+
+Upstream prints a comment that sits inline before the `$props(` call after the `;`
+of the declaration the lowering produced. rsvelte printed it as a statement of its
+own ahead of the script for the whole-object form (`let p = $props()`, where the
+transform drops the comment) and on a line of its own after the statement for the
+rest form (`let { a, ...z } = $props()`, where it survives) — two routes to the
+same wrong line (#4448).
+
+The axis is the comment's distance from the **call**, not from the `let`: read off
+the oracle, `let p = /* c */\n$props()` floats the comment forward while
+`let p =\n/* c */ $props()` trails the declaration, so a comment is moved only
+when nothing but blanks separates it from `$props(`. Newline-freedom alone is not
+enough — `let { a, /* c */ ...rest } = $props()` satisfies it and upstream leaves
+that comment in the pattern. The `$.prop(…)` form is deliberately untouched: with a default the comment belongs inside the call, which the lowering
+already does, and moving it to the statement end would be a second wrong answer
+instead of none.
+
+Measured on 34 cells against Svelte 5.57.0 (the four grids for #4448, #4501,
+#3515 and the newline axis): 10 go from divergent to byte-equal, 0 go the other
+way. The plain destructure keeps the line break that is #4500, and the server
+target is unchanged throughout.

--- a/compatibility/pattern-corpus/issues/4448-props-comment-trailing.md
+++ b/compatibility/pattern-corpus/issues/4448-props-comment-trailing.md
@@ -1,0 +1,20 @@
+# a `$props()` declaration's comment printed off the declaration
+
+**Issue:** [#4448](https://github.com/baseballyama/rsvelte/issues/4448)
+**Repro:** none — `crates/rsvelte_core/tests/props_comment_trailing_4448.rs`
+
+Upstream prints the comment after the `;` of the declaration the `$props()`
+lowering produced. rsvelte printed it as its own statement ahead of the script
+(the whole-object form, where the transform drops the comment) or on its own line
+after the statement (the rest form, where it survives).
+
+The axis is the comment's distance from the `$props(` call, not from the `let`:
+`let p = /* c */\n$props()` floats the comment forward and
+`let p =\n/* c */ $props()` trails the declaration. What decides is whether the
+text between the comment and the call is blanks only — `let { a, /* c */ ...rest }`
+is newline-free and stays in the pattern. All three directions are pinned in the
+test.
+
+No repro can live here, for the same reason as
+`4453-comment-in-removed-props-pattern.md`: `ast_equiv_batch` runs with
+`CommentPolicy::Ignore`, so a comment-only divergence is a pass on both arms.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -1447,6 +1447,31 @@ pub(crate) fn transform_client(
         // them in the comment buffer, so the first generated declarator can
         // carry them the way upstream does; the re-emission loop below prints a
         // statement instead, which is a different position (#4501).
+        // Upstream leaves a `$props()` declaration's comment on the declaration
+        // it lowered to, but only when nothing but blanks separates it from the
+        // call: across a newline it floats forward instead, and with a pattern
+        // between them (`let { a, /* c */ ...rest }`) it stays put (#4448). This
+        // runs before the re-entry below so the comment is moved, not copied.
+        let inline_props_comments: Vec<&str> = props_call_offset(&content.raw)
+            .map(|call| {
+                props_comments
+                    .iter()
+                    .filter(|(offset, comment)| {
+                        let end = offset + comment.len() as u32;
+                        end <= call
+                            && content.raw[end as usize..call as usize]
+                                .chars()
+                                .all(|c| c == ' ' || c == '\t')
+                    })
+                    .map(|(_, comment)| comment.as_str())
+                    .collect()
+            })
+            .unwrap_or_default();
+        if let Some(placed) =
+            place_props_comments_after_rest_props(&transformed_script, &inline_props_comments)
+        {
+            transformed_script = placed;
+        }
         if transformed_script.trim().is_empty() && !props_comments.is_empty() {
             transformed_script = props_comments
                 .iter()
@@ -3289,6 +3314,57 @@ fn script_comment_texts(script: &str) -> Vec<String> {
         .into_iter()
         .map(|(_, comment)| comment)
         .collect()
+}
+
+/// The offset of the declaration's `$props(` call inside a script's raw text.
+fn props_call_offset(raw: &str) -> Option<u32> {
+    find_rune_code(raw.as_bytes(), b"$props(").map(|at| at as u32)
+}
+
+/// Put a `$props()` declaration's comments back on the declaration it lowered
+/// to, printed after its `;` the way upstream does.
+///
+/// The lowering either drops the comment (a whole-object `let p = $props()`) or
+/// leaves it on its own line after the statement (a rest element), and both
+/// print it somewhere upstream does not (#4448). Only the `$.rest_props` form is
+/// handled: with a default the comment belongs *inside* the `$.prop(…)` call,
+/// which the lowering already does when there is no rest element, and moving it
+/// out to the statement end would be a second wrong answer rather than none.
+fn place_props_comments_after_rest_props(script: &str, comments: &[&str]) -> Option<String> {
+    use crate::compiler::phases::phase3_transform::shared::js_scan::find_code;
+
+    if comments.is_empty() || find_code(script.as_bytes(), b"$.prop(").is_some() {
+        return None;
+    }
+    let target = script
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| line.contains("$.rest_props(") && line.trim_end().ends_with(';'))
+        .map(|(index, _)| index)
+        .last()?;
+    let mut out: Vec<String> = Vec::new();
+    for (index, line) in script.lines().enumerate() {
+        // The rest-element form leaves the comment on a line of its own after
+        // the statement; it is the same comment, not a second one.
+        if index != target && comments.iter().any(|comment| line.trim() == *comment) {
+            continue;
+        }
+        if index == target {
+            let mut moved = line.trim_end().to_string();
+            for comment in comments {
+                moved.push(' ');
+                moved.push_str(comment);
+            }
+            out.push(moved);
+        } else {
+            out.push(line.to_string());
+        }
+    }
+    let mut joined = out.join("\n");
+    if script.ends_with('\n') {
+        joined.push('\n');
+    }
+    Some(joined)
 }
 
 /// Comments inside the `$props()` declaration survive upstream's lowering even

--- a/crates/rsvelte_core/tests/props_comment_trailing_4448.rs
+++ b/crates/rsvelte_core/tests/props_comment_trailing_4448.rs
@@ -1,0 +1,176 @@
+//! A `$props()` declaration's comment belongs on the declaration that lowering
+//! produced, printed after its `;`. rsvelte printed it as a statement of its own
+//! ahead of the script (the whole-object form, where the transform drops it) or
+//! on a line of its own after the statement (the rest form, where it survives),
+//! and both are a different line from upstream's (#4448).
+//!
+//! Every expected string below is official Svelte 5.57.0's own output for the
+//! same source (`submodules/svelte`, pin `7bc0a70fe`), read off the oracle
+//! rather than from a neighbouring cell.
+//!
+//! No corpus gate observes any of this: `ast_equiv_batch` runs with
+//! `CommentPolicy::Ignore`, so a comment-only divergence scores `match` on both
+//! arms.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str, name: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some(format!("{name}.svelte")),
+            generate: GenerateMode::Client,
+            name: Some(name.to_string()),
+            ..Default::default()
+        },
+    )
+    .map(|result| result.js.code)
+    .unwrap_or_else(|error| format!("COMPILE_ERROR: {error:?}"))
+}
+
+const TRAILING: &str = "let p = $.rest_props($$props, rest_excludes); /* c */";
+
+/// The whole-object form: the transform drops the comment, so it is re-emitted.
+#[test]
+fn a_whole_object_props_comment_trails_the_lowered_declaration() {
+    let out = client(
+        "<script>let p = /* c */ $props();</script><b>{p.a}</b>\n",
+        "Pa",
+    );
+    assert!(out.contains(TRAILING), "{out}");
+}
+
+/// The rest form: the comment survives the transform on a line of its own after
+/// the statement, so this cell is a move rather than a re-emission — the two
+/// reach the same place by different routes, and a fix for one is not evidence
+/// about the other.
+#[test]
+fn a_rest_element_props_comment_moves_onto_the_declaration() {
+    let out = client(
+        "<script>let { a, ...z } = /* c */ $props();</script><b>{a}{z}</b>\n",
+        "Pb",
+    );
+    assert!(
+        out.contains("let z = $.rest_props($$props, rest_excludes); /* c */"),
+        "{out}"
+    );
+    // The line it used to occupy must be gone, not merely duplicated onto the
+    // declaration.
+    assert_eq!(out.matches("/* c */").count(), 1, "{out}");
+}
+
+/// A statement after the declaration, and one before it: the comment goes on the
+/// declaration's own line either way, which is what says the rule is not "the
+/// end of the script".
+#[test]
+fn a_surviving_statement_does_not_take_the_comment() {
+    let after = client(
+        "<script>let p = /* c */ $props();\nconst k = 1;</script><b>{p.a}{k}</b>\n",
+        "Pe",
+    );
+    assert!(after.contains(TRAILING), "{after}");
+    assert!(
+        after.contains(&format!("{TRAILING}\n\tconst k = 1;")),
+        "{after}"
+    );
+
+    let before = client(
+        "<script>const k = 1;\nlet p = /* c */ $props();</script><b>{p.a}{k}</b>\n",
+        "Pf",
+    );
+    assert!(
+        before.contains(&format!("const k = 1;\n\t{TRAILING}")),
+        "{before}"
+    );
+}
+
+/// The axis is the comment's distance from the `$props(` call, not from the
+/// `let`. Read off the oracle in both directions, because the obvious reading —
+/// "a comment on the declaration's first line trails it" — is the one these two
+/// cells kill: with the call moved to the next line upstream floats the comment
+/// forward, and with the comment moved to the call's line upstream trails it.
+#[test]
+fn a_newline_between_the_comment_and_the_call_floats_it_forward() {
+    // Upstream floats this one onto `var /* c */ b = root();` and rsvelte still
+    // prints it ahead of the declaration, which is the re-emission position
+    // #4501 left in place; what this cell holds is that it is NOT trailed.
+    let floated = client(
+        "<script>let p = /* c */\n\t$props();</script><b>{p.a}</b>\n",
+        "Bx",
+    );
+    assert!(!floated.contains(TRAILING), "{floated}");
+    assert!(floated.contains("/* c */"), "{floated}");
+
+    let trailed = client(
+        "<script>let p =\n\t/* c */ $props();</script><b>{p.a}</b>\n",
+        "By",
+    );
+    assert!(trailed.contains(TRAILING), "{trailed}");
+}
+
+/// A line comment reaches the call only across a newline, so it is always the
+/// floating case — the cell `props_initializer_comment_3515.rs` already pins,
+/// held here too because it is what a rule keyed on the comment's kind rather
+/// than its position would move.
+#[test]
+fn a_line_comment_before_the_call_is_left_where_it_was() {
+    let out = client(
+        "<script>let { a, ...z } = // c\n\t$props();</script><b>{a}{z}</b>\n",
+        "Lrs",
+    );
+    assert!(
+        !out.contains("$.rest_props($$props, rest_excludes); // c"),
+        "{out}"
+    );
+}
+
+/// With a default the comment belongs *inside* the `$.prop(…)` call, which the
+/// lowering already does. This is the control the `$.prop(` guard exists for: a
+/// rule that moved every props comment to the statement end would break it.
+#[test]
+fn a_default_keeps_its_comment_inside_the_prop_call() {
+    let out = client(
+        "<script>let { a = 1 } = /* c */ $props();</script><b>{a}</b>\n",
+        "Pc",
+    );
+    assert!(
+        out.contains("let a = $.prop($$props, 'a', 3, 1 /* c */);"),
+        "{out}"
+    );
+}
+
+/// A default *and* a rest element: upstream still writes the comment inside the
+/// `$.prop(…)` call and rsvelte does not, which is not this issue. The guard
+/// keeps that cell where it is rather than moving it to a second wrong place.
+#[test]
+fn a_default_beside_a_rest_element_is_left_alone() {
+    let out = client(
+        "<script>let { a = 1, ...z } = /* c */ $props();</script><b>{a}{z}</b>\n",
+        "Pg",
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        !out.contains("$.rest_props($$props, rest_excludes); /* c */"),
+        "{out}"
+    );
+}
+
+/// A comment inside the destructuring *pattern* is on the call's line too, so a
+/// predicate keyed on "no newline before the call" catches it and duplicates it.
+/// Upstream leaves it where the pattern put it — this is the cell that says the
+/// text between the comment and the call has to be whitespace, not merely
+/// newline-free. `props_pattern_comment_4453.rs` pins the count; this pins the
+/// position.
+#[test]
+fn a_comment_inside_the_pattern_stays_in_the_pattern() {
+    let out = client(
+        "<script>\n\tlet { a, /* c */ ...rest } = $props();\n</script>\n<i>{a}{rest.b}</i>\n",
+        "Ph",
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("let /* c */ rest = $.rest_props($$props, rest_excludes);"),
+        "{out}"
+    );
+    assert_eq!(out.matches("/* c */").count(), 1, "{out}");
+}


### PR DESCRIPTION
Closes #4448.

## What was wrong

Upstream prints a `$props()` declaration's comment after the `;` of the declaration the lowering
produced:

```js
	let p = $.rest_props($$props, rest_excludes); /* c */
```

rsvelte reached a different line by **two different routes**, so a fix for one would not have been
evidence about the other:

- the whole-object form (`let p = /* c */ $props()`): the transform **drops** the comment, and the
  re-emission loop prints it as a statement of its own ahead of the script;
- the rest form (`let { a, ...z } = /* c */ $props()`): the comment **survives** the transform, on a
  line of its own after the statement, from where it floats to the template root.

Both routes were read off the transform's own output rather than inferred — an env-gated probe on
`transformed_script` prints `"let p = $.rest_props($$props, rest_excludes);\n\n"` for the first and
`"let z = $.rest_props($$props, rest_excludes);\n/* c */\n\n"` for the second.

## The axis, which is not the obvious one

The comment trails the declaration **iff nothing but blanks separates it from the `$props(` call**.
The obvious reading — "a comment on the declaration's first line trails it" — is wrong in both
directions, and the oracle says so on a pair of cells that differ only in where the newline sits:

| source | official |
|---|---|
| `let p = /* c */`⏎`$props();` | `var /* c */`⏎`b = root();` — **floats forward** |
| `let p =`⏎`/* c */ $props();` | `let p = $.rest_props(…); /* c */` — **trails** |

A line comment can only reach the call across a newline, so it is always the floating case. The
first version of this change keyed on the declaration instead and regressed three cells that are EQ
on `main` — including the one `props_initializer_comment_3515.rs` pins — which is how the axis was
found.

"No newline" is not enough on its own, either: `let { a, /* c */ ...rest } = $props()` has none, and
upstream leaves that comment in the pattern (`let /* c */ rest = $.rest_props(…);`). The second
version duplicated it, which the full-suite run caught as
`props_pattern_comment_4453::a_declaration_the_helper_rewrites_keeps_exactly_one_copy` — so the test
is `content.raw[comment_end..call]` being **blanks only**, not merely newline-free.

## The fix

Comments that pass that test are placed at the end of the lowered declaration's own line, before the
re-emission loop runs, so the rest form is a **move** rather than a second copy (the test asserts an
occurrence count, not presence).

The `$.prop(…)` form is excluded by a guard on the script carrying no `$.prop(`. With a default the
comment belongs *inside* the call, which the lowering already does; a default beside a rest element
is the cell that guard exists for, where upstream still writes it inside `$.prop(…)` and moving it
to the statement end would be a second wrong answer instead of none.

## Measured

36 cells across five grids, three arms — official (`submodules/svelte`, pin `7bc0a70fe`,
`VERSION 5.57.0`), `main` at `5050b3be2`, and this branch — verdict full `js.code` byte equality.
Arms are separate binaries: `sha256` `f094843dd0a2…` main, `0c1dd8d7b483…` head.

**Ten cells move, every one DIFF → EQ, and no cell goes EQ → DIFF.**

| grid | DIFF → EQ | EQ → EQ | DIFF → DIFF |
|---|---|---|---|
| the axis grid (block/line × own-line/inline × whole-object/rest) | 4 | 3 | 3 |
| #4448's own shapes | 4 | 1 | 2 |
| #4501's eleven cells + three sibling repros | 2 | 3 | 9 |
| `props_initializer_comment_3515`'s three | 0 | 1 | 2 |
| `props_pattern_comment_4453`'s two (the regression above) | 0 | 2 | 0 |

The cells that stay DIFF are the floating half — upstream puts the comment on `var … = root()` and
rsvelte still prints it ahead of the declaration, which is the re-emission position #4501 left in
place — plus #4500's line break and the `$.prop` + rest cell.

On the server target every one of those 36 cells is byte-identical between the two arms, and all
seven of #4448's own shapes are byte-equal to official under both — which is what says this is in the
client lowering and not in the shared erasure. #4500's and #4516's repros
are byte-identical between the arms and still DIFF against official under both, so the negative
result has its own liveness control.

## Pins

`crates/rsvelte_core/tests/props_comment_trailing_4448.rs`, eight tests: the two routes separately,
the statement-before/statement-after pair (which says the rule is not "the end of the script"), the
two-directional axis pair above, the line-comment cell, the `$.prop` control and the default-plus-rest
cell that holds the guard, and the pattern-internal comment that the "no newline" reading duplicated.
Expected strings are the oracle's own output for each input.

A repro cannot live in `compatibility/pattern-corpus/`: `ast_equiv_batch` runs with
`CommentPolicy::Ignore`, so a comment-only divergence scores `match` on both arms. Recorded as a
no-repro doc under the convention #4556 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
