### PR TITLE
fix(client): flush a pending comment at a generated call's source arrow

### DIFF
--- a/.changeset/arrow-argument-comment-anchor.md
+++ b/.changeset/arrow-argument-comment-anchor.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Flush a pending instance-script comment at a generated call's source arrow argument, matching upstream, instead of deferring it past the whole statement.

--- a/.changeset/component-call-comment-anchor.md
+++ b/.changeset/component-call-comment-anchor.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Anchor the client component call on the tag's source position, so a comment at the end of the instance script is printed before the call instead of after the whole function body.

--- a/compatibility/pattern-corpus/issues/4481-arrow-argument-comment-anchor.md
+++ b/compatibility/pattern-corpus/issues/4481-arrow-argument-comment-anchor.md
@@ -1,0 +1,24 @@
+# a trailing script comment deferred past a generated call
+
+**Issue:** [#4481](https://github.com/baseballyama/rsvelte/issues/4481)
+**Repro:** none — `crates/rsvelte_core/tests/arrow_argument_comment_anchor_4481.rs`
+
+A pending comment flushes at the first node **in print order** that carries a
+position. `$.event('resize', $.window, () => c)` is synthesized, but its last
+argument is the source arrow, which is where upstream flushes; rsvelte's arrows
+carried no span, so the comment was deferred past the whole statement.
+
+Two things decide it. The arrow needs the span (`JsArrowFunction::span`,
+unconditional — the flush point may not depend on `enable_sourcemap`), and the
+chunk's single anchor has to be claimed in print order: a statement prints before
+anything inside it, so `JsStatement::Expression` claims before converting its
+expression. Without the second half the arrow in `<X onclick={() => c} />` takes
+the anchor the component call wants.
+
+`{@html c}` stays divergent: its thunk is synthesized from `c`, not converted
+from a source arrow, and upstream flushes into the thunk's own parameter list.
+`{#key}` has since converged on its own.
+
+No repro can live here, for the same reason as
+`4529-component-call-comment-anchor.md`: `ast_equiv_batch` runs with
+`CommentPolicy::Ignore`, so a comment-only divergence is a pass on both arms.

--- a/compatibility/pattern-corpus/issues/4529-component-call-comment-anchor.md
+++ b/compatibility/pattern-corpus/issues/4529-component-call-comment-anchor.md
@@ -10,6 +10,10 @@ end of the function body — past every statement the template lowered to, which
 one-component cell cannot distinguish from "after the call". Upstream anchors the
 call on the tag's own `start`.
 
+A **dynamic** component (`$.component(node, () => C, …)`) carries no such
+position upstream — the comment flushes into the thunk's parameter list — so the
+anchor is on the static call only.
+
 The dev target is a different writer and still diverges: `add_svelte_meta` wraps
 the call in an arrow, and upstream flushes the comment *inside* the arrow
 (`() => // c` then the call), which a statement-level anchor cannot express.

--- a/compatibility/pattern-corpus/issues/4529-component-call-comment-anchor.md
+++ b/compatibility/pattern-corpus/issues/4529-component-call-comment-anchor.md
@@ -1,0 +1,19 @@
+# a trailing script comment printed after the whole function body
+
+**Issue:** [#4529](https://github.com/baseballyama/rsvelte/issues/4529)
+**Repro:** none — `crates/rsvelte_core/tests/component_call_comment_anchor_4529.rs`
+
+esrap flushes a pending comment at the first generated statement whose source
+position is at or after it. The client component call carried no such position,
+so with a comment at the end of the instance script the flush fell through to the
+end of the function body — past every statement the template lowered to, which a
+one-component cell cannot distinguish from "after the call". Upstream anchors the
+call on the tag's own `start`.
+
+The dev target is a different writer and still diverges: `add_svelte_meta` wraps
+the call in an arrow, and upstream flushes the comment *inside* the arrow
+(`() => // c` then the call), which a statement-level anchor cannot express.
+
+No repro can live here, for the same reason as
+`4448-props-declaration-comment.md`: `ast_equiv_batch` runs with
+`CommentPolicy::Ignore`, so a comment-only divergence is a pass on both arms.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -246,6 +246,7 @@ pub fn unified_build_bind_this(
                 params: params.into(),
                 body: arrow.body,
                 is_async: arrow.is_async,
+                span: None,
             })
         }
         other => {
@@ -273,6 +274,7 @@ pub fn unified_build_bind_this(
                 params: params.into(),
                 body: arrow.body,
                 is_async: arrow.is_async,
+                span: None,
             })
         }
         other => {
@@ -1622,6 +1624,7 @@ fn build_bind_this_with_each_ids(
                 params,
                 body: optional_body,
                 is_async: arrow.is_async,
+                span: None,
             })
         }
         other => {
@@ -1647,6 +1650,7 @@ fn build_bind_this_with_each_ids(
                 params: params.into(),
                 body: arrow.body,
                 is_async: arrow.is_async,
+                span: None,
             })
         }
         other => {
@@ -2726,6 +2730,7 @@ fn merge_store_invalidation_into_setter(
                         params: arrow.params.clone(),
                         body: JsArrowBody::Expression(arena.alloc_expr(seq)),
                         is_async: arrow.is_async,
+                        span: None,
                     })
                 }
                 JsArrowBody::Block(_) => {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -991,6 +991,10 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
                 params: conv_params.into(),
                 body: conv_body,
                 is_async: *is_async,
+                span: match (node.start(), node.end()) {
+                    (Some(start), Some(end)) if start < end => Some((start, end)),
+                    _ => None,
+                },
             })
         }
 
