### PR TITLE
fix(sourcemap): do not emit a segment whose offset is past the source

### DIFF
--- a/.changeset/map-offset-past-source.md
+++ b/.changeset/map-offset-past-source.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Stop emitting client source-map segments whose source offset is past the end of the source: an untranslated chunk coordinate resolved to a position no source line can hold.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.41"
+version = "0.10.42"
 dependencies = [
  "compact_str",
  "memchr",

--- a/compatibility/pattern-corpus/issues/4466-map-offset-past-source.md
+++ b/compatibility/pattern-corpus/issues/4466-map-offset-past-source.md
@@ -1,0 +1,22 @@
+# client source-map segments pointing past the end of a source line
+
+**Issue:** [#4466](https://github.com/baseballyama/rsvelte/issues/4466)
+**Repro:** none — `crates/rsvelte_core/tests/map_offset_past_source_4466.rs`
+
+`RestoreRawMappedSpans::visit_span` returns without writing when a chunk offset
+has no `copied_spans` translation, which leaves the node's span in **chunk**
+coordinates — an offset into the transformed script text. Nothing downstream can
+tell that apart from a source offset, so the map named a position no source line
+can hold (69.9% of one carrier's segments).
+
+Leaving the span located is deliberate: unlocating it instead changes `js.code`
+on ten `pattern-corpus` files, all of them away from official. So the rejection
+is at the two **map emission** sites (`Driver::LocationOffset` and
+`Printer::map_position`), both of which now drop an offset past the mapped
+source's length. `js.code` is byte-identical over the whole corpus.
+
+Both sites are load-bearing: the `Driver` alone leaves 1,637 out-of-range
+segments and `map_position` alone leaves 4,461, against 77 with both.
+
+No repro can live here: the corpus gate compares `js.code`, which this does not
+change.

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.146", features = ["serialize"] }
 oxc_span = "0.146"
 oxc_diagnostics = "0.146"
 oxc_codegen = "0.146"
-rsvelte_esrap = { version = "=0.10.41", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.42", path = "../rsvelte_esrap" }
 oxc_syntax = "0.146"
 oxc_semantic = "0.146"
 

--- a/crates/rsvelte_core/tests/map_offset_past_source_4466.rs
+++ b/crates/rsvelte_core/tests/map_offset_past_source_4466.rs
@@ -1,0 +1,167 @@
+//! A generated node whose span `RestoreRawMappedSpans` could not translate back
+//! keeps its **chunk** coordinate — an offset into the transformed script text,
+//! not into the `.svelte` source. Read as a source position it resolves to a
+//! line that cannot hold it, so the map points past the end of a source line
+//! (#4466). The two emission sites reject such an offset instead of naming a
+//! position that does not exist.
+//!
+//! `sourcemaps_gate.rs` does not see this: its population is the upstream
+//! `sourcemaps` fixtures, whose out-of-range budget is empty both before and
+//! after. The carriers are legacy `$:` and rune-argument components, which live
+//! in `compatibility/pattern-corpus`.
+//!
+//! Columns here are compared in **bytes**, because that is what rsvelte emits
+//! (`offset - line_start`). Official emits UTF-16 columns, so this predicate is
+//! not the one to judge official's map with.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+use std::path::{Path, PathBuf};
+
+fn map_of(path: &Path) -> Option<(String, String)> {
+    let source = std::fs::read_to_string(path).ok()?;
+    let result = compile(
+        &source,
+        CompileOptions {
+            filename: Some(path.to_string_lossy().into_owned()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .ok()?;
+    Some((source, result.js.map?))
+}
+
+/// `(segments, out_of_range)` for one map, where out-of-range means the source
+/// column is past the last byte of the source line the segment names.
+fn count(source: &str, map_json: &str) -> (usize, usize) {
+    let value: serde_json::Value = serde_json::from_str(map_json).expect("map is JSON");
+    let mappings = value
+        .get("mappings")
+        .and_then(serde_json::Value::as_str)
+        .expect("map has mappings");
+    let lines: Vec<&str> = source.split('\n').collect();
+
+    let (mut src_line, mut src_col) = (0i64, 0i64);
+    let (mut total, mut out_of_range) = (0usize, 0usize);
+    for group in mappings.split(';') {
+        for segment in group.split(',').filter(|s| !s.is_empty()) {
+            let fields = vlq(segment);
+            if fields.len() < 4 {
+                continue;
+            }
+            src_line += fields[2];
+            src_col += fields[3];
+            total += 1;
+            let past = usize::try_from(src_line)
+                .ok()
+                .and_then(|line| lines.get(line))
+                .is_none_or(|line| src_col > line.len() as i64);
+            if past {
+                out_of_range += 1;
+            }
+        }
+    }
+    (total, out_of_range)
+}
+
+fn vlq(segment: &str) -> Vec<i64> {
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = Vec::new();
+    let (mut shift, mut value) = (0u32, 0i64);
+    for byte in segment.bytes() {
+        let digit = ALPHABET.iter().position(|&c| c == byte).expect("base64") as i64;
+        value += (digit & 31) << shift;
+        if digit & 32 != 0 {
+            shift += 5;
+            continue;
+        }
+        let negative = value & 1 == 1;
+        value >>= 1;
+        out.push(if negative { -value } else { value });
+        value = 0;
+        shift = 0;
+    }
+    out
+}
+
+fn corpus_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../compatibility/pattern-corpus")
+}
+
+fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk(&path, out);
+        } else if path.extension().is_some_and(|e| e == "svelte") {
+            out.push(path);
+        }
+    }
+}
+
+/// The three carriers #4466 named, as recorded values rather than a direction.
+/// Before the guards they read 309/442, 63/98 and 276/438.
+///
+/// `3071`'s remaining one is a **different shape**: it is the exclusive end of
+/// the last node, which lands exactly at the end of `</script>` — one past the
+/// line's last byte, which is what an exclusive end is. Rejecting it would need
+/// `offset >= len`, and that would drop every legitimate end-of-file end too.
+#[test]
+fn the_named_carriers_point_inside_their_source() {
+    let root = corpus_root();
+    for (relative, expected) in [
+        ("issues/3103-reactive-array-rest.svelte", 0),
+        ("issues/3071-rune-argument-class-in-component.svelte", 1),
+        ("adversarial/legacy/legacy-reactive-ordering.svelte", 0),
+    ] {
+        let path = root.join(relative);
+        let (source, map) =
+            map_of(&path).unwrap_or_else(|| panic!("{relative} compiles with a map"));
+        let (total, out_of_range) = count(&source, &map);
+        assert!(total > 20, "{relative}: only {total} segments — instrument");
+        assert_eq!(
+            out_of_range, expected,
+            "{relative}: {out_of_range} of {total}"
+        );
+    }
+}
+
+/// The corpus-wide ceiling. `main` before this change reads 5,891 of 111,276
+/// (5.3%); the residue is 77 of 105,462 (0.1%), and the ones that are left are
+/// a different shape — an exclusive end landing one past the last byte — not the
+/// untranslated chunk offsets this rejects. A ceiling rather than an equality
+/// because the denominator moves with every codegen change; the direction is
+/// what the test exists to hold.
+#[test]
+fn the_corpus_map_does_not_point_past_a_source_line() {
+    let mut files = Vec::new();
+    walk(&corpus_root(), &mut files);
+    files.sort();
+    assert!(
+        files.len() > 1000,
+        "only {} files — instrument",
+        files.len()
+    );
+
+    let (mut total, mut out_of_range) = (0usize, 0usize);
+    for path in &files {
+        if let Some((source, map)) = map_of(path) {
+            let (t, o) = count(&source, &map);
+            total += t;
+            out_of_range += o;
+        }
+    }
+    assert!(
+        total > 50_000,
+        "only {total} segments compared — instrument"
+    );
+    let share = (out_of_range as f64) / (total as f64);
+    assert!(
+        share < 0.002,
+        "{out_of_range} of {total} segments ({:.2}%) point past the end of a source line",
+        100.0 * share
+    );
+}

--- a/crates/rsvelte_devtools/src/bin/compile_one.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_one.rs
@@ -76,7 +76,13 @@ fn main() {
             ..Default::default()
         },
     ) {
-        Ok(result) => print!("{}", result.js.code),
+        Ok(result) => {
+            if args.iter().any(|a| a == "--map") {
+                print!("{}", result.js.map.unwrap_or_default());
+            } else {
+                print!("{}", result.js.code);
+            }
+        }
         Err(err) => {
             eprintln!("{err:?}");
             std::process::exit(2);

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.41"
+version = "0.10.42"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/command.rs
+++ b/crates/rsvelte_esrap/src/command.rs
@@ -221,6 +221,7 @@ pub(crate) fn flatten_with_map(
     indent: &str,
     capacity: usize,
     source_line_starts: &[u32],
+    source_len: u32,
 ) -> (String, Vec<Mapping>) {
     let mut driver = Driver {
         code: String::with_capacity(
@@ -239,6 +240,7 @@ pub(crate) fn flatten_with_map(
         current_line: 0,
         current_column: 0,
         source_line_starts,
+        source_len,
         last_source_line: 0,
         // Only Location events emit a mapping, so every event is a safe upper
         // bound that avoids repeatedly growing this hot output vector.
@@ -281,6 +283,10 @@ struct Driver<'a> {
     current_line: u32,
     current_column: u32,
     source_line_starts: &'a [u32],
+    /// One past the last byte a source position may name. An offset beyond it
+    /// is a chunk coordinate a lowering could not translate back, and emitting
+    /// it produces a segment pointing past the end of a source line (#4466).
+    source_len: u32,
     /// 1-based line most recently resolved from a source offset. A token's two
     /// anchors, and consecutive tokens, almost always share it.
     last_source_line: u32,
@@ -305,6 +311,9 @@ impl Driver<'_> {
             }
             EventKind::LocationOffset { offset } => {
                 self.flush_pending();
+                if offset > self.source_len {
+                    return;
+                }
                 let line = self.source_line_of(offset);
                 if line == 0 {
                     return;
@@ -550,7 +559,7 @@ mod tests {
         ]);
         assert_eq!(
             print(&buffer, "  ", 0),
-            flatten_with_map(&buffer, "  ", 0, &[]).0
+            flatten_with_map(&buffer, "  ", 0, &[], u32::MAX).0
         );
     }
 
@@ -560,7 +569,7 @@ mod tests {
             TestCommand::Text("ab\ncd"),
             TestCommand::Event(EventKind::Location { line: 3, column: 4 }),
         ]);
-        let (_, mappings) = flatten_with_map(&buffer, "\t", 0, &[]);
+        let (_, mappings) = flatten_with_map(&buffer, "\t", 0, &[], u32::MAX);
         assert_eq!(
             mappings,
             vec![Mapping {

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -283,6 +283,7 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
         let mut printer =
             printer::Printer::<HAS_COMMENTS, true>::with_comments(options, comments, line_starts)
                 .with_placement_source(comment_source)
+                .with_map_source_len(map_source.map_or(u32::MAX, |s| s.len() as u32))
                 .with_split_coordinates(map_line_starts, loc_base, loc_map, brace_mappings, false)
                 .with_src_flushable(src_flushable);
         let mut ctx = context::Context::new_direct(&options.indent, program.source_text.len());
@@ -301,6 +302,7 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
     let mut printer =
         printer::Printer::<HAS_COMMENTS, false>::with_comments(options, comments, line_starts)
             .with_placement_source(comment_source)
+            .with_map_source_len(map_source.map_or(u32::MAX, |s| s.len() as u32))
             .with_split_coordinates(
                 map_line_starts,
                 loc_base,
@@ -322,6 +324,7 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
             &options.indent,
             capacity,
             printer.source_map_line_starts(),
+            map_source.map_or(u32::MAX, |s| s.len() as u32),
         );
         PrintWithMap { code, mappings }
     } else {
@@ -370,6 +373,7 @@ fn print_with_map_impl<const HAS_COMMENTS: bool>(
     let mut printer =
         printer::Printer::<HAS_COMMENTS, false>::with_comments(options, comments, line_starts)
             .with_placement_source(source)
+            .with_map_source_len(source.len() as u32)
             .with_source_map();
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
@@ -380,6 +384,7 @@ fn print_with_map_impl<const HAS_COMMENTS: bool>(
         &options.indent,
         capacity,
         printer.source_map_line_starts(),
+        source.len() as u32,
     );
     pool::give(buffer, returned);
     PrintWithMap { code, mappings }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -908,6 +908,19 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     /// map segment wants. Formatting decisions must keep using
     /// [`Self::offset_to_line_col`], which cannot compare across the two spaces.
     fn map_position(&self, offset: u32) -> Option<(u32, u32)> {
+        self.map_position_inner(offset, false)
+    }
+
+    /// [`Self::map_position`] for a source-map **segment**, which is the only
+    /// consumer that must not name a position the source cannot hold. The
+    /// placement decisions that share this lookup compare offsets and have to
+    /// keep seeing the untranslated one, so the rejection cannot live in
+    /// `map_position` itself (#4466).
+    fn map_segment(&self, offset: u32) -> Option<(u32, u32)> {
+        self.map_position_inner(offset, true)
+    }
+
+    fn map_position_inner(&self, offset: u32, for_segment: bool) -> Option<(u32, u32)> {
         if offset == u32::MAX {
             return None;
         }
@@ -940,7 +953,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 None => offset,
             }
         };
-        if self.map_source_len.is_some_and(|len| offset > len) {
+        if for_segment && self.map_source_len.is_some_and(|len| offset > len) {
             return None;
         }
         let line = usize_to_u32(map_line_starts.partition_point(|&s| s <= offset));
@@ -954,7 +967,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     /// `end` as the token's final source-map position. Prefer the copied run
     /// ending at `offset` over a following range starting at the same boundary;
     /// this matches `RawMapped`'s fallback span restorer.
-    fn map_end_position(&self, offset: u32) -> Option<(u32, u32)> {
+    fn map_segment_end(&self, offset: u32) -> Option<(u32, u32)> {
         if !self.loc_map.is_empty() {
             let index = self.loc_map.partition_point(|range| range.end < offset);
             if let Some(range) = self.loc_map.get(index)
@@ -975,7 +988,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 }
             }
         }
-        self.map_position(offset)
+        self.map_segment(offset)
     }
 
     /// Source-map line and column of a source-space `offset`.
@@ -1009,7 +1022,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             ctx.write(suffix);
             return;
         }
-        if let Some((line, column)) = self.map_position(span.start) {
+        if let Some((line, column)) = self.map_segment(span.start) {
             ctx.location(line, column);
             ctx.write(keyword);
             ctx.location(line, column.saturating_add(usize_to_u32(keyword.len())));
@@ -1038,11 +1051,11 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             return;
         }
 
-        if let Some((line, column)) = self.map_position(span.start) {
+        if let Some((line, column)) = self.map_segment(span.start) {
             ctx.location(line, column);
         }
         ctx.write(content);
-        if let Some((line, column)) = self.map_end_position(span.end) {
+        if let Some((line, column)) = self.map_segment_end(span.end) {
             ctx.location(line, column);
         }
     }
@@ -1089,7 +1102,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         // has none, and rsvelte spells that as an empty or sentinel span.
         let located = !span.is_empty() && span.start != u32::MAX;
         let cursor = if map_ok && located && self.emit_locations {
-            self.map_position(span.start)
+            self.map_segment(span.start)
         } else {
             None
         };
@@ -2560,7 +2573,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         let start = node.span().start;
         let offset_ok = self.function_async_offset_ok(node);
         let gen_suffix = if node.generator { "* " } else { " " };
-        match self.map_position(start) {
+        match self.map_segment(start) {
             Some((line, column)) if node.r#async && offset_ok => {
                 Self::write_source_keyword(ctx, line, column, "async ");
                 let col2 = column + usize_to_u32("async ".len());
@@ -4132,7 +4145,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         // Builder-created calls carry `SPAN` (zero); a nonzero span is an
         // explicit source-backed call such as a lowered directive runtime call.
         if node.span.start != 0
-            && let Some((line, column)) = self.map_position(node.span.start)
+            && let Some((line, column)) = self.map_segment(node.span.start)
         {
             ctx.location(line, column);
         }
@@ -4156,7 +4169,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         }
         self.call_arguments(&node.arguments, node.span().end, comment_argument, ctx);
         if node.span.start != 0
-            && let Some((line, column)) = self.map_end_position(node.span.end)
+            && let Some((line, column)) = self.map_segment_end(node.span.end)
         {
             ctx.location(line, column);
         }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -113,6 +113,8 @@ pub struct Printer<'opt, const HAS_COMMENTS: bool = true, const DIRECT: bool = f
     /// resolved against. Same as `line_starts` unless the caller split the two
     /// coordinate spaces (see [`crate::print_split`]).
     map_line_starts: Option<Vec<u32>>,
+    /// Length of the text source-map positions resolve against, when known.
+    map_source_len: Option<u32>,
     /// Spans below this offset are synthesized and carry no source location, so
     /// they take no part in comment placement — the Rust equivalent of esrap's
     /// `if (node.loc)` guards. `None` = every span is a real location.
@@ -738,6 +740,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             comment_source: None,
             placement_source: None,
             map_line_starts: None,
+            map_source_len: None,
             loc_base: None,
             loc_map: Vec::new(),
             brace_mappings: Vec::new(),
@@ -762,6 +765,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             borrowed_comments: None,
             comment_index: 0,
             map_line_starts: None,
+            map_source_len: None,
             line_starts,
             comment_source: None,
             placement_source: None,
@@ -772,6 +776,15 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             written: Vec::new(),
             map_nodes: true,
         }
+    }
+
+    /// The length of the text source-map positions index. An offset past it is
+    /// a chunk coordinate that `RestoreRawMappedSpans` could not translate, not
+    /// a source position, and emitting it produces a segment pointing past the
+    /// end of a source line (#4466).
+    pub(crate) const fn with_map_source_len(mut self, len: u32) -> Self {
+        self.map_source_len = Some(len);
+        self
     }
 
     /// Decide comment placement by reading `source`, not by comparing lines in
@@ -927,6 +940,9 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 None => offset,
             }
         };
+        if self.map_source_len.is_some_and(|len| offset > len) {
+            return None;
+        }
         let line = usize_to_u32(map_line_starts.partition_point(|&s| s <= offset));
         // `line` is 1-based; its start offset lives at index `line - 1`.
         let line_start = map_line_starts[(line - 1) as usize];

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.41"
+version = "0.10.42"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
Cuts the out-of-range half of #4466 (and of #4454). Does **not** close either, and does **not** fix the mechanism — see *This is the tail, not the class*.

## What was wrong

`RestoreRawMappedSpans::visit_span` writes nothing when `copied_spans` cannot translate an offset, which leaves the node's span in **chunk** coordinates — an offset into the transformed script text, not into the `.svelte` source. Its own comment says so:

> Keep that node in chunk coordinates instead of constructing an invalid OXC span.

Nothing downstream can tell that apart from a source offset, so the map named a position no source line can hold:

```
issues/3103-reactive-array-rest.svelte   309 of 442 segments (69.9%)
   gen 33:10 -> src 12:2   (the file has 11 lines; line 12 is empty)
```

## Why the fix is not "unlocate the span"

Setting the span to `SPAN` when it cannot be mapped takes out-of-range to 0 — and moves `js.code` on **ten** `pattern-corpus` files, every one of them away from official (`FIXED 0 / BROKEN 10`): stray `;;` statements appear and `$.user_effect(/* fx */ () => {})` loses its comment. The span is load-bearing for comment placement. Measured, not assumed; that arm is what said the fix has to be elsewhere.

So the rejection is at the two **map emission** sites, which is output-neutral by construction:

- `command::Driver`, `EventKind::LocationOffset` — the site that produces almost every segment;
- `Printer::map_position` — the `Location { line, column }` path.

Both reject an offset past the length of the text the map resolves against (`map_source` for a split print, `source` otherwise).

Both are load-bearing, which is why neither is dead code:

| arm | out-of-range |
|---|---|
| `main` | 5,891 |
| `Driver` guard only | 1,637 |
| `map_position` guard only | 4,461 |
| both | **77** |

## Measured

`compatibility/pattern-corpus`, 1,387 files, `generate: client`, `dev: false`. Arms are separate `compile_one` binaries built from `main` (`47c5bc5f5`) and this branch; `sha256` `8ea0f979…` / `9f911b5a…`. Columns compared in **bytes**, which is what rsvelte emits.

| arm | segments | out-of-range |
|---|---:|---:|
| `main` | 111,276 | 5,891 (5.3%) |
| this branch | 105,462 | **77 (0.1%)** |
| official, for scale | 92,600 | — |

Official's column is not directly comparable: it emits UTF-16 columns, so a byte-length predicate is the wrong yardstick for it. It is here only to say that 105,462 is not a collapse of coverage — the unlocate arm dropped to 91,444, *below* official, which is the other reason it was rejected.

**`js.code` MOVED = 0** over all 2,774 client+server corpus units.

## This is the tail, not the class

#4466's own second comment establishes that out-of-range is a **filter artefact**: a segment is
out of range exactly when its wrong source position happens to clear a line end, so which
segments qualify is decided by where the file ends. The class underneath is "the segment claims
the wrong source position", and its mechanism is `parse_chunk`'s comment-free path returning
**chunk-local** spans that `map_position` then resolves against the source line table. That is
not touched here, and #4466 explicitly reserves it because making those spans unlocatable also
moves `has_loc` and so moves comment flushing (#4489 / #4492 / #4500 / #4516 / #4517).

So the question this branch has to answer is not "does out-of-range go down" — it must, by
construction — but **does dropping that tail cost any correct segment**. Re-derived here rather
than cited, on the same 1,263 live files (124 skipped: one side throws, or the file carries
U+2028/U+2029). Unit: a segment whose *generated* position starts an identifier; verdict is
whether the *source* position it claims starts the same identifier.

| arm | segments | identifier-judged | correct | out-of-range |
|---|---:|---:|---:|---:|
| official | 92,476 | 39,729 | 33,602 (**84.6%**) | 0 |
| `main` | 111,152 | 48,318 | 27,518 (**57.0%**) | 5,891 |
| this branch | 105,338 | 45,752 | **27,518** (60.1%) | 77 |

**`correct` is identical to the byte.** The branch removes 2,566 identifier-judged segments and
every one of them was already wrong; the other ~3,250 dropped segments are not
identifier-judged. Official's 84.6% is the metric's own floor — esrap legitimately anchors some
nodes at a parent position — so 57.0 → 60.1 is a move toward it and not a claim of correctness.

The cost is that the cheapest instrument for the class gets quieter: out-of-range was the number
#4466 was sized with. The identifier-correct rate above is the one to watch instead, and it is
unmoved in the numerator, which is the point.

## What is left in this branch's own scope

The 77 are a different shape: an **exclusive end** landing exactly one past the last byte of a line, which is what an exclusive end is. Rejecting those would need `offset >= len` and would drop every legitimate end-of-file end. `3071-rune-argument-class-in-component.svelte`'s remaining one is that, and it is pinned as a recorded value rather than driven to zero.

#4466 also asks whether the *surviving* segments are otherwise correct, and #4454 measures a different population (`compatibility/sources`, not materialised here). Both stay open.

## The gate does not see this

`sourcemaps_gate.rs` has an out-of-range budget, and it is **empty before and after** — its population is the upstream `sourcemaps` fixtures, and the carriers are legacy `$:` and rune-argument components that live only in `pattern-corpus`. No re-baseline; `compatibility/sourcemap-known-failures.json` is unchanged.

## Pins

`crates/rsvelte_core/tests/map_offset_past_source_4466.rs`: the three carriers #4466 named as recorded values (0 / 1 / 0, against 309 / 63 / 276 before), and a corpus-wide ceiling with its denominator asserted. Positive control: removing both guards fails both tests and prints the pre-fix numbers exactly (`309 of 442`, `5891 of 111332`).

`compile_one` gains `--map`, the instrument this was measured with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj
