### PR TITLE
fix(client): anchor the component call on the tag's source position

### DIFF
--- a/.changeset/component-call-comment-anchor.md
+++ b/.changeset/component-call-comment-anchor.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Anchor the client component call on the tag's source position, so a comment at the end of the instance script is printed before the call instead of after the whole function body.

--- a/compatibility/pattern-corpus/issues/4529-component-call-comment-anchor.md
+++ b/compatibility/pattern-corpus/issues/4529-component-call-comment-anchor.md
@@ -10,6 +10,10 @@ end of the function body — past every statement the template lowered to, which
 one-component cell cannot distinguish from "after the call". Upstream anchors the
 call on the tag's own `start`.
 
+A **dynamic** component (`$.component(node, () => C, …)`) carries no such
+position upstream — the comment flushes into the thunk's parameter list — so the
+anchor is on the static call only.
+
 The dev target is a different writer and still diverges: `add_svelte_meta` wraps
 the call in an arrow, and upstream flushes the comment *inside* the arrow
 (`() => // c` then the call), which a statement-level anchor cannot express.

--- a/compatibility/pattern-corpus/issues/4529-component-call-comment-anchor.md
+++ b/compatibility/pattern-corpus/issues/4529-component-call-comment-anchor.md
@@ -1,0 +1,19 @@
+# a trailing script comment printed after the whole function body
+
+**Issue:** [#4529](https://github.com/baseballyama/rsvelte/issues/4529)
+**Repro:** none — `crates/rsvelte_core/tests/component_call_comment_anchor_4529.rs`
+
+esrap flushes a pending comment at the first generated statement whose source
+position is at or after it. The client component call carried no such position,
+so with a comment at the end of the instance script the flush fell through to the
+end of the function body — past every statement the template lowered to, which a
+one-component cell cannot distinguish from "after the call". Upstream anchors the
+call on the tag's own `start`.
+
+The dev target is a different writer and still diverges: `add_svelte_meta` wraps
+the call in an arrow, and upstream flushes the comment *inside* the arrow
+(`() => // c` then the call), which a statement-level anchor cannot express.
+
+No repro can live here, for the same reason as
+`4448-props-declaration-comment.md`: `ast_equiv_batch` runs with
+`CommentPolicy::Ignore`, so a comment-only divergence is a pass on both arms.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -3503,15 +3503,18 @@ fn build_component_meta_stmt(
     let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
         crate::compiler::phases::phase3_transform::profile::TF_BC_META,
     );
-    if !dev {
-        return b::stmt(arena, expression);
-    }
-
     let (start, tag_name) = match node {
         ComponentNode::Component(comp) => (comp.start, comp.name.to_string()),
         ComponentNode::SvelteComponent(comp) => (comp.start, "svelte:component".to_string()),
         ComponentNode::SvelteSelf(comp) => (comp.start, "svelte:self".to_string()),
     };
+
+    if !dev {
+        // Upstream anchors the component call on the tag's own source position,
+        // which is where esrap flushes a comment the instance script left
+        // pending — without it the flush falls to the end of the body (#4529).
+        return b::stmt_anchored(arena, expression, Some(start));
+    }
 
     let (line, col) =
         crate::compiler::phases::phase3_transform::utils::locate_in_source(source, start as usize);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -586,6 +586,7 @@ pub fn build_component(
                 &context.state.analysis.name,
                 context.state.dev,
                 &context.state.analysis.source,
+                false,
             );
             statements.push(meta_stmt);
         }
@@ -629,6 +630,7 @@ pub fn build_component(
                 &context.state.analysis.name,
                 context.state.dev,
                 &context.state.analysis.source,
+                true,
             );
             statements.push(meta_stmt);
         }
