### PR TITLE
fix(compiler): float an uninitialized declarator's erased-annotation comment forward

### DIFF
--- a/.changeset/uninit-annotation-comment-forward.md
+++ b/.changeset/uninit-annotation-comment-forward.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Float an uninitialized declarator's erased-annotation comment onto the following statement instead of dropping it, which is where upstream flushes it.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -669,6 +669,7 @@ fn strip_typescript_from_program_impl(
     // projection-less one while the client reads the other.
     let repeat_regions = collect_speculative_type_head_regions(program);
     let declarator_annotations = collect_declarator_annotations(program);
+    let uninit_float_targets = collect_uninit_annotation_float_targets(program);
 
     // Text-based fallback: strip `declare global { ... }`, `declare module ... { ... }`,
     // and `declare namespace ... { ... }` blocks. These may not always be parsed as
@@ -789,10 +790,18 @@ fn strip_typescript_from_program_impl(
                 .iter()
                 .find(|(from, _)| *from == *remove_start)
                 .map(|(_, init_start)| *init_start);
-            // `Some(None)` is an uninitialized declarator: upstream drops the
-            // comment onto the next located node, so this one is not ours to print.
+            // `Some(None)` is an uninitialized declarator: its declaration ends at
+            // the identifier, so upstream flushes the comment at the NEXT located
+            // node instead. Printing it here would put it after the `;`, where the
+            // client's legacy state lowering stops scanning (#4395). Float it to
+            // the following statement when there is one; when the declarator ends
+            // the list upstream carries it out of the script entirely, which no
+            // source-range rewrite can express, so that shape still drops (#4396).
             let flush_at = match declarator_annotation {
-                Some(None) => None,
+                Some(None) => uninit_float_targets
+                    .iter()
+                    .find(|(from, _)| *from == *remove_start)
+                    .map(|(_, at)| Some(*at)),
                 Some(Some(init_start)) => Some(Some(init_start)),
                 None => Some(None),
             };
@@ -1205,6 +1214,61 @@ struct SpeculativeTypeHeads<'r> {
 /// `None` is a declarator with no initializer at all, where upstream attaches
 /// the comment to the next located node instead and re-emitting it here would
 /// put it after the `;`.
+/// For each uninitialized declarator that carries a type annotation, the offset of
+/// the statement that follows its declaration in the same list — the next node
+/// upstream locates, and so where a comment left by the erased annotation is
+/// flushed. A declarator whose declaration ends its list has no such offset and is
+/// absent from the result.
+fn collect_uninit_annotation_float_targets(program: &oxc_ast::ast::Program) -> Vec<(u32, u32)> {
+    use oxc_ast_visit::Visit;
+    use oxc_span::GetSpan;
+    struct V<'r> {
+        targets: &'r mut Vec<(u32, u32)>,
+    }
+    impl<'r> V<'r> {
+        fn scan(&mut self, statements: &[oxc_ast::ast::Statement<'_>]) {
+            for (index, statement) in statements.iter().enumerate() {
+                let oxc_ast::ast::Statement::VariableDeclaration(declaration) = statement else {
+                    continue;
+                };
+                let Some(next) = statements.get(index + 1) else {
+                    continue;
+                };
+                let next_start = next.span().start;
+                for declarator in &declaration.declarations {
+                    if declarator.init.is_none()
+                        && let Some(annotation) = &declarator.type_annotation
+                    {
+                        self.targets.push((annotation.span.start, next_start));
+                    }
+                }
+            }
+        }
+    }
+    impl<'a> oxc_ast_visit::Visit<'a> for V<'_> {
+        fn visit_program(&mut self, it: &oxc_ast::ast::Program<'a>) {
+            self.scan(&it.body);
+            oxc_ast_visit::walk::walk_program(self, it);
+        }
+
+        fn visit_function_body(&mut self, it: &oxc_ast::ast::FunctionBody<'a>) {
+            self.scan(&it.statements);
+            oxc_ast_visit::walk::walk_function_body(self, it);
+        }
+
+        fn visit_block_statement(&mut self, it: &oxc_ast::ast::BlockStatement<'a>) {
+            self.scan(&it.body);
+            oxc_ast_visit::walk::walk_block_statement(self, it);
+        }
+    }
+    let mut targets = Vec::new();
+    V {
+        targets: &mut targets,
+    }
+    .visit_program(program);
+    targets
+}
+
 fn collect_declarator_annotations(program: &oxc_ast::ast::Program) -> Vec<(u32, Option<u32>)> {
     use oxc_ast_visit::Visit;
     use oxc_span::GetSpan;

--- a/crates/rsvelte_core/tests/repeated_type_head_comment_runs_4373.rs
+++ b/crates/rsvelte_core/tests/repeated_type_head_comment_runs_4373.rs
@@ -120,9 +120,10 @@ let { a }: {
 <i>{a}</i>
 ";
 
-/// A declarator with NO initializer: upstream floats the comment to the next
-/// located node and rsvelte drops it (#4396), so nothing here reaches the
-/// repeat at all.
+/// A declarator with NO initializer: its declaration ends at the identifier,
+/// so upstream flushes the head's comments at the NEXT located node instead of
+/// at an initializer. rsvelte floats them the same way (#4396), and the run is
+/// repeated there exactly as it is on an initialized host.
 const UNINITIALIZED: &str = "<script lang=\"ts\">
 let v: {
   // c
@@ -213,6 +214,12 @@ fn cells() -> Vec<(&'static str, String, &'static str, &'static str)> {
             "c c",
             "c c",
         ),
+        (
+            "an inline head on an uninitialized declarator",
+            UNINITIALIZED.to_string(),
+            "c d c d",
+            "c d c d",
+        ),
     ]
 }
 
@@ -258,20 +265,4 @@ fn the_extractor_and_the_compile_are_live() {
         client.contains("export default function C("),
         "not a compiled component: {client}"
     );
-}
-
-/// The hosts where the repeat is right and something upstream of it is not.
-///
-/// These pin what rsvelte answers TODAY, which is not what the oracle answers,
-/// so that the residue is written down rather than merely unexamined. Each cell
-/// names the issue that owns it; when one is fixed this test fails and the row
-/// moves into the table above.
-#[test]
-fn the_blocked_hosts_are_pinned_rather_than_matched() {
-    // An annotation on an UNINITIALIZED declarator is dropped on both targets
-    // (#4396): upstream ends the declaration at the identifier and floats the
-    // comment to the next located node, which rsvelte has no channel for. The
-    // oracle prints `c d c d` on both.
-    assert_eq!(sequence(UNINITIALIZED, GenerateMode::Client), "");
-    assert_eq!(sequence(UNINITIALIZED, GenerateMode::Server), "");
 }