@@ -2773,6 +2777,7 @@ fn transform_rune_call(
                     params: vec![].into(),
                     body: JsArrowBody::Expression(context.arena.alloc_expr(converted)),
                     is_async: false,
+                    span: None,
                 });
 
                 JsExpr::Call(JsCallExpression {
@@ -2875,6 +2880,7 @@ fn transform_rune_call(
                 params: vec![].into(),
                 body: JsArrowBody::Expression(context.arena.alloc_expr(args_array)),
                 is_async: false,
+                span: None,
             });
 
             // Build: (...$$args) => inspector(...$$args)
@@ -2892,6 +2898,7 @@ fn transform_rune_call(
                 )))],
                 body: JsArrowBody::Expression(context.arena.alloc_expr(inspector_call)),
                 is_async: false,
+                span: None,
             });
 
             // Build: $.inspect(args_thunk, fn_wrapper, true)
@@ -3456,6 +3463,7 @@ fn convert_arrow_function(
         params: params.into(),
         body,
         is_async,
+        span: None,
     })
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/key_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/key_block.rs
@@ -82,6 +82,7 @@ pub fn key_block(node: &KeyBlock, context: &mut ComponentContext) -> TransformRe
                 body_block,
             ),
             is_async: false,
+            span: None,
         },
     );
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -3503,15 +3503,18 @@ fn build_component_meta_stmt(
     let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
         crate::compiler::phases::phase3_transform::profile::TF_BC_META,
     );
-    if !dev {
-        return b::stmt(arena, expression);
-    }
-
     let (start, tag_name) = match node {
         ComponentNode::Component(comp) => (comp.start, comp.name.to_string()),
         ComponentNode::SvelteComponent(comp) => (comp.start, "svelte:component".to_string()),
         ComponentNode::SvelteSelf(comp) => (comp.start, "svelte:self".to_string()),
     };
+
+    if !dev {
+        // Upstream anchors the component call on the tag's own source position,
+        // which is where esrap flushes a comment the instance script left
+        // pending — without it the flush falls to the end of the body (#4529).
+        return b::stmt_anchored(arena, expression, Some(start));
+    }
 
     let (line, col) =
         crate::compiler::phases::phase3_transform::utils::locate_in_source(source, start as usize);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -586,6 +586,7 @@ pub fn build_component(
                 &context.state.analysis.name,
                 context.state.dev,
                 &context.state.analysis.source,
+                false,
             );
             statements.push(meta_stmt);
         }
@@ -629,6 +630,7 @@ pub fn build_component(
                 &context.state.analysis.name,
                 context.state.dev,
                 &context.state.analysis.source,
+                true,
             );
             statements.push(meta_stmt);
         }
@@ -3499,6 +3501,7 @@ fn build_component_meta_stmt(
     analysis_name: &str,
     dev: bool,
     source: &str,
+    anchor_comments: bool,
 ) -> JsStatement {
     let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
         crate::compiler::phases::phase3_transform::profile::TF_BC_META,
@@ -3510,10 +3513,12 @@ fn build_component_meta_stmt(
     };
 
     if !dev {
-        // Upstream anchors the component call on the tag's own source position,
-        // which is where esrap flushes a comment the instance script left
-        // pending — without it the flush falls to the end of the body (#4529).
-        return b::stmt_anchored(arena, expression, Some(start));
+        // Upstream anchors the *static* component call on the tag's own source
+        // position, which is where esrap flushes a comment the instance script
+        // left pending — without it the flush falls to the end of the body
+        // (#4529). The `$.component` wrapper carries no such position upstream,
+        // so it must not claim one here.
+        return b::stmt_anchored(arena, expression, anchor_comments.then_some(start));
     }
 
     let (line, col) =

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -1161,6 +1161,7 @@ pub fn apply_transforms_to_expression_with_shadowed(
                 params: arrow.params.clone(),
                 body: transformed_body,
                 is_async: arrow.is_async,
+                span: None,
             })
         }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