@@ -3499,6 +3501,7 @@ fn build_component_meta_stmt(
     analysis_name: &str,
     dev: bool,
     source: &str,
+    anchor_comments: bool,
 ) -> JsStatement {
     let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
         crate::compiler::phases::phase3_transform::profile::TF_BC_META,
@@ -3510,10 +3513,12 @@ fn build_component_meta_stmt(
     };
 
     if !dev {
-        // Upstream anchors the component call on the tag's own source position,
-        // which is where esrap flushes a comment the instance script left
-        // pending — without it the flush falls to the end of the body (#4529).
-        return b::stmt_anchored(arena, expression, Some(start));
+        // Upstream anchors the *static* component call on the tag's own source
+        // position, which is where esrap flushes a comment the instance script
+        // left pending — without it the flush falls to the end of the body
+        // (#4529). The `$.component` wrapper carries no such position upstream,
+        // so it must not claim one here.
+        return b::stmt_anchored(arena, expression, anchor_comments.then_some(start));
     }
 
     let (line, col) =

--- a/crates/rsvelte_core/tests/component_call_comment_anchor_4529.rs
+++ b/crates/rsvelte_core/tests/component_call_comment_anchor_4529.rs
@@ -1,0 +1,77 @@
+//! A comment the instance script leaves pending is flushed by the first
+//! generated statement whose source position is at or after it. The component
+//! call carried no such position, so the flush fell through to the end of the
+//! function body — past every statement the template lowered to, which is what
+//! the two-component cell below shows and what a one-component cell cannot
+//! distinguish from "after the call" (#4529).
+//!
+//! No corpus gate observes this: `ast_equiv_batch` runs with
+//! `CommentPolicy::Ignore`, so a comment-only divergence scores `match` on every
+//! target. A source-shape screen over the 34,933 `.svelte` files of the
+//! populated submodules selects 140 carriers, of which 4 go from divergent to
+//! byte-equal with this change and 0 regress — but none of them can live in
+//! `pattern-corpus` for the same reason.
+//!
+//! Every expected string here is official Svelte 5.57.0's own output for the
+//! same source (`submodules/svelte`, pin `7bc0a70fe`), not a neighbouring cell's.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("C.svelte".into()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .map(|result| result.js.code)
+    .unwrap_or_else(|error| format!("COMPILE_ERROR: {error:?}"))
+}
+
+/// The reported cell: the script holds nothing but the comment.
+#[test]
+fn a_trailing_script_comment_precedes_the_component_call() {
+    let out = client("<script>\n// c\n</script>\n<X />\n");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\t// c\n\tX($$anchor, {});"), "{out}");
+}
+
+/// With a statement before it, so the comment is not simply "the first thing".
+#[test]
+fn a_statement_before_the_comment_does_not_move_it() {
+    let out = client("<script>\nlet p = 1;\n// c\n</script>\n<X {p} />\n");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("\tlet p = 1;\n\n\t// c\n\tX($$anchor, { p });"),
+        "{out}"
+    );
+}
+
+/// The cell that says the old behaviour was "at the end of the body" and not
+/// "after the call": with two components the comment used to land past both of
+/// them and past `$.append`. A one-component cell cannot tell those apart.
+#[test]
+fn the_comment_anchors_on_the_first_call_not_at_the_end_of_the_body() {
+    let out = client("<script>\n// c\n</script>\n<X /><Y />\n");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\t// c\n\tX(node, {});"), "{out}");
+    assert!(
+        !out.contains("$.append($$anchor, fragment);\n\t// c"),
+        "{out}"
+    );
+}
+
+/// The negative: no pending comment, so the anchor must change nothing. Without
+/// it, a change that emitted a stray newline or moved the call would still
+/// satisfy every assertion above.
+#[test]
+fn a_script_with_no_comment_is_unchanged() {
+    let out = client("<script>\nlet p = 1;\n</script>\n<X {p} />\n");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("\tlet p = 1;\n\n\tX($$anchor, { p });"),
+        "{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/component_call_comment_anchor_4529.rs
+++ b/crates/rsvelte_core/tests/component_call_comment_anchor_4529.rs
@@ -75,3 +75,18 @@ fn a_script_with_no_comment_is_unchanged() {
         "{out}"
     );
 }
