### PR TITLE
fix(client): a prop read on a member root does not depend on the source-map option

### DIFF
--- a/.changeset/prop-read-member-root.md
+++ b/.changeset/prop-read-member-root.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/compiler": patch
+---
+
+client: a prop read on a member root no longer depends on the source-map option
+
+The rewrite that turns `p.c` into `p().c` for a `$bindable()` prop was gated on
+the converted object being a `JsExpr::Spanned`, and that wrapper is built only
+under `enable_sourcemap`. With source maps off the read never ran, the update's
+base stayed the bare `p`, and a second writer applied the mutate transform again:
+`p(p().c++, true)` came out as `p(p(p().c++, true), true)`, which passes the
+setter's return value back through the setter (#4570).
+
+The condition now asks about the identifier rather than about the wrapper.
+Whether a span wrapper is present is a source-map question; whether the root
+needs the prop read is not.
+
+Measured over all 1,389 `.svelte` files of `compatibility/pattern-corpus` x
+client/server, 2,536 live units: **0 move** on the default `enable_sourcemap:
+true` path — this cannot touch what anyone compiles today — and exactly the two
+semantic units move under `--no-sourcemap`, both onto official's answer.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -751,17 +751,23 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
                         expression: context.arena.alloc_expr(converted),
                     });
                 }
-                let is_spanned_identifier = matches!(
-                    &converted,
-                    JsExpr::Spanned(inner, _, _)
-                        if matches!(context.arena.get_expr(*inner), JsExpr::Identifier(_))
-                );
+                // Whether the wrapper is there is a source-map question — it is
+                // built only under `enable_sourcemap` — and the read below is
+                // not, so this asks about the identifier and not the wrapper
+                // (#4570).
+                let is_identifier_root = match &converted {
+                    JsExpr::Identifier(_) => true,
+                    JsExpr::Spanned(inner, _, _) => {
+                        matches!(context.arena.get_expr(*inner), JsExpr::Identifier(_))
+                    }
+                    _ => false,
+                };
                 // `get_binding` resolves by name from the root scope, so a
                 // parameter shadowing a prop still answers with the prop's
                 // binding — the identifier arm and the rest-prop branch above
                 // both consult `shadowed_prop_names` for exactly that reason,
                 // and an each key function's parameter is the case that needs it.
-                if is_spanned_identifier
+                if is_identifier_root
                     && let Some(name) = get_jsnode_identifier_name(object_node)
                     && !context.state.shadowed_prop_names.contains(name.as_str())
                     && let Some(binding) = context.state.get_binding(&name)

--- a/crates/rsvelte_core/tests/sourcemap_option_does_not_reach_the_code.rs
+++ b/crates/rsvelte_core/tests/sourcemap_option_does_not_reach_the_code.rs
@@ -60,15 +60,11 @@ fn code(
     .map(|result| result.js.code)
 }
 
-/// The units that depend on the flag today, as a two-sided pin: #4570. Two of
-/// the three are **semantic** — `p(p(p().c++, true), true)` writes the setter's
-/// return value back through the setter — so this is a shrink-only list and not
-/// a tolerance.
-const KNOWN: [&str; 3] = [
-    "issues/3048-bindable-member-update.svelte (Client)",
-    "issues/4046-dev-event-handler-comment.svelte (Client)",
-    "issues/prop-shadowed-by-local-in-template-handler.svelte (Client)",
-];
+/// The units that depend on the flag today, as a two-sided pin: #4570. The two
+/// semantic ones are gone — the prop read on a member root no longer asks about
+/// the span wrapper — and what is left is comment placement, a different
+/// mechanism in the same issue.
+const KNOWN: [&str; 1] = ["issues/4046-dev-event-handler-comment.svelte (Client)"];
 
 #[test]
 fn the_generated_code_is_identical_with_and_without_source_maps() {


### PR DESCRIPTION
Closes #4570.

## What was wrong

The prop read on a member expression's **root** — the rewrite that turns `p.c` into `p().c` for a
`$bindable()` prop — was gated on the converted object being a `JsExpr::Spanned`:

```rust
let is_spanned_identifier = matches!(
    &converted,
    JsExpr::Spanned(inner, _, _) if matches!(context.arena.get_expr(*inner), JsExpr::Identifier(_))
);
```

`source_spanned` builds that wrapper **only under `enable_sourcemap`**
(`expression_converter.rs:163-171`). So with source maps off the read never ran, the update's base
stayed the bare `p`, and a second writer then applied the mutate transform a second time:

```js
// official, and rsvelte with the default enable_sourcemap: true
p(p().c++, true);

// rsvelte with enable_sourcemap: false
p(p(p().c++, true), true);
```

The outer call passes the **setter's return value** back through the setter. It parses and it runs.

## The two writers, and what was actually stopping the second one

`prop_bindable_mutate` fires once with source maps on and twice with them off. Filtered backtraces
at that function, same run:

```
[mutate2] 2: …expression_converter::try_transform_update                      <- both arms
[mutate2] 2: …shared::utils::apply_transforms_to_expression_with_shadowed     <- OFF only
```

The second writer *is* guarded — `utils.rs:1786` skips when `has_call_in_base_chain(update.argument)`,
and its comment names this exact symptom. **That guard is not what was working.** Probed at the
decision site in the arm where it is reached, it returns `false`:

```
[guard] arg=Member { object: Identifier("p"), property: "c" } has_call=false
```

What stopped the second wrap on the default path is that `get_base_object` returned a `Call` there
and an `Identifier` here:

```
enable_sourcemap: true    [upd] base=Call { callee: …, arguments: [] }     -> the branch is not entered
enable_sourcemap: false   [upd] base=Identifier("p")                        -> the branch wraps again
```

which is the missing read, one level up. So this is a single root with two symptoms, and the guard
that looks like the fix is inert in both arms.

## The fix

Ask about the identifier, not about the wrapper. Whether a span wrapper is present is a source-map
question; whether the root is an identifier that needs the prop read is not. The block's own comment
already said the read has to happen — *"A prop read changes that root to a Call anyway; apply that
read before removing the wrapper"* — the condition just asked the wrong thing.

Note what the fix is **not**: teaching the later pass to see through `Spanned` would make *both*
arms double-wrap, because `has_call_in_base_chain` admits the second wrap in both. The correct
output on the default path was being produced by a wrapper that exists for source maps, and nothing
said so.

## Measured

Arms are separate binaries — `sha256` `988802d68bbf…` base, `63c995d245a0…` head — over all 1,389
`.svelte` files of `compatibility/pattern-corpus` x client/server, 2,536 live units (242 error
repros throw on both sides and are excluded).

| arm | base vs head |
|---|---|
| default (`enable_sourcemap: true`) | **MOVED = 0** of 2,536 |
| `--no-sourcemap` | **MOVED = 2** of 2,536 — the two semantic units, both to official's answer |

The zero is the point: this cannot move the path every gate and every user compiles on. It is a
live zero, not an empty instrument — the same sweep with the flag flipped moves exactly the two
units the issue names, and nothing else.

`sourcemap_option_does_not_reach_the_code.rs` (#4571) re-baselines from three pinned entries to one
in this PR, which is what its two-sided pin exists to force. The survivor is
`4046-dev-event-handler-comment.svelte` — comment placement, a different mechanism, tracked on #4570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