@@ -356,6 +356,7 @@ pub fn arrow(arena: &JsArena, params: Vec<JsPattern>, body: JsExpr) -> JsExpr {
         params: params.into(),
         body: JsArrowBody::Expression(arena.alloc_expr(body)),
         is_async: false,
+        span: None,
     })
 }
 
@@ -366,6 +367,7 @@ pub fn arrow_block(params: Vec<JsPattern>, body: Vec<JsStatement>) -> JsExpr {
         params: params.into(),
         body: JsArrowBody::Block(JsBlockStatement::with_body(body)),
         is_async: false,
+        span: None,
     })
 }
 
@@ -387,6 +389,7 @@ pub fn async_arrow(arena: &JsArena, params: Vec<JsPattern>, body: JsExpr) -> JsE
         params: params.into(),
         body: JsArrowBody::Expression(arena.alloc_expr(body)),
         is_async: true,
+        span: None,
     })
 }
 
@@ -396,6 +399,7 @@ pub fn async_arrow_block(params: Vec<JsPattern>, body: Vec<JsStatement>) -> JsEx
         params: params.into(),
         body: JsArrowBody::Block(JsBlockStatement::with_body(body)),
         is_async: true,
+        span: None,
     })
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
@@ -634,6 +634,10 @@ pub struct JsArrowFunction {
     pub params: SmallVec<[JsPattern; 3]>,
     pub body: JsArrowBody,
     pub is_async: bool,
+    /// The source span of the arrow this was converted from, when there is one.
+    /// Unconditional: esrap decides where a pending comment flushes from the
+    /// printed node's span, so this may not depend on `enable_sourcemap`.
+    pub span: Option<(u32, u32)>,
 }
 
 /// Arrow function body.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -960,11 +960,14 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
     fn stmt(&self, stmt: &JsStatement) -> Option<Statement<'a>> {
         match stmt {
             JsStatement::Expression(e) => {
+                // The chunk's anchor is claimed in **print** order, and the
+                // statement prints before anything inside it — so this runs
+                // before the expression is converted, or a source arrow in
+                // argument position would take the anchor the statement wants.
+                let span = self.comment_anchor(e.comment_anchor);
                 let expr = self.expr_id(e.expression)?;
                 Some(Statement::ExpressionStatement(ExpressionStatement::boxed(
-                    self.comment_anchor(e.comment_anchor),
-                    expr,
-                    &self.ab,
+                    span, expr, &self.ab,
                 )))
             }
             JsStatement::Return(r) => {
@@ -2869,9 +2872,14 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
             }
         };
 
