### PR TITLE
fix(compiler): an erased annotation's comment keeps the line it shared with the initializer

### DIFF
--- a/.changeset/erased-annotation-comment-separator.md
+++ b/.changeset/erased-annotation-comment-separator.md
@@ -1,0 +1,26 @@
+---
+"@rsvelte/compiler": patch
+---
+
+compiler: an erased annotation's comment keeps the line it shared with the initializer
+
+A comment left behind by an erased TypeScript annotation is flushed at the
+initializer's start, and the flush wrote a newline after it unconditionally.
+Upstream's printer does not: esrap keeps a leading comment inline when it shared
+the anchored node's source line and breaks only where the source broke. So a
+one-line annotation came out on three lines where official keeps one (#4397).
+
+The separator is now read off the text between the comment's end and the flush
+point — not off the shape of the annotation and not off the shape of the
+initializer. A newline *before* the comment still prints inline, a multi-line
+initializer still prints inline, and a newline *after* the comment still breaks.
+A `//` comment always breaks, since a space there would swallow the rest of the
+line. The two in-place call sites — a whole erased *statement*, which has no
+flush point — keep the newline they had, which is what leaves the `type` alias
+and `interface` cells unchanged.
+
+Measured on nine cells against Svelte 5.57.0: three go from divergent to
+byte-equal on **both** the client and the server, none goes the other way, and
+78 neighbouring cells across six sibling grids are byte-identical between the
+arms. The separator is one byte either way, so every source-projection offset is
+unchanged.

--- a/compatibility/pattern-corpus/issues/4397-erased-annotation-comment-line.md
+++ b/compatibility/pattern-corpus/issues/4397-erased-annotation-comment-line.md
@@ -1,0 +1,19 @@
+# a one-line erased annotation's comment printed on its own line
+
+**Issue:** [#4397](https://github.com/baseballyama/rsvelte/issues/4397)
+**Repro:** none — `crates/rsvelte_core/tests/erased_annotation_comment_line_4397.rs`
+
+The flush that puts an erased annotation's comment back at the initializer wrote
+a newline after it unconditionally. Upstream keeps it inline when the comment
+shared the initializer's source line.
+
+The axis is the text between the comment's end and the flush point: a newline
+*before* the comment (`let a: {`⏎`/* c */ b: number } = { b: 1 };`) still prints
+inline, and a multi-line initializer still prints inline. Only a newline between
+the two breaks the line.
+
+No repro can live here, for the same reason as
+`4453-comment-in-removed-props-pattern.md`: `ast_equiv_batch` runs with
+`CommentPolicy::Ignore`, so a comment-only divergence is a pass on both arms.
+#4397 also records a source-shape screen over 33,890 corpus `.svelte` files that
+selects 0 carriers, so no corpus growth is the instrument for this either.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -810,6 +810,7 @@ fn strip_typescript_from_program_impl(
                             source,
                             comment_start,
                             comment_end,
+                            '\n',
                             &mut output,
                             copied_chunks.as_mut(),
                             reemitted_comment_outputs.as_mut(),
@@ -841,6 +842,7 @@ fn strip_typescript_from_program_impl(
                 source,
                 comment_start,
                 comment_end,
+                '\n',
                 &mut output,
                 copied_chunks.as_mut(),
                 reemitted_comment_outputs.as_mut(),
@@ -938,10 +940,25 @@ fn push_range_flushing_pending(
             output,
             copied_chunks.as_deref_mut(),
         );
+        // esrap keeps a leading comment inline when it shared the anchored
+        // node's source line and breaks only where the source broke, so the
+        // separator is the text between the comment and the flush point — not
+        // the shape of the erased annotation (#4397). A `//` comment would
+        // swallow the rest of the line, so it always breaks.
+        let separator = if source
+            .get(comment_end as usize..flush_at as usize)
+            .is_none_or(|between| between.contains('\n'))
+            || source[comment_start as usize..comment_end as usize].starts_with("//")
+        {
+            '\n'
+        } else {
+            ' '
+        };
         emit_pending_comment(
             source,
             comment_start,
             comment_end,
+            separator,
             output,
             copied_chunks.as_deref_mut(),
             reemitted.as_deref_mut(),
@@ -961,6 +978,7 @@ fn emit_pending_comment(
     source: &str,
     comment_start: u32,
     comment_end: u32,
+    separator: char,
     output: &mut String,
     mut copied_chunks: Option<&mut Vec<CopiedSourceChunk>>,
     reemitted: Option<&mut Vec<Range<u32>>>,
@@ -1006,7 +1024,7 @@ fn emit_pending_comment(
     if let Some(reemitted) = reemitted {
         reemitted.push(output_start..output.len() as u32);
     }
-    output.push('\n');
+    output.push(separator);
 }
 
 fn push_source_range(

--- a/crates/rsvelte_core/tests/erased_annotation_comment.rs
+++ b/crates/rsvelte_core/tests/erased_annotation_comment.rs
@@ -22,10 +22,12 @@
 //! count-keyed grid the one-line-annotation row reads `2 == 2` and EQUAL while
 //! the two copies sit on different lines than upstream puts them on.
 //!
-//! Two cells are deliberately NOT the oracle's output and say so. Upstream emits
+//! One cell is deliberately NOT the oracle's output and says so. Upstream emits
 //! the comment twice through `@sveltejs/acorn-typescript@1.0.10`'s `tsLookAhead`
 //! (see `collect_speculative_type_head_regions`), and rsvelte reproduces that
-//! where it can; the two residual rows are the shapes where it cannot yet.
+//! where it can; the residual row is the shape where it cannot yet — #4397
+//! retired the other one, which is why the one-line annotation is now a matched
+//! cell above rather than a pin below.
 
 use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
@@ -51,12 +53,21 @@ fn compile_lines(body: &str, tmpl: &str) -> Vec<String> {
 /// The cells whose whole generated text upstream and rsvelte agree on.
 #[test]
 fn an_erased_annotations_comment_lands_where_upstream_puts_it() {
-    let cells: [(&str, &str, &str, &[&str]); 5] = [
+    let cells: [(&str, &str, &str, &[&str]); 6] = [
         (
             "multi-line annotation on an initialized declarator",
             "\tlet a: {\n\t\t/* c */\n\t\tb: number;\n\t} = { b: 1 };",
             "{a.b}",
             &["\tlet a = /* c */", "\t/* c */"],
+        ),
+        (
+            // The row above and this one differ only in where the newline sits,
+            // and upstream answers differently: the separator after the flushed
+            // comment is the source text between it and the initializer (#4397).
+            "one-line annotation on an initialized declarator",
+            "\tlet a: { /* c */ b: number } = { b: 1 };",
+            "{a.b}",
+            &["\tlet a = /* c */ /* c */ { b: 1 };"],
         ),
         (
             "one-line interface declaration",
@@ -101,21 +112,15 @@ fn an_erased_annotations_comment_lands_where_upstream_puts_it() {
     assert!(failures.is_empty(), "{}", failures.join("\n"));
 }
 
-/// The two shapes where rsvelte still differs from upstream, pinned so the
-/// difference is a recorded value rather than an unexamined one. Both are
+/// The shape where rsvelte still differs from upstream (#4396), pinned so the
+/// difference is a recorded value rather than an unexamined one. It is
 /// comment-placement only, which is exactly the class `ast_equiv_batch` rescues
-/// under `CommentPolicy::Ignore` — so no corpus gate can hold them.
+/// under `CommentPolicy::Ignore` — so no corpus gate can hold it. #4397 retired
+/// the one-line annotation that used to sit here; issues citing this test under
+/// its old name `the_two_residual_shapes_are_pinned_rather_than_matched` mean
+/// this one.
 #[test]
-fn the_two_residual_shapes_are_pinned_rather_than_matched() {
-    // Upstream: `let a = /* c */ /* c */ { b: 1 };` — both copies on one line.
-    // rsvelte re-emits at the removal point and the printer breaks the line.
-    let got = compile_lines("\tlet a: { /* c */ b: number } = { b: 1 };", "{a.b}");
-    assert_eq!(
-        got,
-        vec!["\tlet a = /* c */".to_string(), "\t/* c */".to_string()],
-        "one-line annotation: the two copies are emitted, on two lines"
-    );
-
+fn the_residual_shape_is_pinned_rather_than_matched() {
     // Upstream: `let a;` then `var /* c */` `/* c */` — the comment floats to the
     // next located node. rsvelte drops it, which is what keeps the declaration's
     // own lowering intact.

--- a/crates/rsvelte_core/tests/erased_annotation_comment_line_4397.rs
+++ b/crates/rsvelte_core/tests/erased_annotation_comment_line_4397.rs
@@ -1,0 +1,132 @@
+//! A comment left behind by an erased type annotation is flushed at the
+//! initializer's start, and the flush wrote a newline after it unconditionally.
+//! Upstream's printer decides that from the comment's own line: esrap keeps the
+//! comment inline when it sat on the initializer's line in the source, and
+//! breaks only when the source broke. So a **one-line** annotation came out on
+//! three lines where official keeps one (#4397).
+//!
+//! The axis is the text between the comment's end and the initializer, not the
+//! shape of the annotation and not the shape of the initializer: A7 has a
+//! newline *before* the comment and still prints inline, A9's initializer spans
+//! lines and still prints inline, and A8 — one newline, after the comment —
+//! is the cell that must keep breaking.
+//!
+//! No corpus gate observes this: `ast_equiv_batch` runs with
+//! `CommentPolicy::Ignore`, so a comment-only divergence scores `match` on every
+//! target, and a source-shape screen over `compatibility/sources` (33,890
+//! `.svelte` files) selects 0 carriers. This test is the whole guard.
+//!
+//! Every expected string here is official Svelte 5.57.0's own output for the
+//! same source (`submodules/svelte`, pin `7bc0a70fe`), not a neighbouring cell's.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+const INLINE: &str = "let a = /* c */ /* c */ { b: 1 };";
+const BROKEN: &str = "let a = /* c */\n\t/* c */\n\t{ b: 1 };";
+
+/// The reported cell: annotation, comment and initializer all on one line.
+#[test]
+fn a_one_line_annotation_keeps_its_comment_on_the_declaration_line() {
+    let out = client(concat!(
+        "<script lang=\"ts\">\n",
+        "\tlet a: { /* c */ b: number } = { b: 1 };\n",
+        "</script>\n",
+        "<i>{a.b}</i>\n"
+    ));
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains(INLINE), "{out}");
+}
+
+/// A newline *before* the comment does not break the line: what upstream reads
+/// is the distance from the comment to the initializer.
+#[test]
+fn a_newline_before_the_comment_does_not_break_the_line() {
+    let out = client(concat!(
+        "<script lang=\"ts\">\n",
+        "\tlet a: {\n",
+        "\t\t/* c */ b: number } = { b: 1 };\n",
+        "</script>\n",
+        "<i>{a.b}</i>\n"
+    ));
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains(INLINE), "{out}");
+}
+
+/// Neither does an initializer that spans lines: the `{` it starts at is still
+/// on the comment's line.
+#[test]
+fn a_multi_line_initializer_does_not_break_the_line() {
+    let out = client(concat!(
+        "<script lang=\"ts\">\n",
+        "\tlet a: { /* c */ b: number } = {\n",
+        "\t\tb: 1\n",
+        "\t};\n",
+        "</script>\n",
+        "<i>{a.b}</i>\n"
+    ));
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains(INLINE), "{out}");
+}
+
+/// The live negative: one newline, between the comment and the initializer.
+/// This cell agreed before the change and must still agree.
+#[test]
+fn a_newline_after_the_comment_still_breaks_the_line() {
+    let out = client(concat!(
+        "<script lang=\"ts\">\n",
+        "\tlet a: { /* c */ b: number\n",
+        "\t} = { b: 1 };\n",
+        "</script>\n",
+        "<i>{a.b}</i>\n"
+    ));
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains(BROKEN), "{out}");
+}
+
+/// The fully multi-line annotation from #4397's own table, which was already
+/// byte-equal and is what localised the defect to the one-line cell.
+#[test]
+fn a_multi_line_annotation_still_breaks_the_line() {
+    let out = client(concat!(
+        "<script lang=\"ts\">\n",
+        "\tlet a: {\n",
+        "\t\t/* c */ b: number\n",
+        "\t} = { b: 1 };\n",
+        "</script>\n",
+        "<i>{a.b}</i>\n"
+    ));
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains(BROKEN), "{out}");
+}
+
+/// A whole erased *statement* has no flush point, so its comments keep the
+/// newline they always had. Official prints both copies on their own lines
+/// ahead of the declaration.
+#[test]
+fn an_erased_type_alias_keeps_its_comments_on_their_own_lines() {
+    let out = client(concat!(
+        "<script lang=\"ts\">\n",
+        "\ttype T = { /* c */ b: number };\n",
+        "\tlet a: T = { b: 1 };\n",
+        "</script>\n",
+        "<i>{a.b}</i>\n"
+    ));
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("/* c */\n\t/* c */\n\tlet a = { b: 1 };"),
+        "{out}"
+    );
+}


### PR DESCRIPTION
Closes #4397.

## What was wrong

A comment left behind by an erased TypeScript **annotation** is flushed at the initializer's start,
and the flush wrote `'\n'` after it unconditionally. Upstream's printer does not: esrap keeps a
leading comment inline when it shared the anchored node's source line and breaks only where the
source broke. So a one-line annotation came out on three lines where official keeps one.

```svelte
<script lang="ts">
	let a: { /* c */ b: number } = { b: 1 };
</script>
```

```js
// official                              // rsvelte, before
let a = /* c */ /* c */ { b: 1 };        let a = /* c */
                                         /* c */
                                         { b: 1 };
```

## The axis

Not "one-line annotations" and not "one-line initializers": the separator is the **text between the
comment's end and the flush point**. The oracle says so on three cells that hold the annotation's
shape fixed and move the newline:

| source | official |
|---|---|
| `let a: { /* c */ b: number } = { b: 1 };` | inline |
| `let a: {`⏎`/* c */ b: number } = { b: 1 };` — newline **before** | inline |
| `let a: { /* c */ b: number } = {`⏎`b: 1`⏎`};` — multi-line initializer | inline |
| `let a: { /* c */ b: number`⏎`} = { b: 1 };` — newline **after** | breaks |

The last row is the live negative control: it is EQ on `main` and must stay EQ.

## The fix

`emit_pending_comment` takes the separator instead of hard-coding `'\n'`. The two in-place call
sites — a whole erased *statement*, which has no flush point — keep `'\n'`, which is what holds the
`type` alias and `interface` cells from #4397's own table unchanged. The flush site inside
`push_range_flushing_pending` reads the source between the comment and the flush point. A `//`
comment always breaks, since a space there would swallow the rest of the line.

The separator is one byte either way, so every `CopiedSourceChunk` and `reemitted_comment_outputs`
offset is unchanged and the projection is untouched.

## Measured

Nine cells, verdict full `js.code` byte equality against official (`submodules/svelte`, pin
`7bc0a70fe`, `VERSION 5.57.0`), three arms — official, `main` at `9b86d816d` (`sha256`
`1695d13114c7…`) and this branch (`b703fe8fdead…`), separate binaries.

| cell | main | this branch |
|---|---|---|
| `let a: { /* c */ b: number } = { b: 1 };` — the reported one | DIFF | **EQ** |
| newline **before** the comment | DIFF | **EQ** |
| multi-line initializer | DIFF | **EQ** |
| newline **after** the comment (live negative) | EQ | EQ |
| multi-line annotation / `type` alias / `interface` / `//` comment | EQ | EQ |
| annotation on an **uninitialized** declarator (#4396, a different mechanism) | DIFF | DIFF |

Identical on the **client and the server**, which is what a change in the shared erasure should
look like — and 78 neighbouring cells across six sibling grids (#4396, #4501, #4448, #3515, #4453
and the `$props()` newline axis, both targets) are byte-identical between the two arms. The
#4397 grid moving six of its own cells is that zero's liveness control.

## Pins

`crates/rsvelte_core/tests/erased_annotation_comment_line_4397.rs`. No repro can live in
`compatibility/pattern-corpus/`: `ast_equiv_batch` runs with `CommentPolicy::Ignore`, so a
comment-only divergence scores `match` on every target, and #4397 records a source-shape screen over
33,890 corpus files selecting 0 carriers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