--- a/crates/rsvelte_core/tests/uninit_annotation_comment_4396.rs
+++ b/crates/rsvelte_core/tests/uninit_annotation_comment_4396.rs
@@ -1,0 +1,133 @@
+//! A declarator with no initializer ends at its identifier, so a comment left
+//! behind by its erased TypeScript annotation has nothing to attach to and was
+//! dropped. Upstream flushes it at the next located node instead (#4396).
+//!
+//! Re-emitting it at the removal point stays wrong for the reason #4395
+//! recorded: the client's legacy state lowering is line-oriented, so a comment
+//! inside the declaration's own line turns `let stats = $.mutable_source(0)`
+//! into `let stats;` — text that parses, runs, and is no longer reactive. The
+//! comment therefore goes on its own line ahead of the FOLLOWING statement.
+//!
+//! Every expected string below is official Svelte 5.57.0's own output for the
+//! same source (`submodules/svelte`, pin `7bc0a70fe`), read off the oracle
+//! rather than inferred from a neighbouring cell. Upstream prints the comment
+//! twice because acorn-typescript speculates over the annotation; that is the
+//! oracle's answer here, not a defect being pinned.
+//!
+//! No corpus gate observes any of this: `ast_equiv_batch` runs with
+//! `CommentPolicy::Ignore`, so a comment-only divergence scores `match` on both
+//! arms.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_with(src: &str, name: &str, generate: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some(format!("{name}.svelte")),
+            generate,
+            name: Some(name.to_string()),
+            ..Default::default()
+        },
+    )
+    .map(|result| result.js.code)
+    .unwrap_or_else(|error| format!("COMPILE_ERROR: {error:?}"))
+}
+
+fn client(src: &str, name: &str) -> String {
+    compile_with(src, name, GenerateMode::Client)
+}
+
+fn server(src: &str, name: &str) -> String {
+    compile_with(src, name, GenerateMode::Server)
+}
+
+/// `let a: { /* c */ b: number } | null;` followed by another statement.
+const BLOCK: &str = "<script lang=\"ts\">\n\tlet a: {\n\t\t/* c */\n\t\tb: number;\n\t} | null;\n\tlet n = 1;\n</script>\n<i>{a}{n}</i>\n";
+
+/// The same with a line comment, which is the spelling the real-world carrier
+/// (`adventurelog`'s `+page.svelte`, `// Legacy fields`) uses.
+const LINE: &str = "<script lang=\"ts\">\n\tlet a: {\n\t\t// c\n\t\tb: number;\n\t} | null;\n\tlet n = 1;\n</script>\n<i>{a}{n}</i>\n";
+
+#[test]
+fn a_block_comment_floats_to_the_next_statement_on_the_client() {
+    let out = client(BLOCK, "Follow");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("\tlet a;\n\n\t/* c */\n\t/* c */\n\tlet n = 1;\n"),
+        "{out}"
+    );
+}
+
+#[test]
+fn a_block_comment_floats_to_the_next_statement_on_the_server() {
+    let out = server(BLOCK, "Follow");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("\tlet a;\n\n\t/* c */\n\t/* c */\n\tlet n = 1;\n"),
+        "{out}"
+    );
+}
+
+#[test]
+fn a_line_comment_floats_to_the_next_statement_on_the_client() {
+    let out = client(LINE, "Lineann");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("\tlet a;\n\n\t// c\n\t// c\n\tlet n = 1;\n"),
+        "{out}"
+    );
+}
+
+#[test]
+fn a_line_comment_floats_to_the_next_statement_on_the_server() {
+    let out = server(LINE, "Lineann");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("\tlet a;\n\n\t// c\n\t// c\n\tlet n = 1;\n"),
+        "{out}"
+    );
+}
+
+/// The hazard #4395 recorded, on the shape the real-world carrier has: a legacy
+/// (non-runes) mutable declaration must keep its initializer. A comment landing
+/// inside the declaration's own line is what turned this into `let stats;`.
+#[test]
+fn the_following_legacy_declaration_keeps_its_initializer() {
+    let out = client(
+        "<script lang=\"ts\">\n\tlet stats: {\n\t\t// Legacy fields\n\t\tb: number;\n\t} | null;\n\tlet user = 0;\n\tfunction bump() { user += 1; }\n</script>\n<i on:click={bump}>{user}</i>\n",
+        "Legacy",
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("// Legacy fields"), "{out}");
+    assert!(out.contains("$.mutable_source(0)"), "{out}");
+}
+
+/// An initialized declarator is unchanged: its comment still goes ahead of the
+/// initializer, which is #4395's own placement.
+#[test]
+fn an_initialized_declarator_is_untouched() {
+    let out = client(
+        "<script lang=\"ts\">\n\tlet a: {\n\t\t/* c */\n\t\tb: number;\n\t} | null = null;\n</script>\n<i>{a}</i>\n",
+        "Init",
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("\tlet a = /* c */\n\t/* c */\n\tnull;\n"),
+        "{out}"
+    );
+}
+
+/// The half this does NOT close: when the declarator ends its statement list,
+/// upstream carries the comment out of the script entirely (onto the template's
+/// own first statement), which no source-range rewrite can express. Pinned so
+/// the gap is a measured fact rather than an unstated one.
+#[test]
+fn a_declarator_that_ends_its_list_still_drops_the_comment() {
+    let out = client(
+        "<script lang=\"ts\">\n\tlet a: {\n\t\t/* c */\n\t\tb: number;\n\t} | null;\n</script>\n<i>{a}</i>\n",
+        "Noinit",
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(!out.contains("/* c */"), "{out}");
+}


### PR DESCRIPTION
Closes #4396.

## What was wrong

A declarator with **no initializer** ends at its identifier, so a comment left behind by its
erased TypeScript annotation has nothing to attach to. rsvelte dropped it; upstream flushes it
at the next located node.

```svelte
<script lang="ts">
	let a: {
		/* c */
		b: number;
	} | null;
	let n = 1;
</script>
<i>{a}{n}</i>
```

```js
// official                    // rsvelte (before)
let a;                         let a;

/* c */                        let n = 1;
/* c */
let n = 1;
```

Upstream prints it twice because acorn-typescript speculates over the annotation; rsvelte already
reproduces that duplication for the **initialized** shape (`let a = /* c */` ⏎ `/* c */` ⏎ `null;`
is byte-equal on `main`), so the machinery was present and only this branch was `None`.

## Why it goes on the following statement and not at the removal point

This is the shape #4395 deliberately left alone, and the reason is still live: the client's legacy
state lowering is line-oriented, so a comment inside the declaration's own line turns
`let stats = $.mutable_source(0)` into `let stats;` — text that parses, runs, and is no longer
reactive. Putting it on its own line ahead of the **next** statement is both upstream's placement
and safe; `the_following_legacy_declaration_keeps_its_initializer` pins exactly that pair.

## What this does NOT close

When the declarator ends its statement list, upstream carries the comment out of the script
entirely, onto the template's own first statement. No source-range rewrite can express that, so
that shape still drops and is pinned as such rather than left unstated.

## Measured

Arms are separate binaries: `sha256 088df89eb48cab8f…` `main` at `b75886891`,
`8411f1d796cc5c9f…` this branch. Oracle is `submodules/svelte` (`VERSION 5.57.0`), the source path
the gates use. Verdict is full `js.code` byte equality.

| cell | target | main | this branch |
|---|---|---|---|
| block comment, statement follows | client | DIFF | **EQ** |
| block comment, statement follows | server | DIFF | **EQ** |
| line comment, statement follows | client | DIFF | **EQ** |
| line comment, statement follows | server | DIFF | **EQ** |
| initialized declarator (control) | client | EQ | EQ |
| initialized declarator (control) | server | EQ | EQ |
| comment outside the annotation (control) | client | EQ | EQ |
| comment outside the annotation (control) | server | EQ | EQ |
| declarator ends its list | client | DIFF | DIFF — the half above |
| declarator ends its list | server | DIFF | DIFF — the half above |

**Nothing else moves.** `compatibility/pattern-corpus`, both targets: `units same=2532 MOVED=0
both-threw=242`.

**Real-world reach, screened rather than pattern-matched.** 34,933 `.svelte` files across the
populated submodules; 22,816 have a TS instance script and 1,235 hold an uninitialized annotated
declarator (both marginals live, so a small carrier count is a property of the population).
Sweeping those 1,235 on both targets: `same=2380 MOVED=2 both-threw=88`, and the two moved units
are one file —
`submodules/adventurelog/frontend/src/routes/profile/[uuid]/+page.svelte`, whose `// Legacy fields`
this restores. Its region now matches the oracle line for line, **including** the
`let stats = $.mutable_source()` beside it that #4395's hazard would have emptied. The file stays
DIFF overall under both arms for an unrelated CSS-hash divergence, so it is a `both_diff` unit
whose comment region converged — which is why the verdict above is per-region on that file and
byte-equality on the grid.

## Pins

`crates/rsvelte_core/tests/uninit_annotation_comment_4396.rs`, 7 tests: the four moved cells, the
`$.mutable_source` hazard, the initialized control, and the still-dropping half.

A repro cannot live in `compatibility/pattern-corpus/`: `ast_equiv_batch` runs with
`CommentPolicy::Ignore`, so a comment-only divergence scores `match` on both arms.

## Provenance

The approach is a re-derivation of `42aed0b3e`, an unpushed commit from four days ago that sat 98
commits behind `main` in another worktree. Its diff no longer applies — `types.rs` has since grown
the `pending` / `flush_at` machinery this rides on — so the hook points, the tests and the
measurements here are new; what carried over is the mechanism and the #4395 hazard it recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5vkJQTh8a9oXgVXJrvRLj