+        // A source arrow in argument position is where esrap flushes a comment
+        // the preceding chunk left pending, when no enclosing statement claimed
+        // the chunk's anchor first (#4481).
+        let span = self.comment_anchor(arrow.span.map(|(start, _)| start));
+
         Some(Expression::ArrowFunctionExpression(
             ArrowFunctionExpression::boxed(
-                SPAN,
+                span,
                 arrow.is_async,
                 None,
                 ArenaBox::new_in(params, &self.ab),

--- a/crates/rsvelte_core/tests/arrow_argument_comment_anchor_4481.rs
+++ b/crates/rsvelte_core/tests/arrow_argument_comment_anchor_4481.rs
@@ -1,0 +1,123 @@
+//! A comment the instance script leaves pending is flushed at the first node
+//! **in print order** that carries a position. Where the enclosing statement has
+//! none — `$.event('resize', $.window, () => c)` is synthesized — upstream's
+//! flush falls to the source arrow in argument position, and rsvelte deferred it
+//! past the whole statement instead (#4481).
+//!
+//! Two things decide this and both are pinned below: the arrow has to carry the
+//! source span at all (it is converted from source, so it has one), and the
+//! claim has to happen in print order — a statement prints before anything
+//! inside it, so an enclosing statement that wants the anchor must take it
+//! first.
+//!
+//! No corpus gate observes this: `ast_equiv_batch` runs with
+//! `CommentPolicy::Ignore`, so a comment-only divergence scores `match` on every
+//! target.
+//!
+//! Every expected string here is official Svelte 5.57.0's own output for the
+//! same source (`submodules/svelte`, pin `7bc0a70fe`), not a neighbouring cell's.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("C.svelte".into()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .map(|result| result.js.code)
+    .unwrap_or_else(|error| format!("COMPILE_ERROR: {error:?}"))
+}
+
+const EVENT_CALL: &str = "\t$.event(\n\t\t'resize',\n\t\t$.window,\n\t\t// x\n\t\t() => c\n\t);";
+
+/// The reported cell. The comment forces the call multiline, which is why one
+/// comment moves eight to ten lines in the issue's table.
+#[test]
+fn a_window_handler_takes_the_comment_into_the_call() {
+    let out = client(
+        "<script>\n\tlet c = 1;\n\t// x\n</script>\n\n<svelte:window onresize={() => c} />\n",
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains(EVENT_CALL), "{out}");
+}
+
+/// The same lowering reached through a different host, so the fix is not keyed
+/// on `svelte:window`.
+#[test]
+fn a_document_handler_takes_the_comment_into_the_call() {
+    let out = client(
+        "<script>\n\tlet c = 1;\n\t// x\n</script>\n\n<svelte:document onclick={() => c} />\n",
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("\t$.event(\n\t\t'click',\n\t\t$.document,\n\t\t// x\n\t\t() => c\n\t);"),
+        "{out}"
+    );
+}
+
+/// A block comment reaches the same place, so the rule is not "a line comment
+/// swallows the rest of the line".
+#[test]
+fn a_block_comment_reaches_the_same_argument() {
+    let out = client(
+        "<script>\n\tlet c = 1;\n\t/* x */\n</script>\n\n<svelte:window onresize={() => c} />\n",
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\t\t/* x */\n\t\t() => c\n\t);"), "{out}");
+}
+
+/// The cell that says the claim happens in **print** order: the component call
+/// statement has a position of its own (#4529), and it prints before the arrow
+/// it contains, so the comment stays on the statement. Claiming inside the
+/// expression first — which is the order the conversion used to run in — puts it
+/// on the `onclick` property instead.
+#[test]
+fn an_enclosing_statement_with_a_position_keeps_the_comment() {
+    let out = client("<script>\n\tlet c = 1;\n\t// x\n</script>\n<X onclick={() => c} />\n");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("\t// x\n\tX($$anchor, { onclick: () => c });"),
+        "{out}"
+    );
+    assert_eq!(out.matches("// x").count(), 1, "{out}");
+}
+
+/// Print order and source order disagree here: `<X>` comes first in the source,
+/// `$.event` first in the output. The comment goes to the arrow, which is what
+/// says the anchor follows the printed program and not the template's order.
+#[test]
+fn print_order_decides_when_it_disagrees_with_source_order() {
+    let out = client(
+        "<script>\n\tlet c = $state(1);\n\t// x\n</script>\n<X {c} /><svelte:window onresize={() => c} />\n",
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains(EVENT_CALL), "{out}");
+    assert!(out.contains("\tX($$anchor, { c });"), "{out}");
+    assert_eq!(out.matches("// x").count(), 1, "{out}");
+}
+
+/// The negative: the same template with no comment must be byte-identical to
+/// what it was, so a change that merely reformatted the call would fail here.
+#[test]
+fn a_handler_with_no_pending_comment_is_unchanged() {
+    let out = client("<script>\n\tlet c = 1;\n</script>\n\n<svelte:window onresize={() => c} />\n");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("\t$.event('resize', $.window, () => c);"),
+        "{out}"
+    );
+}
+
+/// A live control from the issue's own table: this shape carries the comment
+/// through on both sides before and after, so it says the arms differ only
+/// where the issue says they do.
+#[test]
+fn an_element_template_still_places_the_comment_on_the_declarator() {
+    let out = client("<script>\n\tlet c = 1;\n\t// x\n</script>\n\n<b>{c}</b>\n");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\tvar // x\n\tb = root();"), "{out}");
+}