+
+/// The negative that decides the anchor's scope: a **dynamic** component is
+/// lowered to `$.component(node, () => C, …)`, and upstream gives that statement
+/// no source position at all — it flushes the comment into the thunk's own
+/// parameter list instead. Anchoring the wrapper here matched the reported shape
+/// and moved this cell off official, so the anchor is on the static call only.
+#[test]
+fn the_dynamic_component_wrapper_claims_no_anchor() {
+    let out = client(
+        "<script>\n\timport X from \"x\";\n\tconst C = X;\n\t// c\n</script>\n<svelte:component this={C} />\n",
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\t\t(// c\n\t\t) => C,"), "{out}");
+    assert!(!out.contains("\t// c\n\t$.component("), "{out}");
+}

--- a/crates/rsvelte_core/tests/instance_script_dropped_comment_4517.rs
+++ b/crates/rsvelte_core/tests/instance_script_dropped_comment_4517.rs
@@ -100,14 +100,15 @@ fn a_plain_element_template_keeps_officials_declarator_placement() {
     );
 }
 
-/// The unfixed half of the issue. Official emits `// c` *before* the call; the
-/// first pass writes it after, so this is a relocation and out of scope here.
-/// A recovery that claimed relocations too would pass this by accident while
-/// breaking the `keep_*` cells above.
+/// The relocation half of the issue, which #4529 closed by anchoring the static
+/// component call on the tag's source position. This used to pin the comment
+/// *after* the call as out of scope here; it is now official's own placement,
+/// and it still says the recovery in this file is not what moves it — the
+/// `keep_*` cells above are unchanged.
 #[test]
-fn a_self_closing_component_still_trails_its_comment() {
+fn a_self_closing_component_leads_its_comment() {
     assert_eq!(
         client("\t// c", "<X />"),
-        "export default function C($$anchor) {\n\tX($$anchor, {});\n\t// c\n}"
+        "export default function C($$anchor) {\n\t// c\n\tX($$anchor, {});\n}"
     );
 }


### PR DESCRIPTION
Closes #4529.

## What was wrong

esrap flushes a pending comment at the first generated statement whose source position is at or
after it. The client component call carried no such position, so a comment at the end of the
instance script fell through to the **end of the function body**:

```js
export default function C3($$anchor) {
	var fragment = root();
	var node = $.first_child(fragment);
	X(node, {});
	var node_1 = $.sibling(node);
	Y(node_1, {});
	$.append($$anchor, fragment);
	// c
}
```

Upstream puts it before the first call. The two-component cell is what says the old position was
"the end of the body" and not "after the call" — with one component those are the same line, which
is why the issue's own repro cannot distinguish them.

## The fix

`build_component_meta_stmt` returns `b::stmt_anchored(arena, expression, Some(start))` on the
non-dev path, `start` being the tag's own source position — the same value the dev path already
computes for `$.add_svelte_meta`'s line/column arguments, just moved above the early return.

## The dynamic wrapper is excluded

A **dynamic** component is lowered to `$.component(node, () => C, …)`, and upstream gives that
statement no source position at all — it flushes the comment into the thunk's own parameter list:

```js
	$.component(
		node,
		(// c
		) => C,
		($$anchor, $$component) => { … }
	);
```

The first version of this branch anchored the wrapper too, which moved `<svelte:component this={C} />`
off official (EQ on `main` → DIFF). The anchor is on the static call only; the fifth test is that
cell.

`instance_script_dropped_comment_4517`'s relocation cell pinned the pre-fix placement as "the
unfixed half of the issue", so it fails by design here and is updated in place to official's own
output.

## What it does not fix

The **dev** target diverges before and after. `add_svelte_meta` wraps the call in an arrow and
upstream flushes the comment *inside* it:

```js
	$.add_svelte_meta(
		() => // c
		X($anchor, {}),
		'component', …);
```

A statement-level `comment_anchor` cannot express that, so dev is recorded on the issue as residue
rather than closed silently. It is unchanged by this branch (`base=DIFF head=DIFF` on all three
grid cells), so nothing regresses there.

## Measured

Three arms — official (`submodules/svelte`, pin `7bc0a70fe`, `VERSION 5.57.0`), `main`, and this
branch — verdict full `js.code` byte equality. Arms are separate `compile_one` binaries.

| population | result |
|---|---|
| the issue's three shapes, client non-dev | 3 DIFF → EQ |
| the same three, **server** | byte-identical between arms |
| the same three, client **dev** | DIFF → DIFF (the residue above) |
| `compatibility/pattern-corpus` (client + server) | **MOVED = 0** |
| real-world carriers, 140 files × 2 targets = 280 units | **FIXED = 4, BROKEN = 0**, both_eq 81, both_diff 183, threw 12 |

The 140 carriers come from a source-shape screen over the **34,933** `.svelte` files of the
populated submodules (last non-blank line of the instance script is a comment). Its controls:
`ctl_script = 31,659` files match `<script`, `ctl_impossible = 0` — so the screen is reading files
and the zero it can report is a real zero.

## Pins

`crates/rsvelte_core/tests/component_call_comment_anchor_4529.rs`, four tests: the reported shape,
a statement before the comment (so the rule is not "the first thing in the body"), the
two-component cell that separates "after the call" from "at the end of the body", and a
comment-free negative. Every expected string is the oracle's own output for that input.

Positive control: reverting the one-line change fails the three carrier tests and leaves the
comment-free negative passing.

A repro cannot live in `compatibility/pattern-corpus/`: `ast_equiv_batch` runs with
`CommentPolicy::Ignore`, so a comment-only divergence scores `match` on both arms. Recorded as a
no-repro doc under the convention #4556 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