--- a/crates/rsvelte_core/tests/component_call_comment_anchor_4529.rs
+++ b/crates/rsvelte_core/tests/component_call_comment_anchor_4529.rs
@@ -1,0 +1,77 @@
+//! A comment the instance script leaves pending is flushed by the first
+//! generated statement whose source position is at or after it. The component
+//! call carried no such position, so the flush fell through to the end of the
+//! function body — past every statement the template lowered to, which is what
+//! the two-component cell below shows and what a one-component cell cannot
+//! distinguish from "after the call" (#4529).
+//!
+//! No corpus gate observes this: `ast_equiv_batch` runs with
+//! `CommentPolicy::Ignore`, so a comment-only divergence scores `match` on every
+//! target. A source-shape screen over the 34,933 `.svelte` files of the
+//! populated submodules selects 140 carriers, of which 4 go from divergent to
+//! byte-equal with this change and 0 regress — but none of them can live in
+//! `pattern-corpus` for the same reason.
+//!
+//! Every expected string here is official Svelte 5.57.0's own output for the
+//! same source (`submodules/svelte`, pin `7bc0a70fe`), not a neighbouring cell's.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("C.svelte".into()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .map(|result| result.js.code)
+    .unwrap_or_else(|error| format!("COMPILE_ERROR: {error:?}"))
+}
+
+/// The reported cell: the script holds nothing but the comment.
+#[test]
+fn a_trailing_script_comment_precedes_the_component_call() {
+    let out = client("<script>\n// c\n</script>\n<X />\n");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\t// c\n\tX($$anchor, {});"), "{out}");
+}
+
+/// With a statement before it, so the comment is not simply "the first thing".
+#[test]
+fn a_statement_before_the_comment_does_not_move_it() {
+    let out = client("<script>\nlet p = 1;\n// c\n</script>\n<X {p} />\n");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("\tlet p = 1;\n\n\t// c\n\tX($$anchor, { p });"),
+        "{out}"
+    );
+}
+
+/// The cell that says the old behaviour was "at the end of the body" and not
+/// "after the call": with two components the comment used to land past both of
+/// them and past `$.append`. A one-component cell cannot tell those apart.
+#[test]
+fn the_comment_anchors_on_the_first_call_not_at_the_end_of_the_body() {
+    let out = client("<script>\n// c\n</script>\n<X /><Y />\n");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\t// c\n\tX(node, {});"), "{out}");
+    assert!(
+        !out.contains("$.append($$anchor, fragment);\n\t// c"),
+        "{out}"
+    );
+}
+
+/// The negative: no pending comment, so the anchor must change nothing. Without
+/// it, a change that emitted a stray newline or moved the call would still
+/// satisfy every assertion above.
+#[test]
+fn a_script_with_no_comment_is_unchanged() {
+    let out = client("<script>\nlet p = 1;\n</script>\n<X {p} />\n");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("\tlet p = 1;\n\n\tX($$anchor, { p });"),
+        "{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/component_call_comment_anchor_4529.rs
+++ b/crates/rsvelte_core/tests/component_call_comment_anchor_4529.rs
@@ -75,3 +75,18 @@ fn a_script_with_no_comment_is_unchanged() {
         "{out}"
     );
 }
+
+/// The negative that decides the anchor's scope: a **dynamic** component is
+/// lowered to `$.component(node, () => C, …)`, and upstream gives that statement
+/// no source position at all — it flushes the comment into the thunk's own
+/// parameter list instead. Anchoring the wrapper here matched the reported shape
+/// and moved this cell off official, so the anchor is on the static call only.
+#[test]
+fn the_dynamic_component_wrapper_claims_no_anchor() {
+    let out = client(
+        "<script>\n\timport X from \"x\";\n\tconst C = X;\n\t// c\n</script>\n<svelte:component this={C} />\n",
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("\t\t(// c\n\t\t) => C,"), "{out}");
+    assert!(!out.contains("\t// c\n\t$.component("), "{out}");
+}

--- a/crates/rsvelte_core/tests/instance_script_dropped_comment_4517.rs
+++ b/crates/rsvelte_core/tests/instance_script_dropped_comment_4517.rs
@@ -100,14 +100,15 @@ fn a_plain_element_template_keeps_officials_declarator_placement() {
     );
 }
 
-/// The unfixed half of the issue. Official emits `// c` *before* the call; the
-/// first pass writes it after, so this is a relocation and out of scope here.
-/// A recovery that claimed relocations too would pass this by accident while
-/// breaking the `keep_*` cells above.
+/// The relocation half of the issue, which #4529 closed by anchoring the static
+/// component call on the tag's source position. This used to pin the comment
+/// *after* the call as out of scope here; it is now official's own placement,
+/// and it still says the recovery in this file is not what moves it — the
+/// `keep_*` cells above are unchanged.
 #[test]
-fn a_self_closing_component_still_trails_its_comment() {
+fn a_self_closing_component_leads_its_comment() {
     assert_eq!(
         client("\t// c", "<X />"),
-        "export default function C($$anchor) {\n\tX($$anchor, {});\n\t// c\n}"
+        "export default function C($$anchor) {\n\t// c\n\tX($$anchor, {});\n}"
     );
 }


### PR DESCRIPTION
Closes #4481 for the `svelte:window` / `svelte:body` / `svelte:document` cells. `{@html}` stays open on the issue; `{#key}` has since converged on its own.

Stacked on #4574 (#4529) — it corrects the same anchor's scope, and the second commit here depends on it. Rebase onto `main` if #4574 lands first.

## What was wrong

A pending instance-script comment flushes at the first node **in print order** that carries a
position. `$.event('resize', $.window, () => c)` is synthesized, but its last argument is the
source arrow `() => c`, which is where upstream flushes:

```js
	$.event(
		'resize',
		$.window,
		// x
		() => c
	);
```

rsvelte's `JsArrowFunction` carried no span at all, so nothing inside the call could claim the
comment and it was deferred past the whole statement.

## Two halves, each separately load-bearing

1. **`JsArrowFunction::span`**, set from the source node in the expression converter and read in
   `to_oxc`. Unconditional, not gated on `enable_sourcemap`: the flush point is a code-generation
   decision, and `sourcemap_option_does_not_reach_the_code` (#4571) pins that it may not depend on
   the flag. It is not the raw source offset either — a source offset sits *below* `loc_base` under
   split coordinates, so the arrow claims the chunk's comment-space anchor through
   `Synth::comment_anchor`, the same path a statement uses.

2. **Claim order.** `JsStatement::Expression` used to convert its expression and *then* ask for the
   anchor, so a source arrow inside it took the chunk's single anchor first. With (1) alone,
   `<X onclick={() => c} />` regressed from EQ to DIFF — the comment landed on the `onclick`
   property instead of before the component call. The statement now claims first, which is print
   order.

Ablation, in this worktree, against the seven tests:

| arm | result |
|---|---|
| both halves | 7 passed |
| (1) removed | 4 failed — the three call cells and the print-order cell; the enclosing-statement cell and both negatives still pass |
| (2) reverted | 1 failed — the enclosing-statement cell only |

## Measured

Three arms — official (`submodules/svelte`, pin `7bc0a70fe`, `VERSION 5.57.0`), the base
(`main` + #4574), and this branch — verdict full `js.code` byte equality, separate `compile_one`
binaries.

| population | result |
|---|---|
| the issue's eight-cell grid, client | `j_win`, `k_body`, `m_doc` DIFF → EQ; `l_html` DIFF → DIFF; four controls EQ → EQ |
| the same eight with the comment stripped | EQ throughout, both arms — so the divergence is the comment's |
| six adversarial cells (component + arrow, `{#each}` + handler, two handlers, block comment, component **and** window) | 3 DIFF → EQ, 3 unchanged, **0 EQ → DIFF** |
| `compatibility/pattern-corpus`, client + server | **MOVED = 0** (2,532 units) |
| real-world screen, 2,487 files × 2 targets | 16 units moved: **FIXED = 1, BROKEN = 0**, the rest already divergent |

The 2,487-file screen (instance script contains a comment **and** the template contains `=>`) comes
from the 34,933 `.svelte` files of the populated submodules; controls `ctl_script = 31,659`,
`ctl_impossible = 0`, `unread = 3`.

The first version of (1) alone measured `MOVED = 0` on that same screen while fixing the grid —
which is what made the missing second half visible only in the adversarial cells, not in the sweep.

## Pins

`crates/rsvelte_core/tests/arrow_argument_comment_anchor_4481.rs`, seven tests: the three hosts, a
block comment, the enclosing-statement cell that holds half (2), a print-order cell where source
order and print order disagree (`<X {c} /><svelte:window …>` — `$.event` prints first), and two
negatives (no pending comment; the element-template control from the issue's own table). Every
expected string is the oracle's own output for that input.

A repro cannot live in `compatibility/pattern-corpus/`: `ast_equiv_batch` runs with
`CommentPolicy::Ignore`, so a comment-only divergence scores `match` on both arms. Recorded as a
no-repro doc under the convention #4556 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
